### PR TITLE
[cancelled] Spike paginated courses

### DIFF
--- a/server/@types/ui/index.d.ts
+++ b/server/@types/ui/index.d.ts
@@ -44,6 +44,12 @@ type OrganisationWithOfferingEmailPresenter = Organisation & {
   summaryListRows: OrganisationWithOfferingEmailSummaryListRows
 }
 
+type PaginatedArray<T> = {
+  page: number
+  totalItems: number
+  items: Array<T>
+}
+
 export type {
   CoursePresenter,
   ObjectWithHtmlString,
@@ -51,6 +57,7 @@ export type {
   OrganisationWithOfferingEmailPresenter,
   OrganisationWithOfferingEmailSummaryListRows,
   OrganisationWithOfferingId,
+  PaginatedArray,
   SummaryListRow,
   TableRow,
   Tag,

--- a/server/@types/ui/index.d.ts
+++ b/server/@types/ui/index.d.ts
@@ -48,6 +48,7 @@ type PaginatedArray<T> = {
   page: number
   totalItems: number
   items: Array<T>
+  mojPaginationConfig: object
 }
 
 export type {

--- a/server/controllers/find/coursesController.ts
+++ b/server/controllers/find/coursesController.ts
@@ -19,7 +19,8 @@ export default class CoursesController {
 
       const courses = await this.courseService.getCourses(req.user.token)
       const coursePresenters = courses.map(course => presentCourse(course))
-      const paginatedCourses = paginatedArray(coursePresenters)
+      const page = parseInt(req.query.page as string, 10) || 1
+      const paginatedCourses = paginatedArray(coursePresenters, page)
 
       res.render('courses/index', {
         pageHeading: 'List of accredited programmes',

--- a/server/controllers/find/coursesController.ts
+++ b/server/controllers/find/coursesController.ts
@@ -4,6 +4,7 @@ import type { CourseService, OrganisationService } from '../../services'
 import presentCourse from '../../utils/courseUtils'
 import { organisationTableRows } from '../../utils/organisationUtils'
 import { assertHasUser, isNotNull } from '../../utils/typeUtils'
+import { paginatedArray } from '../../utils/utils'
 import type { CourseOffering, Organisation } from '@accredited-programmes/models'
 
 export default class CoursesController {
@@ -17,10 +18,12 @@ export default class CoursesController {
       assertHasUser(req)
 
       const courses = await this.courseService.getCourses(req.user.token)
+      const coursePresenters = courses.map(course => presentCourse(course))
+      const paginatedCourses = paginatedArray(coursePresenters)
 
       res.render('courses/index', {
         pageHeading: 'List of accredited programmes',
-        courses: courses.map(course => presentCourse(course)),
+        paginatedCourses,
       })
     }
   }

--- a/server/utils/pathUtils.ts
+++ b/server/utils/pathUtils.ts
@@ -1,0 +1,17 @@
+const pathWithQuery = (path: string, query: { [key: string]: string | number }) => {
+  const queryString = Object.entries(query).reduce((accumulator, [key, value], entryIndex) => {
+    let newString = accumulator
+
+    if (entryIndex > 0) {
+      newString += '&'
+    }
+
+    newString += `${key}=${value}`
+
+    return newString
+  }, '?')
+
+  return path + queryString
+}
+
+export default pathWithQuery

--- a/server/utils/utils.ts
+++ b/server/utils/utils.ts
@@ -66,7 +66,12 @@ const paginatedArray = <T>(items: Array<T>, currentPage = 1): PaginatedArray<T> 
     mojPaginationConfigItems.push(item)
   })
 
-  const mojPaginationConfig = {
+  const mojPaginationConfig: {
+    items: Array<MojPaginationConfigItem>
+    results: object
+    previous?: object
+    next?: object
+  } = {
     items: mojPaginationConfigItems,
     results: {
       count: totalItems,
@@ -74,6 +79,20 @@ const paginatedArray = <T>(items: Array<T>, currentPage = 1): PaginatedArray<T> 
       to: Math.min(currentPage * perPage, totalItems),
       text: 'courses',
     },
+  }
+
+  if (currentPage > 1) {
+    mojPaginationConfig.previous = {
+      text: 'Previous',
+      href: pathWithQuery(coursesPath, { page: currentPage - 1 }),
+    }
+  }
+
+  if (currentPage < totalPages) {
+    mojPaginationConfig.next = {
+      text: 'Next',
+      href: pathWithQuery(coursesPath, { page: currentPage + 1 }),
+    }
   }
 
   return {

--- a/server/utils/utils.ts
+++ b/server/utils/utils.ts
@@ -1,3 +1,5 @@
+import type { PaginatedArray } from '@accredited-programmes/ui'
+
 const properCase = (word: string): string =>
   word.length >= 1 ? word[0].toUpperCase() + word.toLowerCase().slice(1) : word
 
@@ -29,4 +31,16 @@ const initialiseTitle = (sentence: string): string => {
     .join('')
 }
 
-export { convertToTitleCase, initialiseName, initialiseTitle }
+const paginatedArray = <T>(items: Array<T>, page = 1): PaginatedArray<T> => {
+  const totalItems = items.length
+  const perPage = 10
+  const startIndex = perPage * (page - 1)
+
+  return {
+    page,
+    totalItems,
+    items: items.slice(startIndex, startIndex + perPage),
+  }
+}
+
+export { convertToTitleCase, initialiseName, initialiseTitle, paginatedArray }

--- a/server/views/courses/index.njk
+++ b/server/views/courses/index.njk
@@ -9,7 +9,7 @@
   <h1 class="govuk-heading-l">{{ pageHeading }}</h1>
 
   <div role="list">
-    {% for course in courses %}
+    {% for course in paginatedCourses.items %}
       {{ indexCourseSummary(course) }}
 
       {% if loop.index < courses.length %}
@@ -19,4 +19,9 @@
       {% endif %}
     {% endfor %}
   </div>
+
+  <p>
+    Page: {{ paginatedCourses.page }}<br>
+    Total courses: {{ paginatedCourses.totalItems }}
+  </p>
 {% endblock content %}

--- a/server/views/courses/index.njk
+++ b/server/views/courses/index.njk
@@ -1,3 +1,5 @@
+{% from "moj/components/pagination/macro.njk" import mojPagination %}
+
 {% from "./_indexCourseSummary.njk" import indexCourseSummary %}
 
 {% extends "../partials/layout.njk" %}
@@ -20,8 +22,5 @@
     {% endfor %}
   </div>
 
-  <p>
-    Page: {{ paginatedCourses.page }}<br>
-    Total courses: {{ paginatedCourses.totalItems }}
-  </p>
+  {{ mojPagination(paginatedCourses.mojPaginationConfig) }}
 {% endblock content %}

--- a/wiremock/stubs/courses.json
+++ b/wiremock/stubs/courses.json
@@ -1,7 +1,7 @@
 [
   {
     "id": "654520cc-e109-4f31-81a6-1fc6bc9078b3",
-    "name": "Becoming New Me Plus",
+    "name": "1: Becoming New Me Plus",
     "alternateName": "BNM+",
     "description": "Becoming New Me Plus (BNM+) is a programme...",
     "audiences": [
@@ -35,7 +35,7 @@
   },
   {
     "id": "e4e5e559-739c-4b20-a40f-97d48a4081cb",
-    "name": "Becoming New Me Plus",
+    "name": "1: Becoming New Me Plus",
     "alternateName": "BNM+",
     "description": "Becoming New Me Plus (BNM+) is a programme...",
     "audiences": [
@@ -65,7 +65,7 @@
   },
   {
     "id": "986d6256-5e2c-4792-b93a-568d923cf50c",
-    "name": "Building Better Relationships",
+    "name": "1: Building Better Relationships",
     "alternateName": "BBR",
     "description": "BBR is a programme...",
     "audiences": [
@@ -95,7 +95,7 @@
   },
   {
     "id": "4a1630b7-3280-49b4-b559-53d110b3c27b",
-    "name": "Healthy Identity Intervention",
+    "name": "1: Healthy Identity Intervention",
     "alternateName": "HII",
     "description": "HII is a programme...",
     "audiences": [
@@ -125,7 +125,7 @@
   },
   {
     "id": "197e62b4-4d34-4d30-a51f-e6427100c6c4",
-    "name": "Healthy Sex Programme",
+    "name": "1: Healthy Sex Programme",
     "alternateName": "HSP",
     "description": "HSP is a programme...",
     "audiences": [
@@ -155,7 +155,8 @@
   },
   {
     "id": "654520cc-e109-4f31-81a6-1fc6bc9078b3",
-    "name": "Becoming New Me Plus",
+    "name": "2: Becoming New Me Plus",
+    "alternateName": "BNM+",
     "description": "Becoming New Me Plus (BNM+) is a programme...",
     "audiences": [
       {
@@ -188,7 +189,8 @@
   },
   {
     "id": "e4e5e559-739c-4b20-a40f-97d48a4081cb",
-    "name": "Becoming New Me Plus",
+    "name": "2: Becoming New Me Plus",
+    "alternateName": "BNM+",
     "description": "Becoming New Me Plus (BNM+) is a programme...",
     "audiences": [
       {
@@ -217,7 +219,8 @@
   },
   {
     "id": "986d6256-5e2c-4792-b93a-568d923cf50c",
-    "name": "Building Better Relationships (BBR)",
+    "name": "2: Building Better Relationships",
+    "alternateName": "BBR",
     "description": "BBR is a programme...",
     "audiences": [
       {
@@ -246,7 +249,8 @@
   },
   {
     "id": "4a1630b7-3280-49b4-b559-53d110b3c27b",
-    "name": "Healthy Identity Intervention (HII)",
+    "name": "2: Healthy Identity Intervention",
+    "alternateName": "HII",
     "description": "HII is a programme...",
     "audiences": [
       {
@@ -275,7 +279,8 @@
   },
   {
     "id": "197e62b4-4d34-4d30-a51f-e6427100c6c4",
-    "name": "Healthy Sex Programme (HSP)",
+    "name": "2: Healthy Sex Programme",
+    "alternateName": "HSP",
     "description": "HSP is a programme...",
     "audiences": [
       {
@@ -304,7 +309,8 @@
   },
   {
     "id": "654520cc-e109-4f31-81a6-1fc6bc9078b3",
-    "name": "Becoming New Me Plus",
+    "name": "3: Becoming New Me Plus",
+    "alternateName": "BNM+",
     "description": "Becoming New Me Plus (BNM+) is a programme...",
     "audiences": [
       {
@@ -337,7 +343,8 @@
   },
   {
     "id": "e4e5e559-739c-4b20-a40f-97d48a4081cb",
-    "name": "Becoming New Me Plus",
+    "name": "3: Becoming New Me Plus",
+    "alternateName": "BNM+",
     "description": "Becoming New Me Plus (BNM+) is a programme...",
     "audiences": [
       {
@@ -366,7 +373,8 @@
   },
   {
     "id": "986d6256-5e2c-4792-b93a-568d923cf50c",
-    "name": "Building Better Relationships (BBR)",
+    "name": "3: Building Better Relationships",
+    "alternateName": "BBR",
     "description": "BBR is a programme...",
     "audiences": [
       {
@@ -395,7 +403,8 @@
   },
   {
     "id": "4a1630b7-3280-49b4-b559-53d110b3c27b",
-    "name": "Healthy Identity Intervention (HII)",
+    "name": "3: Healthy Identity Intervention",
+    "alternateName": "HII",
     "description": "HII is a programme...",
     "audiences": [
       {
@@ -424,7 +433,8 @@
   },
   {
     "id": "197e62b4-4d34-4d30-a51f-e6427100c6c4",
-    "name": "Healthy Sex Programme (HSP)",
+    "name": "3: Healthy Sex Programme",
+    "alternateName": "HSP",
     "description": "HSP is a programme...",
     "audiences": [
       {
@@ -453,7 +463,8 @@
   },
   {
     "id": "654520cc-e109-4f31-81a6-1fc6bc9078b3",
-    "name": "Becoming New Me Plus",
+    "name": "4: Becoming New Me Plus",
+    "alternateName": "BNM+",
     "description": "Becoming New Me Plus (BNM+) is a programme...",
     "audiences": [
       {
@@ -486,7 +497,8 @@
   },
   {
     "id": "e4e5e559-739c-4b20-a40f-97d48a4081cb",
-    "name": "Becoming New Me Plus",
+    "name": "4: Becoming New Me Plus",
+    "alternateName": "BNM+",
     "description": "Becoming New Me Plus (BNM+) is a programme...",
     "audiences": [
       {
@@ -515,7 +527,8 @@
   },
   {
     "id": "986d6256-5e2c-4792-b93a-568d923cf50c",
-    "name": "Building Better Relationships (BBR)",
+    "name": "4: Building Better Relationships",
+    "alternateName": "BBR",
     "description": "BBR is a programme...",
     "audiences": [
       {
@@ -544,7 +557,8 @@
   },
   {
     "id": "4a1630b7-3280-49b4-b559-53d110b3c27b",
-    "name": "Healthy Identity Intervention (HII)",
+    "name": "4: Healthy Identity Intervention",
+    "alternateName": "HII",
     "description": "HII is a programme...",
     "audiences": [
       {
@@ -573,7 +587,8 @@
   },
   {
     "id": "197e62b4-4d34-4d30-a51f-e6427100c6c4",
-    "name": "Healthy Sex Programme (HSP)",
+    "name": "4: Healthy Sex Programme",
+    "alternateName": "HSP",
     "description": "HSP is a programme...",
     "audiences": [
       {
@@ -602,7 +617,8 @@
   },
   {
     "id": "654520cc-e109-4f31-81a6-1fc6bc9078b3",
-    "name": "Becoming New Me Plus",
+    "name": "5: Becoming New Me Plus",
+    "alternateName": "BNM+",
     "description": "Becoming New Me Plus (BNM+) is a programme...",
     "audiences": [
       {
@@ -635,7 +651,8 @@
   },
   {
     "id": "e4e5e559-739c-4b20-a40f-97d48a4081cb",
-    "name": "Becoming New Me Plus",
+    "name": "5: Becoming New Me Plus",
+    "alternateName": "BNM+",
     "description": "Becoming New Me Plus (BNM+) is a programme...",
     "audiences": [
       {
@@ -664,7 +681,8 @@
   },
   {
     "id": "986d6256-5e2c-4792-b93a-568d923cf50c",
-    "name": "Building Better Relationships (BBR)",
+    "name": "5: Building Better Relationships",
+    "alternateName": "BBR",
     "description": "BBR is a programme...",
     "audiences": [
       {
@@ -693,7 +711,8 @@
   },
   {
     "id": "4a1630b7-3280-49b4-b559-53d110b3c27b",
-    "name": "Healthy Identity Intervention (HII)",
+    "name": "5: Healthy Identity Intervention",
+    "alternateName": "HII",
     "description": "HII is a programme...",
     "audiences": [
       {
@@ -722,7 +741,8 @@
   },
   {
     "id": "197e62b4-4d34-4d30-a51f-e6427100c6c4",
-    "name": "Healthy Sex Programme (HSP)",
+    "name": "5: Healthy Sex Programme",
+    "alternateName": "HSP",
     "description": "HSP is a programme...",
     "audiences": [
       {

--- a/wiremock/stubs/courses.json
+++ b/wiremock/stubs/courses.json
@@ -152,5 +152,601 @@
         "description": "Example setting"
       }
     ]
+  },
+  {
+    "id": "654520cc-e109-4f31-81a6-1fc6bc9078b3",
+    "name": "Becoming New Me Plus",
+    "description": "Becoming New Me Plus (BNM+) is a programme...",
+    "audiences": [
+      {
+        "id": "5a5e5870-1e0f-43ed-840a-fd53d973865f",
+        "value": "Intimate partner violence"
+      },
+      {
+        "id": "5eb2d80c-d08a-4930-b391-0c5166a8ee03",
+        "value": "General violence"
+      }
+    ],
+    "coursePrerequisites": [
+      {
+        "name": "Gender",
+        "description": "Example gender"
+      },
+      {
+        "name": "Learning needs",
+        "description": "Example learning needs"
+      },
+      {
+        "name": "Risk criteria",
+        "description": "Example risk criteria"
+      },
+      {
+        "name": "Setting",
+        "description": "Example setting"
+      }
+    ]
+  },
+  {
+    "id": "e4e5e559-739c-4b20-a40f-97d48a4081cb",
+    "name": "Becoming New Me Plus",
+    "description": "Becoming New Me Plus (BNM+) is a programme...",
+    "audiences": [
+      {
+        "id": "9adb316f-caab-4f92-ad22-87d3c2bb5c43",
+        "value": "Sexual offence"
+      }
+    ],
+    "coursePrerequisites": [
+      {
+        "name": "Gender",
+        "description": "Example gender"
+      },
+      {
+        "name": "Learning needs",
+        "description": "Example learning needs"
+      },
+      {
+        "name": "Risk criteria",
+        "description": "Example risk criteria"
+      },
+      {
+        "name": "Setting",
+        "description": "Example setting"
+      }
+    ]
+  },
+  {
+    "id": "986d6256-5e2c-4792-b93a-568d923cf50c",
+    "name": "Building Better Relationships (BBR)",
+    "description": "BBR is a programme...",
+    "audiences": [
+      {
+        "id": "782cd9ff-7339-4c0c-8b85-5409ff4d6061",
+        "value": "Intimate partner violence"
+      }
+    ],
+    "coursePrerequisites": [
+      {
+        "name": "Gender",
+        "description": "Example gender"
+      },
+      {
+        "name": "Learning needs",
+        "description": "Example learning needs"
+      },
+      {
+        "name": "Risk criteria",
+        "description": "Example risk criteria"
+      },
+      {
+        "name": "Setting",
+        "description": "Example setting"
+      }
+    ]
+  },
+  {
+    "id": "4a1630b7-3280-49b4-b559-53d110b3c27b",
+    "name": "Healthy Identity Intervention (HII)",
+    "description": "HII is a programme...",
+    "audiences": [
+      {
+        "id": "9d7acd40-4b84-4c9b-b55c-a616ed038ed5",
+        "value": "Extremism"
+      }
+    ],
+    "coursePrerequisites": [
+      {
+        "name": "Gender",
+        "description": "Example gender"
+      },
+      {
+        "name": "Learning needs",
+        "description": "Example learning needs"
+      },
+      {
+        "name": "Risk criteria",
+        "description": "Example risk criteria"
+      },
+      {
+        "name": "Setting",
+        "description": "Example setting"
+      }
+    ]
+  },
+  {
+    "id": "197e62b4-4d34-4d30-a51f-e6427100c6c4",
+    "name": "Healthy Sex Programme (HSP)",
+    "description": "HSP is a programme...",
+    "audiences": [
+      {
+        "id": "005a4cf6-749b-4ac2-9a2d-dd0024c0d34a",
+        "value": "Sexual offence"
+      }
+    ],
+    "coursePrerequisites": [
+      {
+        "name": "Gender",
+        "description": "Example gender"
+      },
+      {
+        "name": "Learning needs",
+        "description": "Example learning needs"
+      },
+      {
+        "name": "Risk criteria",
+        "description": "Example risk criteria"
+      },
+      {
+        "name": "Setting",
+        "description": "Example setting"
+      }
+    ]
+  },
+  {
+    "id": "654520cc-e109-4f31-81a6-1fc6bc9078b3",
+    "name": "Becoming New Me Plus",
+    "description": "Becoming New Me Plus (BNM+) is a programme...",
+    "audiences": [
+      {
+        "id": "5a5e5870-1e0f-43ed-840a-fd53d973865f",
+        "value": "Intimate partner violence"
+      },
+      {
+        "id": "5eb2d80c-d08a-4930-b391-0c5166a8ee03",
+        "value": "General violence"
+      }
+    ],
+    "coursePrerequisites": [
+      {
+        "name": "Gender",
+        "description": "Example gender"
+      },
+      {
+        "name": "Learning needs",
+        "description": "Example learning needs"
+      },
+      {
+        "name": "Risk criteria",
+        "description": "Example risk criteria"
+      },
+      {
+        "name": "Setting",
+        "description": "Example setting"
+      }
+    ]
+  },
+  {
+    "id": "e4e5e559-739c-4b20-a40f-97d48a4081cb",
+    "name": "Becoming New Me Plus",
+    "description": "Becoming New Me Plus (BNM+) is a programme...",
+    "audiences": [
+      {
+        "id": "9adb316f-caab-4f92-ad22-87d3c2bb5c43",
+        "value": "Sexual offence"
+      }
+    ],
+    "coursePrerequisites": [
+      {
+        "name": "Gender",
+        "description": "Example gender"
+      },
+      {
+        "name": "Learning needs",
+        "description": "Example learning needs"
+      },
+      {
+        "name": "Risk criteria",
+        "description": "Example risk criteria"
+      },
+      {
+        "name": "Setting",
+        "description": "Example setting"
+      }
+    ]
+  },
+  {
+    "id": "986d6256-5e2c-4792-b93a-568d923cf50c",
+    "name": "Building Better Relationships (BBR)",
+    "description": "BBR is a programme...",
+    "audiences": [
+      {
+        "id": "782cd9ff-7339-4c0c-8b85-5409ff4d6061",
+        "value": "Intimate partner violence"
+      }
+    ],
+    "coursePrerequisites": [
+      {
+        "name": "Gender",
+        "description": "Example gender"
+      },
+      {
+        "name": "Learning needs",
+        "description": "Example learning needs"
+      },
+      {
+        "name": "Risk criteria",
+        "description": "Example risk criteria"
+      },
+      {
+        "name": "Setting",
+        "description": "Example setting"
+      }
+    ]
+  },
+  {
+    "id": "4a1630b7-3280-49b4-b559-53d110b3c27b",
+    "name": "Healthy Identity Intervention (HII)",
+    "description": "HII is a programme...",
+    "audiences": [
+      {
+        "id": "9d7acd40-4b84-4c9b-b55c-a616ed038ed5",
+        "value": "Extremism"
+      }
+    ],
+    "coursePrerequisites": [
+      {
+        "name": "Gender",
+        "description": "Example gender"
+      },
+      {
+        "name": "Learning needs",
+        "description": "Example learning needs"
+      },
+      {
+        "name": "Risk criteria",
+        "description": "Example risk criteria"
+      },
+      {
+        "name": "Setting",
+        "description": "Example setting"
+      }
+    ]
+  },
+  {
+    "id": "197e62b4-4d34-4d30-a51f-e6427100c6c4",
+    "name": "Healthy Sex Programme (HSP)",
+    "description": "HSP is a programme...",
+    "audiences": [
+      {
+        "id": "005a4cf6-749b-4ac2-9a2d-dd0024c0d34a",
+        "value": "Sexual offence"
+      }
+    ],
+    "coursePrerequisites": [
+      {
+        "name": "Gender",
+        "description": "Example gender"
+      },
+      {
+        "name": "Learning needs",
+        "description": "Example learning needs"
+      },
+      {
+        "name": "Risk criteria",
+        "description": "Example risk criteria"
+      },
+      {
+        "name": "Setting",
+        "description": "Example setting"
+      }
+    ]
+  },
+  {
+    "id": "654520cc-e109-4f31-81a6-1fc6bc9078b3",
+    "name": "Becoming New Me Plus",
+    "description": "Becoming New Me Plus (BNM+) is a programme...",
+    "audiences": [
+      {
+        "id": "5a5e5870-1e0f-43ed-840a-fd53d973865f",
+        "value": "Intimate partner violence"
+      },
+      {
+        "id": "5eb2d80c-d08a-4930-b391-0c5166a8ee03",
+        "value": "General violence"
+      }
+    ],
+    "coursePrerequisites": [
+      {
+        "name": "Gender",
+        "description": "Example gender"
+      },
+      {
+        "name": "Learning needs",
+        "description": "Example learning needs"
+      },
+      {
+        "name": "Risk criteria",
+        "description": "Example risk criteria"
+      },
+      {
+        "name": "Setting",
+        "description": "Example setting"
+      }
+    ]
+  },
+  {
+    "id": "e4e5e559-739c-4b20-a40f-97d48a4081cb",
+    "name": "Becoming New Me Plus",
+    "description": "Becoming New Me Plus (BNM+) is a programme...",
+    "audiences": [
+      {
+        "id": "9adb316f-caab-4f92-ad22-87d3c2bb5c43",
+        "value": "Sexual offence"
+      }
+    ],
+    "coursePrerequisites": [
+      {
+        "name": "Gender",
+        "description": "Example gender"
+      },
+      {
+        "name": "Learning needs",
+        "description": "Example learning needs"
+      },
+      {
+        "name": "Risk criteria",
+        "description": "Example risk criteria"
+      },
+      {
+        "name": "Setting",
+        "description": "Example setting"
+      }
+    ]
+  },
+  {
+    "id": "986d6256-5e2c-4792-b93a-568d923cf50c",
+    "name": "Building Better Relationships (BBR)",
+    "description": "BBR is a programme...",
+    "audiences": [
+      {
+        "id": "782cd9ff-7339-4c0c-8b85-5409ff4d6061",
+        "value": "Intimate partner violence"
+      }
+    ],
+    "coursePrerequisites": [
+      {
+        "name": "Gender",
+        "description": "Example gender"
+      },
+      {
+        "name": "Learning needs",
+        "description": "Example learning needs"
+      },
+      {
+        "name": "Risk criteria",
+        "description": "Example risk criteria"
+      },
+      {
+        "name": "Setting",
+        "description": "Example setting"
+      }
+    ]
+  },
+  {
+    "id": "4a1630b7-3280-49b4-b559-53d110b3c27b",
+    "name": "Healthy Identity Intervention (HII)",
+    "description": "HII is a programme...",
+    "audiences": [
+      {
+        "id": "9d7acd40-4b84-4c9b-b55c-a616ed038ed5",
+        "value": "Extremism"
+      }
+    ],
+    "coursePrerequisites": [
+      {
+        "name": "Gender",
+        "description": "Example gender"
+      },
+      {
+        "name": "Learning needs",
+        "description": "Example learning needs"
+      },
+      {
+        "name": "Risk criteria",
+        "description": "Example risk criteria"
+      },
+      {
+        "name": "Setting",
+        "description": "Example setting"
+      }
+    ]
+  },
+  {
+    "id": "197e62b4-4d34-4d30-a51f-e6427100c6c4",
+    "name": "Healthy Sex Programme (HSP)",
+    "description": "HSP is a programme...",
+    "audiences": [
+      {
+        "id": "005a4cf6-749b-4ac2-9a2d-dd0024c0d34a",
+        "value": "Sexual offence"
+      }
+    ],
+    "coursePrerequisites": [
+      {
+        "name": "Gender",
+        "description": "Example gender"
+      },
+      {
+        "name": "Learning needs",
+        "description": "Example learning needs"
+      },
+      {
+        "name": "Risk criteria",
+        "description": "Example risk criteria"
+      },
+      {
+        "name": "Setting",
+        "description": "Example setting"
+      }
+    ]
+  },
+  {
+    "id": "654520cc-e109-4f31-81a6-1fc6bc9078b3",
+    "name": "Becoming New Me Plus",
+    "description": "Becoming New Me Plus (BNM+) is a programme...",
+    "audiences": [
+      {
+        "id": "5a5e5870-1e0f-43ed-840a-fd53d973865f",
+        "value": "Intimate partner violence"
+      },
+      {
+        "id": "5eb2d80c-d08a-4930-b391-0c5166a8ee03",
+        "value": "General violence"
+      }
+    ],
+    "coursePrerequisites": [
+      {
+        "name": "Gender",
+        "description": "Example gender"
+      },
+      {
+        "name": "Learning needs",
+        "description": "Example learning needs"
+      },
+      {
+        "name": "Risk criteria",
+        "description": "Example risk criteria"
+      },
+      {
+        "name": "Setting",
+        "description": "Example setting"
+      }
+    ]
+  },
+  {
+    "id": "e4e5e559-739c-4b20-a40f-97d48a4081cb",
+    "name": "Becoming New Me Plus",
+    "description": "Becoming New Me Plus (BNM+) is a programme...",
+    "audiences": [
+      {
+        "id": "9adb316f-caab-4f92-ad22-87d3c2bb5c43",
+        "value": "Sexual offence"
+      }
+    ],
+    "coursePrerequisites": [
+      {
+        "name": "Gender",
+        "description": "Example gender"
+      },
+      {
+        "name": "Learning needs",
+        "description": "Example learning needs"
+      },
+      {
+        "name": "Risk criteria",
+        "description": "Example risk criteria"
+      },
+      {
+        "name": "Setting",
+        "description": "Example setting"
+      }
+    ]
+  },
+  {
+    "id": "986d6256-5e2c-4792-b93a-568d923cf50c",
+    "name": "Building Better Relationships (BBR)",
+    "description": "BBR is a programme...",
+    "audiences": [
+      {
+        "id": "782cd9ff-7339-4c0c-8b85-5409ff4d6061",
+        "value": "Intimate partner violence"
+      }
+    ],
+    "coursePrerequisites": [
+      {
+        "name": "Gender",
+        "description": "Example gender"
+      },
+      {
+        "name": "Learning needs",
+        "description": "Example learning needs"
+      },
+      {
+        "name": "Risk criteria",
+        "description": "Example risk criteria"
+      },
+      {
+        "name": "Setting",
+        "description": "Example setting"
+      }
+    ]
+  },
+  {
+    "id": "4a1630b7-3280-49b4-b559-53d110b3c27b",
+    "name": "Healthy Identity Intervention (HII)",
+    "description": "HII is a programme...",
+    "audiences": [
+      {
+        "id": "9d7acd40-4b84-4c9b-b55c-a616ed038ed5",
+        "value": "Extremism"
+      }
+    ],
+    "coursePrerequisites": [
+      {
+        "name": "Gender",
+        "description": "Example gender"
+      },
+      {
+        "name": "Learning needs",
+        "description": "Example learning needs"
+      },
+      {
+        "name": "Risk criteria",
+        "description": "Example risk criteria"
+      },
+      {
+        "name": "Setting",
+        "description": "Example setting"
+      }
+    ]
+  },
+  {
+    "id": "197e62b4-4d34-4d30-a51f-e6427100c6c4",
+    "name": "Healthy Sex Programme (HSP)",
+    "description": "HSP is a programme...",
+    "audiences": [
+      {
+        "id": "005a4cf6-749b-4ac2-9a2d-dd0024c0d34a",
+        "value": "Sexual offence"
+      }
+    ],
+    "coursePrerequisites": [
+      {
+        "name": "Gender",
+        "description": "Example gender"
+      },
+      {
+        "name": "Learning needs",
+        "description": "Example learning needs"
+      },
+      {
+        "name": "Risk criteria",
+        "description": "Example risk criteria"
+      },
+      {
+        "name": "Setting",
+        "description": "Example setting"
+      }
+    ]
   }
 ]

--- a/wiremock/stubs/courses.json
+++ b/wiremock/stubs/courses.json
@@ -768,5 +768,1391 @@
         "description": "Example setting"
       }
     ]
+  },
+  {
+    "id": "654520cc-e109-4f31-81a6-1fc6bc9078b3",
+    "name": "6: Becoming New Me Plus",
+    "alternateName": "BNM+",
+    "description": "Becoming New Me Plus (BNM+) is a programme...",
+    "audiences": [
+      {
+        "id": "5a5e5870-1e0f-43ed-840a-fd53d973865f",
+        "value": "Intimate partner violence"
+      },
+      {
+        "id": "5eb2d80c-d08a-4930-b391-0c5166a8ee03",
+        "value": "General violence"
+      }
+    ],
+    "coursePrerequisites": [
+      {
+        "name": "Gender",
+        "description": "Example gender"
+      },
+      {
+        "name": "Learning needs",
+        "description": "Example learning needs"
+      },
+      {
+        "name": "Risk criteria",
+        "description": "Example risk criteria"
+      },
+      {
+        "name": "Setting",
+        "description": "Example setting"
+      }
+    ]
+  },
+  {
+    "id": "e4e5e559-739c-4b20-a40f-97d48a4081cb",
+    "name": "6: Becoming New Me Plus",
+    "alternateName": "BNM+",
+    "description": "Becoming New Me Plus (BNM+) is a programme...",
+    "audiences": [
+      {
+        "id": "9adb316f-caab-4f92-ad22-87d3c2bb5c43",
+        "value": "Sexual offence"
+      }
+    ],
+    "coursePrerequisites": [
+      {
+        "name": "Gender",
+        "description": "Example gender"
+      },
+      {
+        "name": "Learning needs",
+        "description": "Example learning needs"
+      },
+      {
+        "name": "Risk criteria",
+        "description": "Example risk criteria"
+      },
+      {
+        "name": "Setting",
+        "description": "Example setting"
+      }
+    ]
+  },
+  {
+    "id": "986d6256-5e2c-4792-b93a-568d923cf50c",
+    "name": "6: Building Better Relationships",
+    "alternateName": "BBR",
+    "description": "BBR is a programme...",
+    "audiences": [
+      {
+        "id": "782cd9ff-7339-4c0c-8b85-5409ff4d6061",
+        "value": "Intimate partner violence"
+      }
+    ],
+    "coursePrerequisites": [
+      {
+        "name": "Gender",
+        "description": "Example gender"
+      },
+      {
+        "name": "Learning needs",
+        "description": "Example learning needs"
+      },
+      {
+        "name": "Risk criteria",
+        "description": "Example risk criteria"
+      },
+      {
+        "name": "Setting",
+        "description": "Example setting"
+      }
+    ]
+  },
+  {
+    "id": "4a1630b7-3280-49b4-b559-53d110b3c27b",
+    "name": "6: Healthy Identity Intervention",
+    "alternateName": "HII",
+    "description": "HII is a programme...",
+    "audiences": [
+      {
+        "id": "9d7acd40-4b84-4c9b-b55c-a616ed038ed5",
+        "value": "Extremism"
+      }
+    ],
+    "coursePrerequisites": [
+      {
+        "name": "Gender",
+        "description": "Example gender"
+      },
+      {
+        "name": "Learning needs",
+        "description": "Example learning needs"
+      },
+      {
+        "name": "Risk criteria",
+        "description": "Example risk criteria"
+      },
+      {
+        "name": "Setting",
+        "description": "Example setting"
+      }
+    ]
+  },
+  {
+    "id": "197e62b4-4d34-4d30-a51f-e6427100c6c4",
+    "name": "6: Healthy Sex Programme",
+    "alternateName": "HSP",
+    "description": "HSP is a programme...",
+    "audiences": [
+      {
+        "id": "005a4cf6-749b-4ac2-9a2d-dd0024c0d34a",
+        "value": "Sexual offence"
+      }
+    ],
+    "coursePrerequisites": [
+      {
+        "name": "Gender",
+        "description": "Example gender"
+      },
+      {
+        "name": "Learning needs",
+        "description": "Example learning needs"
+      },
+      {
+        "name": "Risk criteria",
+        "description": "Example risk criteria"
+      },
+      {
+        "name": "Setting",
+        "description": "Example setting"
+      }
+    ]
+  },
+  {
+    "id": "654520cc-e109-4f31-81a6-1fc6bc9078b3",
+    "name": "7: Becoming New Me Plus",
+    "alternateName": "BNM+",
+    "description": "Becoming New Me Plus (BNM+) is a programme...",
+    "audiences": [
+      {
+        "id": "5a5e5870-1e0f-43ed-840a-fd53d973865f",
+        "value": "Intimate partner violence"
+      },
+      {
+        "id": "5eb2d80c-d08a-4930-b391-0c5166a8ee03",
+        "value": "General violence"
+      }
+    ],
+    "coursePrerequisites": [
+      {
+        "name": "Gender",
+        "description": "Example gender"
+      },
+      {
+        "name": "Learning needs",
+        "description": "Example learning needs"
+      },
+      {
+        "name": "Risk criteria",
+        "description": "Example risk criteria"
+      },
+      {
+        "name": "Setting",
+        "description": "Example setting"
+      }
+    ]
+  },
+  {
+    "id": "e4e5e559-739c-4b20-a40f-97d48a4081cb",
+    "name": "7: Becoming New Me Plus",
+    "alternateName": "BNM+",
+    "description": "Becoming New Me Plus (BNM+) is a programme...",
+    "audiences": [
+      {
+        "id": "9adb316f-caab-4f92-ad22-87d3c2bb5c43",
+        "value": "Sexual offence"
+      }
+    ],
+    "coursePrerequisites": [
+      {
+        "name": "Gender",
+        "description": "Example gender"
+      },
+      {
+        "name": "Learning needs",
+        "description": "Example learning needs"
+      },
+      {
+        "name": "Risk criteria",
+        "description": "Example risk criteria"
+      },
+      {
+        "name": "Setting",
+        "description": "Example setting"
+      }
+    ]
+  },
+  {
+    "id": "986d6256-5e2c-4792-b93a-568d923cf50c",
+    "name": "7: Building Better Relationships",
+    "alternateName": "BBR",
+    "description": "BBR is a programme...",
+    "audiences": [
+      {
+        "id": "782cd9ff-7339-4c0c-8b85-5409ff4d6061",
+        "value": "Intimate partner violence"
+      }
+    ],
+    "coursePrerequisites": [
+      {
+        "name": "Gender",
+        "description": "Example gender"
+      },
+      {
+        "name": "Learning needs",
+        "description": "Example learning needs"
+      },
+      {
+        "name": "Risk criteria",
+        "description": "Example risk criteria"
+      },
+      {
+        "name": "Setting",
+        "description": "Example setting"
+      }
+    ]
+  },
+  {
+    "id": "4a1630b7-3280-49b4-b559-53d110b3c27b",
+    "name": "7: Healthy Identity Intervention",
+    "alternateName": "HII",
+    "description": "HII is a programme...",
+    "audiences": [
+      {
+        "id": "9d7acd40-4b84-4c9b-b55c-a616ed038ed5",
+        "value": "Extremism"
+      }
+    ],
+    "coursePrerequisites": [
+      {
+        "name": "Gender",
+        "description": "Example gender"
+      },
+      {
+        "name": "Learning needs",
+        "description": "Example learning needs"
+      },
+      {
+        "name": "Risk criteria",
+        "description": "Example risk criteria"
+      },
+      {
+        "name": "Setting",
+        "description": "Example setting"
+      }
+    ]
+  },
+  {
+    "id": "197e62b4-4d34-4d30-a51f-e6427100c6c4",
+    "name": "7: Healthy Sex Programme",
+    "alternateName": "HSP",
+    "description": "HSP is a programme...",
+    "audiences": [
+      {
+        "id": "005a4cf6-749b-4ac2-9a2d-dd0024c0d34a",
+        "value": "Sexual offence"
+      }
+    ],
+    "coursePrerequisites": [
+      {
+        "name": "Gender",
+        "description": "Example gender"
+      },
+      {
+        "name": "Learning needs",
+        "description": "Example learning needs"
+      },
+      {
+        "name": "Risk criteria",
+        "description": "Example risk criteria"
+      },
+      {
+        "name": "Setting",
+        "description": "Example setting"
+      }
+    ]
+  },
+  {
+    "id": "654520cc-e109-4f31-81a6-1fc6bc9078b3",
+    "name": "8: Becoming New Me Plus",
+    "alternateName": "BNM+",
+    "description": "Becoming New Me Plus (BNM+) is a programme...",
+    "audiences": [
+      {
+        "id": "5a5e5870-1e0f-43ed-840a-fd53d973865f",
+        "value": "Intimate partner violence"
+      },
+      {
+        "id": "5eb2d80c-d08a-4930-b391-0c5166a8ee03",
+        "value": "General violence"
+      }
+    ],
+    "coursePrerequisites": [
+      {
+        "name": "Gender",
+        "description": "Example gender"
+      },
+      {
+        "name": "Learning needs",
+        "description": "Example learning needs"
+      },
+      {
+        "name": "Risk criteria",
+        "description": "Example risk criteria"
+      },
+      {
+        "name": "Setting",
+        "description": "Example setting"
+      }
+    ]
+  },
+  {
+    "id": "e4e5e559-739c-4b20-a40f-97d48a4081cb",
+    "name": "8: Becoming New Me Plus",
+    "alternateName": "BNM+",
+    "description": "Becoming New Me Plus (BNM+) is a programme...",
+    "audiences": [
+      {
+        "id": "9adb316f-caab-4f92-ad22-87d3c2bb5c43",
+        "value": "Sexual offence"
+      }
+    ],
+    "coursePrerequisites": [
+      {
+        "name": "Gender",
+        "description": "Example gender"
+      },
+      {
+        "name": "Learning needs",
+        "description": "Example learning needs"
+      },
+      {
+        "name": "Risk criteria",
+        "description": "Example risk criteria"
+      },
+      {
+        "name": "Setting",
+        "description": "Example setting"
+      }
+    ]
+  },
+  {
+    "id": "986d6256-5e2c-4792-b93a-568d923cf50c",
+    "name": "8: Building Better Relationships",
+    "alternateName": "BBR",
+    "description": "BBR is a programme...",
+    "audiences": [
+      {
+        "id": "782cd9ff-7339-4c0c-8b85-5409ff4d6061",
+        "value": "Intimate partner violence"
+      }
+    ],
+    "coursePrerequisites": [
+      {
+        "name": "Gender",
+        "description": "Example gender"
+      },
+      {
+        "name": "Learning needs",
+        "description": "Example learning needs"
+      },
+      {
+        "name": "Risk criteria",
+        "description": "Example risk criteria"
+      },
+      {
+        "name": "Setting",
+        "description": "Example setting"
+      }
+    ]
+  },
+  {
+    "id": "4a1630b7-3280-49b4-b559-53d110b3c27b",
+    "name": "8: Healthy Identity Intervention",
+    "alternateName": "HII",
+    "description": "HII is a programme...",
+    "audiences": [
+      {
+        "id": "9d7acd40-4b84-4c9b-b55c-a616ed038ed5",
+        "value": "Extremism"
+      }
+    ],
+    "coursePrerequisites": [
+      {
+        "name": "Gender",
+        "description": "Example gender"
+      },
+      {
+        "name": "Learning needs",
+        "description": "Example learning needs"
+      },
+      {
+        "name": "Risk criteria",
+        "description": "Example risk criteria"
+      },
+      {
+        "name": "Setting",
+        "description": "Example setting"
+      }
+    ]
+  },
+  {
+    "id": "197e62b4-4d34-4d30-a51f-e6427100c6c4",
+    "name": "8: Healthy Sex Programme",
+    "alternateName": "HSP",
+    "description": "HSP is a programme...",
+    "audiences": [
+      {
+        "id": "005a4cf6-749b-4ac2-9a2d-dd0024c0d34a",
+        "value": "Sexual offence"
+      }
+    ],
+    "coursePrerequisites": [
+      {
+        "name": "Gender",
+        "description": "Example gender"
+      },
+      {
+        "name": "Learning needs",
+        "description": "Example learning needs"
+      },
+      {
+        "name": "Risk criteria",
+        "description": "Example risk criteria"
+      },
+      {
+        "name": "Setting",
+        "description": "Example setting"
+      }
+    ]
+  },
+  {
+    "id": "654520cc-e109-4f31-81a6-1fc6bc9078b3",
+    "name": "9: Becoming New Me Plus",
+    "alternateName": "BNM+",
+    "description": "Becoming New Me Plus (BNM+) is a programme...",
+    "audiences": [
+      {
+        "id": "5a5e5870-1e0f-43ed-840a-fd53d973865f",
+        "value": "Intimate partner violence"
+      },
+      {
+        "id": "5eb2d80c-d08a-4930-b391-0c5166a8ee03",
+        "value": "General violence"
+      }
+    ],
+    "coursePrerequisites": [
+      {
+        "name": "Gender",
+        "description": "Example gender"
+      },
+      {
+        "name": "Learning needs",
+        "description": "Example learning needs"
+      },
+      {
+        "name": "Risk criteria",
+        "description": "Example risk criteria"
+      },
+      {
+        "name": "Setting",
+        "description": "Example setting"
+      }
+    ]
+  },
+  {
+    "id": "e4e5e559-739c-4b20-a40f-97d48a4081cb",
+    "name": "9: Becoming New Me Plus",
+    "alternateName": "BNM+",
+    "description": "Becoming New Me Plus (BNM+) is a programme...",
+    "audiences": [
+      {
+        "id": "9adb316f-caab-4f92-ad22-87d3c2bb5c43",
+        "value": "Sexual offence"
+      }
+    ],
+    "coursePrerequisites": [
+      {
+        "name": "Gender",
+        "description": "Example gender"
+      },
+      {
+        "name": "Learning needs",
+        "description": "Example learning needs"
+      },
+      {
+        "name": "Risk criteria",
+        "description": "Example risk criteria"
+      },
+      {
+        "name": "Setting",
+        "description": "Example setting"
+      }
+    ]
+  },
+  {
+    "id": "986d6256-5e2c-4792-b93a-568d923cf50c",
+    "name": "9: Building Better Relationships",
+    "alternateName": "BBR",
+    "description": "BBR is a programme...",
+    "audiences": [
+      {
+        "id": "782cd9ff-7339-4c0c-8b85-5409ff4d6061",
+        "value": "Intimate partner violence"
+      }
+    ],
+    "coursePrerequisites": [
+      {
+        "name": "Gender",
+        "description": "Example gender"
+      },
+      {
+        "name": "Learning needs",
+        "description": "Example learning needs"
+      },
+      {
+        "name": "Risk criteria",
+        "description": "Example risk criteria"
+      },
+      {
+        "name": "Setting",
+        "description": "Example setting"
+      }
+    ]
+  },
+  {
+    "id": "4a1630b7-3280-49b4-b559-53d110b3c27b",
+    "name": "9: Healthy Identity Intervention",
+    "alternateName": "HII",
+    "description": "HII is a programme...",
+    "audiences": [
+      {
+        "id": "9d7acd40-4b84-4c9b-b55c-a616ed038ed5",
+        "value": "Extremism"
+      }
+    ],
+    "coursePrerequisites": [
+      {
+        "name": "Gender",
+        "description": "Example gender"
+      },
+      {
+        "name": "Learning needs",
+        "description": "Example learning needs"
+      },
+      {
+        "name": "Risk criteria",
+        "description": "Example risk criteria"
+      },
+      {
+        "name": "Setting",
+        "description": "Example setting"
+      }
+    ]
+  },
+  {
+    "id": "197e62b4-4d34-4d30-a51f-e6427100c6c4",
+    "name": "9: Healthy Sex Programme",
+    "alternateName": "HSP",
+    "description": "HSP is a programme...",
+    "audiences": [
+      {
+        "id": "005a4cf6-749b-4ac2-9a2d-dd0024c0d34a",
+        "value": "Sexual offence"
+      }
+    ],
+    "coursePrerequisites": [
+      {
+        "name": "Gender",
+        "description": "Example gender"
+      },
+      {
+        "name": "Learning needs",
+        "description": "Example learning needs"
+      },
+      {
+        "name": "Risk criteria",
+        "description": "Example risk criteria"
+      },
+      {
+        "name": "Setting",
+        "description": "Example setting"
+      }
+    ]
+  },
+  {
+    "id": "654520cc-e109-4f31-81a6-1fc6bc9078b3",
+    "name": "10: Becoming New Me Plus",
+    "alternateName": "BNM+",
+    "description": "Becoming New Me Plus (BNM+) is a programme...",
+    "audiences": [
+      {
+        "id": "5a5e5870-1e0f-43ed-840a-fd53d973865f",
+        "value": "Intimate partner violence"
+      },
+      {
+        "id": "5eb2d80c-d08a-4930-b391-0c5166a8ee03",
+        "value": "General violence"
+      }
+    ],
+    "coursePrerequisites": [
+      {
+        "name": "Gender",
+        "description": "Example gender"
+      },
+      {
+        "name": "Learning needs",
+        "description": "Example learning needs"
+      },
+      {
+        "name": "Risk criteria",
+        "description": "Example risk criteria"
+      },
+      {
+        "name": "Setting",
+        "description": "Example setting"
+      }
+    ]
+  },
+  {
+    "id": "e4e5e559-739c-4b20-a40f-97d48a4081cb",
+    "name": "10: Becoming New Me Plus",
+    "alternateName": "BNM+",
+    "description": "Becoming New Me Plus (BNM+) is a programme...",
+    "audiences": [
+      {
+        "id": "9adb316f-caab-4f92-ad22-87d3c2bb5c43",
+        "value": "Sexual offence"
+      }
+    ],
+    "coursePrerequisites": [
+      {
+        "name": "Gender",
+        "description": "Example gender"
+      },
+      {
+        "name": "Learning needs",
+        "description": "Example learning needs"
+      },
+      {
+        "name": "Risk criteria",
+        "description": "Example risk criteria"
+      },
+      {
+        "name": "Setting",
+        "description": "Example setting"
+      }
+    ]
+  },
+  {
+    "id": "986d6256-5e2c-4792-b93a-568d923cf50c",
+    "name": "10: Building Better Relationships",
+    "alternateName": "BBR",
+    "description": "BBR is a programme...",
+    "audiences": [
+      {
+        "id": "782cd9ff-7339-4c0c-8b85-5409ff4d6061",
+        "value": "Intimate partner violence"
+      }
+    ],
+    "coursePrerequisites": [
+      {
+        "name": "Gender",
+        "description": "Example gender"
+      },
+      {
+        "name": "Learning needs",
+        "description": "Example learning needs"
+      },
+      {
+        "name": "Risk criteria",
+        "description": "Example risk criteria"
+      },
+      {
+        "name": "Setting",
+        "description": "Example setting"
+      }
+    ]
+  },
+  {
+    "id": "4a1630b7-3280-49b4-b559-53d110b3c27b",
+    "name": "10: Healthy Identity Intervention",
+    "alternateName": "HII",
+    "description": "HII is a programme...",
+    "audiences": [
+      {
+        "id": "9d7acd40-4b84-4c9b-b55c-a616ed038ed5",
+        "value": "Extremism"
+      }
+    ],
+    "coursePrerequisites": [
+      {
+        "name": "Gender",
+        "description": "Example gender"
+      },
+      {
+        "name": "Learning needs",
+        "description": "Example learning needs"
+      },
+      {
+        "name": "Risk criteria",
+        "description": "Example risk criteria"
+      },
+      {
+        "name": "Setting",
+        "description": "Example setting"
+      }
+    ]
+  },
+  {
+    "id": "197e62b4-4d34-4d30-a51f-e6427100c6c4",
+    "name": "10: Healthy Sex Programme",
+    "alternateName": "HSP",
+    "description": "HSP is a programme...",
+    "audiences": [
+      {
+        "id": "005a4cf6-749b-4ac2-9a2d-dd0024c0d34a",
+        "value": "Sexual offence"
+      }
+    ],
+    "coursePrerequisites": [
+      {
+        "name": "Gender",
+        "description": "Example gender"
+      },
+      {
+        "name": "Learning needs",
+        "description": "Example learning needs"
+      },
+      {
+        "name": "Risk criteria",
+        "description": "Example risk criteria"
+      },
+      {
+        "name": "Setting",
+        "description": "Example setting"
+      }
+    ]
+  },
+  {
+    "id": "654520cc-e109-4f31-81a6-1fc6bc9078b3",
+    "name": "11: Becoming New Me Plus",
+    "alternateName": "BNM+",
+    "description": "Becoming New Me Plus (BNM+) is a programme...",
+    "audiences": [
+      {
+        "id": "5a5e5870-1e0f-43ed-840a-fd53d973865f",
+        "value": "Intimate partner violence"
+      },
+      {
+        "id": "5eb2d80c-d08a-4930-b391-0c5166a8ee03",
+        "value": "General violence"
+      }
+    ],
+    "coursePrerequisites": [
+      {
+        "name": "Gender",
+        "description": "Example gender"
+      },
+      {
+        "name": "Learning needs",
+        "description": "Example learning needs"
+      },
+      {
+        "name": "Risk criteria",
+        "description": "Example risk criteria"
+      },
+      {
+        "name": "Setting",
+        "description": "Example setting"
+      }
+    ]
+  },
+  {
+    "id": "e4e5e559-739c-4b20-a40f-97d48a4081cb",
+    "name": "11: Becoming New Me Plus",
+    "alternateName": "BNM+",
+    "description": "Becoming New Me Plus (BNM+) is a programme...",
+    "audiences": [
+      {
+        "id": "9adb316f-caab-4f92-ad22-87d3c2bb5c43",
+        "value": "Sexual offence"
+      }
+    ],
+    "coursePrerequisites": [
+      {
+        "name": "Gender",
+        "description": "Example gender"
+      },
+      {
+        "name": "Learning needs",
+        "description": "Example learning needs"
+      },
+      {
+        "name": "Risk criteria",
+        "description": "Example risk criteria"
+      },
+      {
+        "name": "Setting",
+        "description": "Example setting"
+      }
+    ]
+  },
+  {
+    "id": "986d6256-5e2c-4792-b93a-568d923cf50c",
+    "name": "11: Building Better Relationships",
+    "alternateName": "BBR",
+    "description": "BBR is a programme...",
+    "audiences": [
+      {
+        "id": "782cd9ff-7339-4c0c-8b85-5409ff4d6061",
+        "value": "Intimate partner violence"
+      }
+    ],
+    "coursePrerequisites": [
+      {
+        "name": "Gender",
+        "description": "Example gender"
+      },
+      {
+        "name": "Learning needs",
+        "description": "Example learning needs"
+      },
+      {
+        "name": "Risk criteria",
+        "description": "Example risk criteria"
+      },
+      {
+        "name": "Setting",
+        "description": "Example setting"
+      }
+    ]
+  },
+  {
+    "id": "4a1630b7-3280-49b4-b559-53d110b3c27b",
+    "name": "11: Healthy Identity Intervention",
+    "alternateName": "HII",
+    "description": "HII is a programme...",
+    "audiences": [
+      {
+        "id": "9d7acd40-4b84-4c9b-b55c-a616ed038ed5",
+        "value": "Extremism"
+      }
+    ],
+    "coursePrerequisites": [
+      {
+        "name": "Gender",
+        "description": "Example gender"
+      },
+      {
+        "name": "Learning needs",
+        "description": "Example learning needs"
+      },
+      {
+        "name": "Risk criteria",
+        "description": "Example risk criteria"
+      },
+      {
+        "name": "Setting",
+        "description": "Example setting"
+      }
+    ]
+  },
+  {
+    "id": "197e62b4-4d34-4d30-a51f-e6427100c6c4",
+    "name": "11: Healthy Sex Programme",
+    "alternateName": "HSP",
+    "description": "HSP is a programme...",
+    "audiences": [
+      {
+        "id": "005a4cf6-749b-4ac2-9a2d-dd0024c0d34a",
+        "value": "Sexual offence"
+      }
+    ],
+    "coursePrerequisites": [
+      {
+        "name": "Gender",
+        "description": "Example gender"
+      },
+      {
+        "name": "Learning needs",
+        "description": "Example learning needs"
+      },
+      {
+        "name": "Risk criteria",
+        "description": "Example risk criteria"
+      },
+      {
+        "name": "Setting",
+        "description": "Example setting"
+      }
+    ]
+  },
+  {
+    "id": "654520cc-e109-4f31-81a6-1fc6bc9078b3",
+    "name": "12: Becoming New Me Plus",
+    "alternateName": "BNM+",
+    "description": "Becoming New Me Plus (BNM+) is a programme...",
+    "audiences": [
+      {
+        "id": "5a5e5870-1e0f-43ed-840a-fd53d973865f",
+        "value": "Intimate partner violence"
+      },
+      {
+        "id": "5eb2d80c-d08a-4930-b391-0c5166a8ee03",
+        "value": "General violence"
+      }
+    ],
+    "coursePrerequisites": [
+      {
+        "name": "Gender",
+        "description": "Example gender"
+      },
+      {
+        "name": "Learning needs",
+        "description": "Example learning needs"
+      },
+      {
+        "name": "Risk criteria",
+        "description": "Example risk criteria"
+      },
+      {
+        "name": "Setting",
+        "description": "Example setting"
+      }
+    ]
+  },
+  {
+    "id": "e4e5e559-739c-4b20-a40f-97d48a4081cb",
+    "name": "12: Becoming New Me Plus",
+    "alternateName": "BNM+",
+    "description": "Becoming New Me Plus (BNM+) is a programme...",
+    "audiences": [
+      {
+        "id": "9adb316f-caab-4f92-ad22-87d3c2bb5c43",
+        "value": "Sexual offence"
+      }
+    ],
+    "coursePrerequisites": [
+      {
+        "name": "Gender",
+        "description": "Example gender"
+      },
+      {
+        "name": "Learning needs",
+        "description": "Example learning needs"
+      },
+      {
+        "name": "Risk criteria",
+        "description": "Example risk criteria"
+      },
+      {
+        "name": "Setting",
+        "description": "Example setting"
+      }
+    ]
+  },
+  {
+    "id": "986d6256-5e2c-4792-b93a-568d923cf50c",
+    "name": "12: Building Better Relationships",
+    "alternateName": "BBR",
+    "description": "BBR is a programme...",
+    "audiences": [
+      {
+        "id": "782cd9ff-7339-4c0c-8b85-5409ff4d6061",
+        "value": "Intimate partner violence"
+      }
+    ],
+    "coursePrerequisites": [
+      {
+        "name": "Gender",
+        "description": "Example gender"
+      },
+      {
+        "name": "Learning needs",
+        "description": "Example learning needs"
+      },
+      {
+        "name": "Risk criteria",
+        "description": "Example risk criteria"
+      },
+      {
+        "name": "Setting",
+        "description": "Example setting"
+      }
+    ]
+  },
+  {
+    "id": "4a1630b7-3280-49b4-b559-53d110b3c27b",
+    "name": "12: Healthy Identity Intervention",
+    "alternateName": "HII",
+    "description": "HII is a programme...",
+    "audiences": [
+      {
+        "id": "9d7acd40-4b84-4c9b-b55c-a616ed038ed5",
+        "value": "Extremism"
+      }
+    ],
+    "coursePrerequisites": [
+      {
+        "name": "Gender",
+        "description": "Example gender"
+      },
+      {
+        "name": "Learning needs",
+        "description": "Example learning needs"
+      },
+      {
+        "name": "Risk criteria",
+        "description": "Example risk criteria"
+      },
+      {
+        "name": "Setting",
+        "description": "Example setting"
+      }
+    ]
+  },
+  {
+    "id": "197e62b4-4d34-4d30-a51f-e6427100c6c4",
+    "name": "12: Healthy Sex Programme",
+    "alternateName": "HSP",
+    "description": "HSP is a programme...",
+    "audiences": [
+      {
+        "id": "005a4cf6-749b-4ac2-9a2d-dd0024c0d34a",
+        "value": "Sexual offence"
+      }
+    ],
+    "coursePrerequisites": [
+      {
+        "name": "Gender",
+        "description": "Example gender"
+      },
+      {
+        "name": "Learning needs",
+        "description": "Example learning needs"
+      },
+      {
+        "name": "Risk criteria",
+        "description": "Example risk criteria"
+      },
+      {
+        "name": "Setting",
+        "description": "Example setting"
+      }
+    ]
+  },
+  {
+    "id": "654520cc-e109-4f31-81a6-1fc6bc9078b3",
+    "name": "13: Becoming New Me Plus",
+    "alternateName": "BNM+",
+    "description": "Becoming New Me Plus (BNM+) is a programme...",
+    "audiences": [
+      {
+        "id": "5a5e5870-1e0f-43ed-840a-fd53d973865f",
+        "value": "Intimate partner violence"
+      },
+      {
+        "id": "5eb2d80c-d08a-4930-b391-0c5166a8ee03",
+        "value": "General violence"
+      }
+    ],
+    "coursePrerequisites": [
+      {
+        "name": "Gender",
+        "description": "Example gender"
+      },
+      {
+        "name": "Learning needs",
+        "description": "Example learning needs"
+      },
+      {
+        "name": "Risk criteria",
+        "description": "Example risk criteria"
+      },
+      {
+        "name": "Setting",
+        "description": "Example setting"
+      }
+    ]
+  },
+  {
+    "id": "e4e5e559-739c-4b20-a40f-97d48a4081cb",
+    "name": "13: Becoming New Me Plus",
+    "alternateName": "BNM+",
+    "description": "Becoming New Me Plus (BNM+) is a programme...",
+    "audiences": [
+      {
+        "id": "9adb316f-caab-4f92-ad22-87d3c2bb5c43",
+        "value": "Sexual offence"
+      }
+    ],
+    "coursePrerequisites": [
+      {
+        "name": "Gender",
+        "description": "Example gender"
+      },
+      {
+        "name": "Learning needs",
+        "description": "Example learning needs"
+      },
+      {
+        "name": "Risk criteria",
+        "description": "Example risk criteria"
+      },
+      {
+        "name": "Setting",
+        "description": "Example setting"
+      }
+    ]
+  },
+  {
+    "id": "986d6256-5e2c-4792-b93a-568d923cf50c",
+    "name": "13: Building Better Relationships",
+    "alternateName": "BBR",
+    "description": "BBR is a programme...",
+    "audiences": [
+      {
+        "id": "782cd9ff-7339-4c0c-8b85-5409ff4d6061",
+        "value": "Intimate partner violence"
+      }
+    ],
+    "coursePrerequisites": [
+      {
+        "name": "Gender",
+        "description": "Example gender"
+      },
+      {
+        "name": "Learning needs",
+        "description": "Example learning needs"
+      },
+      {
+        "name": "Risk criteria",
+        "description": "Example risk criteria"
+      },
+      {
+        "name": "Setting",
+        "description": "Example setting"
+      }
+    ]
+  },
+  {
+    "id": "4a1630b7-3280-49b4-b559-53d110b3c27b",
+    "name": "13: Healthy Identity Intervention",
+    "alternateName": "HII",
+    "description": "HII is a programme...",
+    "audiences": [
+      {
+        "id": "9d7acd40-4b84-4c9b-b55c-a616ed038ed5",
+        "value": "Extremism"
+      }
+    ],
+    "coursePrerequisites": [
+      {
+        "name": "Gender",
+        "description": "Example gender"
+      },
+      {
+        "name": "Learning needs",
+        "description": "Example learning needs"
+      },
+      {
+        "name": "Risk criteria",
+        "description": "Example risk criteria"
+      },
+      {
+        "name": "Setting",
+        "description": "Example setting"
+      }
+    ]
+  },
+  {
+    "id": "197e62b4-4d34-4d30-a51f-e6427100c6c4",
+    "name": "13: Healthy Sex Programme",
+    "alternateName": "HSP",
+    "description": "HSP is a programme...",
+    "audiences": [
+      {
+        "id": "005a4cf6-749b-4ac2-9a2d-dd0024c0d34a",
+        "value": "Sexual offence"
+      }
+    ],
+    "coursePrerequisites": [
+      {
+        "name": "Gender",
+        "description": "Example gender"
+      },
+      {
+        "name": "Learning needs",
+        "description": "Example learning needs"
+      },
+      {
+        "name": "Risk criteria",
+        "description": "Example risk criteria"
+      },
+      {
+        "name": "Setting",
+        "description": "Example setting"
+      }
+    ]
+  },
+  {
+    "id": "654520cc-e109-4f31-81a6-1fc6bc9078b3",
+    "name": "14: Becoming New Me Plus",
+    "alternateName": "BNM+",
+    "description": "Becoming New Me Plus (BNM+) is a programme...",
+    "audiences": [
+      {
+        "id": "5a5e5870-1e0f-43ed-840a-fd53d973865f",
+        "value": "Intimate partner violence"
+      },
+      {
+        "id": "5eb2d80c-d08a-4930-b391-0c5166a8ee03",
+        "value": "General violence"
+      }
+    ],
+    "coursePrerequisites": [
+      {
+        "name": "Gender",
+        "description": "Example gender"
+      },
+      {
+        "name": "Learning needs",
+        "description": "Example learning needs"
+      },
+      {
+        "name": "Risk criteria",
+        "description": "Example risk criteria"
+      },
+      {
+        "name": "Setting",
+        "description": "Example setting"
+      }
+    ]
+  },
+  {
+    "id": "e4e5e559-739c-4b20-a40f-97d48a4081cb",
+    "name": "14: Becoming New Me Plus",
+    "alternateName": "BNM+",
+    "description": "Becoming New Me Plus (BNM+) is a programme...",
+    "audiences": [
+      {
+        "id": "9adb316f-caab-4f92-ad22-87d3c2bb5c43",
+        "value": "Sexual offence"
+      }
+    ],
+    "coursePrerequisites": [
+      {
+        "name": "Gender",
+        "description": "Example gender"
+      },
+      {
+        "name": "Learning needs",
+        "description": "Example learning needs"
+      },
+      {
+        "name": "Risk criteria",
+        "description": "Example risk criteria"
+      },
+      {
+        "name": "Setting",
+        "description": "Example setting"
+      }
+    ]
+  },
+  {
+    "id": "986d6256-5e2c-4792-b93a-568d923cf50c",
+    "name": "14: Building Better Relationships",
+    "alternateName": "BBR",
+    "description": "BBR is a programme...",
+    "audiences": [
+      {
+        "id": "782cd9ff-7339-4c0c-8b85-5409ff4d6061",
+        "value": "Intimate partner violence"
+      }
+    ],
+    "coursePrerequisites": [
+      {
+        "name": "Gender",
+        "description": "Example gender"
+      },
+      {
+        "name": "Learning needs",
+        "description": "Example learning needs"
+      },
+      {
+        "name": "Risk criteria",
+        "description": "Example risk criteria"
+      },
+      {
+        "name": "Setting",
+        "description": "Example setting"
+      }
+    ]
+  },
+  {
+    "id": "4a1630b7-3280-49b4-b559-53d110b3c27b",
+    "name": "14: Healthy Identity Intervention",
+    "alternateName": "HII",
+    "description": "HII is a programme...",
+    "audiences": [
+      {
+        "id": "9d7acd40-4b84-4c9b-b55c-a616ed038ed5",
+        "value": "Extremism"
+      }
+    ],
+    "coursePrerequisites": [
+      {
+        "name": "Gender",
+        "description": "Example gender"
+      },
+      {
+        "name": "Learning needs",
+        "description": "Example learning needs"
+      },
+      {
+        "name": "Risk criteria",
+        "description": "Example risk criteria"
+      },
+      {
+        "name": "Setting",
+        "description": "Example setting"
+      }
+    ]
+  },
+  {
+    "id": "197e62b4-4d34-4d30-a51f-e6427100c6c4",
+    "name": "14: Healthy Sex Programme",
+    "alternateName": "HSP",
+    "description": "HSP is a programme...",
+    "audiences": [
+      {
+        "id": "005a4cf6-749b-4ac2-9a2d-dd0024c0d34a",
+        "value": "Sexual offence"
+      }
+    ],
+    "coursePrerequisites": [
+      {
+        "name": "Gender",
+        "description": "Example gender"
+      },
+      {
+        "name": "Learning needs",
+        "description": "Example learning needs"
+      },
+      {
+        "name": "Risk criteria",
+        "description": "Example risk criteria"
+      },
+      {
+        "name": "Setting",
+        "description": "Example setting"
+      }
+    ]
   }
 ]


### PR DESCRIPTION
## Context

We may or may not want to paginate the list of courses, depending on page length and load times with real data. For now, we don't want to add pagination functionality to the API, so we're handling it on the fronted with query params and splicing of all the courses returned from the API

## Changes in this PR

- Spike on pagination
- This would need a little abstraction/separation of concerns work, but the basic flow and principles are there and working

## Screenshots of UI changes

### Before

[no pagination]

### After

<img width="1202" alt="image" src="https://github.com/ministryofjustice/hmpps-accredited-programmes-ui/assets/40244233/ce9a0a28-50bf-48eb-9cc3-669b685bdead">

<img width="1195" alt="image" src="https://github.com/ministryofjustice/hmpps-accredited-programmes-ui/assets/40244233/a4960f34-fd6b-4be1-9054-6d68cc231ddf">

<img width="1200" alt="image" src="https://github.com/ministryofjustice/hmpps-accredited-programmes-ui/assets/40244233/82988bbb-3b90-4fe9-954f-32fc07a7e152">

<img width="1201" alt="image" src="https://github.com/ministryofjustice/hmpps-accredited-programmes-ui/assets/40244233/99c56698-e838-4b9b-86f4-640bdd3d3753">

## Post-merge checklist

<!-- The outer checkboxes can be completed pre-merge -->

- [x] This adds, extends or meaningfully modifies a feature...
  - [ ] ... and I have written or updated an end-to-end test for the happy path in the [Accredited Programmes E2E repo](https://github.com/ministryofjustice/hmpps-accredited-programmes-e2e)
- [ ] This makes new expectations of the API...
  - [ ] ... and I have notified the API developer(s) of changes to the contract tests (Pact), or the API is already compliant
