### PR TITLE
(415) Run Playwright end-to-end tests on CI

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -3,6 +3,7 @@ version: 2.1
 orbs:
   hmpps: ministryofjustice/hmpps@7.2.1
   slack: circleci/slack@4.12.1
+  node: circleci/node@4.5.2
 
 parameters:
   alerts-slack-channel:
@@ -124,6 +125,27 @@ jobs:
       - store_artifacts:
           path: integration-tests/screenshots
 
+  end_to_end_test:
+    docker:
+      - image: mcr.microsoft.com/playwright:v1.34.2-focal
+    circleci_ip_ranges: true # opt-in to jobs running on a restricted set of IPs
+    steps:
+      - run:
+          name: Clone E2E repo
+          command: |
+            git clone https://github.com/ministryofjustice/hmpps-accredited-programmes-e2e.git .
+      - run:
+          name: Update npm
+          command: 'npm install -g npm@latest'
+      - node/install-packages
+      - run:
+          name: E2E Check
+          command: |
+            npx playwright test
+      - store_artifacts:
+          path: test_results
+          destination: test_results
+
   tag_pact_version:
     environment:
       PACT_BROKER_BASE_URL: "https://pact-broker-prod.apps.live-1.cloud-platform.service.justice.gov.uk"
@@ -179,6 +201,14 @@ workflows:
             - integration_test
             - build_docker
           helm_timeout: 5m
+      - end_to_end_test:
+          context: hmpps-common-vars
+          filters:
+            branches:
+              only:
+                - main
+          requires:
+            - deploy_dev
       - tag_pact_version:
           name: "tag_pact_version_dev"
           tag: "deployed:dev"

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -11,3 +11,10 @@
 ### Before
 
 ### After
+
+## Pre merge checklist
+
+- [ ] Have you written an end-to-end test for the happy path in the [Accredited
+  Programmes E2E
+  repo](https://github.com/ministryofjustice/hmpps-accredited-programmes-e2e)
+  (if necessary)?

--- a/doc/adr/0003-use-playwright-for-end-to-end-tests.md
+++ b/doc/adr/0003-use-playwright-for-end-to-end-tests.md
@@ -1,0 +1,59 @@
+# 3. Use Playwright for end-to-end tests
+
+Date: 2023-05-26
+
+## Status
+
+Accepted
+
+## Context
+
+We have a suite of integration tests in this repository that use
+[Cypress](https://www.cypress.io/) to test the application locally against a
+mock API. We'd like to be able to test the application as a whole with a real
+backend to ensure everything is working as expected on a deployed environment.
+
+Although in [the ADR where we documented our decision to use
+Pact](./0002-use-pact-for-contract-testing.md) we decided we'd use contract
+tests instead of end-to-end (E2E) tests to cover some of this functionality,
+contract tests don't quite cover everything we might want to test, so, for the
+sake of confidence, we would like to keep using a suite of E2E tests somewhere.
+
+Other teams, particularly the Approved Premises team, initially trialled
+running Cypress against a deployed environment but have moved away from this
+due to slowness, flakiness and conflicting Typescript settings between their
+main codebase and the code used to write the E2E tests.
+
+## Decision
+
+As the Approved Premises team [have
+done](https://github.com/ministryofjustice/hmpps-approved-premises-ui/blob/main/doc/architecture/decisions/0010-use-playwright-for-end-to-end-tests.md),
+we're going to trial using a suite of E2E tests in a different repo using
+[Playwright](https://playwright.dev/). This is a more lightweight alternative
+to Cypress, which is in use in other parts of HMPPS (See
+<https://github.com/ministryofjustice/hmpps-probation-integration-e2e-tests>).
+
+These tests will be run in the `end_to_end_test` CircleCI pipeline on the
+development environment, after the environment has deployed, both on the UI and
+API codebases.
+
+We will deliberately keep the tests focused, as more of a smoke test to ensure
+the application runs as expected, rather than reusing integration test code
+which is more robust and has a lot of expectations.
+
+We will keep an eye on these tests and how they go, because there is a balance
+between us having a consistently passing test suite (which may suggest our
+happy path is too "happy") and a test suite that breaks a lot, but for
+legitimate reasons (i.e. a change in the UI or API that breaks functionality).
+
+## Consequences
+
+This will mean we're maintaining two test suites, one for integration and one
+for E2E tests, however:
+
+- The E2E tests will be kept deliberately simplistic, only testing the "happy
+  path", with minimal expectations
+- We will be able to use the VSCode [Playwright Test
+  extension](https://marketplace.visualstudio.com/items?itemName=ms-playwright.playwright),
+  which will allow us to "record" any new/changed tests - meaning we can
+  rapidly generate / iterate E2E tests


### PR DESCRIPTION
## Context

<!-- Is there a Trello ticket you can link to? -->
[Trello card](https://trello.com/c/zGaYc1r5/415-add-e2e-tests)
<!-- Do you need to add any environment variables? -->
<!-- Is an ADR required? An ADR should be added if this PR introduces a change to the architecture. -->

## Changes in this PR

We now run end-to-end tests on the deployed dev environment after that stage in the CI process to ensure
the "real" service as a whole is working as expected, as opposed to our Cypress integration tests which are running against a mock backend.

The script clones the e2e test repo locally, installs dependencies and runs the Playwright test script.

Log in secrets are stored in the Circle CI env vars.
