### PR TITLE
Update backing service images in `script/update`

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,6 +52,13 @@ To run linting, typechecking and the test suite, run:
   script/test
 ```
 
+By default, this will update backing service images (e.g. the API) and
+dependencies. If you want skip the update when running the full test suite, run:
+
+```bash
+  script/test --skip-update
+```
+
 The API will run on port 9091 in the test environment.
 
 ### Running unit tests

--- a/script/test
+++ b/script/test
@@ -10,9 +10,20 @@ if [ -n "$DEBUG" ]; then
   set -x
 fi
 
-echo "==> Updating..."
+UPDATE=true
 
-script/update
+for arg in "$@"
+do
+  if [[ $arg == "--skip-update" ]]; then
+    UPDATE=false
+  fi
+done
+
+if [ "$UPDATE" = true ]; then
+  echo "==> Updating..."
+
+  script/update --skip-backing-service-images
+fi
 
 echo "==> Linting the code..."
 

--- a/script/update
+++ b/script/update
@@ -6,6 +6,10 @@ set -e
 
 cd "$(dirname "$0")/.."
 
+echo "==> Pulling latest backing service images..."
+
+docker compose pull
+
 echo "==> Bootstrapping..."
 
 script/bootstrap


### PR DESCRIPTION
## Context

We currently have to remember to run `docker compose pull` to bring in API changes

## Changes in this PR

This updates all backing service images when running `script/update`. This is automatically run in `script/test`, but an option to run `script/test` without the update (to images or any other dependencies) is provided