### PR TITLE
(511) Update course offering page

### DIFF
--- a/integration_tests/pages/find/course.ts
+++ b/integration_tests/pages/find/course.ts
@@ -40,7 +40,7 @@ export default class CoursePage extends Page {
           cy.get('.govuk-table__cell:nth-of-type(2)').should('have.text', 'N/A')
           cy.get('.govuk-table__cell:nth-of-type(3)').should('have.text', organisation.address.county || 'Not found')
           cy.get('.govuk-table__cell:nth-of-type(4)').should('have.text', `Contact prison (${organisation.name})`)
-          cy.get('.govuk-table__cell:nth-of-type(4) a').should(
+          cy.get('.govuk-table__cell:nth-of-type(4) .govuk-link').should(
             'have.attr',
             'href',
             findPaths.courses.offerings.show({ id: this.course.id, courseOfferingId: organisation.courseOfferingId }),

--- a/integration_tests/pages/find/courseOffering.ts
+++ b/integration_tests/pages/find/courseOffering.ts
@@ -31,9 +31,5 @@ export default class CourseOfferingPage extends Page {
     cy.get('.govuk-summary-list').then(summaryListElement => {
       this.shouldContainSummaryListRows(this.organisation.summaryListRows, summaryListElement)
     })
-
-    cy.get('.govuk-button').then(buttonLinkElement => {
-      this.shouldContainButtonLink('Make referral', `mailto:${this.courseOffering.contactEmail}`, buttonLinkElement)
-    })
   }
 }

--- a/integration_tests/pages/page.ts
+++ b/integration_tests/pages/page.ts
@@ -1,4 +1,4 @@
-import type { SummaryListRow, Tag } from '@accredited-programmes/ui'
+import type { ObjectWithHtmlString, ObjectWithTextString, SummaryListRow, Tag } from '@accredited-programmes/ui'
 
 export type PageElement = Cypress.Chainable<JQuery>
 
@@ -51,7 +51,9 @@ export default abstract class Page {
           })
 
           cy.get('.govuk-summary-list__value').then(summaryListValueElement => {
-            const { actual, expected } = this.parseHtml(summaryListValueElement, row.value.text)
+            const expectedValue =
+              'text' in row.value ? (row.value as ObjectWithTextString).text : (row.value as ObjectWithHtmlString).html
+            const { actual, expected } = this.parseHtml(summaryListValueElement, expectedValue)
             expect(actual).to.equal(expected)
           })
         })

--- a/integration_tests/pages/page.ts
+++ b/integration_tests/pages/page.ts
@@ -32,13 +32,6 @@ export default abstract class Page {
 
   manageDetails = (): PageElement => cy.get('[data-qa=manageDetails]')
 
-  shouldContainButtonLink(text: string, href: string, buttonLinkElement: JQuery<HTMLElement>): void {
-    const textContent = this.parseHtml(buttonLinkElement, text)
-    expect(textContent.actual).to.equal(textContent.expected)
-
-    cy.wrap(buttonLinkElement).should('have.attr', 'href', href)
-  }
-
   shouldContainSummaryListRows(rows: Array<SummaryListRow>, summaryListElement: JQuery<HTMLElement>): void {
     cy.wrap(summaryListElement).within(() => {
       cy.get('.govuk-summary-list__row').each((rowElement, rowElementIndex) => {

--- a/server/@types/ui/index.d.ts
+++ b/server/@types/ui/index.d.ts
@@ -1,32 +1,27 @@
 import type { Course, CourseOffering, Organisation } from '@accredited-programmes/models'
 
-type TagColour = 'blue' | 'green' | 'grey' | 'orange' | 'pink' | 'purple' | 'red' | 'turquoise' | 'yellow'
-
-type Tag = {
-  text: string
-  classes: `govuk-tag govuk-tag--${TagColour}`
+type ObjectWithTextString<T = string> = {
+  text: T
 }
 
-type SummaryListRow<T = string, U = string> = {
-  key: {
-    text: T
-  }
-  value: {
-    text: U
-  }
-}
-
-type TableCellWithText = {
-  text: string
-}
-
-type TableCellWithHtml = {
+type ObjectWithHtmlString = {
   html: string
 }
 
-type TableCell = TableCellWithText | TableCellWithHtml
+type ObjectWithTextOrHtmlString = ObjectWithTextString | ObjectWithHtmlString
 
-type TableRow = Array<TableCell>
+type TagColour = 'blue' | 'green' | 'grey' | 'orange' | 'pink' | 'purple' | 'red' | 'turquoise' | 'yellow'
+
+type Tag = ObjectWithTextString & {
+  classes: `govuk-tag govuk-tag--${TagColour}`
+}
+
+type SummaryListRow<T = string, U = ObjectWithTextOrHtmlString> = {
+  key: ObjectWithTextString<T>
+  value: U
+}
+
+type TableRow = Array<ObjectWithTextOrHtmlString>
 
 type CoursePresenter = Course & {
   audienceTags: Array<Tag>
@@ -38,10 +33,10 @@ type OrganisationWithOfferingId = Organisation & {
 }
 
 type OrganisationWithOfferingEmailSummaryListRows = [
-  SummaryListRow<'Prison category', string>,
-  SummaryListRow<'Address', string>,
-  SummaryListRow<'Region', string>,
-  SummaryListRow<'Email address', CourseOffering['contactEmail']>,
+  SummaryListRow<'Prison category', ObjectWithTextString>,
+  SummaryListRow<'Address', ObjectWithTextString>,
+  SummaryListRow<'Region', ObjectWithTextString>,
+  SummaryListRow<'Email address', ObjectWithTextString<CourseOffering['contactEmail']>>,
 ]
 
 type OrganisationWithOfferingEmailPresenter = Organisation & {
@@ -50,6 +45,8 @@ type OrganisationWithOfferingEmailPresenter = Organisation & {
 
 export type {
   CoursePresenter,
+  ObjectWithHtmlString,
+  ObjectWithTextString,
   OrganisationWithOfferingEmailPresenter,
   OrganisationWithOfferingEmailSummaryListRows,
   OrganisationWithOfferingId,

--- a/server/@types/ui/index.d.ts
+++ b/server/@types/ui/index.d.ts
@@ -36,7 +36,7 @@ type OrganisationWithOfferingEmailSummaryListRows = [
   SummaryListRow<'Prison category', ObjectWithTextString>,
   SummaryListRow<'Address', ObjectWithTextString>,
   SummaryListRow<'Region', ObjectWithTextString>,
-  SummaryListRow<'Email address', ObjectWithTextString<CourseOffering['contactEmail']>>,
+  SummaryListRow<'Email address', ObjectWithHtmlString>,
 ]
 
 type OrganisationWithOfferingEmailPresenter = Organisation & {

--- a/server/controllers/find/courseOfferingsController.test.ts
+++ b/server/controllers/find/courseOfferingsController.test.ts
@@ -37,7 +37,6 @@ describe('CoursesOfferingsController', () => {
         pageHeading: course.name,
         course: presentCourse(course),
         organisation: presentOrganisationWithOfferingEmail(organisation, courseOffering.contactEmail),
-        emailHref: `mailto:${courseOffering.contactEmail}`,
       })
     })
   })

--- a/server/controllers/find/courseOfferingsController.ts
+++ b/server/controllers/find/courseOfferingsController.ts
@@ -34,7 +34,6 @@ export default class CourseOfferingsController {
         pageHeading: course.name,
         course: presentCourse(course),
         organisation: presentOrganisationWithOfferingEmail(organisation, courseOffering.contactEmail),
-        emailHref: `mailto:${courseOffering.contactEmail}`,
       })
     }
   }

--- a/server/utils/organisationUtils.test.ts
+++ b/server/utils/organisationUtils.test.ts
@@ -123,7 +123,9 @@ describe('organisationUtils', () => {
             },
             {
               key: { text: 'Email address' },
-              value: { text: 'nobody-hmp-what@digital.justice.gov.uk' },
+              value: {
+                html: '<a class="govuk-link" href="mailto:nobody-hmp-what@digital.justice.gov.uk">nobody-hmp-what@digital.justice.gov.uk</a>',
+              },
             },
           ],
         })
@@ -152,7 +154,9 @@ describe('organisationUtils', () => {
             },
             {
               key: { text: 'Email address' },
-              value: { text: 'nobody-hmp-what@digital.justice.gov.uk' },
+              value: {
+                html: '<a class="govuk-link" href="mailto:nobody-hmp-what@digital.justice.gov.uk">nobody-hmp-what@digital.justice.gov.uk</a>',
+              },
             },
           ],
         })

--- a/server/utils/organisationUtils.test.ts
+++ b/server/utils/organisationUtils.test.ts
@@ -47,7 +47,7 @@ describe('organisationUtils', () => {
             { text: organisationsWithOfferingIds[0].category },
             { text: organisationsWithOfferingIds[0].address.county },
             {
-              html: `<a href="/programmes/${course.id}/offerings/${organisationsWithOfferingIds[0].courseOfferingId}" class="govuk-link">Contact prison <span class="govuk-visually-hidden">(${organisationsWithOfferingIds[0].name})</span></a>`,
+              html: `<a class="govuk-link" href="/programmes/${course.id}/offerings/${organisationsWithOfferingIds[0].courseOfferingId}">Contact prison <span class="govuk-visually-hidden">(${organisationsWithOfferingIds[0].name})</span></a>`,
             },
           ],
           [
@@ -55,7 +55,7 @@ describe('organisationUtils', () => {
             { text: organisationsWithOfferingIds[1].category },
             { text: organisationsWithOfferingIds[1].address.county },
             {
-              html: `<a href="/programmes/${course.id}/offerings/${organisationsWithOfferingIds[1].courseOfferingId}" class="govuk-link">Contact prison <span class="govuk-visually-hidden">(${organisationsWithOfferingIds[1].name})</span></a>`,
+              html: `<a class="govuk-link" href="/programmes/${course.id}/offerings/${organisationsWithOfferingIds[1].courseOfferingId}">Contact prison <span class="govuk-visually-hidden">(${organisationsWithOfferingIds[1].name})</span></a>`,
             },
           ],
           [
@@ -63,7 +63,7 @@ describe('organisationUtils', () => {
             { text: organisationsWithOfferingIds[2].category },
             { text: organisationsWithOfferingIds[2].address.county },
             {
-              html: `<a href="/programmes/${course.id}/offerings/${organisationsWithOfferingIds[2].courseOfferingId}" class="govuk-link">Contact prison <span class="govuk-visually-hidden">(${organisationsWithOfferingIds[2].name})</span></a>`,
+              html: `<a class="govuk-link" href="/programmes/${course.id}/offerings/${organisationsWithOfferingIds[2].courseOfferingId}">Contact prison <span class="govuk-visually-hidden">(${organisationsWithOfferingIds[2].name})</span></a>`,
             },
           ],
         ])
@@ -81,7 +81,7 @@ describe('organisationUtils', () => {
             { text: organisationWithOfferingId.category },
             { text: 'Not found' },
             {
-              html: `<a href="/programmes/${course.id}/offerings/${organisationWithOfferingId.courseOfferingId}" class="govuk-link">Contact prison <span class="govuk-visually-hidden">(${organisationWithOfferingId.name})</span></a>`,
+              html: `<a class="govuk-link" href="/programmes/${course.id}/offerings/${organisationWithOfferingId.courseOfferingId}">Contact prison <span class="govuk-visually-hidden">(${organisationWithOfferingId.name})</span></a>`,
             },
           ],
         ])

--- a/server/utils/organisationUtils.ts
+++ b/server/utils/organisationUtils.ts
@@ -26,7 +26,7 @@ const organisationTableRows = (course: Course, organisations: Array<Organisation
       courseOfferingId: organisation.courseOfferingId,
     })
     const visuallyHiddenPrisonInformation = `<span class="govuk-visually-hidden">(${organisation.name})</span>`
-    const contactLink = `<a href="${offeringPath}" class="govuk-link">Contact prison ${visuallyHiddenPrisonInformation}</a>`
+    const contactLink = `<a class="govuk-link" href="${offeringPath}">Contact prison ${visuallyHiddenPrisonInformation}</a>`
 
     return [
       { text: organisation.name },

--- a/server/utils/organisationUtils.ts
+++ b/server/utils/organisationUtils.ts
@@ -62,7 +62,7 @@ const organisationWithOfferingEmailSummaryListRows = (
     },
     {
       key: { text: 'Email address' },
-      value: { text: email },
+      value: { html: `<a class="govuk-link" href="mailto:${email}">${email}</a>` },
     },
   ]
 }

--- a/server/views/courses/offerings/show.njk
+++ b/server/views/courses/offerings/show.njk
@@ -21,11 +21,6 @@
         classes: 'govuk-summary-list--no-border',
         rows: organisation.summaryListRows
       }) }}
-
-      {{ govukButton({
-        text: 'Make referral',
-        href: emailHref
-      }) }}
     </div>
   </div>
 {% endblock content %}


### PR DESCRIPTION
## Context

The designs for the course offering page have been updated

## Changes in this PR

In course offering page:
- Add link to email address
- Remove "Make referral" button

Elsewhere: various bits of groundwork and minor consistency edits

## Screenshots of UI changes

### Before

<img width="642" alt="image" src="https://github.com/ministryofjustice/hmpps-accredited-programmes-ui/assets/40244233/85cd22df-0894-4741-9d5e-0e9392b0d897">

### After

<img width="810" alt="image" src="https://github.com/ministryofjustice/hmpps-accredited-programmes-ui/assets/40244233/8018875b-34bc-42ec-88a6-0d2bb5f459ca">

## Post-merge checklist

- [ ] Have you written an end-to-end test for the happy path in the [Accredited Programmes E2E repo](https://github.com/ministryofjustice/hmpps-accredited-programmes-e2e) (if necessary)?
