### PR TITLE
(497) Use paths in routes

### DIFF
--- a/integration_tests/e2e/find.cy.ts
+++ b/integration_tests/e2e/find.cy.ts
@@ -1,4 +1,4 @@
-import paths from '../../server/paths/find'
+import findPaths from '../../server/paths/find'
 import { courseFactory, courseOfferingFactory, prisonFactory } from '../../server/testutils/factories'
 import { organisationFromPrison } from '../../server/utils/organisationUtils'
 import { CourseOfferingPage, CoursePage, CoursesPage } from '../pages/find'
@@ -20,7 +20,7 @@ context('Find', () => {
 
     cy.task('stubCourses', courses)
 
-    cy.visit(paths.courses.index({}))
+    cy.visit(findPaths.courses.index({}))
 
     const coursesPage = Page.verifyOnPage(CoursesPage)
     coursesPage.shouldHaveCourses(courses)
@@ -50,7 +50,7 @@ context('Find', () => {
     cy.task('stubCourse', course)
     cy.task('stubCourseOfferings', { courseId: course.id, courseOfferings })
 
-    cy.visit(paths.courses.show({ id: course.id }))
+    cy.visit(findPaths.courses.show({ id: course.id }))
 
     const coursePage = Page.verifyOnPage(CoursePage, course)
     coursePage.shouldHaveCourse()
@@ -69,7 +69,7 @@ context('Find', () => {
     cy.task('stubCourseOffering', { courseId: course.id, courseOffering })
     cy.task('stubPrison', prison)
 
-    cy.visit(paths.courses.offerings.show({ id: course.id, courseOfferingId: courseOffering.id }))
+    cy.visit(findPaths.courses.offerings.show({ id: course.id, courseOfferingId: courseOffering.id }))
 
     const courseOfferingPage = CoursePage.verifyOnPage(CourseOfferingPage, { courseOffering, course, organisation })
     courseOfferingPage.shouldHaveAudience()

--- a/integration_tests/mockApis/courses.ts
+++ b/integration_tests/mockApis/courses.ts
@@ -1,6 +1,6 @@
 import type { SuperAgentRequest } from 'superagent'
 
-import paths from '../../server/paths/api'
+import apiPaths from '../../server/paths/api'
 import { stubFor } from '../../wiremock'
 import type { Course, CourseOffering } from '@accredited-programmes/models'
 
@@ -9,7 +9,7 @@ export default {
     stubFor({
       request: {
         method: 'GET',
-        url: paths.courses.show({ id: course.id }),
+        url: apiPaths.courses.show({ id: course.id }),
       },
       response: {
         status: 200,
@@ -22,7 +22,7 @@ export default {
     stubFor({
       request: {
         method: 'GET',
-        url: paths.courses.index({}),
+        url: apiPaths.courses.index({}),
       },
       response: {
         status: 200,
@@ -35,7 +35,7 @@ export default {
     stubFor({
       request: {
         method: 'GET',
-        url: paths.courses.offerings.index({ id: args.courseId }),
+        url: apiPaths.courses.offerings.index({ id: args.courseId }),
       },
       response: {
         status: 200,
@@ -48,7 +48,7 @@ export default {
     stubFor({
       request: {
         method: 'GET',
-        url: paths.courses.offerings.show({ id: args.courseId, courseOfferingId: args.courseOffering.id }),
+        url: apiPaths.courses.offerings.show({ id: args.courseId, courseOfferingId: args.courseOffering.id }),
       },
       response: {
         status: 200,

--- a/integration_tests/mockApis/prisons.ts
+++ b/integration_tests/mockApis/prisons.ts
@@ -1,6 +1,6 @@
 import type { SuperAgentRequest } from 'superagent'
 
-import paths from '../../server/paths/prisonApi'
+import prisonApiPaths from '../../server/paths/prisonApi'
 import { stubFor } from '../../wiremock'
 import type { Prison } from '@prison-api'
 
@@ -9,7 +9,7 @@ export default {
     stubFor({
       request: {
         method: 'GET',
-        url: paths.prisons.show({ agencyId: prison.agencyId }),
+        url: prisonApiPaths.prisons.show({ agencyId: prison.agencyId }),
       },
       response: {
         status: 200,

--- a/integration_tests/pages/find/course.ts
+++ b/integration_tests/pages/find/course.ts
@@ -1,4 +1,4 @@
-import paths from '../../../server/paths/find'
+import findPaths from '../../../server/paths/find'
 import presentCourse from '../../../server/utils/courseUtils'
 import Page from '../page'
 import type { Course } from '@accredited-programmes/models'
@@ -43,7 +43,7 @@ export default class CoursePage extends Page {
           cy.get('.govuk-table__cell:nth-of-type(4) a').should(
             'have.attr',
             'href',
-            paths.courses.offerings.show({ id: this.course.id, courseOfferingId: organisation.courseOfferingId }),
+            findPaths.courses.offerings.show({ id: this.course.id, courseOfferingId: organisation.courseOfferingId }),
           )
         })
       })

--- a/integration_tests/pages/find/courses.ts
+++ b/integration_tests/pages/find/courses.ts
@@ -1,4 +1,4 @@
-import paths from '../../../server/paths/find'
+import findPaths from '../../../server/paths/find'
 import presentCourse from '../../../server/utils/courseUtils'
 import Page from '../page'
 import type { Course } from '@accredited-programmes/models'
@@ -13,7 +13,7 @@ export default class CoursesPage extends Page {
       cy.wrap(courseElement).within(() => {
         const course = presentCourse(courses[courseElementIndex])
 
-        cy.get('a').should('have.attr', 'href', paths.courses.show({ id: course.id }))
+        cy.get('a').should('have.attr', 'href', findPaths.courses.show({ id: course.id }))
         cy.get('a h2').should('have.text', course.name)
 
         cy.get('p:first-of-type').then(tagContainerElement => {

--- a/server/controllers/dashboardController.test.ts
+++ b/server/controllers/dashboardController.test.ts
@@ -3,7 +3,7 @@ import { createMock } from '@golevelup/ts-jest'
 import type { NextFunction, Request, Response } from 'express'
 
 import DashboardController from './dashboardController'
-import paths from '../paths/find'
+import findPaths from '../paths/find'
 
 describe('DashboardController', () => {
   const request: DeepMocked<Request> = createMock<Request>({})
@@ -24,7 +24,7 @@ describe('DashboardController', () => {
 
       expect(response.render).toHaveBeenCalledWith('dashboard/index', {
         pageHeading: 'Accredited Programmes',
-        findPath: paths.courses.index({}),
+        findPath: findPaths.courses.index({}),
       })
     })
   })

--- a/server/controllers/dashboardController.ts
+++ b/server/controllers/dashboardController.ts
@@ -1,13 +1,13 @@
 import type { Request, RequestHandler, Response } from 'express'
 
-import paths from '../paths/find'
+import findPaths from '../paths/find'
 
 export default class DashboardController {
   index(): RequestHandler {
     return (_req: Request, res: Response) => {
       res.render('dashboard/index', {
         pageHeading: 'Accredited Programmes',
-        findPath: paths.courses.index({}),
+        findPath: findPaths.courses.index({}),
       })
     }
   }

--- a/server/controllers/find/index.ts
+++ b/server/controllers/find/index.ts
@@ -1,0 +1,15 @@
+import CourseOfferingsController from './courseOfferingsController'
+import CoursesController from './coursesController'
+import type { Services } from '../../services'
+
+const controllers = (services: Services) => {
+  const coursesController = new CoursesController(services.courseService, services.organisationService)
+  const courseOfferingsController = new CourseOfferingsController(services.courseService, services.organisationService)
+
+  return {
+    coursesController,
+    courseOfferingsController,
+  }
+}
+
+export default controllers

--- a/server/controllers/index.ts
+++ b/server/controllers/index.ts
@@ -1,17 +1,13 @@
 import DashboardController from './dashboardController'
-import CourseOfferingsController from './find/courseOfferingsController'
-import CoursesController from './find/coursesController'
+import findControllers from './find'
 import type { Services } from '../services'
 
 export const controllers = (services: Services) => {
-  const coursesController = new CoursesController(services.courseService, services.organisationService)
-  const courseOfferingsController = new CourseOfferingsController(services.courseService, services.organisationService)
   const dashboardController = new DashboardController()
 
   return {
-    coursesController,
     dashboardController,
-    courseOfferingsController,
+    ...findControllers(services),
   }
 }
 

--- a/server/data/courseClient.test.ts
+++ b/server/data/courseClient.test.ts
@@ -3,7 +3,7 @@ import { pactWith } from 'jest-pact'
 
 import CourseClient from './courseClient'
 import config from '../config'
-import paths from '../paths/api'
+import apiPaths from '../paths/api'
 import { courseFactory, courseOfferingFactory } from '../testutils/factories'
 
 pactWith({ consumer: 'Accredited Programmes UI', provider: 'Accredited Programmes API' }, provider => {
@@ -32,7 +32,7 @@ pactWith({ consumer: 'Accredited Programmes UI', provider: 'Accredited Programme
         uponReceiving: 'A request for all courses',
         withRequest: {
           method: 'GET',
-          path: paths.courses.index({}),
+          path: apiPaths.courses.index({}),
           headers: {
             authorization: `Bearer ${token}`,
           },
@@ -58,7 +58,7 @@ pactWith({ consumer: 'Accredited Programmes UI', provider: 'Accredited Programme
         uponReceiving: `A request for course "${course.id}"`,
         withRequest: {
           method: 'GET',
-          path: paths.courses.show({ id: course.id }),
+          path: apiPaths.courses.show({ id: course.id }),
           headers: {
             authorization: `Bearer ${token}`,
           },
@@ -84,7 +84,7 @@ pactWith({ consumer: 'Accredited Programmes UI', provider: 'Accredited Programme
         uponReceiving: `A request for course "${course.id}"'s offerings`,
         withRequest: {
           method: 'GET',
-          path: paths.courses.offerings.index({ id: course.id }),
+          path: apiPaths.courses.offerings.index({ id: course.id }),
           headers: {
             authorization: `Bearer ${token}`,
           },
@@ -110,7 +110,7 @@ pactWith({ consumer: 'Accredited Programmes UI', provider: 'Accredited Programme
         uponReceiving: `A request for course offering "${courseOffering.id}"`,
         withRequest: {
           method: 'GET',
-          path: paths.courses.offerings.show({ id: course.id, courseOfferingId: courseOffering.id }),
+          path: apiPaths.courses.offerings.show({ id: course.id, courseOfferingId: courseOffering.id }),
           headers: {
             authorization: `Bearer ${token}`,
           },

--- a/server/data/courseClient.ts
+++ b/server/data/courseClient.ts
@@ -1,7 +1,7 @@
 import RestClient from './restClient'
 import type { ApiConfig } from '../config'
 import config from '../config'
-import paths from '../paths/api'
+import apiPaths from '../paths/api'
 import type { Course, CourseOffering } from '@accredited-programmes/models'
 
 export default class CourseClient {
@@ -12,22 +12,22 @@ export default class CourseClient {
   }
 
   async all(): Promise<Array<Course>> {
-    return (await this.restClient.get({ path: paths.courses.index({}) })) as Array<Course>
+    return (await this.restClient.get({ path: apiPaths.courses.index({}) })) as Array<Course>
   }
 
   async find(id: Course['id']): Promise<Course> {
-    return (await this.restClient.get({ path: paths.courses.show({ id }) })) as Course
+    return (await this.restClient.get({ path: apiPaths.courses.show({ id }) })) as Course
   }
 
   async findOfferings(courseId: Course['id']): Promise<Array<CourseOffering>> {
     return (await this.restClient.get({
-      path: paths.courses.offerings.index({ id: courseId }),
+      path: apiPaths.courses.offerings.index({ id: courseId }),
     })) as Array<CourseOffering>
   }
 
   async findOffering(courseId: Course['id'], courseOfferingId: CourseOffering['id']): Promise<CourseOffering> {
     return (await this.restClient.get({
-      path: paths.courses.offerings.show({ id: courseId, courseOfferingId }),
+      path: apiPaths.courses.offerings.show({ id: courseId, courseOfferingId }),
     })) as CourseOffering
   }
 }

--- a/server/data/prisonClient.ts
+++ b/server/data/prisonClient.ts
@@ -1,7 +1,7 @@
 import RestClient from './restClient'
 import type { ApiConfig } from '../config'
 import config from '../config'
-import paths from '../paths/prisonApi'
+import prisonApiPaths from '../paths/prisonApi'
 import type { Prison } from '@prison-api'
 
 export default class PrisonClient {
@@ -12,6 +12,6 @@ export default class PrisonClient {
   }
 
   async getPrison(agencyId: string): Promise<Prison> {
-    return (await this.restClient.get({ path: paths.prisons.show({ agencyId }) })) as Prison
+    return (await this.restClient.get({ path: prisonApiPaths.prisons.show({ agencyId }) })) as Prison
   }
 }

--- a/server/routes/find.ts
+++ b/server/routes/find.ts
@@ -1,15 +1,16 @@
 import type { Router } from 'express'
 
 import type { Controllers } from '../controllers'
+import findPaths from '../paths/find'
 import actions from '../utils/routeUtils'
 
 export default function routes(controllers: Controllers, router: Router): Router {
   const { get } = actions(router)
   const { coursesController, courseOfferingsController } = controllers
 
-  get('/programmes', coursesController.index())
-  get('/programmes/:id', coursesController.show())
-  get('/programmes/:id/offerings/:courseOfferingId', courseOfferingsController.show())
+  get(findPaths.courses.index.pattern, coursesController.index())
+  get(findPaths.courses.show.pattern, coursesController.show())
+  get(findPaths.courses.offerings.show.pattern, courseOfferingsController.show())
 
   return router
 }

--- a/server/routes/find.ts
+++ b/server/routes/find.ts
@@ -1,0 +1,15 @@
+import type { Router } from 'express'
+
+import type { Controllers } from '../controllers'
+import actions from '../utils/routeUtils'
+
+export default function routes(controllers: Controllers, router: Router): Router {
+  const { get } = actions(router)
+  const { coursesController, courseOfferingsController } = controllers
+
+  get('/programmes', coursesController.index())
+  get('/programmes/:id', coursesController.show())
+  get('/programmes/:id/offerings/:courseOfferingId', courseOfferingsController.show())
+
+  return router
+}

--- a/server/routes/index.ts
+++ b/server/routes/index.ts
@@ -1,19 +1,17 @@
-import { type RequestHandler, Router } from 'express'
+import { Router } from 'express'
 
+import findRoutes from './find'
 import type { Controllers } from '../controllers'
-import asyncMiddleware from '../middleware/asyncMiddleware'
+import actions from '../utils/routeUtils'
 
 export default function routes(controllers: Controllers): Router {
   const router = Router()
-  const get = (path: string | string[], handler: RequestHandler) => router.get(path, asyncMiddleware(handler))
+  const { get } = actions(router)
 
-  const { dashboardController, coursesController, courseOfferingsController } = controllers
-
+  const { dashboardController } = controllers
   get('/', dashboardController.index())
 
-  get('/programmes', coursesController.index())
-  get('/programmes/:id', coursesController.show())
-  get('/programmes/:id/offerings/:courseOfferingId', courseOfferingsController.show())
+  findRoutes(controllers, router)
 
   return router
 }

--- a/server/utils/organisationUtils.ts
+++ b/server/utils/organisationUtils.ts
@@ -1,4 +1,4 @@
-import paths from '../paths/find'
+import findPaths from '../paths/find'
 import type { Course, CourseOffering, Organisation, OrganisationAddress } from '@accredited-programmes/models'
 import type {
   OrganisationWithOfferingEmailPresenter,
@@ -27,7 +27,7 @@ const organisationFromPrison = (id: Organisation['id'], prison: Prison): Organis
 
 const organisationTableRows = (course: Course, organisations: Array<OrganisationWithOfferingId>): Array<TableRow> => {
   return organisations.map(organisation => {
-    const offeringPath = paths.courses.offerings.show({
+    const offeringPath = findPaths.courses.offerings.show({
       id: course.id,
       courseOfferingId: organisation.courseOfferingId,
     })

--- a/server/utils/routeUtils.ts
+++ b/server/utils/routeUtils.ts
@@ -1,0 +1,9 @@
+import type { RequestHandler, Router } from 'express'
+
+import asyncMiddleware from '../middleware/asyncMiddleware'
+
+export default function actions(router: Router) {
+  return {
+    get: (path: string | Array<string>, handler: RequestHandler) => router.get(path, asyncMiddleware(handler)),
+  }
+}

--- a/wiremock/scripts/stubApis.ts
+++ b/wiremock/scripts/stubApis.ts
@@ -1,5 +1,5 @@
 /* eslint-disable no-console */
-import paths from '../../server/paths/api'
+import apiPaths from '../../server/paths/api'
 import { stubFor } from '../index'
 import { courseOfferings, courses } from '../stubs'
 
@@ -9,7 +9,7 @@ stubs.push(async () =>
   stubFor({
     request: {
       method: 'GET',
-      url: paths.courses.index({}),
+      url: apiPaths.courses.index({}),
     },
     response: {
       status: 200,
@@ -26,7 +26,7 @@ courses.forEach(course => {
     stubFor({
       request: {
         method: 'GET',
-        url: paths.courses.show({ id: course.id }),
+        url: apiPaths.courses.show({ id: course.id }),
       },
       response: {
         status: 200,
@@ -42,7 +42,7 @@ courses.forEach(course => {
     stubFor({
       request: {
         method: 'GET',
-        url: paths.courses.offerings.index({ id: course.id }),
+        url: apiPaths.courses.offerings.index({ id: course.id }),
       },
       response: {
         status: 200,
@@ -59,7 +59,7 @@ courses.forEach(course => {
       stubFor({
         request: {
           method: 'GET',
-          url: paths.courses.offerings.show({ id: course.id, courseOfferingId: courseOffering.id }),
+          url: apiPaths.courses.offerings.show({ id: course.id, courseOfferingId: courseOffering.id }),
         },
         response: {
           status: 200,


### PR DESCRIPTION
## Context

We were still hardcoding paths in our router. Per Approved Premises, we can get the path patterns with the `.pattern` method. Some of the groundwork for this in Approved Premises was done in https://github.com/ministryofjustice/hmpps-approved-premises-ui/pull/138, which adds namespacing in controllers, paths and routers. We already have this in our paths, but not in our controllers or routers

Also related to paths, we import a `paths` object from three different sources across the app, which can be a little confusing when reading code snippets

## Changes in this PR

- clarify which paths are being used where
- namespace controllers and routers
- use path patterns in routes