### PR TITLE
Make E2E reminder post-merge

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -12,7 +12,7 @@
 
 ### After
 
-## Pre merge checklist
+## Post-merge checklist
 
 - [ ] Have you written an end-to-end test for the happy path in the [Accredited
   Programmes E2E


### PR DESCRIPTION
## Changes in this PR

Changes the E2E test-writing reminder to be post-merge. 

These tests will run against the deployed environment, so would always be failing if we ran them before merging...
