### PR TITLE
Switch to `rem`

### DIFF
--- a/assets/scss/components/_dashboard.scss
+++ b/assets/scss/components/_dashboard.scss
@@ -7,14 +7,14 @@
   flex: 1;
 
   margin-right: -21.8vw;
-  margin-bottom: -60px;
+  margin-bottom: -3.75rem;
   margin-left: -21.8vw;
-  padding: 30px 21.8vw;
+  padding: 1.875rem 21.8vw;
 
   background: #f0f4f5;
 
   @media (width <= 40em) {
-    margin-bottom: -35px;
+    margin-bottom: -2.1875rem;
   }
 }
 
@@ -35,16 +35,16 @@
   position: relative;
 
   width: 100%;
-  margin-bottom: 40px;
-  padding: 25px;
+  margin-bottom: 2.5rem;
+  padding: 1.5625rem;
 
   background: #fff;
-  border: 1px solid #d9dadb;
-  border-bottom-width: 5px;
+  border: 0.0625rem solid #d9dadb;
+  border-bottom-width: 0.3125rem;
 
   &--linked {
     &:active {
-      bottom: -1px;
+      bottom: -0.0625rem;
     }
 
     &:hover {
@@ -53,12 +53,12 @@
   }
 
   @media (width <= 48.0525em) {
-    margin-bottom: 15px;
+    margin-bottom: 0.9375rem;
   }
 }
 
 .dashboard__card-heading {
-  margin-bottom: 15px;
+  margin-bottom: 0.9375rem;
 }
 
 .dashboard__card-description {
@@ -79,8 +79,8 @@
       text-decoration: none;
 
       background-color: #fd0;
-      outline: 3px solid transparent;
-      box-shadow: 0 -2px #fd0, 0 4px #0b0c0c;
+      outline: 0.1875rem solid transparent;
+      box-shadow: 0 -0.125rem #fd0, 0 0.25rem #0b0c0c;
     }
   }
 }

--- a/assets/scss/components/_header-bar.scss
+++ b/assets/scss/components/_header-bar.scss
@@ -16,7 +16,7 @@
     @include govuk-responsive-margin(2, 'right');
 
     position: relative;
-    top: -2px;
+    top: -0.125rem;
     fill: govuk-colour('white');
   }
 
@@ -102,7 +102,7 @@
         @include govuk-responsive-padding(4, 'right');
 
         margin-bottom: 0;
-        border-right: 1px solid govuk-colour('white');
+        border-right: 0.0625rem solid govuk-colour('white');
       }
 
       margin-bottom: govuk-spacing(1);
@@ -134,7 +134,7 @@
   display: flex;
   flex-wrap: wrap;
   width: 100%;
-  border-bottom: 1px solid $govuk-border-colour;
+  border-bottom: 0.0625rem solid $govuk-border-colour;
 
   &__location {
     @include govuk-font($size: 19, $weight: 'bold');

--- a/assets/scss/local.scss
+++ b/assets/scss/local.scss
@@ -1,3 +1,3 @@
 .govuk-main-wrapper {
-  min-height: 600px;
+  min-height: 37.5rem;
 }


### PR DESCRIPTION
## Changes in this PR

Switch to `rem` in `assets/scss/components/*` and `assets/scss/local`, but not `assets/scss/application` since that interacts with a Node module and its behaviour may rely on a specific unit

Media queries still use `em` since `rem` aren't proper media query units and `em` is more consistent across browsers and usage scenarios than `px`:
- https://github.com/at-import/breakpoint/issues/132#issuecomment-86539326
- https://zellwk.com/blog/media-query-units
- https://stackoverflow.com/a/74798205/4002016
- https://stackoverflow.com/a/60830895/4002016