### PR TITLE
(400b) Recommit lost changes

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,7 +42,7 @@ To run the application as above but with a mocked API (port 9093), run:
 script/server --mock-api
 ```
 
-API endpoint stubbing is set up in `/wiremock/stubApis.ts`.
+API endpoint stubbing is set up in `/wiremock/scripts/stubApis.ts`.
 
 ## Running the tests
 

--- a/doc/adr/0001-mock-api-endpoints-in-dev.md
+++ b/doc/adr/0001-mock-api-endpoints-in-dev.md
@@ -27,3 +27,8 @@ response fixtures in the UI and connecting to a running API backend application.
 
 This will unblock frontend work and prevent future blocks should there be any
 hurdles encountered in API development.
+
+We'll need to make sure we keep the data structures of the API and UI in sync
+when relying on a mocked server, but we believe we can be alerted of any changes
+through contract testing with Pact and, where they exist, generate types from
+the API.

--- a/package.json
+++ b/package.json
@@ -5,8 +5,8 @@
   "repository": "git@github.com:ministryofjustice/hmpps-accredited-programmes-ui.git",
   "license": "MIT",
   "scripts": {
-    "api-stubs:create": "npx ts-node --transpile-only ./wiremock/stubApis.ts",
-    "api-stubs:reset": "npx ts-node --transpile-only ./wiremock/resetStubs.ts",
+    "api-stubs:create": "npx ts-node --transpile-only ./wiremock/scripts/stubApis.ts",
+    "api-stubs:reset": "npx ts-node --transpile-only ./wiremock/scripts/resetStubs.ts",
     "prepare": "husky install",
     "copy-views": "cp -R server/views dist/server/",
     "compile-sass": "sass --quiet-deps --no-source-map --load-path=node_modules/govuk-frontend --load-path=node_modules/@ministryofjustice/frontend --load-path=. assets/scss/application.scss:./assets/stylesheets/application.css assets/scss/application-ie8.scss:./assets/stylesheets/application-ie8.css --style compressed",

--- a/script/bootstrap
+++ b/script/bootstrap
@@ -13,5 +13,3 @@ echo "==> Installing application dependencies..."
 
 nodenv install --skip-existing
 npm install
-
-script/utils/start-backing-services

--- a/wiremock/scripts/resetStubs.ts
+++ b/wiremock/scripts/resetStubs.ts
@@ -1,0 +1,8 @@
+/* eslint-disable no-console */
+import { resetStubs } from '../index'
+
+process.stdout.write('Resetting stubs... ')
+
+resetStubs().then(_response => {
+  process.stdout.write('done!\n')
+})

--- a/wiremock/scripts/stubApis.ts
+++ b/wiremock/scripts/stubApis.ts
@@ -1,0 +1,29 @@
+/* eslint-disable no-console */
+import { stubFor } from '../index'
+import programmes from '../stubs/programmes.json'
+
+const stubs = []
+
+stubs.push(async () =>
+  stubFor({
+    request: {
+      method: 'GET',
+      url: '/programmes',
+    },
+    response: {
+      status: 200,
+      headers: {
+        'Content-Type': 'application/json;charset=UTF-8',
+      },
+      jsonBody: programmes,
+    },
+  }),
+)
+
+console.log('Stubbing APIs')
+
+stubs.forEach(stub =>
+  stub().then(response => {
+    console.log(`Stubbed ${response.body.request.method} ${response.body.request.url}`)
+  }),
+)


### PR DESCRIPTION
## Context

We lost some changes in #38 after [this force push](https://github.com/ministryofjustice/hmpps-accredited-programmes-ui/compare/973aa00b8a8d6523d711603aac620939eab8c1c7..048105ba8545edb24c5bd051a19fa68606d62723)

## Changes in this PR

- move Wiremock scripts into descriptive subdirectory
- add additional ADR consequence
- remove unnecessary call to start backing services