### PR TITLE
(453) Use page headings as titles and other such niceties

### DIFF
--- a/integration_tests/pages/authManageDetails.ts
+++ b/integration_tests/pages/authManageDetails.ts
@@ -2,6 +2,6 @@ import Page from './page'
 
 export default class AuthManageDetailsPage extends Page {
   constructor() {
-    super('Your account details')
+    super('Your account details', { external: true })
   }
 }

--- a/integration_tests/pages/authSignIn.ts
+++ b/integration_tests/pages/authSignIn.ts
@@ -2,6 +2,6 @@ import Page from './page'
 
 export default class AuthSignInPage extends Page {
   constructor() {
-    super('Sign in')
+    super('Sign in', { external: true })
   }
 }

--- a/integration_tests/pages/find/course.ts
+++ b/integration_tests/pages/find/course.ts
@@ -9,7 +9,7 @@ export default class CoursePage extends Page {
 
   constructor(course: Course) {
     const coursePresenter = presentCourse(course)
-    super(coursePresenter.nameAndAlternateName, course.name)
+    super(coursePresenter.nameAndAlternateName, { customPageTitleEnd: coursePresenter.name })
     this.course = coursePresenter
   }
 

--- a/integration_tests/pages/find/course.ts
+++ b/integration_tests/pages/find/course.ts
@@ -9,7 +9,7 @@ export default class CoursePage extends Page {
 
   constructor(course: Course) {
     const coursePresenter = presentCourse(course)
-    super(coursePresenter.nameAndAlternateName, { customPageTitleEnd: coursePresenter.name })
+    super(coursePresenter.nameAndAlternateName)
     this.course = coursePresenter
   }
 

--- a/integration_tests/pages/find/courseOffering.ts
+++ b/integration_tests/pages/find/courseOffering.ts
@@ -13,9 +13,12 @@ export default class CourseOfferingPage extends Page {
 
   constructor(args: { courseOffering: CourseOffering; course: Course; organisation: Organisation }) {
     const { courseOffering, organisation, course } = args
-    super(course.name, { customPageTitleEnd: `${course.name}, ${organisation.name}` })
+    const coursePresenter = presentCourse(course)
+    super(coursePresenter.nameAndAlternateName, {
+      customPageTitleEnd: `${coursePresenter.nameAndAlternateName}, ${organisation.name}`,
+    })
     this.courseOffering = courseOffering
-    this.course = presentCourse(course)
+    this.course = coursePresenter
     this.organisation = presentOrganisationWithOfferingEmail(organisation, courseOffering.contactEmail)
   }
 

--- a/integration_tests/pages/find/courseOffering.ts
+++ b/integration_tests/pages/find/courseOffering.ts
@@ -13,7 +13,7 @@ export default class CourseOfferingPage extends Page {
 
   constructor(args: { courseOffering: CourseOffering; course: Course; organisation: Organisation }) {
     const { courseOffering, organisation, course } = args
-    super(course.name, `${course.name}, ${organisation.name}`)
+    super(course.name, { customPageTitleEnd: `${course.name}, ${organisation.name}` })
     this.courseOffering = courseOffering
     this.course = presentCourse(course)
     this.organisation = presentOrganisationWithOfferingEmail(organisation, courseOffering.contactEmail)

--- a/integration_tests/pages/find/courses.ts
+++ b/integration_tests/pages/find/courses.ts
@@ -5,7 +5,7 @@ import type { Course } from '@accredited-programmes/models'
 
 export default class CoursesPage extends Page {
   constructor() {
-    super('List of accredited programmes', 'Programmes')
+    super('List of accredited programmes', { customPageTitleEnd: 'Programmes' })
   }
 
   shouldHaveCourses(courses: Array<Course>) {

--- a/integration_tests/pages/find/courses.ts
+++ b/integration_tests/pages/find/courses.ts
@@ -5,7 +5,7 @@ import type { Course } from '@accredited-programmes/models'
 
 export default class CoursesPage extends Page {
   constructor() {
-    super('List of accredited programmes', { customPageTitleEnd: 'Programmes' })
+    super('List of accredited programmes')
   }
 
   shouldHaveCourses(courses: Array<Course>) {

--- a/integration_tests/pages/index.ts
+++ b/integration_tests/pages/index.ts
@@ -3,7 +3,7 @@ import Page from './page'
 
 export default class IndexPage extends Page {
   constructor() {
-    super('Accredited Programmes', 'Home')
+    super('Accredited Programmes', { customPageTitleEnd: 'Home' })
   }
 
   headerUserName = (): PageElement => cy.get('[data-qa=header-user-name]')

--- a/integration_tests/pages/page.ts
+++ b/integration_tests/pages/page.ts
@@ -4,20 +4,33 @@ import type { ObjectWithHtmlString, ObjectWithTextString, SummaryListRow, Tag } 
 export type PageElement = Cypress.Chainable<JQuery>
 
 export default abstract class Page {
+  customPageTitleEnd: string | undefined
+
+  external: boolean
+
   static verifyOnPage<T, U = unknown>(constructor: new (...args: Array<U>) => T, ...args: Array<U>): T {
     return new constructor(...args)
   }
 
-  constructor(private readonly mainHeading: string, private readonly customTitle?: string) {
+  constructor(private readonly pageHeading: string, options?: { customPageTitleEnd?: string; external?: boolean }) {
+    this.customPageTitleEnd = options?.customPageTitleEnd
+    this.external = options?.external || false
     this.checkOnPage()
   }
 
   checkOnPage(): void {
-    if (this.customTitle) {
-      cy.title().should('equal', `HMPPS Accredited Programmes - ${this.customTitle}`)
+    if (!this.external) {
+      let expectedTitle = 'HMPPS Accredited Programmes'
+      const pageTitleEnd = this.customPageTitleEnd || this.pageHeading
+
+      if (pageTitleEnd) {
+        expectedTitle += ` - ${pageTitleEnd}`
+      }
+
+      cy.title().should('equal', expectedTitle)
     }
 
-    cy.get('.govuk-heading-l').contains(this.mainHeading)
+    cy.get('.govuk-heading-l').contains(this.pageHeading)
   }
 
   signOut = (): PageElement => cy.get('[data-qa=signOut]')

--- a/server/views/courses/index.njk
+++ b/server/views/courses/index.njk
@@ -2,7 +2,7 @@
 
 {% extends "../partials/layout.njk" %}
 
-{% set pageTitle = applicationName + " - Programmes" %}
+{% set customPageTitleEnd = "Programmes" %}
 {% set mainClasses = "app-container govuk-body" %}
 
 {% block content %}

--- a/server/views/courses/index.njk
+++ b/server/views/courses/index.njk
@@ -2,7 +2,6 @@
 
 {% extends "../partials/layout.njk" %}
 
-{% set customPageTitleEnd = "Programmes" %}
 {% set mainClasses = "app-container govuk-body" %}
 
 {% block content %}

--- a/server/views/courses/index.njk
+++ b/server/views/courses/index.njk
@@ -2,8 +2,6 @@
 
 {% extends "../partials/layout.njk" %}
 
-{% set mainClasses = "app-container govuk-body" %}
-
 {% block content %}
   <h1 class="govuk-heading-l">{{ pageHeading }}</h1>
 

--- a/server/views/courses/offerings/show.njk
+++ b/server/views/courses/offerings/show.njk
@@ -5,7 +5,7 @@
 
 {% extends "../../partials/layout.njk" %}
 
-{% set pageTitle = applicationName + " - " + course.name + ", " + organisation.name %}
+{% set customPageTitleEnd = course.name + ", " + organisation.name %}
 {% set mainClasses = "app-container govuk-body" %}
 
 {% block content %}

--- a/server/views/courses/offerings/show.njk
+++ b/server/views/courses/offerings/show.njk
@@ -6,7 +6,6 @@
 {% extends "../../partials/layout.njk" %}
 
 {% set customPageTitleEnd = course.nameAndAlternateName + ", " + organisation.name %}
-{% set mainClasses = "app-container govuk-body" %}
 
 {% block content %}
   <h1 class="govuk-heading-l">{{ pageHeading }}</h1>

--- a/server/views/courses/offerings/show.njk
+++ b/server/views/courses/offerings/show.njk
@@ -5,7 +5,7 @@
 
 {% extends "../../partials/layout.njk" %}
 
-{% set customPageTitleEnd = course.name + ", " + organisation.name %}
+{% set customPageTitleEnd = course.nameAndAlternateName + ", " + organisation.name %}
 {% set mainClasses = "app-container govuk-body" %}
 
 {% block content %}

--- a/server/views/courses/show.njk
+++ b/server/views/courses/show.njk
@@ -4,8 +4,6 @@
 
 {% extends "../partials/layout.njk" %}
 
-{% set mainClasses = "app-container govuk-body" %}
-
 {% block content %}
   <h1 class="govuk-heading-l">{{ pageHeading }}</h1>
 

--- a/server/views/courses/show.njk
+++ b/server/views/courses/show.njk
@@ -4,7 +4,6 @@
 
 {% extends "../partials/layout.njk" %}
 
-{% set customPageTitleEnd = course.name %}
 {% set mainClasses = "app-container govuk-body" %}
 
 {% block content %}

--- a/server/views/courses/show.njk
+++ b/server/views/courses/show.njk
@@ -4,7 +4,7 @@
 
 {% extends "../partials/layout.njk" %}
 
-{% set pageTitle = applicationName + " - " + course.name %}
+{% set customPageTitleEnd = course.name %}
 {% set mainClasses = "app-container govuk-body" %}
 
 {% block content %}

--- a/server/views/dashboard/index.njk
+++ b/server/views/dashboard/index.njk
@@ -1,6 +1,6 @@
 {% extends "../partials/layout.njk" %}
 
-{% set pageTitle = applicationName + " - Home" %}
+{% set customPageTitleEnd = "Home" %}
 {% set mainClasses = "app-container govuk-body dashboard__main" %}
 
 {% block content %}

--- a/server/views/pages/error.njk
+++ b/server/views/pages/error.njk
@@ -1,6 +1,6 @@
 {% extends "../partials/layout.njk" %}
 
-{% set pageTitle = applicationName + " - Error" %}
+{% set customPageTitleEnd = "Error" %}
 {% set mainClasses = "app-container govuk-body" %}
 
 {% block content %}

--- a/server/views/partials/layout.njk
+++ b/server/views/partials/layout.njk
@@ -37,6 +37,10 @@
   {% include "./header.njk" %}
 {% endblock header %}
 
+{% if not mainClasses %}
+  {% set mainClasses = "app-container govuk-body" %}
+{% endif %}
+
 {% block beforeContent %}
   {{ govukPhaseBanner({
     tag: {

--- a/server/views/partials/layout.njk
+++ b/server/views/partials/layout.njk
@@ -2,8 +2,14 @@
 
 {% extends "govuk/template.njk" %}
 
+{% if customPageTitleEnd %}
+  {% set pageTitleEnd = " - " + customPageTitleEnd %}
+{% elif pageHeading %}
+  {% set pageTitleEnd = " - " + pageHeading %}
+{% endif %}
+
 {% block pageTitle %}
-  {{pageTitle | default(applicationName)}}
+  {{ applicationName }}{{ pageTitleEnd }}
 {% endblock pageTitle %}
 
 {% block head %}


### PR DESCRIPTION
## Context

We set page heading and page titles separately, but generally the heading can be reused in the title. There were some other unDRY patterns within the views

## Changes in this PR

- Default to `applicationName` and `pageHeading` if `pageTitle` is not set
- Remove some custom `pageTitle`s
- Use `nameAndAlternateName` in one place it wasn't being used
- DRY up setting of `mainClasses`
- DRY up `h1` creation

## Release checklist

[Release process documentation](../doc/how-to/perform-a-release.md)

As part of our continuous deployment strategy we must ensure that this work is
ready to be released once merged.

### Pre-merge

- [ ] There are changes required to the Accredited Programmes API for this change to work...
  - [ ] ... and they been released to production already

### Post-merge

<!-- The outer checkboxes can be completed pre-merge -->

- [ ] This adds, extends or meaningfully modifies a feature...
  - [ ] ... and I have written or updated an end-to-end test for the happy path in the [Accredited Programmes E2E repo](https://github.com/ministryofjustice/hmpps-accredited-programmes-e2e)
- [ ] This makes new expectations of the API...
  - [ ] ... and I have notified the API developer(s) of changes to the contract tests (Pact), or the API is already compliant
- [ ] [Manually approve](../doc/how-to/perform-a-release.md#releasing-to-the-preprod-environment) release to preprod
- [ ] [Manually approve](../doc/how-to/perform-a-release.md#releasing-to-the-production-environment) release to prod

<!-- Should a release fail at any step, you as the author should now lead the work to
fix it as soon as possible. You can monitor deployment failures in CircleCI
itself and application errors are found in
[Sentry](https://ministryofjustice.sentry.io/projects/hmpps-accredited-programmes-ui/?project=4505330122686464&referrer=sidebar&statsPeriod=24h). -->
