### PR TITLE
(400) Set up mocks

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,6 @@
 # HMPPS Accredited Programmes UI
-[![repo standards badge](https://img.shields.io/badge/dynamic/json?color=blue&style=flat&logo=github&label=MoJ%20Compliant&query=%24.result&url=https%3A%2F%2Foperations-engineering-reports.cloud-platform.service.justice.gov.uk%2Fapi%2Fv1%2Fcompliant_public_repositories%2Fhmpps-accredited-programmes-ui)](https://operations-engineering-reports.cloud-platform.service.justice.gov.uk/public-github-repositories.html#hmpps-accredited-programmes-ui "Link to report")
+
+[![repo standards badge](https://img.shields.io/badge/dynamic/json?color=blue&style=flat&logo=github&label=MoJ%20Compliant&query=%24.result&url=https%3A%2F%2Foperations-engineering-reports.cloud-platform.service.justice.gov.uk%2Fapi%2Fv1%2Fcompliant_public_repositories%2Fhmpps-accredited-programmes-ui)](https://operations-engineering-reports.cloud-platform.service.justice.gov.uk/public-github-repositories.html#hmpps-accredited-programmes-ui 'Link to report')
 [![CircleCI](https://circleci.com/gh/ministryofjustice/hmpps-accredited-programmes-ui/tree/main.svg?style=svg)](https://circleci.com/gh/ministryofjustice/hmpps-accredited-programmes-ui)
 
 ## Prerequisites
@@ -25,11 +26,23 @@ script/bootstrap
 
 ## Running the application
 
-To start Docker, run all backing services, and then the application itself, run:
+### With the current API
+
+To start Docker, run all backing services including a local copy of the current API (port 9092), and then the application itself, run:
 
 ```bash
   script/server
 ```
+
+### With a mocked API
+
+To run the application as above but with a mocked API (port 9093), run:
+
+```bash
+script/server --mock-api
+```
+
+API endpoint stubbing is set up in `/wiremock/stubApis.ts`.
 
 ## Running the tests
 
@@ -38,6 +51,8 @@ To run linting, typechecking and the test suite, run:
 ```bash
   script/test
 ```
+
+The API will run on port 9091 in the test environment.
 
 ### Running unit tests
 
@@ -60,4 +75,3 @@ You can run them with the Cypress UI with:
 ```bash
   npm run test:integration:ui
 ```
-

--- a/cypress.config.ts
+++ b/cypress.config.ts
@@ -3,7 +3,7 @@ import { defineConfig } from 'cypress'
 import auth from './integration_tests/mockApis/auth'
 import programmes from './integration_tests/mockApis/programmes'
 import tokenVerification from './integration_tests/mockApis/tokenVerification'
-import { resetStubs } from './integration_tests/mockApis/wiremock'
+import { resetStubs } from './wiremock'
 
 export default defineConfig({
   chromeWebSecurity: false,

--- a/doc/adr/0001-mock-api-endpoints-in-dev.md
+++ b/doc/adr/0001-mock-api-endpoints-in-dev.md
@@ -1,0 +1,29 @@
+# 1. Provide optional mocked API endpoints in development
+
+Date: 2023-05-16
+
+## Status
+
+Accepted
+
+## Context
+
+We've been blocked by setbacks in API development for this project, and we want
+UI development to be able to continue (both now and in any similar situations in
+the future) regardless of the status of API development.
+
+## Decision
+
+We already use Wiremock for stubbing tests in the test environment. We will
+extend this to make Wiremock available for use in development, as well as adding
+some scripts to stub the API endpoints we want to use. These will run when we
+start the app with a given flag, but will also be able to be run at will.
+
+The scripts to start the server or just the backing services will accept a flag
+to mock the API, which will allow us to toggle between using using canned
+response fixtures in the UI and connecting to a running API backend application.
+
+## Consequences
+
+This will unblock frontend work and prevent future blocks should there be any
+hurdles encountered in API development.

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -35,6 +35,15 @@ services:
       - SPRING_PROFILES_ACTIVE=dev
       - APPLICATION_AUTHENTICATION_UI_ALLOWLIST=0.0.0.0/0
 
+  wiremock:
+    image: wiremock/wiremock
+    networks:
+      - hmpps
+    container_name: wiremock
+    restart: always
+    ports:
+      - "9093:8080"
+
   app:
     build: .
     networks:

--- a/integration_tests/mockApis/auth.ts
+++ b/integration_tests/mockApis/auth.ts
@@ -2,7 +2,7 @@ import jwt from 'jsonwebtoken'
 import { Response } from 'superagent'
 
 import tokenVerification from './tokenVerification'
-import { getMatchingRequests, stubFor } from './wiremock'
+import { getMatchingRequests, stubFor } from '../../wiremock'
 
 const createToken = () => {
   const payload = {

--- a/integration_tests/mockApis/programmes.ts
+++ b/integration_tests/mockApis/programmes.ts
@@ -1,7 +1,7 @@
 import { SuperAgentRequest } from 'superagent'
 
-import { stubFor } from './wiremock'
 import paths from '../../server/paths/api'
+import { stubFor } from '../../wiremock'
 import type { AccreditedProgramme } from '@accredited-programmes/models'
 
 export default {

--- a/integration_tests/mockApis/tokenVerification.ts
+++ b/integration_tests/mockApis/tokenVerification.ts
@@ -1,6 +1,6 @@
 import { SuperAgentRequest } from 'superagent'
 
-import { stubFor } from './wiremock'
+import { stubFor } from '../../wiremock'
 
 export default {
   stubTokenVerificationPing: (status = 200): SuperAgentRequest =>

--- a/package-lock.json
+++ b/package-lock.json
@@ -92,6 +92,7 @@
         "start-server-and-test": "^2.0.0",
         "supertest": "^6.3.3",
         "ts-jest": "^29.1.0",
+        "ts-node": "^10.9.1",
         "typescript": "^5.0.0"
       },
       "engines": {
@@ -2042,6 +2043,28 @@
         "node": ">=0.1.90"
       }
     },
+    "node_modules/@cspotcode/source-map-support": {
+      "version": "0.8.1",
+      "resolved": "https://registry.npmjs.org/@cspotcode/source-map-support/-/source-map-support-0.8.1.tgz",
+      "integrity": "sha512-IchNf6dN4tHoMFIn/7OE8LWZ19Y6q/67Bmf6vnGREv8RSbBVb9LPJxEcnwrcwX6ixSvaiGoomAUvu4YSxXrVgw==",
+      "dev": true,
+      "dependencies": {
+        "@jridgewell/trace-mapping": "0.3.9"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@cspotcode/source-map-support/node_modules/@jridgewell/trace-mapping": {
+      "version": "0.3.9",
+      "resolved": "https://registry.npmjs.org/@jridgewell/trace-mapping/-/trace-mapping-0.3.9.tgz",
+      "integrity": "sha512-3Belt6tdc8bPgAtbcmdtNJlirVoTmEb5e2gC94PnkwEW9jI6CAHUeoG85tjWP5WquqfavoMtMwiG4P926ZKKuQ==",
+      "dev": true,
+      "dependencies": {
+        "@jridgewell/resolve-uri": "^3.0.3",
+        "@jridgewell/sourcemap-codec": "^1.4.10"
+      }
+    },
     "node_modules/@cypress/request": {
       "version": "2.88.11",
       "resolved": "https://registry.npmjs.org/@cypress/request/-/request-2.88.11.tgz",
@@ -2982,6 +3005,30 @@
         "node": ">= 10"
       }
     },
+    "node_modules/@tsconfig/node10": {
+      "version": "1.0.9",
+      "resolved": "https://registry.npmjs.org/@tsconfig/node10/-/node10-1.0.9.tgz",
+      "integrity": "sha512-jNsYVVxU8v5g43Erja32laIDHXeoNvFEpX33OK4d6hljo3jDhCBDhx5dhCCTMWUojscpAagGiRkBKxpdl9fxqA==",
+      "dev": true
+    },
+    "node_modules/@tsconfig/node12": {
+      "version": "1.0.11",
+      "resolved": "https://registry.npmjs.org/@tsconfig/node12/-/node12-1.0.11.tgz",
+      "integrity": "sha512-cqefuRsh12pWyGsIoBKJA9luFu3mRxCA+ORZvA4ktLSzIuCUtWVxGIuXigEwO5/ywWFMZ2QEGKWvkZG1zDMTag==",
+      "dev": true
+    },
+    "node_modules/@tsconfig/node14": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/@tsconfig/node14/-/node14-1.0.3.tgz",
+      "integrity": "sha512-ysT8mhdixWK6Hw3i1V2AeRqZ5WfXg1G43mqoYlM2nc6388Fq5jcXyr5mRsqViLx/GJYdoL0bfXD8nmF+Zn/Iow==",
+      "dev": true
+    },
+    "node_modules/@tsconfig/node16": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/@tsconfig/node16/-/node16-1.0.4.tgz",
+      "integrity": "sha512-vxhUy4J8lyeyinH7Azl1pdd43GJhZH/tP2weN8TntQblOY+A0XbT8DJk1/oCPuOOyg/Ja757rG0CgHcWC8OfMA==",
+      "dev": true
+    },
     "node_modules/@types/babel__core": {
       "version": "7.20.0",
       "resolved": "https://registry.npmjs.org/@types/babel__core/-/babel__core-7.20.0.tgz",
@@ -3607,6 +3654,15 @@
       "dev": true,
       "peerDependencies": {
         "acorn": "^6.0.0 || ^7.0.0 || ^8.0.0"
+      }
+    },
+    "node_modules/acorn-walk": {
+      "version": "8.2.0",
+      "resolved": "https://registry.npmjs.org/acorn-walk/-/acorn-walk-8.2.0.tgz",
+      "integrity": "sha512-k+iyHEuPgSw6SbuDpGQM+06HQUa04DZ3o+F6CSzXMvvI5KMvnaEqXe+YVe555R9nn6GPt404fos4wcgpw12SDA==",
+      "dev": true,
+      "engines": {
+        "node": ">=0.4.0"
       }
     },
     "node_modules/agent-base": {
@@ -5121,6 +5177,12 @@
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz",
       "integrity": "sha512-3lqz5YjWTYnW6dlDa5TLaTCcShfar1e40rmcJVwCBJC6mWlFuj0eCHIElmG1g5kyuJ/GD+8Wn4FFCcz4gJPfaQ==",
+      "dev": true
+    },
+    "node_modules/create-require": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/create-require/-/create-require-1.1.1.tgz",
+      "integrity": "sha512-dcKFX3jn0MpIaXjisoRvexIJVEKzaq7z2rZKxf+MSr9TkdmHmsU4m2lcLojrj/FHl8mk5VxMmYA+ftRkP/3oKQ==",
       "dev": true
     },
     "node_modules/cross-spawn": {
@@ -12288,6 +12350,64 @@
         "node": ">=12"
       }
     },
+    "node_modules/ts-node": {
+      "version": "10.9.1",
+      "resolved": "https://registry.npmjs.org/ts-node/-/ts-node-10.9.1.tgz",
+      "integrity": "sha512-NtVysVPkxxrwFGUUxGYhfux8k78pQB3JqYBXlLRZgdGUqTO5wU/UyHop5p70iEbGhB7q5KmiZiU0Y3KlJrScEw==",
+      "dev": true,
+      "dependencies": {
+        "@cspotcode/source-map-support": "^0.8.0",
+        "@tsconfig/node10": "^1.0.7",
+        "@tsconfig/node12": "^1.0.7",
+        "@tsconfig/node14": "^1.0.0",
+        "@tsconfig/node16": "^1.0.2",
+        "acorn": "^8.4.1",
+        "acorn-walk": "^8.1.1",
+        "arg": "^4.1.0",
+        "create-require": "^1.1.0",
+        "diff": "^4.0.1",
+        "make-error": "^1.1.1",
+        "v8-compile-cache-lib": "^3.0.1",
+        "yn": "3.1.1"
+      },
+      "bin": {
+        "ts-node": "dist/bin.js",
+        "ts-node-cwd": "dist/bin-cwd.js",
+        "ts-node-esm": "dist/bin-esm.js",
+        "ts-node-script": "dist/bin-script.js",
+        "ts-node-transpile-only": "dist/bin-transpile.js",
+        "ts-script": "dist/bin-script-deprecated.js"
+      },
+      "peerDependencies": {
+        "@swc/core": ">=1.2.50",
+        "@swc/wasm": ">=1.2.50",
+        "@types/node": "*",
+        "typescript": ">=2.7"
+      },
+      "peerDependenciesMeta": {
+        "@swc/core": {
+          "optional": true
+        },
+        "@swc/wasm": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/ts-node/node_modules/arg": {
+      "version": "4.1.3",
+      "resolved": "https://registry.npmjs.org/arg/-/arg-4.1.3.tgz",
+      "integrity": "sha512-58S9QDqG0Xx27YwPSt9fJxivjYl432YCwfDMfZ+71RAqUrZef7LrKQZ3LHLOwCS4FLNBplP533Zx895SeOCHvA==",
+      "dev": true
+    },
+    "node_modules/ts-node/node_modules/diff": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/diff/-/diff-4.0.2.tgz",
+      "integrity": "sha512-58lmxKSA4BNyLz+HHMUzlOEpg09FV+ev6ZMe3vJihgdxzgcwZ8VoEEPmALCZG9LmqfVoNMMKpttIYTVG6uDY7A==",
+      "dev": true,
+      "engines": {
+        "node": ">=0.3.1"
+      }
+    },
     "node_modules/tsconfig-paths": {
       "version": "3.14.2",
       "resolved": "https://registry.npmjs.org/tsconfig-paths/-/tsconfig-paths-3.14.2.tgz",
@@ -12611,6 +12731,12 @@
         "uuid": "dist/bin/uuid"
       }
     },
+    "node_modules/v8-compile-cache-lib": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/v8-compile-cache-lib/-/v8-compile-cache-lib-3.0.1.tgz",
+      "integrity": "sha512-wa7YjyUGfNZngI/vtK0UHAN+lgDCxBPCylVXGp0zu59Fz5aiGtNXaq3DhIov063MorB+VfufLh3JlF2KdTK3xg==",
+      "dev": true
+    },
     "node_modules/v8-to-istanbul": {
       "version": "9.1.0",
       "resolved": "https://registry.npmjs.org/v8-to-istanbul/-/v8-to-istanbul-9.1.0.tgz",
@@ -12912,6 +13038,15 @@
       "dependencies": {
         "buffer-crc32": "~0.2.3",
         "fd-slicer": "~1.1.0"
+      }
+    },
+    "node_modules/yn": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/yn/-/yn-3.1.1.tgz",
+      "integrity": "sha512-Ux4ygGWsu2c7isFWe8Yu1YluJmqVhxqK2cLXNQA5AcC3QfbGNpM7fu0Y8b/z16pXLnFxZYvWhd3fhBY9DLmC6Q==",
+      "dev": true,
+      "engines": {
+        "node": ">=6"
       }
     },
     "node_modules/yocto-queue": {

--- a/package.json
+++ b/package.json
@@ -5,6 +5,8 @@
   "repository": "git@github.com:ministryofjustice/hmpps-accredited-programmes-ui.git",
   "license": "MIT",
   "scripts": {
+    "api-stubs:create": "npx ts-node --transpile-only ./wiremock/stubApis.ts",
+    "api-stubs:reset": "npx ts-node --transpile-only ./wiremock/resetStubs.ts",
     "prepare": "husky install",
     "copy-views": "cp -R server/views dist/server/",
     "compile-sass": "sass --quiet-deps --no-source-map --load-path=node_modules/govuk-frontend --load-path=node_modules/@ministryofjustice/frontend --load-path=. assets/scss/application.scss:./assets/stylesheets/application.css assets/scss/application-ie8.scss:./assets/stylesheets/application-ie8.css --style compressed",
@@ -179,6 +181,7 @@
     "start-server-and-test": "^2.0.0",
     "supertest": "^6.3.3",
     "ts-jest": "^29.1.0",
+    "ts-node": "^10.9.1",
     "typescript": "^5.0.0"
   },
   "optionalDependencies": {

--- a/script/bootstrap
+++ b/script/bootstrap
@@ -13,3 +13,5 @@ echo "==> Installing application dependencies..."
 
 nodenv install --skip-existing
 npm install
+
+script/utils/start-backing-services

--- a/script/server
+++ b/script/server
@@ -7,6 +7,13 @@ set -e
 
 cd "$(dirname "$0")/.."
 
+for arg in "$@"
+do
+  if [[ $arg == "--mock-api" ]]; then
+    MOCK_API=true
+  fi
+done
+
 cleanup() {
   echo "==> Tearing down any old containers..."
   docker-compose down
@@ -15,8 +22,16 @@ trap cleanup EXIT
 
 script/utils/launch-docker
 
-script/utils/start-backing-services
+if [ "$MOCK_API" = true ]; then
+  script/utils/start-backing-services --mock-api
+else
+  script/utils/start-backing-services
+fi
 
 echo "==> Starting the server..."
 
-npm run start:dev
+if [ "$MOCK_API" = true ]; then
+  ACCREDITED_PROGRAMMES_API_URL=http://localhost:9093 npm run start:dev
+else
+  npm run start:dev
+fi

--- a/script/utils/start-backing-services
+++ b/script/utils/start-backing-services
@@ -2,4 +2,20 @@
 
 echo "==> Starting the backing services in Docker..."
 
-docker-compose up --scale=app=0 -d
+for arg in "$@"
+do
+  if [[ $arg == "--mock-api" ]]; then
+    MOCK_API=true
+  fi
+done
+
+if [ "$MOCK_API" = true ]; then
+  docker-compose up --scale=app=0 --scale=hmpps-accredited-programmes-api=0 -d
+
+  echo "==> Stubbing API endpoints..."
+
+  npm run api-stubs:reset > /dev/null
+  npm run api-stubs:create > /dev/null
+else
+  docker-compose up --scale=app=0 --scale=wiremock=0 -d
+fi

--- a/wiremock/index.ts
+++ b/wiremock/index.ts
@@ -7,7 +7,7 @@ const url = `${wiremockEndpoint}/__admin`
 const stubFor = (mapping: Record<string, unknown>): SuperAgentRequest =>
   superagent.post(`${url}/mappings`).send(mapping)
 
-const getMatchingRequests = body => superagent.post(`${url}/requests/find`).send(body)
+const getMatchingRequests = (body: object) => superagent.post(`${url}/requests/find`).send(body)
 
 const resetStubs = (): Promise<Array<Response>> =>
   Promise.all([superagent.delete(`${url}/mappings`), superagent.delete(`${url}/requests`)])

--- a/wiremock/index.ts
+++ b/wiremock/index.ts
@@ -1,6 +1,6 @@
 import superagent, { Response, SuperAgentRequest } from 'superagent'
 
-const wiremockEndpoint = process.env.CYPRESS ? 'http://localhost:9091' : 'http://localhost:9092'
+const wiremockEndpoint = process.env.CYPRESS ? 'http://localhost:9091' : 'http://localhost:9093'
 
 const url = `${wiremockEndpoint}/__admin`
 

--- a/wiremock/resetStubs.ts
+++ b/wiremock/resetStubs.ts
@@ -1,0 +1,8 @@
+/* eslint-disable no-console */
+import { resetStubs } from './index'
+
+console.log('Resetting stubs')
+
+resetStubs().then(_response => {
+  console.log('Done!')
+})

--- a/wiremock/stubApis.ts
+++ b/wiremock/stubApis.ts
@@ -1,0 +1,29 @@
+/* eslint-disable no-console */
+import { stubFor } from './index'
+import programmes from './stubs/programmes.json'
+
+const stubs = []
+
+stubs.push(async () =>
+  stubFor({
+    request: {
+      method: 'GET',
+      url: '/programmes',
+    },
+    response: {
+      status: 200,
+      headers: {
+        'Content-Type': 'application/json;charset=UTF-8',
+      },
+      jsonBody: programmes,
+    },
+  }),
+)
+
+console.log('Stubbing APIs')
+
+stubs.forEach(s =>
+  s().then(response => {
+    console.log(`Stubbed ${response.body.request.method} ${response.body.request.url}`)
+  }),
+)

--- a/wiremock/stubs/programmes.json
+++ b/wiremock/stubs/programmes.json
@@ -1,0 +1,102 @@
+[
+  {
+    "id": "654520cc-e109-4f31-81a6-1fc6bc9078b3",
+    "name": "Becoming New Me Plus",
+    "programmeType": "Accredited Programme",
+    "description": "Becoming New Me Plus (BNM+) is a programme...",
+    "programmePrerequisites": [
+      {
+        "key": "Setting",
+        "value": "Example setting"
+      },
+      {
+        "key": "Risk criteria",
+        "value": "Example risk criteria"
+      },
+      {
+        "key": "Criminogenic needs",
+        "value": "Example criminogenic needs"
+      }
+    ]
+  },
+  {
+    "id": "e4e5e559-739c-4b20-a40f-97d48a4081cb",
+    "name": "Becoming New Me Plus",
+    "programmeType": "Accredited Programme",
+    "description": "Becoming New Me Plus (BNM+) is a programme...",
+    "programmePrerequisites": [
+      {
+        "key": "Setting",
+        "value": "Example setting"
+      },
+      {
+        "key": "Risk criteria",
+        "value": "Example risk criteria"
+      },
+      {
+        "key": "Criminogenic needs",
+        "value": "Example criminogenic needs"
+      }
+    ]
+  },
+  {
+    "id": "986d6256-5e2c-4792-b93a-568d923cf50c",
+    "name": "Building Better Relationships (BBR)",
+    "programmeType": "Accredited Programme",
+    "description": "BBR is a programme...",
+    "programmePrerequisites": [
+      {
+        "key": "Setting",
+        "value": "Example setting"
+      },
+      {
+        "key": "Risk criteria",
+        "value": "Example risk criteria"
+      },
+      {
+        "key": "Criminogenic needs",
+        "value": "Example criminogenic needs"
+      }
+    ]
+  },
+  {
+    "id": "4a1630b7-3280-49b4-b559-53d110b3c27b",
+    "name": "Healthy Identity Intervention (HII)",
+    "programmeType": "Accredited Programme",
+    "description": "HII is a programme...",
+    "programmePrerequisites": [
+      {
+        "key": "Setting",
+        "value": "Example setting"
+      },
+      {
+        "key": "Risk criteria",
+        "value": "Example risk criteria"
+      },
+      {
+        "key": "Criminogenic needs",
+        "value": "Example criminogenic needs"
+      }
+    ]
+  },
+  {
+    "id": "197e62b4-4d34-4d30-a51f-e6427100c6c4",
+    "name": "Healthy Sex Programme (HSP)",
+    "programmeType": "Accredited Programme",
+    "description": "HSP is a programme...",
+    "programmePrerequisites": [
+      {
+        "key": "Setting",
+        "value": "Example setting"
+      },
+      {
+        "key": "Risk criteria",
+        "value": "Example risk criteria"
+      },
+      {
+        "key": "Criminogenic needs",
+        "value": "Example criminogenic needs"
+      }
+    ]
+  }
+]


### PR DESCRIPTION
## Context

[Trello card](https://trello.com/c/OoaO2VpR/400-use-wiremock-as-a-fake-api-in-local-development)

## Changes in this PR

This adds the ability to mock the Accredited Programmes API locally so that UI work can progress independent of API development progress.

The application can now be started up with `script/server --mock-api` to return this canned response.

We'll need to make sure we update these as the data in the API changes, but we're hoping to be notified to do so with Pact when we add that in future. 