### PR TITLE
Remove explicit factory params

### DIFF
--- a/server/testutils/factories/course.ts
+++ b/server/testutils/factories/course.ts
@@ -7,11 +7,11 @@ import buildListBetween from './factoryHelpers'
 import { convertToTitleCase } from '../../utils/utils'
 import type { Course } from '@accredited-programmes/models'
 
-export default Factory.define<Course>(({ params }) => ({
+export default Factory.define<Course>(() => ({
   id: faker.string.uuid(),
   name: `${convertToTitleCase(faker.color.human())} Course`,
   description: faker.lorem.sentences(),
-  audiences: params.audiences || buildListBetween(courseAudienceFactory, { min: 1, max: 3 }),
+  audiences: buildListBetween(courseAudienceFactory, { min: 1, max: 3 }),
   coursePrerequisites: [
     coursePrerequisiteFactory.setting().build(),
     coursePrerequisiteFactory.riskCriteria().build(),

--- a/server/testutils/factories/courseAudience.ts
+++ b/server/testutils/factories/courseAudience.ts
@@ -3,15 +3,13 @@ import { Factory } from 'fishery'
 
 import type { CourseAudience } from '@accredited-programmes/models'
 
-export default Factory.define<CourseAudience>(({ params }) => ({
+export default Factory.define<CourseAudience>(() => ({
   id: faker.string.uuid(),
-  value:
-    params.value ||
-    faker.helpers.arrayElement([
-      'Extremism',
-      'General violence',
-      'Intimate partner violence',
-      'Online sexual violence',
-      'Sexual violence',
-    ]),
+  value: faker.helpers.arrayElement([
+    'Extremism',
+    'General violence',
+    'Intimate partner violence',
+    'Online sexual violence',
+    'Sexual violence',
+  ]),
 }))


### PR DESCRIPTION
## Context

We're explicitly using params here in a way that's built in with Fishery, so it's redundant: we get this behaviour for free

## Changes in this PR

Default to implicit param overrides in factories