### PR TITLE
Update course audience options

### DIFF
--- a/server/testutils/factories/courseAudience.ts
+++ b/server/testutils/factories/courseAudience.ts
@@ -6,10 +6,11 @@ import type { CourseAudience } from '@accredited-programmes/models'
 export default Factory.define<CourseAudience>(() => ({
   id: faker.string.uuid(),
   value: faker.helpers.arrayElement([
-    'Extremism',
-    'General violence',
+    'Extremism offence',
+    'Gang offence',
     'Intimate partner violence',
-    'Online sexual violence',
-    'Sexual violence',
+    'Non-intimate partner violence',
+    'Sexual offence',
+    'Violent offence',
   ]),
 }))

--- a/server/utils/courseUtils.test.ts
+++ b/server/utils/courseUtils.test.ts
@@ -9,7 +9,7 @@ describe('courseUtils', () => {
         alternateName: 'LC',
         audiences: [
           courseAudienceFactory.build({ value: 'Intimate partner violence' }),
-          courseAudienceFactory.build({ value: 'General violence' }),
+          courseAudienceFactory.build({ value: 'Violent offence' }),
         ],
         coursePrerequisites: [
           coursePrerequisiteFactory.gender().build(),
@@ -28,8 +28,8 @@ describe('courseUtils', () => {
             classes: 'govuk-tag govuk-tag--green',
           },
           {
-            text: 'General violence',
-            classes: 'govuk-tag govuk-tag--purple',
+            text: 'Violent offence',
+            classes: 'govuk-tag govuk-tag--yellow',
           },
         ],
         prerequisiteSummaryListRows: [

--- a/server/utils/courseUtils.ts
+++ b/server/utils/courseUtils.ts
@@ -3,11 +3,12 @@ import type { CoursePresenter, SummaryListRow, Tag, TagColour } from '@accredite
 
 const audienceTags = (audiences: Array<CourseAudience>): Array<Tag> => {
   const audienceColourMap: { [key: CourseAudience['value']]: TagColour } = {
-    Extremism: 'blue',
-    'General violence': 'purple',
+    'Extremism offence': 'turquoise',
+    'Gang offence': 'purple',
     'Intimate partner violence': 'green',
-    'Online sexual offence': 'orange',
-    'Sexual violence': 'red',
+    'Non-intimate partner violence': 'pink',
+    'Sexual offence': 'orange',
+    'Violent offence': 'yellow',
   }
 
   return audiences.map(audience => {

--- a/wiremock/stubs/courses.json
+++ b/wiremock/stubs/courses.json
@@ -11,7 +11,7 @@
       },
       {
         "id": "5eb2d80c-d08a-4930-b391-0c5166a8ee03",
-        "value": "General violence"
+        "value": "Violent offence"
       }
     ],
     "coursePrerequisites": [
@@ -101,7 +101,7 @@
     "audiences": [
       {
         "id": "9d7acd40-4b84-4c9b-b55c-a616ed038ed5",
-        "value": "Extremism"
+        "value": "Extremism offence"
       }
     ],
     "coursePrerequisites": [


### PR DESCRIPTION
## Context

Since we added audiences and corresponding tag colours, the data have changed

## Changes in this PR

Update course audience options and related tag colours, based on the latest data and design input

## Screenshots of UI changes

### Before

<img width="550" alt="image" src="https://github.com/ministryofjustice/hmpps-accredited-programmes-ui/assets/40244233/e8f95e5f-b6ce-4f40-9e2a-ce8cf974cb68">

### After

<img width="556" alt="image" src="https://github.com/ministryofjustice/hmpps-accredited-programmes-ui/assets/40244233/9b011ebd-6333-470d-ab70-dbdc03b67bc7">

## Release checklist

[Release process documentation](../doc/how-to/perform-a-release.md)

As part of our continuous deployment strategy we must ensure that this work is
ready to be released once merged.

### Pre-merge

- [x] There are changes required to the Accredited Programmes API for this change to work...
  - [x] ... and they been released to production already

### Post-merge

<!-- The outer checkboxes can be completed pre-merge -->

- [ ] This adds, extends or meaningfully modifies a feature...
  - [ ] ... and I have written or updated an end-to-end test for the happy path in the [Accredited Programmes E2E repo](https://github.com/ministryofjustice/hmpps-accredited-programmes-e2e)
- [x] This makes new expectations of the API...
  - [x] ... and I have notified the API developer(s) of changes to the contract tests (Pact), or the API is already compliant
- [ ] [Manually approve](../doc/how-to/perform-a-release.md#releasing-to-the-preprod-environment) release to preprod
- [ ] [Manually approve](../doc/how-to/perform-a-release.md#releasing-to-the-production-environment) release to prod

<!-- Should a release fail at any step, you as the author should now lead the work to
fix it as soon as possible. You can monitor deployment failures in CircleCI
itself and application errors are found in
[Sentry](https://ministryofjustice.sentry.io/projects/hmpps-accredited-programmes-ui/?project=4505330122686464&referrer=sidebar&statsPeriod=24h). -->
