### PR TITLE
(525) Block fixup and squash commits

### DIFF
--- a/.github/workflows/git.yml
+++ b/.github/workflows/git.yml
@@ -1,0 +1,15 @@
+name: Git
+
+on:
+  pull_request:
+
+jobs:
+  message-check:
+    name: Block fixup, squash and merge commits
+
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v3
+      - name: Block fixup and squash commits
+        uses: 13rac1/block-fixup-merge-action@v2.0.0


### PR DESCRIPTION
## Context

It's currently possible to merge PRs with fixup and squash commits still in the commit history. These should be rebased to squash into or fix up the relevant commits before merging to `main`

## Changes in this PR

Add workflow which will fail if fixup or squash commits are present

This doesn't block merge commits. I did try [this action](https://github.com/marketplace/actions/block-merge-and-autosquash-commits) which includes that, but it had a missing dependency/module not found error. [This action](https://github.com/marketplace/actions/block-merge-commits) might do the job, but it appears to require access to secrets, which I'd be more cautious about

## Release checklist

[Release process documentation](../doc/how-to/perform-a-release.md)

As part of our continuous deployment strategy we must ensure that this work is
ready to be released once merged.

### Pre-merge

- [ ] There are changes required to the Accredited Programmes API for this change to work...
  - [ ] ... and they been released to production already

### Post-merge

<!-- The outer checkboxes can be completed pre-merge -->

- [ ] This adds, extends or meaningfully modifies a feature...
  - [ ] ... and I have written or updated an end-to-end test for the happy path in the [Accredited Programmes E2E repo](https://github.com/ministryofjustice/hmpps-accredited-programmes-e2e)
- [ ] This makes new expectations of the API...
  - [ ] ... and I have notified the API developer(s) of changes to the contract tests (Pact), or the API is already compliant
- [ ] [Manually approve](../doc/how-to/perform-a-release.md#releasing-to-the-preprod-environment) release to preprod
- [ ] [Manually approve](../doc/how-to/perform-a-release.md#releasing-to-the-production-environment) release to prod

<!-- Should a release fail at any step, you as the author should now lead the work to
fix it as soon as possible. You can monitor deployment failures in CircleCI
itself and application errors are found in
[Sentry](https://ministryofjustice.sentry.io/projects/hmpps-accredited-programmes-ui/?project=4505330122686464&referrer=sidebar&statsPeriod=24h). -->
