### PR TITLE
Replace deprecated Faker methods

### DIFF
--- a/server/testutils/factories/programme.ts
+++ b/server/testutils/factories/programme.ts
@@ -5,8 +5,8 @@ import type { AccreditedProgramme } from '@accredited-programmes/models'
 import programmePrerequisiteFactory from './programmePrerequisite'
 
 export default Factory.define<AccreditedProgramme>(() => ({
-  name: faker.random.words(),
-  programmeType: faker.random.words(),
+  name: faker.word.words(),
+  programmeType: faker.word.words(),
   description: faker.lorem.sentences(),
   programmePrerequisites: programmePrerequisiteFactory.buildList(3),
 }))

--- a/server/testutils/factories/programmePrerequisite.ts
+++ b/server/testutils/factories/programmePrerequisite.ts
@@ -4,6 +4,6 @@ import { faker } from '@faker-js/faker/locale/en_GB'
 import type { ProgrammePrerequisite } from '@accredited-programmes/models'
 
 export default Factory.define<ProgrammePrerequisite>(() => ({
-  key: faker.random.alphaNumeric(),
-  value: faker.random.words(),
+  key: faker.word.words(),
+  value: faker.word.words(),
 }))


### PR DESCRIPTION
## Context

We recently upgraded to Faker v8, which deprecated `.random`, which will be removed in v9.

## Changes in this PR

This replaces those methods with non-deprecated alternatives. It also updates the programme prerequisite factory so that the key is one or more words, rather than one character, making it more realistic