### PR TITLE
(492) Get docker-compose working locally with new DB

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -23,6 +23,23 @@ services:
       - SPRING_PROFILES_ACTIVE=dev
       - APPLICATION_AUTHENTICATION_UI_ALLOWLIST=0.0.0.0/0
 
+  postgresql:
+    image: postgres
+    container_name: postgres
+    networks:
+      - hmpps
+    restart: always
+    ports:
+      - '5432:5432'
+    healthcheck:
+      test: [ "CMD", "pg_isready", "--username=admin", "--dbname=postgres"]
+      interval: 10s
+      timeout: 5s
+      retries: 5
+    environment:
+      - POSTGRES_USER=admin
+      - POSTGRES_PASSWORD=admin_password
+
   hmpps-accredited-programmes-api:
     image: quay.io/hmpps/hmpps-accredited-programmes-api:latest
     restart: always
@@ -33,8 +50,15 @@ services:
       - '9091:8080'
     healthcheck:
       test: ['CMD', 'curl', '-f', 'http://localhost:8080/health']
+    depends_on:
+      postgresql:
+        condition: service_healthy
     environment:
       - HMPPS_AUTH_URL=http://hmpps-auth:8080/auth
+      - SPRING_PROFILES_ACTIVE=dev,local,seed
+      - SPRING_DATASOURCE_URL=jdbc:postgresql://postgresql:5432/postgres
+      - SPRING_DATASOURCE_USERNAME=admin
+      - SPRING_DATASOURCE_PASSWORD=admin_password
 
   prison-register-api:
     image: quay.io/hmpps/prison-register:latest
@@ -62,7 +86,8 @@ services:
     build: .
     networks:
       - hmpps
-    depends_on: [redis]
+    depends_on:
+      - redis
     ports:
       - '3000:3000'
     environment:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -82,23 +82,5 @@ services:
     ports:
       - '9099:8080'
 
-  app:
-    build: .
-    networks:
-      - hmpps
-    depends_on:
-      - redis
-    ports:
-      - '3000:3000'
-    environment:
-      - REDIS_HOST=redis
-      - HMPPS_AUTH_EXTERNAL_URL=http://localhost:9090/auth
-      - HMPPS_AUTH_URL=http://hmpps-auth:8080/auth
-      # These will need to match new creds in the seed auth service auth
-      - API_CLIENT_ID=client-id
-      - API_CLIENT_SECRET=client-secret
-      - SYSTEM_CLIENT_ID=system-client-id
-      - SYSTEM_CLIENT_SECRET=system-client-secret
-
 networks:
   hmpps:

--- a/script/utils/start-backing-services
+++ b/script/utils/start-backing-services
@@ -10,12 +10,12 @@ do
 done
 
 if [ "$MOCK_API" = true ]; then
-  docker-compose up --scale=hmpps-accredited-programmes-api=0 -d
+  docker compose up --scale=hmpps-accredited-programmes-api=0 -d
 
   echo "==> Stubbing API endpoints..."
 
   npm run api-stubs:reset > /dev/null
   npm run api-stubs:create > /dev/null
 else
-  docker-compose up --scale=wiremock=0 -d
+  docker compose up --scale=wiremock=0 -d
 fi

--- a/script/utils/start-backing-services
+++ b/script/utils/start-backing-services
@@ -10,7 +10,7 @@ do
 done
 
 if [ "$MOCK_API" = true ]; then
-  docker compose up --scale=hmpps-accredited-programmes-api=0 -d
+  docker compose up --scale=hmpps-accredited-programmes-api=0 --scale=postgresql=0 -d
 
   echo "==> Stubbing API endpoints..."
 

--- a/script/utils/start-backing-services
+++ b/script/utils/start-backing-services
@@ -10,12 +10,12 @@ do
 done
 
 if [ "$MOCK_API" = true ]; then
-  docker-compose up --scale=app=0 --scale=hmpps-accredited-programmes-api=0 -d
+  docker-compose up --scale=hmpps-accredited-programmes-api=0 -d
 
   echo "==> Stubbing API endpoints..."
 
   npm run api-stubs:reset > /dev/null
   npm run api-stubs:create > /dev/null
 else
-  docker-compose up --scale=app=0 --scale=wiremock=0 -d
+  docker-compose up --scale=wiremock=0 -d
 fi


### PR DESCRIPTION
## Context

<!-- Is there a Trello ticket you can link to? -->

https://trello.com/c/VDp60gWQ/492-fix-ui-version-of-the-api-now-that-a-database-has-a-been-added

<!-- Do you need to add any environment variables? -->
<!-- Is an ADR required? An ADR should be added if this PR introduces a change to the architecture. -->

`script/server` started failing once we added the database to the API, as we weren't starting a postgres database.

## Changes in this PR

This starts all the necessary backing services for running the API and our dependencies locally now that the API has a `seed` environment to start up with data.

## Post-merge checklist

<!-- The outer checkboxes can be completed pre-merge -->

- [ ] This adds or extends a feature...
  - [ ] ... and I have written or updated an end-to-end test for the happy path in the [Accredited Programmes E2E repo](https://github.com/ministryofjustice/hmpps-accredited-programmes-e2e)
- [ ] This makes new expectations of the API...
  - [ ] ... and I have notifed the API developer(s) of changes to the contract tests (Pact), or the API is already compliant
