### PR TITLE
Add linting and formatting

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -49,7 +49,7 @@ jobs:
             npm run record-build-info
       - run: # Run linter after build because the integration test code depend on compiled typescript...
           name: Linter check
-          command: npm run lint
+          command: npm run lint:ci
       - persist_to_workspace:
           root: .
           paths:

--- a/.djlintrc
+++ b/.djlintrc
@@ -1,0 +1,6 @@
+{
+  "extension": "njk",
+  "files": ["server/views"],
+  "ignore": "T001",
+  "profile": "nunjucks"
+}

--- a/.gitignore
+++ b/.gitignore
@@ -119,7 +119,6 @@ dist
 
 assets/stylesheets/*.css
 .idea
-.vscode
 build-info.json
 dist/
 test_results/

--- a/.vscode/extensions.json
+++ b/.vscode/extensions.json
@@ -1,0 +1,5 @@
+{
+  "recommendations": [
+    "okitavera.vscode-nunjucks-formatter"
+  ]
+}

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,7 @@
+{
+  "[nj][njk][nunjucks][twig]": {
+    "editor.defaultFormatter": "okitavera.vscode-nunjucks-formatter",
+    "editor.formatOnSave": true
+  },
+  "nunjucksFormat.newline": true
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -20,6 +20,7 @@
         "connect-flash": "^0.1.1",
         "connect-redis": "^7.0.0",
         "csurf": "^1.11.0",
+        "djlint": "*",
         "express": "^4.18.2",
         "express-prom-bundle": "^6.6.0",
         "express-session": "^1.17.3",
@@ -95,6 +96,9 @@
       "engines": {
         "node": "^v18.16.0",
         "npm": "^9"
+      },
+      "optionalDependencies": {
+        "djlint": "^1.27.0"
       }
     },
     "node_modules/@ampproject/remapping": {
@@ -3684,7 +3688,7 @@
       "version": "5.0.1",
       "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
       "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
-      "dev": true,
+      "devOptional": true,
       "engines": {
         "node": ">=8"
       }
@@ -3693,7 +3697,7 @@
       "version": "4.3.0",
       "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
       "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
-      "dev": true,
+      "devOptional": true,
       "dependencies": {
         "color-convert": "^2.0.1"
       },
@@ -4697,7 +4701,7 @@
       "version": "8.0.1",
       "resolved": "https://registry.npmjs.org/cliui/-/cliui-8.0.1.tgz",
       "integrity": "sha512-BSeNnyus75C4//NQ9gQt1/csTXyo/8Sb+afLAkzAptFuMsod9HFokGNudZpi/oQV73hnVK+sR+5PVRMd+Dr7YQ==",
-      "dev": true,
+      "devOptional": true,
       "dependencies": {
         "string-width": "^4.2.0",
         "strip-ansi": "^6.0.1",
@@ -4756,7 +4760,7 @@
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
       "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
-      "dev": true,
+      "devOptional": true,
       "dependencies": {
         "color-name": "~1.1.4"
       },
@@ -4768,7 +4772,7 @@
       "version": "1.1.4",
       "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
       "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
-      "dev": true
+      "devOptional": true
     },
     "node_modules/colorette": {
       "version": "2.0.19",
@@ -5450,6 +5454,20 @@
         "node": ">=8"
       }
     },
+    "node_modules/djlint": {
+      "version": "1.27.0",
+      "resolved": "https://registry.npmjs.org/djlint/-/djlint-1.27.0.tgz",
+      "integrity": "sha512-NgWh6ILXVg89Xz4omBInTMGd+ZQOCdDzagWaaHK9yMsTKfvB3Q3iiCXQViWi4eWtJHVHUydlEM1vTQkexgwQdg==",
+      "hasInstallScript": true,
+      "optional": true,
+      "dependencies": {
+        "python-shell": "^5.0.0",
+        "yargs": "17.7.2"
+      },
+      "bin": {
+        "djlint": "bin/index.js"
+      }
+    },
     "node_modules/doctrine": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/doctrine/-/doctrine-3.0.0.tgz",
@@ -5550,7 +5568,7 @@
       "version": "8.0.0",
       "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
       "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==",
-      "dev": true
+      "devOptional": true
     },
     "node_modules/encodeurl": {
       "version": "1.0.2",
@@ -5695,7 +5713,7 @@
       "version": "3.1.1",
       "resolved": "https://registry.npmjs.org/escalade/-/escalade-3.1.1.tgz",
       "integrity": "sha512-k0er2gUkLf8O0zKJiAhmkTnJlTvINGv7ygDNPbeIsX/TJjGJZHuh9B2UxbsaEkmlEo9MfhrSzmhIlhRlI2GXnw==",
-      "dev": true,
+      "devOptional": true,
       "engines": {
         "node": ">=6"
       }
@@ -6869,7 +6887,7 @@
       "version": "2.0.5",
       "resolved": "https://registry.npmjs.org/get-caller-file/-/get-caller-file-2.0.5.tgz",
       "integrity": "sha512-DyFP3BM/3YHTQOCUL/w0OZHR0lpKeGrxotcHWcqNEdnltqFwXVfhEBQ94eIo34AfQpo0rGki4cyIiftY06h2Fg==",
-      "dev": true,
+      "devOptional": true,
       "engines": {
         "node": "6.* || 8.* || >= 10.*"
       }
@@ -10655,6 +10673,15 @@
         }
       ]
     },
+    "node_modules/python-shell": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/python-shell/-/python-shell-5.0.0.tgz",
+      "integrity": "sha512-RUOOOjHLhgR1MIQrCtnEqz/HJ1RMZBIN+REnpSUrfft2bXqXy69fwJASVziWExfFXsR1bCY0TznnHooNsCo0/w==",
+      "optional": true,
+      "engines": {
+        "node": ">=0.10"
+      }
+    },
     "node_modules/qs": {
       "version": "6.11.0",
       "resolved": "https://registry.npmjs.org/qs/-/qs-6.11.0.tgz",
@@ -10870,7 +10897,7 @@
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/require-directory/-/require-directory-2.1.1.tgz",
       "integrity": "sha512-fGxEI7+wsG9xrvdjsrlmL22OMTTiHRwAMroiEeMgq8gzoLC/PQr7RsRDSTLUg/bZAZtF+TVIkHc6/4RIKrui+Q==",
-      "dev": true,
+      "devOptional": true,
       "engines": {
         "node": ">=0.10.0"
       }
@@ -11566,7 +11593,7 @@
       "version": "4.2.3",
       "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
       "integrity": "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==",
-      "dev": true,
+      "devOptional": true,
       "dependencies": {
         "emoji-regex": "^8.0.0",
         "is-fullwidth-code-point": "^3.0.0",
@@ -11580,7 +11607,7 @@
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-3.0.0.tgz",
       "integrity": "sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg==",
-      "dev": true,
+      "devOptional": true,
       "engines": {
         "node": ">=8"
       }
@@ -11634,7 +11661,7 @@
       "version": "6.0.1",
       "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
       "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
-      "dev": true,
+      "devOptional": true,
       "dependencies": {
         "ansi-regex": "^5.0.1"
       },
@@ -12410,7 +12437,7 @@
       "version": "7.0.0",
       "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-7.0.0.tgz",
       "integrity": "sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==",
-      "dev": true,
+      "devOptional": true,
       "dependencies": {
         "ansi-styles": "^4.0.0",
         "string-width": "^4.1.0",
@@ -12476,7 +12503,7 @@
       "version": "5.0.8",
       "resolved": "https://registry.npmjs.org/y18n/-/y18n-5.0.8.tgz",
       "integrity": "sha512-0pfFzegeDWJHJIAmTLRP2DwHjdF5s7jo9tuztdQxAhINCdvS+3nGINqPd00AphqJR/0LhANUS6/+7SCb98YOfA==",
-      "dev": true,
+      "devOptional": true,
       "engines": {
         "node": ">=10"
       }
@@ -12497,10 +12524,10 @@
       }
     },
     "node_modules/yargs": {
-      "version": "17.7.1",
-      "resolved": "https://registry.npmjs.org/yargs/-/yargs-17.7.1.tgz",
-      "integrity": "sha512-cwiTb08Xuv5fqF4AovYacTFNxk62th7LKJ6BL9IGUpTJrWoU7/7WdQGTP2SjKf1dUNBGzDd28p/Yfs/GI6JrLw==",
-      "dev": true,
+      "version": "17.7.2",
+      "resolved": "https://registry.npmjs.org/yargs/-/yargs-17.7.2.tgz",
+      "integrity": "sha512-7dSzzRQ++CKnNI/krKnYRV7JKKPUXMEh61soaHKg9mrWEhzFWhFnxPxGl+69cD1Ou63C13NUPCnmIcrvqCuM6w==",
+      "devOptional": true,
       "dependencies": {
         "cliui": "^8.0.1",
         "escalade": "^3.1.1",
@@ -12557,7 +12584,7 @@
       "version": "21.1.1",
       "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-21.1.1.tgz",
       "integrity": "sha512-tVpsJW7DdjecAiFpbIB1e3qxIQsE6NoPc5/eTdrbbIC4h0LVsWhnoa3g+m2HclBIujHzsxZ4VJVA+GUuc2/LBw==",
-      "dev": true,
+      "devOptional": true,
       "engines": {
         "node": ">=12"
       }

--- a/package.json
+++ b/package.json
@@ -19,7 +19,8 @@
     "watch-node-feature": "export $(cat integration.env) && nodemon --watch dist/ $NODE_DEBUG_OPTION dist/server.js | bunyan -o short",
     "start-integration-env:dev": "npm run build && concurrently -k -p \"[{name}]\" -n \"Views,TypeScript,Node,Sass\" -c \"yellow.bold,cyan.bold,green.bold,blue.bold\" \"npm run watch-views\" \"npm run watch-ts\" \"npm run watch-node-feature\" \"npm run watch-sass\"",
     "record-build-info": "node ./bin/record-build-info",
-    "lint": "eslint . --cache --max-warnings 0",
+    "lint": "eslint . --cache --max-warnings 0 && djlint .",
+    "lint:ci": "eslint . --cache --max-warnings 0",
     "typecheck": "tsc && tsc -p integration_tests",
     "test": "jest",
     "test:ci": "jest --runInBand",
@@ -177,5 +178,8 @@
     "supertest": "^6.3.3",
     "ts-jest": "^29.1.0",
     "typescript": "^5.0.0"
+  },
+  "optionalDependencies": {
+    "djlint": "^1.27.0"
   }
 }

--- a/server/views/autherror.njk
+++ b/server/views/autherror.njk
@@ -7,4 +7,4 @@
   <p>
     You are not authorised to use this application.
   </p>
-{% endblock %}
+{% endblock content %}

--- a/server/views/dashboard/index.njk
+++ b/server/views/dashboard/index.njk
@@ -4,7 +4,6 @@
 {% set mainClasses = "app-container govuk-body" %}
 
 {% block content %}
-
   <h1>{{ pageHeading }}</h1>
 
   <a class="govuk-link" href="{{ findPath }}">Find an accredited programme</a>

--- a/server/views/dashboard/index.njk
+++ b/server/views/dashboard/index.njk
@@ -7,4 +7,4 @@
   <h1>{{ pageHeading }}</h1>
 
   <a class="govuk-link" href="{{ findPath }}">Find an accredited programme</a>
-{% endblock %}
+{% endblock content %}

--- a/server/views/pages/error.njk
+++ b/server/views/pages/error.njk
@@ -4,9 +4,7 @@
 {% set mainClasses = "app-container govuk-body" %}
 
 {% block content %}
-
   <h1>{{ message }}</h1>
   <h2>{{ status }}</h2>
   <pre>{{ stack }}</pre>
-
 {% endblock %}

--- a/server/views/pages/error.njk
+++ b/server/views/pages/error.njk
@@ -7,4 +7,4 @@
   <h1>{{ message }}</h1>
   <h2>{{ status }}</h2>
   <pre>{{ stack }}</pre>
-{% endblock %}
+{% endblock content %}

--- a/server/views/partials/breadCrumb.njk
+++ b/server/views/partials/breadCrumb.njk
@@ -2,31 +2,24 @@
 
 {% macro breadCrumb(pageTitle, breadCrumbList) %}
 
-  {% set rows = [ {
-    text: "Home",
-    href: '/'
-    } ]
-  %}
+  {% set rows = [
+    {
+      text: "Home",
+      href: '/'
+    }
+  ]
+ %}
 
   {% for item in breadCrumbList %}
-    {% set rows = (rows.push(
-      {
-        text: item.title,
-        href: item.href
-      }
-    ), rows) %}
+    {% set rows = (rows.push({text: item.title, href: item.href}), rows) %}
   {% endfor %}
 
-  {% set completedRows = (rows.push(
-    {
-      text: pageTitle
-    }
-  ), rows) %}
+  {% set completedRows = (rows.push({text: pageTitle}), rows) %}
 
-{{ govukBreadcrumbs({
-  collapseOnMobile: true,
-  items: completedRows,
-  classes: "govuk-!-display-none-print"
-}) }}
+  {{ govukBreadcrumbs({
+    collapseOnMobile: true,
+    items: completedRows,
+    classes: "govuk-!-display-none-print"
+  }) }}
 
 {% endmacro %}

--- a/server/views/partials/layout.njk
+++ b/server/views/partials/layout.njk
@@ -10,7 +10,7 @@
   <script src="/assets/js/html5shiv-3.7.3.min.js"></script>
   <![endif]-->
 
-  <script src="/assets/js/jquery.min.js"></script> 
+  <script src="/assets/js/jquery.min.js"></script>
   <script src="https://code.jquery.com/ui/1.12.1/jquery-ui.min.js"
           integrity="sha256-VazP97ZCwtekAsvgPBSUwPFKdrwD3unUfSGVYrahUqU="
           nonce="{{ cspNonce }}"
@@ -19,14 +19,15 @@
 
 {% endblock %}
 
-{% block pageTitle %}{{pageTitle | default(applicationName)}}{% endblock %}
+{% block pageTitle %}
+  {{pageTitle | default(applicationName)}}
+{% endblock %}
 
 {% block header %}
   {% include "./header.njk" %}
 {% endblock %}
 
-{% block bodyStart %}
-{% endblock %}
+{% block bodyStart %}{% endblock %}
 
 {% block bodyEnd %}
   {# Run JavaScript at end of the

--- a/server/views/partials/layout.njk
+++ b/server/views/partials/layout.njk
@@ -17,17 +17,17 @@
           crossorigin="anonymous"></script>
   <link href="https://code.jquery.com/ui/1.12.1/themes/ui-lightness/jquery-ui.css" rel="stylesheet" nonce="{{ cspNonce }}" crossorigin>
 
-{% endblock %}
+{% endblock head %}
 
 {% block pageTitle %}
   {{pageTitle | default(applicationName)}}
-{% endblock %}
+{% endblock pageTitle %}
 
 {% block header %}
   {% include "./header.njk" %}
-{% endblock %}
+{% endblock header %}
 
-{% block bodyStart %}{% endblock %}
+{% block bodyStart %}{% endblock bodyStart %}
 
 {% block bodyEnd %}
   {# Run JavaScript at end of the
@@ -35,4 +35,4 @@
   <script src="/assets/govuk/all.js"></script>
   <script src="/assets/govukFrontendInit.js"></script>
   <script src="/assets/moj/all.js"></script>
-{% endblock %}
+{% endblock bodyEnd %}

--- a/server/views/programmes/index.njk
+++ b/server/views/programmes/index.njk
@@ -1,7 +1,7 @@
 <h1>{{ pageHeading }}</h1>
 
 <ul>
-{% for programme in programmes %}
-  <li>{{ programme.name }}</li>
-{% endfor %}
+  {% for programme in programmes %}
+    <li>{{ programme.name }}</li>
+  {% endfor %}
 </ul>


### PR DESCRIPTION
## Context

#25 (unmerged) added djLint for both linting and formatting of Nunjucks files. The formatting side had some very questionable choices. After consulting with the Approved Premises team, I've tested another approach, which would replace #25

## Changes in this PR

This uses Nunjucks Template Formatter (NTF) for formatting, which is just a VSCode extension. Not ideal if we have team members who don't use VSCode, but it does formats templates much more sensibly. For formatting and for our current team setup, this is probably fine

djLint is still used for linting, including in `npm run lint`, used in `script/test` (but skipped in the CI). One rule is turned off due to conflicting with a formatting choice of NTF that isn't immediately obviously configurable