### PR TITLE
Sort imports

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -33,6 +33,12 @@
         "plugin:prettier/recommended"
       ],
       "rules": {
+        "sort-imports": [
+          "error",
+          {
+            "ignoreDeclarationSort": true
+          }
+        ],
         "@typescript-eslint/no-use-before-define": 0,
         "class-methods-use-this": 0,
         "no-useless-constructor": 0,

--- a/integration_tests/mockApis/auth.ts
+++ b/integration_tests/mockApis/auth.ts
@@ -1,7 +1,7 @@
 import jwt from 'jsonwebtoken'
 import { Response } from 'superagent'
 
-import { stubFor, getMatchingRequests } from './wiremock'
+import { getMatchingRequests, stubFor } from './wiremock'
 import tokenVerification from './tokenVerification'
 
 const createToken = () => {

--- a/integration_tests/mockApis/wiremock.ts
+++ b/integration_tests/mockApis/wiremock.ts
@@ -1,4 +1,4 @@
-import superagent, { SuperAgentRequest, Response } from 'superagent'
+import superagent, { Response, SuperAgentRequest } from 'superagent'
 
 const url = 'http://localhost:9091/__admin'
 

--- a/server/data/index.ts
+++ b/server/data/index.ts
@@ -3,7 +3,7 @@
  * Do appinsights first as it does some magic instrumentation work, i.e. it affects other 'require's
  * In particular, applicationinsights automatically collects bunyan logs
  */
-import { initialiseAppInsights, buildAppInsightsClient } from '../utils/azureAppInsights'
+import { buildAppInsightsClient, initialiseAppInsights } from '../utils/azureAppInsights'
 
 initialiseAppInsights()
 buildAppInsightsClient()

--- a/server/data/restClientMetricsMiddleware.test.ts
+++ b/server/data/restClientMetricsMiddleware.test.ts
@@ -1,9 +1,9 @@
 import superagent from 'superagent'
 import nock from 'nock'
 import {
-  restClientMetricsMiddleware,
   normalizePath,
   requestHistogram,
+  restClientMetricsMiddleware,
   timeoutCounter,
 } from './restClientMetricsMiddleware'
 

--- a/server/errorHandler.ts
+++ b/server/errorHandler.ts
@@ -1,4 +1,4 @@
-import type { Request, Response, NextFunction } from 'express'
+import type { NextFunction, Request, Response } from 'express'
 import type { HTTPError } from 'superagent'
 import logger from '../logger'
 

--- a/server/middleware/asyncMiddleware.ts
+++ b/server/middleware/asyncMiddleware.ts
@@ -1,4 +1,4 @@
-import type { Request, Response, NextFunction, RequestHandler } from 'express'
+import type { NextFunction, Request, RequestHandler, Response } from 'express'
 
 export default function asyncMiddleware(fn: RequestHandler) {
   return (req: Request, res: Response, next: NextFunction): void => {

--- a/server/middleware/setUpWebSecurity.ts
+++ b/server/middleware/setUpWebSecurity.ts
@@ -1,4 +1,4 @@
-import express, { Router, Request, Response, NextFunction } from 'express'
+import express, { NextFunction, Request, Response, Router } from 'express'
 import helmet from 'helmet'
 import crypto from 'crypto'
 

--- a/server/utils/azureAppInsights.ts
+++ b/server/utils/azureAppInsights.ts
@@ -1,4 +1,4 @@
-import { setup, defaultClient, TelemetryClient, DistributedTracingModes } from 'applicationinsights'
+import { DistributedTracingModes, TelemetryClient, defaultClient, setup } from 'applicationinsights'
 import applicationVersion from '../applicationVersion'
 
 function defaultName(): string {


### PR DESCRIPTION
## Context

On the Approved Premises UI repo, a linting rule dictates that when importing multiple things from one module, the imports are alphabetised. This like a useful thing to do here too

## Changes in this PR

This adds a linter check for ordering imports alphabetically (within a single line, not between lines) and fixes resulting errors