### PR TITLE
Fix ingress host (2)

### DIFF
--- a/helm_deploy/values-dev.yaml
+++ b/helm_deploy/values-dev.yaml
@@ -5,10 +5,10 @@ generic-service:
   replicaCount: 2
 
   ingress:
-    host: hmpps-accredited-programmes-dev.hmpps.service.justice.gov.uk
+    host: accredited-programmes-dev.hmpps.service.justice.gov.uk
 
   env:
-    INGRESS_URL: "https://hmpps-accredited-programmes-dev.hmpps.service.justice.gov.uk"
+    INGRESS_URL: "https://accredited-programmes-dev.hmpps.service.justice.gov.uk"
     HMPPS_AUTH_URL: "https://sign-in-dev.hmpps.service.justice.gov.uk/auth"
     TOKEN_VERIFICATION_API_URL: "https://token-verification-api-dev.prison.service.justice.gov.uk"
 


### PR DESCRIPTION
## Changes in this PR

Removes `hmpps` from ingress host

This should now match up with the URL we've configured in the Cloud Platform Environments repo [here](https://github.com/ministryofjustice/cloud-platform-environments/blob/2a98d2873bcb1f27b0157d8b3b54bdeefda33c31/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-accredited-programmes-dev/06-certificates.yaml#L13)