### PR TITLE
(593) Combine multiple prerequisites

### DIFF
--- a/server/testutils/factories/course.ts
+++ b/server/testutils/factories/course.ts
@@ -20,6 +20,7 @@ export default Factory.define<Course>(({ params }) => {
       coursePrerequisiteFactory.gender().build(),
       coursePrerequisiteFactory.learningNeeds().build(),
       coursePrerequisiteFactory.riskCriteria().build(),
+      coursePrerequisiteFactory.riskCriteria().build(),
       coursePrerequisiteFactory.setting().build(),
     ],
   }

--- a/server/utils/courseUtils.test.ts
+++ b/server/utils/courseUtils.test.ts
@@ -53,6 +53,20 @@ describe('courseUtils', () => {
       })
     })
 
+    describe('when a course has multiple prerequisites with the same name', () => {
+      it('combines the descriptions of the matching prerequisites', () => {
+        const riskCriteriaPrerequisites = coursePrerequisiteFactory.riskCriteria().buildList(2)
+        const course = courseFactory.build({ coursePrerequisites: riskCriteriaPrerequisites })
+        const coursePresenter = presentCourse(course)
+        const riskCriteriaSummaryListRows = coursePresenter.prerequisiteSummaryListRows[2]
+
+        expect(riskCriteriaSummaryListRows).toEqual({
+          key: { text: 'Risk criteria' },
+          value: { text: `${riskCriteriaPrerequisites[0].description}, ${riskCriteriaPrerequisites[1].description}` },
+        })
+      })
+    })
+
     describe('when a course has no `alternateName`', () => {
       it('just uses the `name` as the `nameAndAlternateName`', () => {
         const course = courseFactory.build({ alternateName: null })

--- a/server/utils/courseUtils.ts
+++ b/server/utils/courseUtils.ts
@@ -1,5 +1,5 @@
 import type { Course, CourseAudience, CoursePrerequisite } from '@accredited-programmes/models'
-import type { CoursePresenter, SummaryListRow, Tag, TagColour } from '@accredited-programmes/ui'
+import type { CoursePresenter, ObjectWithTextString, SummaryListRow, Tag, TagColour } from '@accredited-programmes/ui'
 
 const audienceTags = (audiences: Array<CourseAudience>): Array<Tag> => {
   const audienceColourMap: { [key: CourseAudience['value']]: TagColour } = {
@@ -34,9 +34,17 @@ const prerequisiteSummaryListRows = (prerequisites: Array<CoursePrerequisite>): 
   prerequisites.forEach(prerequisite => {
     const index = order[prerequisite.name]
 
-    summaryListRows[index] = {
-      key: { text: prerequisite.name },
-      value: { text: prerequisite.description },
+    if (index === undefined) {
+      return
+    }
+
+    if (summaryListRows[index]) {
+      ;(summaryListRows[index].value as ObjectWithTextString).text += `, ${prerequisite.description}`
+    } else {
+      summaryListRows[index] = {
+        key: { text: prerequisite.name },
+        value: { text: prerequisite.description },
+      }
     }
   })
 

--- a/wiremock/stubs/courses.json
+++ b/wiremock/stubs/courses.json
@@ -88,6 +88,10 @@
         "description": "Example risk criteria"
       },
       {
+        "name": "Risk criteria",
+        "description": "Example risk criteria 2"
+      },
+      {
         "name": "Setting",
         "description": "Example setting"
       }
@@ -146,6 +150,10 @@
       {
         "name": "Risk criteria",
         "description": "Example risk criteria"
+      },
+      {
+        "name": "Risk criteria",
+        "description": "Example risk criteria 2"
       },
       {
         "name": "Setting",


### PR DESCRIPTION
## Context

In some cases, a single course has multiple prerequisites with the same name. The current code will only display the last of these in such cases

## Changes in this PR

- Concatenate prerequisites with the same name
- Ensure we are working on the assumption (default) that there can be multiple prerequisites with the same name on a single cause

## Screenshots of UI changes

### Before

![image](https://github.com/ministryofjustice/hmpps-accredited-programmes-ui/assets/40244233/12cf47c7-df46-4611-82a1-1e3a559039b2)

### After

![image](https://github.com/ministryofjustice/hmpps-accredited-programmes-ui/assets/40244233/2e1e5004-28f5-4d77-ad64-ccda37bb5a53)

## Release checklist

[Release process documentation](../doc/how-to/perform-a-release.md)

As part of our continuous deployment strategy we must ensure that this work is
ready to be released once merged.

### Pre-merge

- [ ] There are changes required to the Accredited Programmes API for this change to work...
  - [ ] ... and they have been released to production already

### Post-merge

<!-- The outer checkboxes can be completed pre-merge -->

- [x] This adds, extends or meaningfully modifies a feature...
  - [ ] ... and I have written or updated an end-to-end test for the happy path in the [Accredited Programmes E2E repo](https://github.com/ministryofjustice/hmpps-accredited-programmes-e2e)
- [x] This makes new expectations of the API...
  - [x] ... and I have notified the API developer(s) of changes to the contract tests (Pact), or the API is already compliant
- [ ] [Manually approve](../doc/how-to/perform-a-release.md#releasing-to-the-preprod-environment) release to preprod
- [ ] [Manually approve](../doc/how-to/perform-a-release.md#releasing-to-the-production-environment) release to prod

<!-- Should a release fail at any step, you as the author should now lead the work to
fix it as soon as possible. You can monitor deployment failures in CircleCI
itself and application errors are found in
[Sentry](https://ministryofjustice.sentry.io/projects/hmpps-accredited-programmes-ui/?project=4505330122686464&referrer=sidebar&statsPeriod=24h). -->
