### PR TITLE
Disable E2E CI step

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -133,27 +133,6 @@ jobs:
       - store_artifacts:
           path: test_results/integration/xml
 
-  end_to_end_test:
-    docker:
-      - image: mcr.microsoft.com/playwright:v1.34.2-focal
-    circleci_ip_ranges: true # opt-in to jobs running on a restricted set of IPs
-    steps:
-      - run:
-          name: Clone E2E repo
-          command: |
-            git clone https://github.com/ministryofjustice/hmpps-accredited-programmes-e2e.git .
-      - run:
-          name: Update npm
-          command: 'npm install -g npm@latest'
-      - node/install-packages
-      - run:
-          name: E2E Check
-          command: |
-            npx playwright test
-      - store_artifacts:
-          path: test_results
-          destination: test_results
-
   tag_pact_version:
     environment:
       PACT_BROKER_BASE_URL: 'https://pact-broker-prod.apps.live-1.cloud-platform.service.justice.gov.uk'
@@ -208,14 +187,6 @@ workflows:
             - unit_test
             - integration_test
             - build_docker
-      - end_to_end_test:
-          context: hmpps-common-vars
-          filters:
-            branches:
-              only:
-                - main
-          requires:
-            - deploy_dev
       - tag_pact_version:
           name: 'tag_pact_version_dev'
           tag: 'deployed:dev'


### PR DESCRIPTION
## Context

This is currently failing due to a change in the data in dev, which is now showing real or real-ish data, and has no email addresses

## Changes in this PR

Disable E2E CI step. We'll re-enable this soon, but for now we don't want the failing step

## Release checklist

[Release process documentation](../doc/how-to/perform-a-release.md)

As part of our continuous deployment strategy we must ensure that this work is
ready to be released once merged.

### Pre-merge

- [ ] There are changes required to the Accredited Programmes API for this change to work...
  - [ ] ... and they been released to production already

### Post-merge

<!-- The outer checkboxes can be completed pre-merge -->

- [ ] This adds, extends or meaningfully modifies a feature...
  - [ ] ... and I have written or updated an end-to-end test for the happy path in the [Accredited Programmes E2E repo](https://github.com/ministryofjustice/hmpps-accredited-programmes-e2e)
- [ ] This makes new expectations of the API...
  - [ ] ... and I have notified the API developer(s) of changes to the contract tests (Pact), or the API is already compliant
- [ ] [Manually approve](../doc/how-to/perform-a-release.md#releasing-to-the-preprod-environment) release to preprod
- [ ] [Manually approve](../doc/how-to/perform-a-release.md#releasing-to-the-production-environment) release to prod

<!-- Should a release fail at any step, you as the author should now lead the work to
fix it as soon as possible. You can monitor deployment failures in CircleCI
itself and application errors are found in
[Sentry](https://ministryofjustice.sentry.io/projects/hmpps-accredited-programmes-ui/?project=4505330122686464&referrer=sidebar&statsPeriod=24h). -->
