### PR TITLE
Enable djLint error highlighting in VSCode

### DIFF
--- a/.djlintrc
+++ b/.djlintrc
@@ -1,6 +1,5 @@
 {
   "extension": "njk",
-  "files": ["server/views"],
   "ignore": "T001",
   "profile": "nunjucks"
 }


### PR DESCRIPTION
## Context

When deciding to use Nunjucks Template Formatter for formatting and djLint only for linting, the `files` key was added to `.djlintrc` to be more specific about where to lint. When evaluating djLint as a formatter (as well as a linter), this key was omitted as it would produce unwanted behaviour in VSCode when using on-save autoformatting

However, it appears that with this key, VSCode also fails to highlight linting errors in the editor. Removing the key fixes the behaviour, allowing you to see errors without needing to run `npm run lint` or `script test`

## Changes in this PR

This therefore removes the key to enable Nunjucks linting error highlighting

## Screenshots of UI changes

### Before

<img width="114" alt="image" src="https://github.com/ministryofjustice/hmpps-accredited-programmes-ui/assets/40244233/5f9432d7-1157-4b04-82fc-7acb8824daa2">

### After

<img width="117" alt="image" src="https://github.com/ministryofjustice/hmpps-accredited-programmes-ui/assets/40244233/ede38f2d-1575-4248-a058-8f721c761fae">
