### PR TITLE
Update dependencies before testing

### DIFF
--- a/script/test
+++ b/script/test
@@ -4,21 +4,27 @@
 
 set -e
 
+cd "$(dirname "$0")/.."
+
+if [ -n "$DEBUG" ]; then
+  set -x
+fi
+
+echo "==> Updating..."
+
+script/update
+
 echo "==> Linting the code..."
 
 npm run lint
 
-echo "==> Typechecking the code"
+echo "==> Typechecking the code..."
 
 npm run typecheck
 
 echo "==> Running unit tests..."
 
 npm run test
-
-echo "==> Starting the backing services in Docker..."
-
-script/utils/launch-docker
 
 echo "==> Running integration tests..."
 

--- a/script/update
+++ b/script/update
@@ -1,0 +1,11 @@
+#!/bin/sh
+
+# script/update: Update the application to run for its current checkout.
+
+set -e
+
+cd "$(dirname "$0")/.."
+
+echo "==> Bootstrapping..."
+
+script/bootstrap


### PR DESCRIPTION
## Changes in this PR

This adds an `update` script, which currently just wraps around `bootstrap`. It's added at the start of the `test` script to ensure dependencies are resolved before testing (when running `script/test`, not `npm run test`/`npm run test:integration` etc)