### PR TITLE
(362) Pass user token with request to API

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -21,6 +21,8 @@ services:
       - "9092:8080"
     healthcheck:
       test: ['CMD', 'curl', '-f', 'http://localhost:8080/health']
+    environment:
+      - HMPPS_AUTH_URL=http://hmpps-auth:8080/auth
 
   hmpps-auth:
     image: quay.io/hmpps/hmpps-auth:latest

--- a/server/controllers/find/coursesController.test.ts
+++ b/server/controllers/find/coursesController.test.ts
@@ -8,7 +8,8 @@ import { courseFactory } from '../../testutils/factories'
 import { courseListItems } from '../../utils/courseUtils'
 
 describe('CoursesController', () => {
-  const request: DeepMocked<Request> = createMock<Request>({})
+  const token = 'SOME_TOKEN'
+  const request: DeepMocked<Request> = createMock<Request>({ user: { token } })
   const response: DeepMocked<Response> = createMock<Response>({})
   const next: DeepMocked<NextFunction> = createMock<NextFunction>({})
 
@@ -34,7 +35,7 @@ describe('CoursesController', () => {
         courseListItems: courseListItems(courses),
       })
 
-      expect(courseService.getCourses).toHaveBeenCalledWith('token')
+      expect(courseService.getCourses).toHaveBeenCalledWith(token)
     })
   })
 })

--- a/server/controllers/find/coursesController.ts
+++ b/server/controllers/find/coursesController.ts
@@ -7,8 +7,8 @@ export default class CoursesController {
   constructor(private readonly courseService: CourseService) {}
 
   index(): TypedRequestHandler<Request, Response> {
-    return async (_req: Request, res: Response) => {
-      const courses = await this.courseService.getCourses('token')
+    return async (req: Request, res: Response) => {
+      const courses = await this.courseService.getCourses(req.user.token)
 
       res.render('courses/index', {
         pageHeading: 'List of accredited programmes',


### PR DESCRIPTION
## Context

<!-- Is there a Trello ticket you can link to? -->
[Trello card](https://trello.com/c/UwKlC3n8/362-add-token-to-http-request-for-authenticating-with-our-api-after-hmpps-auth-has-been-added)
<!-- Do you need to add any environment variables? -->
<!-- Is an ADR required? An ADR should be added if this PR introduces a change to the architecture. -->

## Changes in this PR

1. Sets the `HMPPS_AUTH_URL` environment variable on the local Accredited Programmes API run with Docker, as it's missing on start up with our local configuration now that the API's been secured behind HMPPS Auth.
2. We now pass the logged-in-user's auth token with our request to the Accredited Programmes API to authenticate with it.

