### PR TITLE
Fix Cypress/TypeScript/VSCode integration

### DIFF
--- a/integration_tests/tsconfig.json
+++ b/integration_tests/tsconfig.json
@@ -7,12 +7,12 @@
     "types": ["cypress", "express", "express-session"],
     "esModuleInterop": true,
     "skipLibCheck": true,
-    "typeRoots": ["../server/@types"],
+    "typeRoots": ["../server/@types", "../node_modules/@types", "../node_modules/cypress/types"],
     "paths": {
       "@accredited-programmes/models": ["../server/@types/models/index.d.ts"],
       "@accredited-programmes/ui": ["../server/@types/ui/index.d.ts"],
       "@prison-api": ["../server/@types/prisonApi/index.d.ts"]
     }
   },
-  "include": ["**/*.ts"]
+  "include": ["**/*.ts", "../node_modules/cypress"]
 }


### PR DESCRIPTION
## Context

After running various updates today (macOS and brew formulae and casks), I started seeing a few errors in the `integration_tests` folder:
- in `integration_tests/tsconfig.json`, TS2688: `Cannot find type definition file for 'cypress'` and `Cannot find type definition file for 'express-session'`
- in `integration_tests/**/*.ts`, TS2304: `Cannot find name 'cy'` and `Cannot find name` with various other Cypress-related objects

## Changes in this PR

The `typeRoots` change fixes the former, while the `include` change fixes the latter. This was hard to debug, but the following helped:
- https://stackoverflow.com/a/53938729/4002016 (I think - as well as the Approved Premises config)
- https://github.com/cypress-io/cypress/issues/1152#issuecomment-355794417