### PR TITLE
(403) Add Prison client

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -35,6 +35,18 @@ services:
       - SPRING_PROFILES_ACTIVE=dev
       - APPLICATION_AUTHENTICATION_UI_ALLOWLIST=0.0.0.0/0
 
+  prison-api:
+    image: quay.io/hmpps/prison-api:latest
+    networks:
+      - hmpps
+    container_name: prison-api
+    ports:
+      - "9091:8080"
+    healthcheck:
+      test: ["CMD", "curl", "-f", "http://localhost:8080/health"]
+    environment:
+      - SPRING_PROFILES_ACTIVE=nomis-hsqldb
+
   wiremock:
     image: wiremock/wiremock
     networks:

--- a/helm_deploy/values-dev.yaml
+++ b/helm_deploy/values-dev.yaml
@@ -13,6 +13,7 @@ generic-service:
     INGRESS_URL: "https://accredited-programmes-dev.hmpps.service.justice.gov.uk"
     HMPPS_AUTH_URL: "https://sign-in-dev.hmpps.service.justice.gov.uk/auth"
     TOKEN_VERIFICATION_API_URL: "https://token-verification-api-dev.prison.service.justice.gov.uk"
+    PRISON_API_URL: "https://api-dev.prison.service.justice.gov.uk"
 
   allowlist: null
 

--- a/integration_tests/tsconfig.json
+++ b/integration_tests/tsconfig.json
@@ -10,7 +10,8 @@
     "baseUrl": "..",
     "paths": {
       "@accredited-programmes/models": ["server/@types/models/index.d.ts"],
-      "@accredited-programmes/ui": ["server/@types/ui/index.d.ts"]
+      "@accredited-programmes/ui": ["server/@types/ui/index.d.ts"],
+      "@prison-api": ["server/@types/prisonApi/index.d.ts"]
     }
   },
   "include": ["**/*.ts"]

--- a/server/@types/prisonApi/Prison.ts
+++ b/server/@types/prisonApi/Prison.ts
@@ -1,0 +1,10 @@
+import type { PrisonAddress } from './PrisonAddress'
+
+export type Prison = {
+  agencyId: string
+  premise: string
+  locality: string
+  city: string
+  country: string
+  addresses: PrisonAddress[]
+}

--- a/server/@types/prisonApi/PrisonAddress.ts
+++ b/server/@types/prisonApi/PrisonAddress.ts
@@ -1,0 +1,9 @@
+export type PrisonAddress = {
+  premise: string
+  street: string
+  locality: string
+  town: string
+  postalCode: string
+  country: string
+  primary: boolean
+}

--- a/server/@types/prisonApi/index.d.ts
+++ b/server/@types/prisonApi/index.d.ts
@@ -1,0 +1,2 @@
+export type { Prison } from './Prison'
+export type { PrisonAddress } from './PrisonAddress'

--- a/server/config.ts
+++ b/server/config.ts
@@ -65,6 +65,14 @@ export default {
       },
       agent: new AgentConfig(Number(get('HMPPS_AUTH_TIMEOUT_RESPONSE', 10000))),
     },
+    prisonApi: {
+      url: get('PRISON_API_URL', 'http://localhost:9091', requiredInProduction),
+      timeout: {
+        response: Number(get('PRISON_API_TIMEOUT_RESPONSE', 10000)),
+        deadline: Number(get('PRISON_API_TIMEOUT_DEADLINE', 10000)),
+      },
+      agent: new AgentConfig(Number(get('HMPPS_AUTH_TIMEOUT_RESPONSE', 10000))),
+    },
     tokenVerification: {
       url: get('TOKEN_VERIFICATION_API_URL', 'http://localhost:8100', requiredInProduction),
       timeout: {

--- a/server/data/prisonClient.test.ts
+++ b/server/data/prisonClient.test.ts
@@ -1,0 +1,41 @@
+import nock from 'nock'
+
+import PrisonClient from './prisonClient'
+import config from '../config'
+import prisonFactory from '../testutils/factories/prison'
+import type { Prison } from '@prison-api'
+
+describe('PrisonClient', () => {
+  let fakePrisonApi: nock.Scope
+  let prisonClient: PrisonClient
+
+  const token = 'token-1'
+
+  beforeEach(() => {
+    fakePrisonApi = nock(config.apis.prisonApi.url)
+    prisonClient = new PrisonClient(token)
+  })
+
+  afterEach(() => {
+    if (!nock.isDone()) {
+      nock.cleanAll()
+      throw new Error('Not all nock interceptors were used!')
+    }
+    nock.abortPendingRequests()
+    nock.cleanAll()
+  })
+
+  describe('getPrison', () => {
+    const prison: Prison = prisonFactory.build()
+
+    it('should get a Prison by its `agencyId`', async () => {
+      fakePrisonApi
+        .get(`/api/agencies/prison/${prison.agencyId}`)
+        .matchHeader('authorization', `Bearer ${token}`)
+        .reply(200, prison)
+
+      const output = await prisonClient.getPrison(prison.agencyId)
+      expect(output).toEqual(prison)
+    })
+  })
+})

--- a/server/data/prisonClient.ts
+++ b/server/data/prisonClient.ts
@@ -1,0 +1,17 @@
+import RestClient from './restClient'
+import type { ApiConfig } from '../config'
+import config from '../config'
+import paths from '../paths/prisonApi'
+import type { Prison } from '@prison-api'
+
+export default class PrisonClient {
+  restClient: RestClient
+
+  constructor(token: string) {
+    this.restClient = new RestClient('prisonClient', config.apis.prisonApi as ApiConfig, token)
+  }
+
+  async getPrison(agencyId: string): Promise<Prison> {
+    return (await this.restClient.get({ path: paths.prisons.show({ agencyId }) })) as Prison
+  }
+}

--- a/server/paths/prisonApi.ts
+++ b/server/paths/prisonApi.ts
@@ -1,0 +1,9 @@
+import { path } from 'static-path'
+
+const prisonPath = path('/api/agencies/prison/:agencyId')
+
+export default {
+  prisons: {
+    show: prisonPath,
+  },
+}

--- a/server/testutils/factories/prison.ts
+++ b/server/testutils/factories/prison.ts
@@ -1,0 +1,24 @@
+import { faker } from '@faker-js/faker/locale/en_GB'
+import { Factory } from 'fishery'
+
+import prisonAddressFactory from './prisonAddress'
+import type { Prison } from '@prison-api'
+
+export default Factory.define<Prison>(({ params }) => {
+  const locality = params.locality || faker.location.county()
+  const city = params.city || faker.location.city()
+  const country = params.country || 'United Kingdom'
+  const premise = params.premise || `HMP ${locality}`
+
+  return {
+    agencyId: faker.string.alpha({ length: 3, casing: 'upper' }),
+    premise,
+    locality,
+    city,
+    country,
+    addresses: [
+      prisonAddressFactory.build({ premise, locality, country, town: city, primary: true }),
+      prisonAddressFactory.build({ premise, primary: false }),
+    ],
+  }
+})

--- a/server/testutils/factories/prisonAddress.ts
+++ b/server/testutils/factories/prisonAddress.ts
@@ -1,0 +1,19 @@
+import { faker } from '@faker-js/faker/locale/en_GB'
+import { Factory } from 'fishery'
+
+import type { PrisonAddress } from '@prison-api'
+
+export default Factory.define<PrisonAddress>(({ params }) => {
+  const locality = params.locality || faker.location.county()
+  const premise = `HMP ${locality}`
+
+  return {
+    premise,
+    street: faker.location.streetAddress(),
+    locality,
+    town: faker.location.city(),
+    postalCode: faker.location.zipCode(),
+    country: 'United Kingdom',
+    primary: true,
+  }
+})

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -19,7 +19,8 @@
     "baseUrl": ".",
     "paths": {
       "@accredited-programmes/models": ["server/@types/models/index.d.ts"],
-      "@accredited-programmes/ui": ["server/@types/ui/index.d.ts"]
+      "@accredited-programmes/ui": ["server/@types/ui/index.d.ts"],
+      "@prison-api": ["server/@types/prisonApi/index.d.ts"]
     }
   },
   "exclude": ["node_modules", "assets/**/*.js", "integration_tests", "dist", "cypress.config.ts"],


### PR DESCRIPTION
## Context

<!-- Is there a Trello ticket you can link to? -->
https://trello.com/c/d4yEqtSO/403-fetch-prison-information
<!-- Do you need to add any environment variables? -->
<!-- Is an ADR required? An ADR should be added if this PR introduces a change to the architecture. -->

## Changes in this PR

This adds a Prison client for fetching Prison data from the Prisons API. We'll use it to populate the "Offerings" page in the near future. It also starts up the Prisons API locally as a backing service.

There's still an ongoing conversation as to whether this is the correct API to use, but it does seem to have what we need, for now at least. We'll wrangle the Prison object we get back into our own internal `Organisation` model in future work.

