### PR TITLE
(582) Update audiences per current data

### DIFF
--- a/server/testutils/factories/courseAudience.ts
+++ b/server/testutils/factories/courseAudience.ts
@@ -8,9 +8,9 @@ export default Factory.define<CourseAudience>(() => ({
   value: faker.helpers.arrayElement([
     'Extremism offence',
     'Gang offence',
-    'Intimate partner violence',
-    'Non-intimate partner violence',
+    'General offence',
+    'General violence offence',
+    'Intimate partner violence offence',
     'Sexual offence',
-    'Violent offence',
   ]),
 }))

--- a/server/utils/courseUtils.test.ts
+++ b/server/utils/courseUtils.test.ts
@@ -8,8 +8,8 @@ describe('courseUtils', () => {
         name: 'Lime Course',
         alternateName: 'LC',
         audiences: [
-          courseAudienceFactory.build({ value: 'Intimate partner violence' }),
-          courseAudienceFactory.build({ value: 'Violent offence' }),
+          courseAudienceFactory.build({ value: 'Intimate partner violence offence' }),
+          courseAudienceFactory.build({ value: 'General violence offence' }),
         ],
         coursePrerequisites: [
           coursePrerequisiteFactory.gender().build(),
@@ -24,11 +24,11 @@ describe('courseUtils', () => {
         nameAndAlternateName: 'Lime Course (LC)',
         audienceTags: [
           {
-            text: 'Intimate partner violence',
+            text: 'Intimate partner violence offence',
             classes: 'govuk-tag govuk-tag--green',
           },
           {
-            text: 'Violent offence',
+            text: 'General violence offence',
             classes: 'govuk-tag govuk-tag--yellow',
           },
         ],

--- a/server/utils/courseUtils.ts
+++ b/server/utils/courseUtils.ts
@@ -5,10 +5,10 @@ const audienceTags = (audiences: Array<CourseAudience>): Array<Tag> => {
   const audienceColourMap: { [key: CourseAudience['value']]: TagColour } = {
     'Extremism offence': 'turquoise',
     'Gang offence': 'purple',
-    'Intimate partner violence': 'green',
-    'Non-intimate partner violence': 'pink',
+    'General offence': 'pink',
+    'General violence offence': 'yellow',
+    'Intimate partner violence offence': 'green',
     'Sexual offence': 'orange',
-    'Violent offence': 'yellow',
   }
 
   return audiences.map(audience => {

--- a/wiremock/stubs/courses.json
+++ b/wiremock/stubs/courses.json
@@ -7,11 +7,11 @@
     "audiences": [
       {
         "id": "5a5e5870-1e0f-43ed-840a-fd53d973865f",
-        "value": "Intimate partner violence"
+        "value": "Intimate partner violence offence"
       },
       {
         "id": "5eb2d80c-d08a-4930-b391-0c5166a8ee03",
-        "value": "Violent offence"
+        "value": "General violence offence"
       }
     ],
     "coursePrerequisites": [
@@ -71,7 +71,7 @@
     "audiences": [
       {
         "id": "782cd9ff-7339-4c0c-8b85-5409ff4d6061",
-        "value": "Intimate partner violence"
+        "value": "Intimate partner violence offence"
       }
     ],
     "coursePrerequisites": [


### PR DESCRIPTION
## Context

The audiences have changed again

## Changes in this PR

- Update the audiences and corresponding tag colours

## Screenshots of UI changes

### Before


### After


## Release checklist

[Release process documentation](../doc/how-to/perform-a-release.md)

As part of our continuous deployment strategy we must ensure that this work is
ready to be released once merged.

### Pre-merge

- [x] There are changes required to the Accredited Programmes API for this change to work...
  - [x] ... and they been released to production already

(the audiences that are out of date on the API Docker seed data will default to blue tags locally; but this will fix things on dev)

### Post-merge

<!-- The outer checkboxes can be completed pre-merge -->

- [ ] This adds, extends or meaningfully modifies a feature...
  - [ ] ... and I have written or updated an end-to-end test for the happy path in the [Accredited Programmes E2E repo](https://github.com/ministryofjustice/hmpps-accredited-programmes-e2e)
- [x] This makes new expectations of the API...
  - [x] ... and I have notified the API developer(s) of changes to the contract tests (Pact), or the API is already compliant
- [ ] [Manually approve](../doc/how-to/perform-a-release.md#releasing-to-the-preprod-environment) release to preprod
- [ ] [Manually approve](../doc/how-to/perform-a-release.md#releasing-to-the-production-environment) release to prod

<!-- Should a release fail at any step, you as the author should now lead the work to
fix it as soon as possible. You can monitor deployment failures in CircleCI
itself and application errors are found in
[Sentry](https://ministryofjustice.sentry.io/projects/hmpps-accredited-programmes-ui/?project=4505330122686464&referrer=sidebar&statsPeriod=24h). -->
