### PR TITLE
Upgrade to Node 18.16

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -18,7 +18,7 @@ parameters:
 
   node-version:
     type: string
-    default: 18.15-browsers
+    default: 18.16-browsers
 
 jobs:
   build:

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 # Stage: base image
-FROM node:18.15-bullseye-slim as base
+FROM node:18.16-bullseye-slim as base
 
 ARG BUILD_NUMBER=1_0_0
 ARG GIT_REF=not-available

--- a/package-lock.json
+++ b/package-lock.json
@@ -90,7 +90,7 @@
         "typescript": "^5.0.0"
       },
       "engines": {
-        "node": "^v18.15.0",
+        "node": "^v18.16.0",
         "npm": "^9"
       }
     },
@@ -3205,9 +3205,9 @@
       "dev": true
     },
     "node_modules/@types/node": {
-      "version": "18.15.11",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-18.15.11.tgz",
-      "integrity": "sha512-E5Kwq2n4SbMzQOn6wnmBjuK9ouqlURrcZDVfbo9ftDDTFt3nk7ZKK4GMOzoYgnpQJKcxwQw+lGaBvvlMo0qN/Q==",
+      "version": "18.16.3",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-18.16.3.tgz",
+      "integrity": "sha512-OPs5WnnT1xkCBiuQrZA4+YAV4HEJejmHneyraIaxsbev5yCEr6KMwINNFP9wQeFIw8FWcoTqF3vQsa5CDaI+8Q==",
       "dev": true
     },
     "node_modules/@types/nunjucks": {
@@ -5220,9 +5220,9 @@
       }
     },
     "node_modules/cypress/node_modules/@types/node": {
-      "version": "14.18.42",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-14.18.42.tgz",
-      "integrity": "sha512-xefu+RBie4xWlK8hwAzGh3npDz/4VhF6icY/shU+zv/1fNn+ZVG7T7CRwe9LId9sAYRPxI+59QBPuKL3WpyGRg==",
+      "version": "14.18.43",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-14.18.43.tgz",
+      "integrity": "sha512-n3eFEaoem0WNwLux+k272P0+aq++5o05bA9CfiwKPdYPB5ZambWKdWoeHy7/OJiizMhzg27NLaZ6uzjLTzXceQ==",
       "dev": true
     },
     "node_modules/dashdash": {

--- a/package.json
+++ b/package.json
@@ -32,7 +32,7 @@
     "clean": "rm -rf dist build node_modules stylesheets"
   },
   "engines": {
-    "node": "^v18.15.0",
+    "node": "^v18.16.0",
     "npm": "^9"
   },
   "jest": {
@@ -135,7 +135,7 @@
     "@types/http-errors": "^2.0.1",
     "@types/jest": "^29.5.0",
     "@types/jsonwebtoken": "^9.0.1",
-    "@types/node": "^18.15.11",
+    "@types/node": "^18.16.3",
     "@types/nunjucks": "^3.2.2",
     "@types/passport": "^1.0.12",
     "@types/passport-oauth2": "^1.4.12",


### PR DESCRIPTION
## Context

We were getting some high severity warnings relating to [CVE-2022-29458][1]

## Changes in this PR

Over on the CAS3/Temporary Accommodation UI project, they were already setting the engine to 18 in package.json, but @tahb set CircleCI and Docker to use 18, which resolved the warnings. We were already on 18, but upgrading from 18.15 to 18.16 fixes the issues locally, as confirmed by running the commands below

Before the changes (three high severity warnings will show):
```
$ docker build . -t test-16
$ docker run --rm -v trivy-cache:/root/.cache/ -v /var/run/docker.sock:/var/run/docker.sock aquasec/trivy:latest image --exit-code 100 --no-progress --severity HIGH,CRITICAL --ignore-unfixed --skip-dirs /usr/local/lib/node_modules/npm --skip-files /app/agent.jar test-16
```

After the changes (no warnings will show):
```
$ docker build . -t test-18
$ docker run --rm -v trivy-cache:/root/.cache/ -v /var/run/docker.sock:/var/run/docker.sock aquasec/trivy:latest image --exit-code 100 --no-progress --severity HIGH,CRITICAL --ignore-unfixed --skip-dirs /usr/local/lib/node_modules/npm --skip-files /app/agent.jar test-18
```

[1]: https://github.com/ministryofjustice/hmpps-temporary-accommodation-ui/pull/334/commits/1bf175fbec12c610705b31437a7fddf4a15ef495#:~:text=high%20warnings%20via-,CVE%2D2022%2D29458,-chore/upgrade%2Ddockerfile