### PR TITLE
(516) Display acronyms

### DIFF
--- a/integration_tests/pages/find/course.ts
+++ b/integration_tests/pages/find/course.ts
@@ -8,8 +8,9 @@ export default class CoursePage extends Page {
   course: CoursePresenter
 
   constructor(course: Course) {
-    super(course.name, course.name)
-    this.course = presentCourse(course)
+    const coursePresenter = presentCourse(course)
+    super(coursePresenter.nameAndAlternateName, course.name)
+    this.course = coursePresenter
   }
 
   shouldHaveCourse() {

--- a/integration_tests/pages/find/courses.ts
+++ b/integration_tests/pages/find/courses.ts
@@ -14,7 +14,7 @@ export default class CoursesPage extends Page {
         const course = presentCourse(courses[courseElementIndex])
 
         cy.get('.govuk-link').should('have.attr', 'href', findPaths.courses.show({ id: course.id }))
-        cy.get('.govuk-heading-m .govuk-link').should('have.text', course.name)
+        cy.get('.govuk-heading-m .govuk-link').should('have.text', course.nameAndAlternateName)
 
         cy.get('p:first-of-type').then(tagContainerElement => {
           this.shouldContainTags(course.audienceTags, tagContainerElement)

--- a/server/@types/models/Course.ts
+++ b/server/@types/models/Course.ts
@@ -4,6 +4,7 @@ import type { CoursePrerequisite } from './CoursePrerequisite'
 export type Course = {
   id: string
   name: string
+  alternateName: string | null
   description: string
   audiences: Array<CourseAudience>
   coursePrerequisites: Array<CoursePrerequisite>

--- a/server/@types/ui/index.d.ts
+++ b/server/@types/ui/index.d.ts
@@ -24,6 +24,7 @@ type SummaryListRow<T = string, U = ObjectWithTextOrHtmlString> = {
 type TableRow = Array<ObjectWithTextOrHtmlString>
 
 type CoursePresenter = Course & {
+  nameAndAlternateName: string
   audienceTags: Array<Tag>
   prerequisiteSummaryListRows: Array<SummaryListRow>
 }

--- a/server/controllers/find/courseOfferingsController.test.ts
+++ b/server/controllers/find/courseOfferingsController.test.ts
@@ -33,9 +33,11 @@ describe('CoursesOfferingsController', () => {
       const requestHandler = courseOfferingsController.show()
       await requestHandler(request, response, next)
 
+      const coursePresenter = presentCourse(course)
+
       expect(response.render).toHaveBeenCalledWith('courses/offerings/show', {
-        pageHeading: course.name,
-        course: presentCourse(course),
+        pageHeading: coursePresenter.nameAndAlternateName,
+        course: coursePresenter,
         organisation: presentOrganisationWithOfferingEmail(organisation, courseOffering.contactEmail),
       })
     })

--- a/server/controllers/find/courseOfferingsController.ts
+++ b/server/controllers/find/courseOfferingsController.ts
@@ -30,9 +30,11 @@ export default class CourseOfferingsController {
         })
       }
 
+      const coursePresenter = presentCourse(course)
+
       res.render('courses/offerings/show', {
-        pageHeading: course.name,
-        course: presentCourse(course),
+        pageHeading: coursePresenter.nameAndAlternateName,
+        course: coursePresenter,
         organisation: presentOrganisationWithOfferingEmail(organisation, courseOffering.contactEmail),
       })
     }

--- a/server/controllers/find/coursesController.test.ts
+++ b/server/controllers/find/coursesController.test.ts
@@ -77,9 +77,11 @@ describe('CoursesController', () => {
           expect(organisationService.getOrganisation).toHaveBeenCalledWith(token, organisation.id),
         )
 
+        const coursePresenter = presentCourse(course)
+
         expect(response.render).toHaveBeenCalledWith('courses/show', {
-          pageHeading: course.name,
-          course: presentCourse(course),
+          pageHeading: coursePresenter.nameAndAlternateName,
+          course: coursePresenter,
           organisationsTableData: organisationTableRows(course, organisationsWithOfferingIds),
         })
       })
@@ -120,9 +122,11 @@ describe('CoursesController', () => {
           expect(organisationService.getOrganisation).toHaveBeenCalledWith(token, organisation.id),
         )
 
+        const coursePresenter = presentCourse(course)
+
         expect(response.render).toHaveBeenCalledWith('courses/show', {
-          pageHeading: course.name,
-          course: presentCourse(course),
+          pageHeading: coursePresenter.nameAndAlternateName,
+          course: coursePresenter,
           organisationsTableData: organisationTableRows(course, existingOrganisationsWithOfferingIds),
         })
       })

--- a/server/controllers/find/coursesController.ts
+++ b/server/controllers/find/coursesController.ts
@@ -47,9 +47,11 @@ export default class CoursesController {
 
       const organisationsTableData = organisationTableRows(course, organisationsWithOfferingIds)
 
+      const coursePresenter = presentCourse(course)
+
       res.render('courses/show', {
-        pageHeading: course.name,
-        course: presentCourse(course),
+        pageHeading: coursePresenter.nameAndAlternateName,
+        course: coursePresenter,
         organisationsTableData,
       })
     }

--- a/server/testutils/factories/course.ts
+++ b/server/testutils/factories/course.ts
@@ -4,18 +4,23 @@ import { Factory } from 'fishery'
 import courseAudienceFactory from './courseAudience'
 import coursePrerequisiteFactory from './coursePrerequisite'
 import buildListBetween from './factoryHelpers'
-import { convertToTitleCase } from '../../utils/utils'
+import { convertToTitleCase, initialiseTitle } from '../../utils/utils'
 import type { Course } from '@accredited-programmes/models'
 
-export default Factory.define<Course>(() => ({
-  id: faker.string.uuid(),
-  name: `${convertToTitleCase(faker.color.human())} Course`,
-  description: faker.lorem.sentences(),
-  audiences: buildListBetween(courseAudienceFactory, { min: 1, max: 3 }),
-  coursePrerequisites: [
-    coursePrerequisiteFactory.gender().build(),
-    coursePrerequisiteFactory.learningNeeds().build(),
-    coursePrerequisiteFactory.riskCriteria().build(),
-    coursePrerequisiteFactory.setting().build(),
-  ],
-}))
+export default Factory.define<Course>(({ params }) => {
+  const name = `${convertToTitleCase(faker.color.human())} Course`
+
+  return {
+    id: faker.string.uuid(),
+    name,
+    alternateName: initialiseTitle(params.name || name),
+    description: faker.lorem.sentences(),
+    audiences: buildListBetween(courseAudienceFactory, { min: 1, max: 3 }),
+    coursePrerequisites: [
+      coursePrerequisiteFactory.gender().build(),
+      coursePrerequisiteFactory.learningNeeds().build(),
+      coursePrerequisiteFactory.riskCriteria().build(),
+      coursePrerequisiteFactory.setting().build(),
+    ],
+  }
+})

--- a/server/utils/courseUtils.test.ts
+++ b/server/utils/courseUtils.test.ts
@@ -5,6 +5,8 @@ describe('courseUtils', () => {
   describe('presentCourse', () => {
     it('returns a course with UI-formatted audience and prerequisite data', () => {
       const course = courseFactory.build({
+        name: 'Lime Course',
+        alternateName: 'LC',
         audiences: [
           courseAudienceFactory.build({ value: 'Intimate partner violence' }),
           courseAudienceFactory.build({ value: 'General violence' }),
@@ -19,6 +21,7 @@ describe('courseUtils', () => {
 
       expect(presentCourse(course)).toEqual({
         ...course,
+        nameAndAlternateName: 'Lime Course (LC)',
         audienceTags: [
           {
             text: 'Intimate partner violence',
@@ -47,6 +50,14 @@ describe('courseUtils', () => {
             value: { text: course.coursePrerequisites[1].description },
           },
         ],
+      })
+    })
+
+    describe('when a course has no `alternateName`', () => {
+      it('just uses the `name` as the `nameAndAlternateName`', () => {
+        const course = courseFactory.build({ alternateName: null })
+
+        expect(presentCourse(course).nameAndAlternateName).toEqual(course.name)
       })
     })
   })

--- a/server/utils/courseUtils.ts
+++ b/server/utils/courseUtils.ts
@@ -43,8 +43,11 @@ const prerequisiteSummaryListRows = (prerequisites: Array<CoursePrerequisite>): 
 }
 
 const presentCourse = (course: Course): CoursePresenter => {
+  const nameAndAlternateName = course.alternateName ? `${course.name} (${course.alternateName})` : course.name
+
   return {
     ...course,
+    nameAndAlternateName,
     audienceTags: audienceTags(course.audiences),
     prerequisiteSummaryListRows: prerequisiteSummaryListRows(course.coursePrerequisites),
   }

--- a/server/utils/utils.test.ts
+++ b/server/utils/utils.test.ts
@@ -1,6 +1,6 @@
 import { convertToTitleCase, initialiseName, initialiseTitle } from './utils'
 
-describe('convert to title case', () => {
+describe('convertToTitleCase', () => {
   it.each([
     [null, null, ''],
     ['empty string', '', ''],
@@ -16,7 +16,7 @@ describe('convert to title case', () => {
   })
 })
 
-describe('initialise name', () => {
+describe('initialiseName', () => {
   it.each([
     [undefined, undefined, null],
     ['Empty string', '', null],

--- a/server/utils/utils.test.ts
+++ b/server/utils/utils.test.ts
@@ -1,44 +1,46 @@
 import { convertToTitleCase, initialiseName, initialiseTitle } from './utils'
 
-describe('convertToTitleCase', () => {
-  it.each([
-    [null, null, ''],
-    ['empty string', '', ''],
-    ['Lower case', 'robert', 'Robert'],
-    ['Upper case', 'ROBERT', 'Robert'],
-    ['Mixed case', 'RoBErT', 'Robert'],
-    ['Multiple words', 'RobeRT SMiTH', 'Robert Smith'],
-    ['Leading spaces', '  RobeRT', '  Robert'],
-    ['Trailing spaces', 'RobeRT  ', 'Robert  '],
-    ['Hyphenated', 'Robert-John SmiTH-jONes-WILSON', 'Robert-John Smith-Jones-Wilson'],
-  ])('%s convertToTitleCase(%s, %s)', (_inputType: string | null, input: string | null, expectedOutput: string) => {
-    expect(convertToTitleCase(input)).toEqual(expectedOutput)
+describe('utils', () => {
+  describe('convertToTitleCase', () => {
+    it.each([
+      [null, null, ''],
+      ['empty string', '', ''],
+      ['Lower case', 'robert', 'Robert'],
+      ['Upper case', 'ROBERT', 'Robert'],
+      ['Mixed case', 'RoBErT', 'Robert'],
+      ['Multiple words', 'RobeRT SMiTH', 'Robert Smith'],
+      ['Leading spaces', '  RobeRT', '  Robert'],
+      ['Trailing spaces', 'RobeRT  ', 'Robert  '],
+      ['Hyphenated', 'Robert-John SmiTH-jONes-WILSON', 'Robert-John Smith-Jones-Wilson'],
+    ])('%s convertToTitleCase(%s, %s)', (_inputType: string | null, input: string | null, expectedOutput: string) => {
+      expect(convertToTitleCase(input)).toEqual(expectedOutput)
+    })
   })
-})
 
-describe('initialiseName', () => {
-  it.each([
-    [undefined, undefined, null],
-    ['Empty string', '', null],
-    ['One word', 'robert', 'r. robert'],
-    ['Two words', 'Robert James', 'R. James'],
-    ['Three words', 'Robert James Smith', 'R. Smith'],
-    ['Double barrelled', 'Robert-John Smith-Jones-Wilson', 'R. Smith-Jones-Wilson'],
-  ])(
-    '%s initialiseName(%s, %s)',
-    (_inputType: string | undefined, input: string | undefined, expectedOutput: string | null) => {
-      expect(initialiseName(input)).toEqual(expectedOutput)
-    },
-  )
-})
+  describe('initialiseName', () => {
+    it.each([
+      [undefined, undefined, null],
+      ['Empty string', '', null],
+      ['One word', 'robert', 'r. robert'],
+      ['Two words', 'Robert James', 'R. James'],
+      ['Three words', 'Robert James Smith', 'R. Smith'],
+      ['Double barrelled', 'Robert-John Smith-Jones-Wilson', 'R. Smith-Jones-Wilson'],
+    ])(
+      '%s initialiseName(%s, %s)',
+      (_inputType: string | undefined, input: string | undefined, expectedOutput: string | null) => {
+        expect(initialiseName(input)).toEqual(expectedOutput)
+      },
+    )
+  })
 
-describe('intitialiseTitle', () => {
-  it.each([
-    ['One word', 'Lime', 'L'],
-    ['Two words', 'Lime Course', 'LC'],
-    ['Hyphenated word', 'Lime-course', 'L'],
-    ['Mixed case word', 'LimeCourse', 'L'],
-  ])('%s initialiseTitle(%s, %s)', (_inputType: string, input: string, expectedOutput: string) => {
-    expect(initialiseTitle(input)).toEqual(expectedOutput)
+  describe('intitialiseTitle', () => {
+    it.each([
+      ['One word', 'Lime', 'L'],
+      ['Two words', 'Lime Course', 'LC'],
+      ['Hyphenated word', 'Lime-course', 'L'],
+      ['Mixed case word', 'LimeCourse', 'L'],
+    ])('%s initialiseTitle(%s, %s)', (_inputType: string, input: string, expectedOutput: string) => {
+      expect(initialiseTitle(input)).toEqual(expectedOutput)
+    })
   })
 })

--- a/server/utils/utils.test.ts
+++ b/server/utils/utils.test.ts
@@ -1,4 +1,4 @@
-import { convertToTitleCase, initialiseName } from './utils'
+import { convertToTitleCase, initialiseName, initialiseTitle } from './utils'
 
 describe('convert to title case', () => {
   it.each([
@@ -30,4 +30,15 @@ describe('initialise name', () => {
       expect(initialiseName(input)).toEqual(expectedOutput)
     },
   )
+})
+
+describe('intitialiseTitle', () => {
+  it.each([
+    ['One word', 'Lime', 'L'],
+    ['Two words', 'Lime Course', 'LC'],
+    ['Hyphenated word', 'Lime-course', 'L'],
+    ['Mixed case word', 'LimeCourse', 'L'],
+  ])('%s initialiseTitle(%s, %s)', (_inputType: string, input: string, expectedOutput: string) => {
+    expect(initialiseTitle(input)).toEqual(expectedOutput)
+  })
 })

--- a/server/utils/utils.ts
+++ b/server/utils/utils.ts
@@ -22,4 +22,11 @@ const initialiseName = (fullName?: string): string | null => {
   return `${array[0][0]}. ${array.reverse()[0]}`
 }
 
-export { convertToTitleCase, initialiseName }
+const initialiseTitle = (sentence: string): string => {
+  return sentence
+    .split(' ')
+    .map(word => word[0].toUpperCase())
+    .join('')
+}
+
+export { convertToTitleCase, initialiseName, initialiseTitle }

--- a/server/views/courses/_indexCourseSummary.njk
+++ b/server/views/courses/_indexCourseSummary.njk
@@ -7,7 +7,7 @@
     <div class="govuk-grid-column-two-thirds" role="listitem">
 
       <h2 class="govuk-heading-m">
-        <a class="govuk-link" href="/programmes/{{ course.id }}">{{ course.name }}</a>
+        <a class="govuk-link" href="/programmes/{{ course.id }}">{{ course.nameAndAlternateName }}</a>
       </h2>
 
       {{ audienceTags(course.audienceTags) }}

--- a/wiremock/stubs/courses.json
+++ b/wiremock/stubs/courses.json
@@ -2,6 +2,7 @@
   {
     "id": "654520cc-e109-4f31-81a6-1fc6bc9078b3",
     "name": "Becoming New Me Plus",
+    "alternateName": "BNM+",
     "description": "Becoming New Me Plus (BNM+) is a programme...",
     "audiences": [
       {
@@ -35,6 +36,7 @@
   {
     "id": "e4e5e559-739c-4b20-a40f-97d48a4081cb",
     "name": "Becoming New Me Plus",
+    "alternateName": "BNM+",
     "description": "Becoming New Me Plus (BNM+) is a programme...",
     "audiences": [
       {
@@ -63,7 +65,8 @@
   },
   {
     "id": "986d6256-5e2c-4792-b93a-568d923cf50c",
-    "name": "Building Better Relationships (BBR)",
+    "name": "Building Better Relationships",
+    "alternateName": "BBR",
     "description": "BBR is a programme...",
     "audiences": [
       {
@@ -92,7 +95,8 @@
   },
   {
     "id": "4a1630b7-3280-49b4-b559-53d110b3c27b",
-    "name": "Healthy Identity Intervention (HII)",
+    "name": "Healthy Identity Intervention",
+    "alternateName": "HII",
     "description": "HII is a programme...",
     "audiences": [
       {
@@ -121,7 +125,8 @@
   },
   {
     "id": "197e62b4-4d34-4d30-a51f-e6427100c6c4",
-    "name": "Healthy Sex Programme (HSP)",
+    "name": "Healthy Sex Programme",
+    "alternateName": "HSP",
     "description": "HSP is a programme...",
     "audiences": [
       {


### PR DESCRIPTION
## Context

We want to display an initialised form of course names alongside the course name

## Changes in this PR

This adds `alternateName` to courses and inserts it in the UI

## Screenshots of UI changes

### Before

Note: this does show the initialised forms on the second and third courses, because they were in the `name` in our stubs (removed in this PR), whereas in the screenshot below, they are pulled from `alternateName`

![image](https://github.com/ministryofjustice/hmpps-accredited-programmes-ui/assets/40244233/24fa30c8-fc25-49a5-8c22-93dc3600f2f5)

### After

![image](https://github.com/ministryofjustice/hmpps-accredited-programmes-ui/assets/40244233/dd23f202-5d2f-4de7-9160-54a9f00bfcdf)

## Post-merge checklist

- [x] This adds, extends or meaningfully modifies a feature...
  - [ ] ... and I have written or updated an end-to-end test for the happy path in the [Accredited Programmes E2E repo](https://github.com/ministryofjustice/hmpps-accredited-programmes-e2e)
- [x] This makes new expectations of the API...
  - [ ] ... and I have notified the API developer(s) of changes to the contract tests (Pact), or the API is already compliant
