### PR TITLE
(445) Fix port clash

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -106,7 +106,7 @@ jobs:
           command: curl -o wiremock.jar https://repo1.maven.org/maven2/com/github/tomakehurst/wiremock-standalone/2.27.1/wiremock-standalone-2.27.1.jar
       - run:
           name: Run wiremock
-          command: java -jar wiremock.jar --port 9091
+          command: java -jar wiremock.jar --port 9199
           background: true
       - run:
           name: Run the node app.

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -62,7 +62,7 @@ jobs:
 
   unit_test:
     environment:
-      PACT_BROKER_BASE_URL: "https://pact-broker-prod.apps.live-1.cloud-platform.service.justice.gov.uk"
+      PACT_BROKER_BASE_URL: 'https://pact-broker-prod.apps.live-1.cloud-platform.service.justice.gov.uk'
     executor:
       name: hmpps/node
       tag: << pipeline.parameters.node-version >>
@@ -91,7 +91,7 @@ jobs:
     executor:
       name: hmpps/node_redis
       node_tag: << pipeline.parameters.node-version >>
-      redis_tag: "6.2"
+      redis_tag: '6.2'
     steps:
       - checkout
       - attach_workspace:
@@ -148,7 +148,7 @@ jobs:
 
   tag_pact_version:
     environment:
-      PACT_BROKER_BASE_URL: "https://pact-broker-prod.apps.live-1.cloud-platform.service.justice.gov.uk"
+      PACT_BROKER_BASE_URL: 'https://pact-broker-prod.apps.live-1.cloud-platform.service.justice.gov.uk'
     executor:
       name: hmpps/node
       tag: 16.17-browsers
@@ -188,7 +188,7 @@ workflows:
                 - main
       - hmpps/deploy_env:
           name: deploy_dev
-          env: "dev"
+          env: 'dev'
           jira_update: true
           context: hmpps-common-vars
           filters:
@@ -210,47 +210,47 @@ workflows:
           requires:
             - deploy_dev
       - tag_pact_version:
-          name: "tag_pact_version_dev"
-          tag: "deployed:dev"
+          name: 'tag_pact_version_dev'
+          tag: 'deployed:dev'
           requires: [deploy_dev]
           context: [hmpps-common-vars]
-#      - request-preprod-approval:
-#          type: approval
-#          requires:
-#            - deploy_dev
-#      - hmpps/deploy_env:
-#          name: deploy_preprod
-#          env: "preprod"
-#          jira_update: true
-#          jira_env_type: staging
-#          context:
-#            - hmpps-common-vars
-#            - hmpps-accredited-programmes-ui-preprod
-#          requires:
-#            - request-preprod-approval
-#          helm_timeout: 5m
-#      - request-prod-approval:
-#          type: approval
-#          requires:
-#            - deploy_preprod
-#      - hmpps/deploy_env:
-#          name: deploy_prod
-#          env: "prod"
-#          jira_update: true
-#          jira_env_type: production
-#          slack_notification: true
-#          slack_channel_name: << pipeline.parameters.releases-slack-channel >>
-#          context:
-#            - hmpps-common-vars
-#            - hmpps-accredited-programmes-ui-prod
-#          requires:
-#            - request-prod-approval
-#          helm_timeout: 5m
+  #      - request-preprod-approval:
+  #          type: approval
+  #          requires:
+  #            - deploy_dev
+  #      - hmpps/deploy_env:
+  #          name: deploy_preprod
+  #          env: "preprod"
+  #          jira_update: true
+  #          jira_env_type: staging
+  #          context:
+  #            - hmpps-common-vars
+  #            - hmpps-accredited-programmes-ui-preprod
+  #          requires:
+  #            - request-preprod-approval
+  #          helm_timeout: 5m
+  #      - request-prod-approval:
+  #          type: approval
+  #          requires:
+  #            - deploy_preprod
+  #      - hmpps/deploy_env:
+  #          name: deploy_prod
+  #          env: "prod"
+  #          jira_update: true
+  #          jira_env_type: production
+  #          slack_notification: true
+  #          slack_channel_name: << pipeline.parameters.releases-slack-channel >>
+  #          context:
+  #            - hmpps-common-vars
+  #            - hmpps-accredited-programmes-ui-prod
+  #          requires:
+  #            - request-prod-approval
+  #          helm_timeout: 5m
 
   security:
     triggers:
       - schedule:
-          cron: "58 6 * * 1-5"
+          cron: '58 6 * * 1-5'
           filters:
             branches:
               only:
@@ -276,7 +276,7 @@ workflows:
   security-weekly:
     triggers:
       - schedule:
-          cron: "19 6 * * 1"
+          cron: '19 6 * * 1'
           filters:
             branches:
               only:

--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ script/bootstrap
 
 ### With the current API
 
-To start Docker, run all backing services including a local copy of the current API (port 9092), and then the application itself, run:
+To start Docker, run all backing services including a local copy of the Accredited Programmes API (port 9091) and the Prison API (port 9092), and then the application itself, run:
 
 ```bash
   script/server
@@ -36,7 +36,7 @@ To start Docker, run all backing services including a local copy of the current 
 
 ### With a mocked API
 
-To run the application as above but with a mocked API (port 9093), run:
+To run the application as above but with a mocked Accredited Programmes API (port 9099), run:
 
 ```bash
 script/server --mock-api
@@ -59,7 +59,7 @@ dependencies. If you want skip the update when running the full test suite, run:
   script/test --skip-update
 ```
 
-The API will run on port 9091 in the test environment.
+The Accredited Programmes API will run on port 9199 in the test environment.
 
 ### Running unit tests
 

--- a/docker-compose-test.yml
+++ b/docker-compose-test.yml
@@ -15,7 +15,7 @@ services:
     container_name: wiremock
     restart: always
     ports:
-      - "9091:8080"
+      - "9199:8080"
 
 networks:
   hmpps_int:

--- a/docker-compose-test.yml
+++ b/docker-compose-test.yml
@@ -1,6 +1,5 @@
 version: '3.1'
 services:
-
   redis:
     image: 'redis:6.2'
     networks:
@@ -11,11 +10,11 @@ services:
   wiremock:
     image: wiremock/wiremock
     networks:
-    - hmpps_int
+      - hmpps_int
     container_name: wiremock
     restart: always
     ports:
-      - "9199:8080"
+      - '9199:8080'
 
 networks:
   hmpps_int:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -10,19 +10,6 @@ services:
     ports:
       - '6379:6379'
 
-  hmpps-accredited-programmes-api:
-    image: quay.io/hmpps/hmpps-accredited-programmes-api:latest
-    restart: always
-    networks:
-      - hmpps
-    container_name: accredited-programmes-api
-    ports:
-      - '9091:8080'
-    healthcheck:
-      test: ['CMD', 'curl', '-f', 'http://localhost:8080/health']
-    environment:
-      - HMPPS_AUTH_URL=http://hmpps-auth:8080/auth
-
   hmpps-auth:
     image: quay.io/hmpps/hmpps-auth:latest
     networks:
@@ -35,6 +22,19 @@ services:
     environment:
       - SPRING_PROFILES_ACTIVE=dev
       - APPLICATION_AUTHENTICATION_UI_ALLOWLIST=0.0.0.0/0
+
+  hmpps-accredited-programmes-api:
+    image: quay.io/hmpps/hmpps-accredited-programmes-api:latest
+    restart: always
+    networks:
+      - hmpps
+    container_name: accredited-programmes-api
+    ports:
+      - '9091:8080'
+    healthcheck:
+      test: ['CMD', 'curl', '-f', 'http://localhost:8080/health']
+    environment:
+      - HMPPS_AUTH_URL=http://hmpps-auth:8080/auth
 
   prison-api:
     image: quay.io/hmpps/prison-api:latest

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -18,7 +18,7 @@ services:
       - hmpps
     container_name: accredited-programmes-api
     ports:
-      - "9092:8080"
+      - "9091:8080"
     healthcheck:
       test: ['CMD', 'curl', '-f', 'http://localhost:8080/health']
     environment:
@@ -43,7 +43,7 @@ services:
       - hmpps
     container_name: prison-api
     ports:
-      - "9091:8080"
+      - "9092:8080"
     healthcheck:
       test: ["CMD", "curl", "-f", "http://localhost:8080/health"]
     environment:
@@ -56,7 +56,7 @@ services:
     container_name: wiremock
     restart: always
     ports:
-      - "9093:8080"
+      - "9099:8080"
 
   app:
     build: .

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,6 +1,5 @@
 version: '3.1'
 services:
-
   redis:
     image: 'redis:6.2'
     networks:
@@ -18,7 +17,7 @@ services:
       - hmpps
     container_name: accredited-programmes-api
     ports:
-      - "9091:8080"
+      - '9091:8080'
     healthcheck:
       test: ['CMD', 'curl', '-f', 'http://localhost:8080/health']
     environment:
@@ -30,9 +29,9 @@ services:
       - hmpps
     container_name: hmpps-auth
     ports:
-      - "9090:8080"
+      - '9090:8080'
     healthcheck:
-      test: ["CMD", "curl", "-f", "http://localhost:8080/auth/health"]
+      test: ['CMD', 'curl', '-f', 'http://localhost:8080/auth/health']
     environment:
       - SPRING_PROFILES_ACTIVE=dev
       - APPLICATION_AUTHENTICATION_UI_ALLOWLIST=0.0.0.0/0
@@ -43,9 +42,9 @@ services:
       - hmpps
     container_name: prison-api
     ports:
-      - "9092:8080"
+      - '9092:8080'
     healthcheck:
-      test: ["CMD", "curl", "-f", "http://localhost:8080/health"]
+      test: ['CMD', 'curl', '-f', 'http://localhost:8080/health']
     environment:
       - SPRING_PROFILES_ACTIVE=nomis-hsqldb
 
@@ -56,7 +55,7 @@ services:
     container_name: wiremock
     restart: always
     ports:
-      - "9099:8080"
+      - '9099:8080'
 
   app:
     build: .
@@ -64,7 +63,7 @@ services:
       - hmpps
     depends_on: [redis]
     ports:
-      - "3000:3000"
+      - '3000:3000'
     environment:
       - REDIS_HOST=redis
       - HMPPS_AUTH_EXTERNAL_URL=http://localhost:9090/auth

--- a/helm_deploy/hmpps-accredited-programmes-ui/values.yaml
+++ b/helm_deploy/hmpps-accredited-programmes-ui/values.yaml
@@ -6,12 +6,12 @@ generic-service:
 
   image:
     repository: quay.io/hmpps/hmpps-accredited-programmes-ui
-    tag: app_version    # override at deployment time
+    tag: app_version # override at deployment time
     port: 3000
 
   ingress:
     enabled: true
-    host: app-hostname.local    # override per environment
+    host: app-hostname.local # override per environment
     tlsSecretName: hmpps-accredited-programmes-ui-cert
 
   livenessProbe:
@@ -30,10 +30,10 @@ generic-service:
 
   # Environment variables to load into the deployment
   env:
-    NODE_ENV: "production"
-    REDIS_TLS_ENABLED: "true"
-    TOKEN_VERIFICATION_ENABLED: "true"
-    APPLICATIONINSIGHTS_CONNECTION_STRING: "InstrumentationKey=$(APPINSIGHTS_INSTRUMENTATIONKEY);IngestionEndpoint=https://northeurope-0.in.applicationinsights.azure.com/;LiveEndpoint=https://northeurope.livediagnostics.monitor.azure.com/"
+    NODE_ENV: 'production'
+    REDIS_TLS_ENABLED: 'true'
+    TOKEN_VERIFICATION_ENABLED: 'true'
+    APPLICATIONINSIGHTS_CONNECTION_STRING: 'InstrumentationKey=$(APPINSIGHTS_INSTRUMENTATIONKEY);IngestionEndpoint=https://northeurope-0.in.applicationinsights.azure.com/;LiveEndpoint=https://northeurope.livediagnostics.monitor.azure.com/'
 
   # Pre-existing kubernetes secrets to load as environment variables in the deployment.
   # namespace_secrets:
@@ -42,25 +42,25 @@ generic-service:
 
   namespace_secrets:
     hmpps-accredited-programmes-ui:
-      APPINSIGHTS_INSTRUMENTATIONKEY: "APPINSIGHTS_INSTRUMENTATIONKEY"
-      API_CLIENT_ID: "API_CLIENT_ID"
-      API_CLIENT_SECRET: "API_CLIENT_SECRET"
-      SYSTEM_CLIENT_ID: "SYSTEM_CLIENT_ID"
-      SYSTEM_CLIENT_SECRET: "SYSTEM_CLIENT_SECRET"
-      SESSION_SECRET: "SESSION_SECRET"
+      APPINSIGHTS_INSTRUMENTATIONKEY: 'APPINSIGHTS_INSTRUMENTATIONKEY'
+      API_CLIENT_ID: 'API_CLIENT_ID'
+      API_CLIENT_SECRET: 'API_CLIENT_SECRET'
+      SYSTEM_CLIENT_ID: 'SYSTEM_CLIENT_ID'
+      SYSTEM_CLIENT_SECRET: 'SYSTEM_CLIENT_SECRET'
+      SESSION_SECRET: 'SESSION_SECRET'
     elasticache-redis:
-      REDIS_HOST: "primary_endpoint_address"
-      REDIS_AUTH_TOKEN: "auth_token"
+      REDIS_HOST: 'primary_endpoint_address'
+      REDIS_AUTH_TOKEN: 'auth_token'
 
   allowlist:
-    office: "217.33.148.210/32"
-    health-kick: "35.177.252.195/32"
-    petty-france-wifi: "213.121.161.112/28"
-    global-protect: "35.176.93.186/32"
-    mojvpn: "81.134.202.29/32"
-    cloudplatform-live-1: "35.178.209.113/32"
-    cloudplatform-live-2: "3.8.51.207/32"
-    cloudplatform-live-3: "35.177.252.54/32"
+    office: '217.33.148.210/32'
+    health-kick: '35.177.252.195/32'
+    petty-france-wifi: '213.121.161.112/28'
+    global-protect: '35.176.93.186/32'
+    mojvpn: '81.134.202.29/32'
+    cloudplatform-live-1: '35.178.209.113/32'
+    cloudplatform-live-2: '3.8.51.207/32'
+    cloudplatform-live-3: '35.177.252.54/32'
 
 generic-prometheus-alerts:
   targetApplication: hmpps-accredited-programmes-ui

--- a/helm_deploy/values-dev.yaml
+++ b/helm_deploy/values-dev.yaml
@@ -9,11 +9,11 @@ generic-service:
     tlsSecretName: hmpps-accredited-programmes-dev-cert
 
   env:
-    ACCREDITED_PROGRAMMES_API_URL: "https://accredited-programmes-api-dev.hmpps.service.justice.gov.uk"
-    INGRESS_URL: "https://accredited-programmes-dev.hmpps.service.justice.gov.uk"
-    HMPPS_AUTH_URL: "https://sign-in-dev.hmpps.service.justice.gov.uk/auth"
-    TOKEN_VERIFICATION_API_URL: "https://token-verification-api-dev.prison.service.justice.gov.uk"
-    PRISON_API_URL: "https://api-dev.prison.service.justice.gov.uk"
+    ACCREDITED_PROGRAMMES_API_URL: 'https://accredited-programmes-api-dev.hmpps.service.justice.gov.uk'
+    INGRESS_URL: 'https://accredited-programmes-dev.hmpps.service.justice.gov.uk'
+    HMPPS_AUTH_URL: 'https://sign-in-dev.hmpps.service.justice.gov.uk/auth'
+    TOKEN_VERIFICATION_API_URL: 'https://token-verification-api-dev.prison.service.justice.gov.uk'
+    PRISON_API_URL: 'https://api-dev.prison.service.justice.gov.uk'
 
   allowlist: null
 

--- a/integration.env
+++ b/integration.env
@@ -1,11 +1,11 @@
 PORT=3007
-HMPPS_AUTH_URL=http://localhost:9091/auth
-TOKEN_VERIFICATION_API_URL=http://localhost:9091/verification
+HMPPS_AUTH_URL=http://localhost:9199/auth
+TOKEN_VERIFICATION_API_URL=http://localhost:9199/verification
 TOKEN_VERIFICATION_ENABLED=true
 NODE_ENV=development
 API_CLIENT_ID=clientid
 API_CLIENT_SECRET=clientsecret
 SYSTEM_CLIENT_ID=clientid
 SYSTEM_CLIENT_SECRET=clientsecret
-ACCREDITED_PROGRAMMES_API_URL=http://localhost:9091
+ACCREDITED_PROGRAMMES_API_URL=http://localhost:9199
 INTEGRATION_ENV=true

--- a/script/server
+++ b/script/server
@@ -31,7 +31,7 @@ fi
 echo "==> Starting the server..."
 
 if [ "$MOCK_API" = true ]; then
-  ACCREDITED_PROGRAMMES_API_URL=http://localhost:9093 npm run start:dev
+  ACCREDITED_PROGRAMMES_API_URL=http://localhost:9099 npm run start:dev
 else
   npm run start:dev
 fi

--- a/server/config.ts
+++ b/server/config.ts
@@ -58,7 +58,7 @@ export default {
       systemClientSecret: get('SYSTEM_CLIENT_SECRET', 'clientsecret', requiredInProduction),
     },
     accreditedProgrammesApi: {
-      url: get('ACCREDITED_PROGRAMMES_API_URL', 'http://localhost:9092', requiredInProduction),
+      url: get('ACCREDITED_PROGRAMMES_API_URL', 'http://localhost:9091', requiredInProduction),
       timeout: {
         response: Number(get('ACCREDITED_PROGRAMMES_API_TIMEOUT_RESPONSE', 10000)),
         deadline: Number(get('ACCREDITED_PROGRAMMES_API_TIMEOUT_DEADLINE', 10000)),
@@ -66,7 +66,7 @@ export default {
       agent: new AgentConfig(Number(get('HMPPS_AUTH_TIMEOUT_RESPONSE', 10000))),
     },
     prisonApi: {
-      url: get('PRISON_API_URL', 'http://localhost:9091', requiredInProduction),
+      url: get('PRISON_API_URL', 'http://localhost:9092', requiredInProduction),
       timeout: {
         response: Number(get('PRISON_API_TIMEOUT_RESPONSE', 10000)),
         deadline: Number(get('PRISON_API_TIMEOUT_DEADLINE', 10000)),

--- a/wiremock/index.ts
+++ b/wiremock/index.ts
@@ -1,7 +1,7 @@
 import type { Response, SuperAgentRequest } from 'superagent'
 import superagent from 'superagent'
 
-const wiremockEndpoint = process.env.CYPRESS ? 'http://localhost:9091' : 'http://localhost:9093'
+const wiremockEndpoint = process.env.CYPRESS ? 'http://localhost:9199' : 'http://localhost:9099'
 
 const url = `${wiremockEndpoint}/__admin`
 


### PR DESCRIPTION
## Context

The use of 9091 both as the prisons API in non-test environments and Wiremock in test environments causes a conflict if you run integration tests while the local server is running

## Changes in this PR

This fixes the port clash and implements more of a system for port choice

Note that the integration tests will fail without fixing the endpoint in `wiremock/scripts/stubApis`, which is addressed in a separate PR: https://github.com/ministryofjustice/hmpps-accredited-programmes-ui/pull/49/commits/2b4a723cb1c5bce0299543471f2d8fa436151c6a