### PR TITLE
Sort imports redux

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -5,86 +5,41 @@
     "jest": true
   },
 
-  "plugins": ["import", "no-only-tests"],
+  "extends": [
+    "airbnb-base",
+    "plugin:@typescript-eslint/eslint-recommended",
+    "plugin:@typescript-eslint/recommended",
+    "plugin:prettier/recommended"
+  ],
+
+  "plugins": ["@typescript-eslint", "import", "no-only-tests"],
 
   "settings": {
     "import/parsers": {
       "@typescript-eslint/parser": [".ts", ".tsx"]
     },
     "import/resolver": {
-      "typescript": {
-        "alwaysTryTypes": true
-      },
       "node": {
         "extensions": [".js", ".jsx", ".ts", ".tsx", ".json"]
+      },
+      "typescript": {
+        "alwaysTryTypes": true
       }
     }
   },
 
-  "overrides": [
-    {
-      "plugins": ["@typescript-eslint", "import"],
-      "parser": "@typescript-eslint/parser",
-      "files": ["**/*.ts"],
-      "excludedFiles": "*.js",
-      "extends": [
-        "plugin:@typescript-eslint/eslint-recommended",
-        "plugin:@typescript-eslint/recommended",
-        "plugin:prettier/recommended"
-      ],
-      "rules": {
-        "import/order": [
-          "error",
-          {
-            "alphabetize": { "order": "asc", "orderImportKind": "asc" },
-            "groups": [["builtin", "external"]],
-            "newlines-between": "always"
-          }
-        ],
-        "sort-imports": [
-          "error",
-          {
-            "ignoreDeclarationSort": true
-          }
-        ],
-        "@typescript-eslint/no-use-before-define": 0,
-        "class-methods-use-this": 0,
-        "no-useless-constructor": 0,
-        "@typescript-eslint/no-unused-vars": [
-          1,
-          {
-            "argsIgnorePattern": "res|next|^err|_",
-            "ignoreRestSiblings": true
-          }
-        ],
-        "@typescript-eslint/semi": 0,
-        "import/no-unresolved": "error",
-        "prettier/prettier": [
-          "error",
-          {
-            "trailingComma": "all",
-            "singleQuote": true,
-            "printWidth": 120,
-            "semi": false
-          }
-        ]
-      }
-    }
-  ],
-
-  "extends": ["airbnb-base", "plugin:prettier/recommended"],
-
   "rules": {
-    "no-unused-vars": [
+    "@typescript-eslint/no-use-before-define": 0,
+    "@typescript-eslint/no-unused-vars": [
       1,
       {
         "argsIgnorePattern": "res|next|^err|_",
         "ignoreRestSiblings": true
       }
     ],
-    "no-use-before-define": 0,
-    "semi": 0,
-    "import/no-unresolved": "error",
+    "@typescript-eslint/semi": 0,
+    "class-methods-use-this": 0,
+    "comma-dangle": ["error", "always-multiline"],
     "import/extensions": [
       "error",
       "ignorePackages",
@@ -96,12 +51,35 @@
         "tsx": "never"
       }
     ],
-    "comma-dangle": ["error", "always-multiline"],
     "import/no-extraneous-dependencies": [
       "error",
       { "devDependencies": ["**/*.test.js", "**/*.test.ts", "**/testutils/**", "cypress.config.ts"] }
     ],
+    "import/no-unresolved": "error",
+    "import/order": [
+      "error",
+      {
+        "alphabetize": { "order": "asc", "orderImportKind": "asc" },
+        "groups": [["builtin", "external"]],
+        "newlines-between": "always"
+      }
+    ],
     "no-only-tests/no-only-tests": "error",
+    "no-unused-vars": [
+      1,
+      {
+        "argsIgnorePattern": "res|next|^err|_",
+        "ignoreRestSiblings": true
+      }
+    ],
+    "no-use-before-define": 0,
+    "no-useless-constructor": 0,
+    "sort-imports": [
+      "error",
+      {
+        "ignoreDeclarationSort": true
+      }
+    ],
     "prettier/prettier": [
       "error",
       {
@@ -110,6 +88,7 @@
         "printWidth": 120,
         "semi": false
       }
-    ]
+    ],
+    "semi": 0
   }
 }

--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -23,7 +23,7 @@
 
   "overrides": [
     {
-      "plugins": ["@typescript-eslint"],
+      "plugins": ["@typescript-eslint", "import"],
       "parser": "@typescript-eslint/parser",
       "files": ["**/*.ts"],
       "excludedFiles": "*.js",
@@ -33,6 +33,14 @@
         "plugin:prettier/recommended"
       ],
       "rules": {
+        "import/order": [
+          "error",
+          {
+            "alphabetize": { "order": "asc", "orderImportKind": "asc" },
+            "groups": [["builtin", "external"]],
+            "newlines-between": "always"
+          }
+        ],
         "sort-imports": [
           "error",
           {

--- a/.gitignore
+++ b/.gitignore
@@ -122,7 +122,8 @@ assets/stylesheets/*.css
 build-info.json
 dist/
 test_results/
-integration_tests/videos/
+integration_tests/downloads/
 integration_tests/screenshots/
+integration_tests/videos/
 */*.iml
 **/Chart.lock

--- a/cypress.config.ts
+++ b/cypress.config.ts
@@ -7,6 +7,7 @@ import { resetStubs } from './integration_tests/mockApis/wiremock'
 
 export default defineConfig({
   chromeWebSecurity: false,
+  downloadsFolder: 'integration_tests/downloads',
   fixturesFolder: 'integration_tests/fixtures',
   screenshotsFolder: 'integration_tests/screenshots',
   videosFolder: 'integration_tests/videos',

--- a/cypress.config.ts
+++ b/cypress.config.ts
@@ -1,8 +1,9 @@
 import { defineConfig } from 'cypress'
-import { resetStubs } from './integration_tests/mockApis/wiremock'
+
 import auth from './integration_tests/mockApis/auth'
 import programmes from './integration_tests/mockApis/programmes'
 import tokenVerification from './integration_tests/mockApis/tokenVerification'
+import { resetStubs } from './integration_tests/mockApis/wiremock'
 
 export default defineConfig({
   chromeWebSecurity: false,

--- a/integration_tests/e2e/find.cy.ts
+++ b/integration_tests/e2e/find.cy.ts
@@ -1,6 +1,6 @@
+import { programmeFactory } from '../../server/testutils/factories'
 import ProgrammesPage from '../pages/find/programmes'
 import Page from '../pages/page'
-import { programmeFactory } from '../../server/testutils/factories'
 
 context('Find', () => {
   beforeEach(() => {

--- a/integration_tests/e2e/login.cy.ts
+++ b/integration_tests/e2e/login.cy.ts
@@ -1,7 +1,7 @@
-import IndexPage from '../pages/index'
-import AuthSignInPage from '../pages/authSignIn'
-import Page from '../pages/page'
 import AuthManageDetailsPage from '../pages/authManageDetails'
+import AuthSignInPage from '../pages/authSignIn'
+import IndexPage from '../pages/index'
+import Page from '../pages/page'
 
 context('SignIn', () => {
   beforeEach(() => {

--- a/integration_tests/mockApis/auth.ts
+++ b/integration_tests/mockApis/auth.ts
@@ -1,8 +1,8 @@
 import jwt from 'jsonwebtoken'
 import { Response } from 'superagent'
 
-import { getMatchingRequests, stubFor } from './wiremock'
 import tokenVerification from './tokenVerification'
+import { getMatchingRequests, stubFor } from './wiremock'
 
 const createToken = () => {
   const payload = {

--- a/integration_tests/mockApis/programmes.ts
+++ b/integration_tests/mockApis/programmes.ts
@@ -1,7 +1,8 @@
 import { SuperAgentRequest } from 'superagent'
-import type { AccreditedProgramme } from '@accredited-programmes/models'
+
 import { stubFor } from './wiremock'
 import paths from '../../server/paths/api'
+import type { AccreditedProgramme } from '@accredited-programmes/models'
 
 export default {
   stubProgrammes: (programmes: Array<AccreditedProgramme>): SuperAgentRequest =>

--- a/integration_tests/mockApis/tokenVerification.ts
+++ b/integration_tests/mockApis/tokenVerification.ts
@@ -1,4 +1,5 @@
 import { SuperAgentRequest } from 'superagent'
+
 import { stubFor } from './wiremock'
 
 export default {

--- a/integration_tests/pages/find/programmes.ts
+++ b/integration_tests/pages/find/programmes.ts
@@ -1,6 +1,6 @@
-import type { AccreditedProgramme } from '@accredited-programmes/models'
-import Page from '../page'
 import { prerequisiteSummaryListRows } from '../../../server/utils/programmeUtils'
+import Page from '../page'
+import type { AccreditedProgramme } from '@accredited-programmes/models'
 
 export default class ProgrammesPage extends Page {
   constructor() {

--- a/logger.ts
+++ b/logger.ts
@@ -1,5 +1,6 @@
 import bunyan from 'bunyan'
 import bunyanFormat from 'bunyan-format'
+
 import config from './server/config'
 
 const formatOut = bunyanFormat({ outputMode: 'short', color: !config.production })

--- a/server.ts
+++ b/server.ts
@@ -1,8 +1,8 @@
 // Require app insights before anything else to allow for instrumentation of bunyan and express
 import 'applicationinsights'
 
-import { app, metricsApp } from './server/index'
 import logger from './logger'
+import { app, metricsApp } from './server/index'
 
 app.listen(app.get('port'), () => {
   logger.info(`Server listening on port ${app.get('port')}`)

--- a/server/app.ts
+++ b/server/app.ts
@@ -1,25 +1,22 @@
 import express from 'express'
-
-import path from 'path'
 import createError from 'http-errors'
+import path from 'path'
 
-import nunjucksSetup from './utils/nunjucksSetup'
+import { Controllers } from './controllers'
 import errorHandler from './errorHandler'
 import authorisationMiddleware from './middleware/authorisationMiddleware'
-import { metricsMiddleware } from './monitoring/metricsApp'
-
 import setUpAuthentication from './middleware/setUpAuthentication'
 import setUpCsrf from './middleware/setUpCsrf'
 import setUpCurrentUser from './middleware/setUpCurrentUser'
 import setUpHealthChecks from './middleware/setUpHealthChecks'
 import setUpStaticResources from './middleware/setUpStaticResources'
-import setUpWebRequestParsing from './middleware/setupRequestParsing'
 import setUpWebSecurity from './middleware/setUpWebSecurity'
 import setUpWebSession from './middleware/setUpWebSession'
-
+import setUpWebRequestParsing from './middleware/setupRequestParsing'
+import { metricsMiddleware } from './monitoring/metricsApp'
 import routes from './routes'
 import type { Services } from './services'
-import { Controllers } from './controllers'
+import nunjucksSetup from './utils/nunjucksSetup'
 
 export default function createApp(controllers: Controllers, services: Services): express.Application {
   const app = express()

--- a/server/authentication/auth.ts
+++ b/server/authentication/auth.ts
@@ -1,9 +1,9 @@
+import type { RequestHandler } from 'express'
 import passport from 'passport'
 import { Strategy } from 'passport-oauth2'
-import type { RequestHandler } from 'express'
 
-import config from '../config'
 import generateOauthClientToken from './clientCredentials'
+import config from '../config'
 import type { TokenVerifier } from '../data/tokenVerification'
 
 passport.serializeUser((user, done) => {

--- a/server/controllers/dashboardController.test.ts
+++ b/server/controllers/dashboardController.test.ts
@@ -1,5 +1,6 @@
-import { NextFunction, Request, Response } from 'express'
 import { DeepMocked, createMock } from '@golevelup/ts-jest'
+import { NextFunction, Request, Response } from 'express'
+
 import DashboardController from './dashboardController'
 import paths from '../paths/find'
 

--- a/server/controllers/dashboardController.ts
+++ b/server/controllers/dashboardController.ts
@@ -1,4 +1,5 @@
 import { Request, RequestHandler, Response } from 'express'
+
 import paths from '../paths/find'
 
 export default class DashboardController {

--- a/server/controllers/find/programmesController.test.ts
+++ b/server/controllers/find/programmesController.test.ts
@@ -1,9 +1,9 @@
-import { NextFunction, Request, Response } from 'express'
 import { DeepMocked, createMock } from '@golevelup/ts-jest'
+import { NextFunction, Request, Response } from 'express'
 
 import ProgrammesController from './programmesController'
-import { programmeFactory } from '../../testutils/factories'
 import { ProgrammeService } from '../../services'
+import { programmeFactory } from '../../testutils/factories'
 import { programmeListItems } from '../../utils/programmeUtils'
 
 describe('ProgrammesController', () => {

--- a/server/controllers/find/programmesController.ts
+++ b/server/controllers/find/programmesController.ts
@@ -1,4 +1,5 @@
 import type { Request, Response, TypedRequestHandler } from 'express'
+
 import ProgrammeService from '../../services/programmeService'
 import { programmeListItems } from '../../utils/programmeUtils'
 

--- a/server/controllers/index.ts
+++ b/server/controllers/index.ts
@@ -1,6 +1,6 @@
-import { Services } from '../services'
 import DashboardController from './dashboardController'
 import ProgrammesController from './find/programmesController'
+import { Services } from '../services'
 
 export const controllers = (services: Services) => {
   const dashboardController = new DashboardController()

--- a/server/data/healthCheck.test.ts
+++ b/server/data/healthCheck.test.ts
@@ -1,4 +1,5 @@
 import nock from 'nock'
+
 import { serviceCheckFactory } from './healthCheck'
 import { AgentConfig } from '../config'
 

--- a/server/data/healthCheck.ts
+++ b/server/data/healthCheck.ts
@@ -1,5 +1,6 @@
-import superagent from 'superagent'
 import Agent, { HttpsAgent } from 'agentkeepalive'
+import superagent from 'superagent'
+
 import logger from '../../logger'
 import { AgentConfig } from '../config'
 

--- a/server/data/hmppsAuthClient.test.ts
+++ b/server/data/hmppsAuthClient.test.ts
@@ -1,8 +1,8 @@
 import nock from 'nock'
 
-import config from '../config'
 import HmppsAuthClient from './hmppsAuthClient'
 import TokenStore from './tokenStore'
+import config from '../config'
 
 jest.mock('./tokenStore')
 

--- a/server/data/hmppsAuthClient.ts
+++ b/server/data/hmppsAuthClient.ts
@@ -1,11 +1,11 @@
 import superagent from 'superagent'
 import { URLSearchParams } from 'url'
 
+import RestClient from './restClient'
 import type TokenStore from './tokenStore'
 import logger from '../../logger'
-import config from '../config'
 import generateOauthClientToken from '../authentication/clientCredentials'
-import RestClient from './restClient'
+import config from '../config'
 
 const timeoutSpec = config.apis.hmppsAuth.timeout
 const hmppsAuthUrl = config.apis.hmppsAuth.url

--- a/server/data/index.ts
+++ b/server/data/index.ts
@@ -1,4 +1,4 @@
-/* eslint-disable import/first */
+/* eslint-disable import/first, import/order */
 /*
  * Do appinsights first as it does some magic instrumentation work, i.e. it affects other 'require's
  * In particular, applicationinsights automatically collects bunyan logs
@@ -7,6 +7,8 @@ import { buildAppInsightsClient, initialiseAppInsights } from '../utils/azureApp
 
 initialiseAppInsights()
 buildAppInsightsClient()
+
+/* eslint-enable import/order */
 
 import HmppsAuthClient from './hmppsAuthClient'
 import ProgrammeClient from './programmeClient'

--- a/server/data/programmeClient.ts
+++ b/server/data/programmeClient.ts
@@ -1,7 +1,7 @@
-import type { AccreditedProgramme } from '@accredited-programmes/models'
-import config, { ApiConfig } from '../config'
 import RestClient from './restClient'
+import config, { ApiConfig } from '../config'
 import paths from '../paths/api'
+import type { AccreditedProgramme } from '@accredited-programmes/models'
 
 export default class ProgrammeClient {
   restClient: RestClient

--- a/server/data/restClient.ts
+++ b/server/data/restClient.ts
@@ -1,12 +1,12 @@
-import superagent from 'superagent'
 import Agent, { HttpsAgent } from 'agentkeepalive'
 import { Readable } from 'stream'
+import superagent from 'superagent'
 
+import { restClientMetricsMiddleware } from './restClientMetricsMiddleware'
 import logger from '../../logger'
-import sanitiseError from '../sanitisedError'
 import { ApiConfig } from '../config'
 import type { UnsanitisedError } from '../sanitisedError'
-import { restClientMetricsMiddleware } from './restClientMetricsMiddleware'
+import sanitiseError from '../sanitisedError'
 
 interface GetRequest {
   path?: string

--- a/server/data/restClientMetricsMiddleware.test.ts
+++ b/server/data/restClientMetricsMiddleware.test.ts
@@ -1,5 +1,6 @@
-import superagent from 'superagent'
 import nock from 'nock'
+import superagent from 'superagent'
+
 import {
   normalizePath,
   requestHistogram,

--- a/server/data/tokenStore.ts
+++ b/server/data/tokenStore.ts
@@ -1,5 +1,4 @@
 import type { RedisClient } from './redisClient'
-
 import logger from '../../logger'
 
 export default class TokenStore {

--- a/server/data/tokenVerification.test.ts
+++ b/server/data/tokenVerification.test.ts
@@ -1,5 +1,6 @@
-import nock from 'nock'
 import { Request } from 'express'
+import nock from 'nock'
+
 import verifyToken from './tokenVerification'
 import config from '../config'
 

--- a/server/data/tokenVerification.ts
+++ b/server/data/tokenVerification.ts
@@ -1,8 +1,9 @@
-import superagent from 'superagent'
 import type { Request } from 'express'
-import getSanitisedError from '../sanitisedError'
-import config from '../config'
+import superagent from 'superagent'
+
 import logger from '../../logger'
+import config from '../config'
+import getSanitisedError from '../sanitisedError'
 
 function getApiClientToken(token: string) {
   return superagent

--- a/server/errorHandler.test.ts
+++ b/server/errorHandler.test.ts
@@ -1,10 +1,10 @@
 import express, { type Express } from 'express'
 import createError from 'http-errors'
+import path from 'path'
 import request from 'supertest'
 
-import path from 'path'
-import nunjucksSetup from './utils/nunjucksSetup'
 import errorHandler from './errorHandler'
+import nunjucksSetup from './utils/nunjucksSetup'
 
 const setupApp = (production: boolean): Express => {
   const app = express()

--- a/server/errorHandler.ts
+++ b/server/errorHandler.ts
@@ -1,5 +1,6 @@
 import type { NextFunction, Request, Response } from 'express'
 import type { HTTPError } from 'superagent'
+
 import logger from '../logger'
 
 export default function createErrorHandler(production: boolean) {

--- a/server/index.ts
+++ b/server/index.ts
@@ -1,8 +1,9 @@
 import promClient from 'prom-client'
-import { createMetricsApp } from './monitoring/metricsApp'
+
 import createApp from './app'
-import { services } from './services'
 import { controllers } from './controllers'
+import { createMetricsApp } from './monitoring/metricsApp'
+import { services } from './services'
 
 promClient.collectDefaultMetrics()
 

--- a/server/middleware/authorisationMiddleware.test.ts
+++ b/server/middleware/authorisationMiddleware.test.ts
@@ -1,5 +1,5 @@
-import jwt from 'jsonwebtoken'
 import type { Request, Response } from 'express'
+import jwt from 'jsonwebtoken'
 
 import authorisationMiddleware from './authorisationMiddleware'
 

--- a/server/middleware/authorisationMiddleware.ts
+++ b/server/middleware/authorisationMiddleware.ts
@@ -1,8 +1,8 @@
-import jwtDecode from 'jwt-decode'
 import type { RequestHandler } from 'express'
+import jwtDecode from 'jwt-decode'
 
-import logger from '../../logger'
 import asyncMiddleware from './asyncMiddleware'
+import logger from '../../logger'
 
 export default function authorisationMiddleware(authorisedRoles: string[] = []): RequestHandler {
   return asyncMiddleware((req, res, next) => {

--- a/server/middleware/populateCurrentUser.ts
+++ b/server/middleware/populateCurrentUser.ts
@@ -1,4 +1,5 @@
 import { RequestHandler } from 'express'
+
 import logger from '../../logger'
 import UserService from '../services/userService'
 

--- a/server/middleware/setUpAuthentication.ts
+++ b/server/middleware/setUpAuthentication.ts
@@ -1,9 +1,10 @@
+import flash from 'connect-flash'
 import type { Router } from 'express'
 import express from 'express'
 import passport from 'passport'
-import flash from 'connect-flash'
-import config from '../config'
+
 import auth from '../authentication/auth'
+import config from '../config'
 
 const router = express.Router()
 

--- a/server/middleware/setUpCsrf.ts
+++ b/server/middleware/setUpCsrf.ts
@@ -1,5 +1,5 @@
-import { Router } from 'express'
 import csurf from 'csurf'
+import { Router } from 'express'
 
 const testMode = process.env.NODE_ENV === 'test'
 

--- a/server/middleware/setUpCurrentUser.ts
+++ b/server/middleware/setUpCurrentUser.ts
@@ -1,7 +1,8 @@
 import { Router } from 'express'
+
+import populateCurrentUser from './populateCurrentUser'
 import auth from '../authentication/auth'
 import tokenVerifier from '../data/tokenVerification'
-import populateCurrentUser from './populateCurrentUser'
 import type { Services } from '../services'
 
 export default function setUpCurrentUser({ userService }: Services): Router {

--- a/server/middleware/setUpStaticResources.ts
+++ b/server/middleware/setUpStaticResources.ts
@@ -1,7 +1,7 @@
-import path from 'path'
 import compression from 'compression'
 import express, { Router } from 'express'
 import noCache from 'nocache'
+import path from 'path'
 
 import config from '../config'
 

--- a/server/middleware/setUpWebSecurity.ts
+++ b/server/middleware/setUpWebSecurity.ts
@@ -1,6 +1,6 @@
+import crypto from 'crypto'
 import express, { NextFunction, Request, Response, Router } from 'express'
 import helmet from 'helmet'
-import crypto from 'crypto'
 
 export default function setUpWebSecurity(): Router {
   const router = express.Router()

--- a/server/middleware/setUpWebSession.ts
+++ b/server/middleware/setUpWebSession.ts
@@ -1,10 +1,11 @@
-import { v4 as uuidv4 } from 'uuid'
-import session from 'express-session'
 import RedisStore from 'connect-redis'
 import express, { Router } from 'express'
-import { createRedisClient } from '../data/redisClient'
-import config from '../config'
+import session from 'express-session'
+import { v4 as uuidv4 } from 'uuid'
+
 import logger from '../../logger'
+import config from '../config'
+import { createRedisClient } from '../data/redisClient'
 
 export default function setUpWebSession(): Router {
   const client = createRedisClient()

--- a/server/routes/index.ts
+++ b/server/routes/index.ts
@@ -1,7 +1,7 @@
 import { type RequestHandler, Router } from 'express'
 
-import asyncMiddleware from '../middleware/asyncMiddleware'
 import { Controllers } from '../controllers'
+import asyncMiddleware from '../middleware/asyncMiddleware'
 
 // eslint-disable-next-line @typescript-eslint/no-unused-vars
 export default function routes(controllers: Controllers): Router {

--- a/server/services/healthCheck.test.ts
+++ b/server/services/healthCheck.test.ts
@@ -1,5 +1,5 @@
-import healthCheck from './healthCheck'
 import type { HealthCheckCallback, HealthCheckService } from './healthCheck'
+import healthCheck from './healthCheck'
 
 describe('Healthcheck', () => {
   it('Healthcheck reports healthy', done => {

--- a/server/services/healthCheck.ts
+++ b/server/services/healthCheck.ts
@@ -1,7 +1,8 @@
 import promClient from 'prom-client'
-import { serviceCheckFactory } from '../data/healthCheck'
-import config from '../config'
+
 import type { AgentConfig } from '../config'
+import config from '../config'
+import { serviceCheckFactory } from '../data/healthCheck'
 
 const healthCheckGauge = new promClient.Gauge({
   name: 'upstream_healthcheck',

--- a/server/services/index.ts
+++ b/server/services/index.ts
@@ -1,6 +1,6 @@
-import { dataAccess } from '../data'
 import ProgrammeService from './programmeService'
 import UserService from './userService'
+import { dataAccess } from '../data'
 
 export const services = () => {
   const { hmppsAuthClient, programmeClientBuilder } = dataAccess()

--- a/server/services/programmeService.test.ts
+++ b/server/services/programmeService.test.ts
@@ -1,6 +1,6 @@
-import { programmeFactory } from '../testutils/factories'
-import ProgrammeClient from '../data/programmeClient'
 import ProgrammeService from './programmeService'
+import ProgrammeClient from '../data/programmeClient'
+import { programmeFactory } from '../testutils/factories'
 
 jest.mock('../data/programmeClient')
 

--- a/server/services/programmeService.ts
+++ b/server/services/programmeService.ts
@@ -1,6 +1,6 @@
-import type { AccreditedProgramme } from '@accredited-programmes/models'
 import { RestClientBuilder } from '../data'
 import ProgrammeClient from '../data/programmeClient'
+import type { AccreditedProgramme } from '@accredited-programmes/models'
 
 export default class ProgrammeService {
   constructor(private readonly programmeClientFactory: RestClientBuilder<ProgrammeClient>) {}

--- a/server/services/userService.ts
+++ b/server/services/userService.ts
@@ -1,5 +1,5 @@
-import { convertToTitleCase } from '../utils/utils'
 import type HmppsAuthClient from '../data/hmppsAuthClient'
+import { convertToTitleCase } from '../utils/utils'
 
 interface UserDetails {
   name: string

--- a/server/testutils/factories/programme.ts
+++ b/server/testutils/factories/programme.ts
@@ -1,8 +1,8 @@
-import { Factory } from 'fishery'
 import { faker } from '@faker-js/faker/locale/en_GB'
+import { Factory } from 'fishery'
 
-import type { AccreditedProgramme } from '@accredited-programmes/models'
 import programmePrerequisiteFactory from './programmePrerequisite'
+import type { AccreditedProgramme } from '@accredited-programmes/models'
 
 export default Factory.define<AccreditedProgramme>(() => ({
   name: faker.random.words(),

--- a/server/testutils/factories/programmePrerequisite.ts
+++ b/server/testutils/factories/programmePrerequisite.ts
@@ -1,5 +1,5 @@
-import { Factory } from 'fishery'
 import { faker } from '@faker-js/faker/locale/en_GB'
+import { Factory } from 'fishery'
 
 import type { ProgrammePrerequisite } from '@accredited-programmes/models'
 

--- a/server/utils/azureAppInsights.ts
+++ b/server/utils/azureAppInsights.ts
@@ -1,4 +1,5 @@
 import { DistributedTracingModes, TelemetryClient, defaultClient, setup } from 'applicationinsights'
+
 import applicationVersion from '../applicationVersion'
 
 function defaultName(): string {

--- a/server/utils/nunjucksSetup.ts
+++ b/server/utils/nunjucksSetup.ts
@@ -1,7 +1,8 @@
 /* eslint-disable no-param-reassign */
-import nunjucks from 'nunjucks'
 import express from 'express'
+import nunjucks from 'nunjucks'
 import * as pathModule from 'path'
+
 import { initialiseName } from './utils'
 
 const production = process.env.NODE_ENV === 'production'

--- a/server/utils/programmeUtils.test.ts
+++ b/server/utils/programmeUtils.test.ts
@@ -1,5 +1,5 @@
-import { programmeFactory, programmePrerequisiteFactory } from '../testutils/factories'
 import { prerequisiteSummaryListRows, programmeListItems } from './programmeUtils'
+import { programmeFactory, programmePrerequisiteFactory } from '../testutils/factories'
 
 describe('programmeUtils', () => {
   describe('prerequisiteSummaryListRows', () => {


### PR DESCRIPTION
## Context

#22 added sorting of members within multiple member import declarations, but not sorting between import declarations

## Changes in this PR

- Add sorting and grouping between import lines
- Simplify/tidy up ESLint config
- Make Cypress folders more consistent