### PR TITLE
Specify Python version 3 in Docker build

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -29,7 +29,7 @@ ARG BUILD_NUMBER=1_0_0
 ARG GIT_REF=not-available
 
 RUN apt-get update && \
-        apt-get install -y make python g++
+        apt-get install -y make python3 g++
 
 COPY package*.json ./
 RUN CYPRESS_INSTALL_BINARY=0 npm ci --no-audit


### PR DESCRIPTION
## Context

For some reason the build has started failing with:
```
npm ERR! gyp ERR! find Python - version is 2.7.18 - should be >=3.6.0
npm ERR! gyp ERR! find Python - THIS VERSION OF PYTHON IS NOT SUPPORTED
```

## Changes in this PR

Specifies that we should install Python version 3 in our Docker build - this a dependency of `node-gyp`
