### PR TITLE
(598) Display secondary contact email address if one exists

### DIFF
--- a/integration_tests/e2e/find.cy.ts
+++ b/integration_tests/e2e/find.cy.ts
@@ -57,22 +57,48 @@ context('Find', () => {
     coursePage.shouldHaveOrganisations(organisationsWithOfferingIds)
   })
 
-  it('Shows a single offering', () => {
-    cy.signIn()
+  describe('Viewing a single offering', () => {
+    it('shows a single offering with no secondary email address', () => {
+      cy.signIn()
 
-    const course = courseFactory.build()
-    const courseOffering = courseOfferingFactory.build()
-    const prison = prisonFactory.build({ prisonId: courseOffering.organisationId })
-    const organisation = organisationFromPrison('an-ID', prison)
+      const course = courseFactory.build()
+      const courseOffering = courseOfferingFactory.build({
+        secondaryContactEmail: '',
+      })
+      const prison = prisonFactory.build({ prisonId: courseOffering.organisationId })
+      const organisation = organisationFromPrison('an-ID', prison)
 
-    cy.task('stubCourse', course)
-    cy.task('stubCourseOffering', { courseId: course.id, courseOffering })
-    cy.task('stubPrison', prison)
+      cy.task('stubCourse', course)
+      cy.task('stubCourseOffering', { courseId: course.id, courseOffering })
+      cy.task('stubPrison', prison)
 
-    cy.visit(findPaths.courses.offerings.show({ courseId: course.id, courseOfferingId: courseOffering.id }))
+      cy.visit(findPaths.courses.offerings.show({ courseId: course.id, courseOfferingId: courseOffering.id }))
 
-    const courseOfferingPage = CoursePage.verifyOnPage(CourseOfferingPage, { courseOffering, course, organisation })
-    courseOfferingPage.shouldHaveAudience()
-    courseOfferingPage.shouldHaveOrganisationWithOfferingEmail()
+      const courseOfferingPage = CoursePage.verifyOnPage(CourseOfferingPage, { courseOffering, course, organisation })
+      courseOfferingPage.shouldHaveAudience()
+      courseOfferingPage.shouldHaveOrganisationWithOfferingEmails()
+      courseOfferingPage.shouldNotContainSecondaryContactEmailSummaryListItem()
+    })
+
+    it('shows a single offering with a secondary email address', () => {
+      cy.signIn()
+
+      const course = courseFactory.build()
+      const courseOffering = courseOfferingFactory.build({
+        secondaryContactEmail: 'secondary-contact@nowhere.com',
+      })
+      const prison = prisonFactory.build({ prisonId: courseOffering.organisationId })
+      const organisation = organisationFromPrison('an-ID', prison)
+
+      cy.task('stubCourse', course)
+      cy.task('stubCourseOffering', { courseId: course.id, courseOffering })
+      cy.task('stubPrison', prison)
+
+      cy.visit(findPaths.courses.offerings.show({ courseId: course.id, courseOfferingId: courseOffering.id }))
+
+      const courseOfferingPage = CoursePage.verifyOnPage(CourseOfferingPage, { courseOffering, course, organisation })
+      courseOfferingPage.shouldHaveAudience()
+      courseOfferingPage.shouldHaveOrganisationWithOfferingEmails()
+    })
   })
 })

--- a/integration_tests/pages/find/courseOffering.ts
+++ b/integration_tests/pages/find/courseOffering.ts
@@ -1,15 +1,15 @@
 import presentCourse from '../../../server/utils/courseUtils'
-import { presentOrganisationWithOfferingEmail } from '../../../server/utils/organisationUtils'
+import { presentOrganisationWithOfferingEmails } from '../../../server/utils/organisationUtils'
 import Page from '../page'
 import type { Course, CourseOffering, Organisation } from '@accredited-programmes/models'
-import type { CoursePresenter, OrganisationWithOfferingEmailPresenter } from '@accredited-programmes/ui'
+import type { CoursePresenter, OrganisationWithOfferingEmailsPresenter } from '@accredited-programmes/ui'
 
 export default class CourseOfferingPage extends Page {
   course: CoursePresenter
 
   courseOffering: CourseOffering
 
-  organisation: OrganisationWithOfferingEmailPresenter
+  organisation: OrganisationWithOfferingEmailsPresenter
 
   constructor(args: { courseOffering: CourseOffering; course: Course; organisation: Organisation }) {
     const { courseOffering, organisation, course } = args
@@ -19,7 +19,7 @@ export default class CourseOfferingPage extends Page {
     })
     this.courseOffering = courseOffering
     this.course = coursePresenter
-    this.organisation = presentOrganisationWithOfferingEmail(organisation, courseOffering.contactEmail)
+    this.organisation = presentOrganisationWithOfferingEmails(organisation, courseOffering)
   }
 
   shouldHaveAudience() {
@@ -30,11 +30,15 @@ export default class CourseOfferingPage extends Page {
     })
   }
 
-  shouldHaveOrganisationWithOfferingEmail() {
+  shouldHaveOrganisationWithOfferingEmails() {
     cy.get('.govuk-heading-m').should('have.text', this.organisation.name)
 
     cy.get('.govuk-summary-list').then(summaryListElement => {
       this.shouldContainSummaryListRows(this.organisation.summaryListRows, summaryListElement)
     })
+  }
+
+  shouldNotContainSecondaryContactEmailSummaryListItem() {
+    cy.get('.govuk-summary-list').should('not.contain', 'Secondary email address')
   }
 }

--- a/integration_tests/pages/page.ts
+++ b/integration_tests/pages/page.ts
@@ -37,11 +37,15 @@ export default abstract class Page {
 
   manageDetails = (): PageElement => cy.get('[data-qa=manageDetails]')
 
-  shouldContainSummaryListRows(rows: Array<SummaryListRow>, summaryListElement: JQuery<HTMLElement>): void {
+  shouldContainSummaryListRows(rows: Array<SummaryListRow | undefined>, summaryListElement: JQuery<HTMLElement>): void {
     cy.wrap(summaryListElement).within(() => {
       cy.get('.govuk-summary-list__row').each((rowElement, rowElementIndex) => {
         cy.wrap(rowElement).within(() => {
           const row = rows[rowElementIndex]
+
+          if (row === undefined) {
+            return
+          }
 
           cy.get('.govuk-summary-list__key').then(summaryListKeyElement => {
             const { actual, expected } = helpers.parseHtml(summaryListKeyElement, row.key.text)

--- a/server/@types/models/CourseOffering.ts
+++ b/server/@types/models/CourseOffering.ts
@@ -2,4 +2,5 @@ export type CourseOffering = {
   id: string
   organisationId: string
   contactEmail: string
+  secondaryContactEmail?: string
 }

--- a/server/@types/ui/index.d.ts
+++ b/server/@types/ui/index.d.ts
@@ -33,22 +33,23 @@ type OrganisationWithOfferingId = Organisation & {
   courseOfferingId: CourseOffering['id']
 }
 
-type OrganisationWithOfferingEmailSummaryListRows = [
+type OrganisationWithOfferingEmailsSummaryListRows = [
   SummaryListRow<'Address', ObjectWithTextString>,
   SummaryListRow<'County', ObjectWithTextString>,
   SummaryListRow<'Email address', ObjectWithHtmlString>,
+  SummaryListRow<'Secondary email address', ObjectWithHtmlString>?,
 ]
 
-type OrganisationWithOfferingEmailPresenter = Organisation & {
-  summaryListRows: OrganisationWithOfferingEmailSummaryListRows
+type OrganisationWithOfferingEmailsPresenter = Organisation & {
+  summaryListRows: OrganisationWithOfferingEmailsSummaryListRows
 }
 
 export type {
   CoursePresenter,
   ObjectWithHtmlString,
   ObjectWithTextString,
-  OrganisationWithOfferingEmailPresenter,
-  OrganisationWithOfferingEmailSummaryListRows,
+  OrganisationWithOfferingEmailsPresenter,
+  OrganisationWithOfferingEmailsSummaryListRows,
   OrganisationWithOfferingId,
   SummaryListRow,
   TableRow,

--- a/server/controllers/find/courseOfferingsController.test.ts
+++ b/server/controllers/find/courseOfferingsController.test.ts
@@ -6,7 +6,7 @@ import CourseOfferingsController from './courseOfferingsController'
 import type { CourseService, OrganisationService } from '../../services'
 import { courseFactory, courseOfferingFactory, organisationFactory } from '../../testutils/factories'
 import presentCourse from '../../utils/courseUtils'
-import { presentOrganisationWithOfferingEmail } from '../../utils/organisationUtils'
+import { presentOrganisationWithOfferingEmails } from '../../utils/organisationUtils'
 
 describe('CoursesOfferingsController', () => {
   describe('show', () => {
@@ -38,7 +38,7 @@ describe('CoursesOfferingsController', () => {
       expect(response.render).toHaveBeenCalledWith('courses/offerings/show', {
         pageHeading: coursePresenter.nameAndAlternateName,
         course: coursePresenter,
-        organisation: presentOrganisationWithOfferingEmail(organisation, courseOffering.contactEmail),
+        organisation: presentOrganisationWithOfferingEmails(organisation, courseOffering),
       })
     })
   })

--- a/server/controllers/find/courseOfferingsController.ts
+++ b/server/controllers/find/courseOfferingsController.ts
@@ -3,7 +3,7 @@ import createError from 'http-errors'
 
 import type { CourseService, OrganisationService } from '../../services'
 import presentCourse from '../../utils/courseUtils'
-import { presentOrganisationWithOfferingEmail } from '../../utils/organisationUtils'
+import { presentOrganisationWithOfferingEmails } from '../../utils/organisationUtils'
 import { assertHasUser } from '../../utils/typeUtils'
 
 export default class CourseOfferingsController {
@@ -35,7 +35,7 @@ export default class CourseOfferingsController {
       res.render('courses/offerings/show', {
         pageHeading: coursePresenter.nameAndAlternateName,
         course: coursePresenter,
-        organisation: presentOrganisationWithOfferingEmail(organisation, courseOffering.contactEmail),
+        organisation: presentOrganisationWithOfferingEmails(organisation, courseOffering),
       })
     }
   }

--- a/server/data/courseClient.test.ts
+++ b/server/data/courseClient.test.ts
@@ -32,6 +32,7 @@ pactWith({ consumer: 'Accredited Programmes UI', provider: 'Accredited Programme
   const courseOfferings = courseOfferingFactory.buildList(3)
   const courseOffering = courseOfferingFactory.build({
     id: '20f3abc8-dd92-43ae-b88e-5797a0ad3f4b',
+    secondaryContactEmail: 'nobody2-iry@digital.justice.gov.uk',
   })
 
   describe('all', () => {

--- a/server/testutils/factories/courseOffering.ts
+++ b/server/testutils/factories/courseOffering.ts
@@ -9,4 +9,5 @@ export default Factory.define<CourseOffering>(() => ({
   id: faker.string.uuid(),
   organisationId: faker.string.alpha({ length: 3, casing: 'upper' }),
   contactEmail: `nobody-${organisationId.toLowerCase()}@digital.justice.gov.uk`,
+  secondaryContactEmail: '',
 }))

--- a/server/utils/organisationUtils.test.ts
+++ b/server/utils/organisationUtils.test.ts
@@ -3,9 +3,15 @@ import { faker } from '@faker-js/faker/locale/en_GB'
 import {
   organisationFromPrison,
   organisationTableRows,
-  presentOrganisationWithOfferingEmail,
+  presentOrganisationWithOfferingEmails,
 } from './organisationUtils'
-import { courseFactory, organisationAddressFactory, organisationFactory, prisonFactory } from '../testutils/factories'
+import {
+  courseFactory,
+  courseOfferingFactory,
+  organisationAddressFactory,
+  organisationFactory,
+  prisonFactory,
+} from '../testutils/factories'
 import type { OrganisationWithOfferingId } from '@accredited-programmes/ui'
 
 describe('organisationUtils', () => {
@@ -98,11 +104,15 @@ describe('organisationUtils', () => {
       }),
     })
 
-    const email = `nobody-hmp-what@digital.justice.gov.uk`
+    const offering = courseOfferingFactory.build({
+      organisationId: organisation.id,
+      contactEmail: 'nobody-hmp-what@digital.justice.gov.uk',
+      secondaryContactEmail: 'nobody2-hmp-what@digital.justice.gov.uk',
+    })
 
     describe('when all fields are present', () => {
-      it('returns an organisation and course offering email with UI-formatted data', () => {
-        expect(presentOrganisationWithOfferingEmail(organisation, email)).toEqual({
+      it('returns an organisation with its course offering emails with UI-formatted data', () => {
+        expect(presentOrganisationWithOfferingEmails(organisation, offering)).toEqual({
           ...organisation,
           summaryListRows: [
             {
@@ -119,6 +129,12 @@ describe('organisationUtils', () => {
                 html: '<a class="govuk-link" href="mailto:nobody-hmp-what@digital.justice.gov.uk">nobody-hmp-what@digital.justice.gov.uk</a>',
               },
             },
+            {
+              key: { text: 'Secondary email address' },
+              value: {
+                html: '<a class="govuk-link" href="mailto:nobody2-hmp-what@digital.justice.gov.uk">nobody2-hmp-what@digital.justice.gov.uk</a>',
+              },
+            },
           ],
         })
       })
@@ -129,7 +145,42 @@ describe('organisationUtils', () => {
         const organisationDuplicate = { ...organisation }
         organisationDuplicate.address.county = null
 
-        expect(presentOrganisationWithOfferingEmail(organisationDuplicate, email)).toEqual({
+        expect(presentOrganisationWithOfferingEmails(organisationDuplicate, offering)).toEqual({
+          ...organisation,
+          summaryListRows: [
+            {
+              key: { text: 'Address' },
+              value: { text: '123 Alphabet Street, Thine District, That Town Over There, HE3 3TA' },
+            },
+            {
+              key: { text: 'County' },
+              value: { text: 'Not found' },
+            },
+            {
+              key: { text: 'Email address' },
+              value: {
+                html: '<a class="govuk-link" href="mailto:nobody-hmp-what@digital.justice.gov.uk">nobody-hmp-what@digital.justice.gov.uk</a>',
+              },
+            },
+            {
+              key: { text: 'Secondary email address' },
+              value: {
+                html: '<a class="govuk-link" href="mailto:nobody2-hmp-what@digital.justice.gov.uk">nobody2-hmp-what@digital.justice.gov.uk</a>',
+              },
+            },
+          ],
+        })
+      })
+    })
+
+    describe('when the offering does not have a secondary contact email', () => {
+      it('does not include a secondary email address field', () => {
+        const offeringWithNoSecondaryContactEmail = courseOfferingFactory.build({
+          contactEmail: 'nobody-hmp-what@digital.justice.gov.uk',
+          secondaryContactEmail: '',
+        })
+
+        expect(presentOrganisationWithOfferingEmails(organisation, offeringWithNoSecondaryContactEmail)).toEqual({
           ...organisation,
           summaryListRows: [
             {

--- a/server/utils/organisationUtils.ts
+++ b/server/utils/organisationUtils.ts
@@ -1,8 +1,8 @@
 import findPaths from '../paths/find'
 import type { Course, CourseOffering, Organisation, OrganisationAddress } from '@accredited-programmes/models'
 import type {
-  OrganisationWithOfferingEmailPresenter,
-  OrganisationWithOfferingEmailSummaryListRows,
+  OrganisationWithOfferingEmailsPresenter,
+  OrganisationWithOfferingEmailsSummaryListRows,
   OrganisationWithOfferingId,
   TableRow,
 } from '@accredited-programmes/ui'
@@ -40,9 +40,11 @@ const concatenatedOrganisationAddress = (address: OrganisationAddress): string =
 
 const organisationWithOfferingEmailSummaryListRows = (
   organisation: Organisation,
-  email: CourseOffering['contactEmail'],
-): OrganisationWithOfferingEmailSummaryListRows => {
-  return [
+  offering: CourseOffering,
+): OrganisationWithOfferingEmailsSummaryListRows => {
+  const mailToLink = (email: string) => `<a class="govuk-link" href="mailto:${email}">${email}</a>`
+
+  const summaryListRows: OrganisationWithOfferingEmailsSummaryListRows = [
     {
       key: { text: 'Address' },
       value: { text: concatenatedOrganisationAddress(organisation.address) },
@@ -53,19 +55,28 @@ const organisationWithOfferingEmailSummaryListRows = (
     },
     {
       key: { text: 'Email address' },
-      value: { html: `<a class="govuk-link" href="mailto:${email}">${email}</a>` },
+      value: { html: mailToLink(offering.contactEmail) },
     },
   ]
+
+  if (offering.secondaryContactEmail) {
+    summaryListRows.push({
+      key: { text: 'Secondary email address' },
+      value: { html: mailToLink(offering.secondaryContactEmail) },
+    })
+  }
+
+  return summaryListRows
 }
 
-const presentOrganisationWithOfferingEmail = (
+const presentOrganisationWithOfferingEmails = (
   organisation: Organisation,
-  email: CourseOffering['contactEmail'],
-): OrganisationWithOfferingEmailPresenter => {
+  offering: CourseOffering,
+): OrganisationWithOfferingEmailsPresenter => {
   return {
     ...organisation,
-    summaryListRows: organisationWithOfferingEmailSummaryListRows(organisation, email),
+    summaryListRows: organisationWithOfferingEmailSummaryListRows(organisation, offering),
   }
 }
 
-export { organisationFromPrison, organisationTableRows, presentOrganisationWithOfferingEmail }
+export { organisationFromPrison, organisationTableRows, presentOrganisationWithOfferingEmails }

--- a/wiremock/stubs/courseOfferings.json
+++ b/wiremock/stubs/courseOfferings.json
@@ -2,16 +2,20 @@
   {
     "id": "e78237cd-8244-4256-a1e8-8fb29b1f2f76",
     "organisationId": "BMI",
-    "contactEmail": "nobody-bmi@digital.justice.gov.uk"
+    "contactEmail": "nobody-bmi@digital.justice.gov.uk",
+    "secondaryContactEmail": ""
   },
   {
     "id": "c09bf65b-5eba-448b-ad1f-0f8349fcfdb2",
     "organisationId": "BXI",
-    "contactEmail": "nobody-bxi@digital.justice.gov.uk"
+    "contactEmail": "nobody-bxi@digital.justice.gov.uk",
+    "secondaryContactEmail": "nobody2-bxi@digital.justice.gov.uk"
+
   },
   {
     "id": "c09bf65b-5eba-448b-ad1f-0f8349fcfdb2",
     "organisationId": "TRO",
-    "contactEmail": "nobody-tro@digital.justice.gov.uk"
+    "contactEmail": "nobody-tro@digital.justice.gov.uk",
+    "secondaryContactEmail": ""
   }
 ]


### PR DESCRIPTION
## Context

<!-- Is there a Trello ticket you can link to? -->

https://trello.com/c/fNkfLBoN/598-read-secondary-contact-email-address-in-the-ui

<!-- Do you need to add any environment variables? -->
<!-- Is an ADR required? An ADR should be added if this PR introduces a change to the architecture. -->

We've now added an optional secondary contact email address for Offerings to the API for Courses that might have two email addresses for a referral. We need to display this to users.

## Changes in this PR

Displays a secondary offering email on the "Offering" page if one exists.

If no secondary offering email exists, we don't render the summary list item at all.

There's a fair bit going on in the main commit of this PR as I've renamed some functions and changed return values of types to support a possibly-undefined summary list item, but I wanted to make sure all tests were passing.

The integration tests here aren't exactly DRY, but we can refactor them once we have a bit more time if we think it's necessary.

## Screenshots of UI changes

### Before

![Screenshot 2023-07-11 at 14 53 54](https://github.com/ministryofjustice/hmpps-accredited-programmes-ui/assets/19826940/18e71b93-7ccf-49d2-995e-960e480879c1)

### After

![Screenshot 2023-07-11 at 14 53 38](https://github.com/ministryofjustice/hmpps-accredited-programmes-ui/assets/19826940/76c4fcc4-13a4-4f38-a21b-ae2f116f265a)

## Release checklist

[Release process documentation](../doc/how-to/perform-a-release.md)

As part of our continuous deployment strategy we must ensure that this work is
ready to be released once merged.

### Pre-merge

- [x] There are changes required to the Accredited Programmes API for this change to work...
  - [ ] ... and they have been released to production already

### Post-merge

<!-- The outer checkboxes can be completed pre-merge -->

- [ ] This adds, extends or meaningfully modifies a feature...
  - [ ] ... and I have written or updated an end-to-end test for the happy path in the [Accredited Programmes E2E repo](https://github.com/ministryofjustice/hmpps-accredited-programmes-e2e)
- [x] This makes new expectations of the API...
  - [x] ... and I have notified the API developer(s) of changes to the contract tests (Pact), or the API is already compliant
- [ ] [Manually approve](../doc/how-to/perform-a-release.md#releasing-to-the-preprod-environment) release to preprod
- [ ] [Manually approve](../doc/how-to/perform-a-release.md#releasing-to-the-production-environment) release to prod

<!-- Should a release fail at any step, you as the author should now lead the work to
fix it as soon as possible. You can monitor deployment failures in CircleCI
itself and application errors are found in
[Sentry](https://ministryofjustice.sentry.io/projects/hmpps-accredited-programmes-ui/?project=4505330122686464&referrer=sidebar&statsPeriod=24h). -->
