### PR TITLE
Remove base path from tsconfig

### DIFF
--- a/integration_tests/tsconfig.json
+++ b/integration_tests/tsconfig.json
@@ -7,11 +7,10 @@
     "esModuleInterop": true,
     "skipLibCheck": true,
     "typeRoots": ["../server/@types"],
-    "baseUrl": "..",
     "paths": {
-      "@accredited-programmes/models": ["server/@types/models/index.d.ts"],
-      "@accredited-programmes/ui": ["server/@types/ui/index.d.ts"],
-      "@prison-api": ["server/@types/prisonApi/index.d.ts"]
+      "@accredited-programmes/models": ["../server/@types/models/index.d.ts"],
+      "@accredited-programmes/ui": ["../server/@types/ui/index.d.ts"],
+      "@prison-api": ["../server/@types/prisonApi/index.d.ts"]
     }
   },
   "include": ["**/*.ts"]

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -16,11 +16,10 @@
     "noImplicitAny": true,
     "experimentalDecorators": true,
     "typeRoots": ["./server/@types", "./node_modules/@types"],
-    "baseUrl": ".",
     "paths": {
-      "@accredited-programmes/models": ["server/@types/models/index.d.ts"],
-      "@accredited-programmes/ui": ["server/@types/ui/index.d.ts"],
-      "@prison-api": ["server/@types/prisonApi/index.d.ts"]
+      "@accredited-programmes/models": ["./server/@types/models/index.d.ts"],
+      "@accredited-programmes/ui": ["./server/@types/ui/index.d.ts"],
+      "@prison-api": ["./server/@types/prisonApi/index.d.ts"]
     }
   },
   "exclude": ["node_modules", "assets/**/*.js", "integration_tests", "dist", "cypress.config.ts"],


### PR DESCRIPTION
## Context

This appears to be unnecessary, and is causing some of VSCode's import suggestions to be in the form `server/**` rather than `./*` or `../*`

## Changes in this PR

Remove `baseUrl` from `tsconfig` to keep import style consistent

## Post-merge checklist

- [ ] Have you written an end-to-end test for the happy path in the [Accredited Programmes E2E repo](https://github.com/ministryofjustice/hmpps-accredited-programmes-e2e) (if necessary)?
