### PR TITLE
(520) Display prison category (again)

### DIFF
--- a/integration_tests/pages/find/course.ts
+++ b/integration_tests/pages/find/course.ts
@@ -38,9 +38,10 @@ export default class CoursePage extends Page {
 
         cy.wrap(tableRowElement).within(() => {
           cy.get('.govuk-table__cell:first-of-type').should('have.text', organisation.name)
-          cy.get('.govuk-table__cell:nth-of-type(2)').should('have.text', organisation.address.county || 'Not found')
-          cy.get('.govuk-table__cell:nth-of-type(3)').should('have.text', `Contact prison (${organisation.name})`)
-          cy.get('.govuk-table__cell:nth-of-type(3) .govuk-link').should(
+          cy.get('.govuk-table__cell:nth-of-type(2)').should('have.text', 'N/A')
+          cy.get('.govuk-table__cell:nth-of-type(3)').should('have.text', organisation.address.county || 'Not found')
+          cy.get('.govuk-table__cell:nth-of-type(4)').should('have.text', `Contact prison (${organisation.name})`)
+          cy.get('.govuk-table__cell:nth-of-type(4) .govuk-link').should(
             'have.attr',
             'href',
             findPaths.courses.offerings.show({

--- a/integration_tests/pages/find/course.ts
+++ b/integration_tests/pages/find/course.ts
@@ -38,7 +38,7 @@ export default class CoursePage extends Page {
 
         cy.wrap(tableRowElement).within(() => {
           cy.get('.govuk-table__cell:first-of-type').should('have.text', organisation.name)
-          cy.get('.govuk-table__cell:nth-of-type(2)').should('have.text', 'N/A')
+          cy.get('.govuk-table__cell:nth-of-type(2)').should('have.text', organisation.category)
           cy.get('.govuk-table__cell:nth-of-type(3)').should('have.text', organisation.address.county || 'Not found')
           cy.get('.govuk-table__cell:nth-of-type(4)').should('have.text', `Contact prison (${organisation.name})`)
           cy.get('.govuk-table__cell:nth-of-type(4) .govuk-link').should(

--- a/server/@types/prisonRegisterApi/index.d.ts
+++ b/server/@types/prisonRegisterApi/index.d.ts
@@ -22,6 +22,7 @@ type PrisonOperator = {
 type Prison = {
   prisonId: string
   prisonName: string
+  categories: string[]
   active: boolean
   male: boolean
   female: boolean

--- a/server/@types/ui/index.d.ts
+++ b/server/@types/ui/index.d.ts
@@ -34,6 +34,7 @@ type OrganisationWithOfferingId = Organisation & {
 }
 
 type OrganisationWithOfferingEmailsSummaryListRows = [
+  SummaryListRow<'Prison category', ObjectWithTextString>,
   SummaryListRow<'Address', ObjectWithTextString>,
   SummaryListRow<'County', ObjectWithTextString>,
   SummaryListRow<'Email address', ObjectWithHtmlString>,

--- a/server/services/organisationService.test.ts
+++ b/server/services/organisationService.test.ts
@@ -23,7 +23,7 @@ describe('OrganisationService', () => {
     describe('when the prison client finds the corresponding prison', () => {
       describe("and it's active", () => {
         it('returns the specified organisation', async () => {
-          const prison = prisonFactory.build()
+          const prison = prisonFactory.build({ categories: ['A'] })
           const prisonAddress = prison.addresses[0]
 
           prisonClient.getPrison.mockResolvedValue(prison)
@@ -33,7 +33,7 @@ describe('OrganisationService', () => {
           expect(result).toEqual({
             id: prison.prisonId,
             name: prison.prisonName,
-            category: 'N/A',
+            category: 'A',
             address: {
               addressLine1: prisonAddress.addressLine1,
               addressLine2: prisonAddress.addressLine2,

--- a/server/testutils/factories/prison.ts
+++ b/server/testutils/factories/prison.ts
@@ -15,6 +15,7 @@ export default Factory.define<Prison>(({ params }) => {
     male: faker.datatype.boolean(),
     female: faker.datatype.boolean(),
     contracted: faker.datatype.boolean(),
+    categories: [faker.helpers.arrayElement(['A', 'B', 'C'])],
     types: [
       {
         code: 'HMP',

--- a/server/utils/organisationUtils.test.ts
+++ b/server/utils/organisationUtils.test.ts
@@ -98,7 +98,7 @@ describe('organisationUtils', () => {
   describe('presentOrganisationWithOfferingEmail', () => {
     const organisation = organisationFactory.build({
       name: 'HMP What',
-      category: 'Category C',
+      category: 'C',
       address: organisationAddressFactory.build({
         addressLine1: '123 Alphabet Street',
         addressLine2: 'Thine District',
@@ -119,6 +119,10 @@ describe('organisationUtils', () => {
         expect(presentOrganisationWithOfferingEmails(organisation, offering)).toEqual({
           ...organisation,
           summaryListRows: [
+            {
+              key: { text: 'Prison category' },
+              value: { text: 'C' },
+            },
             {
               key: { text: 'Address' },
               value: { text: '123 Alphabet Street, Thine District, That Town Over There, Thisshire, HE3 3TA' },
@@ -152,6 +156,10 @@ describe('organisationUtils', () => {
         expect(presentOrganisationWithOfferingEmails(organisationDuplicate, offering)).toEqual({
           ...organisation,
           summaryListRows: [
+            {
+              key: { text: 'Prison category' },
+              value: { text: 'C' },
+            },
             {
               key: { text: 'Address' },
               value: { text: '123 Alphabet Street, Thine District, That Town Over There, HE3 3TA' },
@@ -187,6 +195,10 @@ describe('organisationUtils', () => {
         expect(presentOrganisationWithOfferingEmails(organisation, offeringWithNoSecondaryContactEmail)).toEqual({
           ...organisation,
           summaryListRows: [
+            {
+              key: { text: 'Prison category' },
+              value: { text: 'C' },
+            },
             {
               key: { text: 'Address' },
               value: { text: '123 Alphabet Street, Thine District, That Town Over There, HE3 3TA' },

--- a/server/utils/organisationUtils.test.ts
+++ b/server/utils/organisationUtils.test.ts
@@ -16,16 +16,22 @@ import type { OrganisationWithOfferingId } from '@accredited-programmes/ui'
 
 describe('organisationUtils', () => {
   describe('organisationFromPrison', () => {
-    it('returns an organisation given an ID and a prison', () => {
-      const prison = prisonFactory.build()
+    it('returns an organisation given an ID and a prison, joining its categories into a string', () => {
+      const prison = prisonFactory.build({ categories: ['A', 'B'] })
       const { addressLine1, addressLine2, town, county, postcode, country } = prison.addresses[0]
 
       expect(organisationFromPrison('an-ID', prison)).toEqual({
         id: 'an-ID',
         name: prison.prisonName,
-        category: 'N/A',
+        category: 'A/B',
         address: { addressLine1, addressLine2, town, county, postalCode: postcode, country },
       })
+    })
+
+    it('returns "Not available"" for the category if one cannot be found', () => {
+      const prison = prisonFactory.build({ categories: [] })
+
+      expect(organisationFromPrison('an-ID', prison).category).toEqual('Not available')
     })
   })
 

--- a/server/utils/organisationUtils.test.ts
+++ b/server/utils/organisationUtils.test.ts
@@ -50,6 +50,7 @@ describe('organisationUtils', () => {
         expect(organisationTableRows(course, organisationsWithOfferingIds)).toEqual([
           [
             { text: organisationsWithOfferingIds[0].name },
+            { text: organisationsWithOfferingIds[0].category },
             { text: organisationsWithOfferingIds[0].address.county },
             {
               html: `<a class="govuk-link" href="/programmes/${course.id}/offerings/${organisationsWithOfferingIds[0].courseOfferingId}">Contact prison <span class="govuk-visually-hidden">(${organisationsWithOfferingIds[0].name})</span></a>`,
@@ -57,6 +58,7 @@ describe('organisationUtils', () => {
           ],
           [
             { text: organisationsWithOfferingIds[1].name },
+            { text: organisationsWithOfferingIds[1].category },
             { text: organisationsWithOfferingIds[1].address.county },
             {
               html: `<a class="govuk-link" href="/programmes/${course.id}/offerings/${organisationsWithOfferingIds[1].courseOfferingId}">Contact prison <span class="govuk-visually-hidden">(${organisationsWithOfferingIds[1].name})</span></a>`,
@@ -64,6 +66,7 @@ describe('organisationUtils', () => {
           ],
           [
             { text: organisationsWithOfferingIds[2].name },
+            { text: organisationsWithOfferingIds[2].category },
             { text: organisationsWithOfferingIds[2].address.county },
             {
               html: `<a class="govuk-link" href="/programmes/${course.id}/offerings/${organisationsWithOfferingIds[2].courseOfferingId}">Contact prison <span class="govuk-visually-hidden">(${organisationsWithOfferingIds[2].name})</span></a>`,
@@ -81,6 +84,7 @@ describe('organisationUtils', () => {
         expect(organisationTableRows(course, [organisationWithOfferingId])).toEqual([
           [
             { text: organisationWithOfferingId.name },
+            { text: organisationWithOfferingId.category },
             { text: 'Not found' },
             {
               html: `<a class="govuk-link" href="/programmes/${course.id}/offerings/${organisationWithOfferingId.courseOfferingId}">Contact prison <span class="govuk-visually-hidden">(${organisationWithOfferingId.name})</span></a>`,

--- a/server/utils/organisationUtils.test.ts
+++ b/server/utils/organisationUtils.test.ts
@@ -16,8 +16,8 @@ import type { OrganisationWithOfferingId } from '@accredited-programmes/ui'
 
 describe('organisationUtils', () => {
   describe('organisationFromPrison', () => {
-    it('returns an organisation given an ID and a prison, joining its categories into a string', () => {
-      const prison = prisonFactory.build({ categories: ['A', 'B'] })
+    it('returns an organisation given an ID and a prison, sorting and joining its categories into a string', () => {
+      const prison = prisonFactory.build({ categories: ['B', 'A'] })
       const { addressLine1, addressLine2, town, county, postcode, country } = prison.addresses[0]
 
       expect(organisationFromPrison('an-ID', prison)).toEqual({

--- a/server/utils/organisationUtils.ts
+++ b/server/utils/organisationUtils.ts
@@ -14,7 +14,7 @@ const organisationFromPrison = (organisationId: Organisation['id'], prison: Pris
   return {
     id: organisationId,
     name: prison.prisonName,
-    category: 'N/A',
+    category: prison.categories.length > 0 ? prison.categories.join('/') : 'Not available',
     address: { addressLine1, addressLine2, town, county, postalCode: postcode, country },
   }
 }

--- a/server/utils/organisationUtils.ts
+++ b/server/utils/organisationUtils.ts
@@ -51,6 +51,10 @@ const organisationWithOfferingEmailsSummaryListRows = (
 
   const summaryListRows: OrganisationWithOfferingEmailsSummaryListRows = [
     {
+      key: { text: 'Prison category' },
+      value: { text: organisation.category },
+    },
+    {
       key: { text: 'Address' },
       value: { text: concatenatedOrganisationAddress(organisation.address) },
     },

--- a/server/utils/organisationUtils.ts
+++ b/server/utils/organisationUtils.ts
@@ -28,7 +28,12 @@ const organisationTableRows = (course: Course, organisations: Array<Organisation
     const visuallyHiddenPrisonInformation = `<span class="govuk-visually-hidden">(${organisation.name})</span>`
     const contactLink = `<a class="govuk-link" href="${offeringPath}">Contact prison ${visuallyHiddenPrisonInformation}</a>`
 
-    return [{ text: organisation.name }, { text: organisation.address.county || 'Not found' }, { html: contactLink }]
+    return [
+      { text: organisation.name },
+      { text: organisation.category },
+      { text: organisation.address.county || 'Not found' },
+      { html: contactLink },
+    ]
   })
 }
 

--- a/server/utils/organisationUtils.ts
+++ b/server/utils/organisationUtils.ts
@@ -38,7 +38,7 @@ const concatenatedOrganisationAddress = (address: OrganisationAddress): string =
     .join(', ')
 }
 
-const organisationWithOfferingEmailSummaryListRows = (
+const organisationWithOfferingEmailsSummaryListRows = (
   organisation: Organisation,
   offering: CourseOffering,
 ): OrganisationWithOfferingEmailsSummaryListRows => {
@@ -75,7 +75,7 @@ const presentOrganisationWithOfferingEmails = (
 ): OrganisationWithOfferingEmailsPresenter => {
   return {
     ...organisation,
-    summaryListRows: organisationWithOfferingEmailSummaryListRows(organisation, offering),
+    summaryListRows: organisationWithOfferingEmailsSummaryListRows(organisation, offering),
   }
 }
 

--- a/server/utils/organisationUtils.ts
+++ b/server/utils/organisationUtils.ts
@@ -10,11 +10,12 @@ import type { Prison } from '@prison-register-api'
 
 const organisationFromPrison = (organisationId: Organisation['id'], prison: Prison): Organisation => {
   const { addressLine1, addressLine2, town, county, postcode, country } = prison.addresses[0]
+  const categories = prison.categories.length > 0 ? prison.categories.sort().join('/') : 'Not available'
 
   return {
     id: organisationId,
     name: prison.prisonName,
-    category: prison.categories.length > 0 ? prison.categories.join('/') : 'Not available',
+    category: categories,
     address: { addressLine1, addressLine2, town, county, postalCode: postcode, country },
   }
 }

--- a/server/views/courses/_locationsTable.njk
+++ b/server/views/courses/_locationsTable.njk
@@ -12,6 +12,12 @@
       }
     },
     {
+      text: "Category",
+      attributes: {
+        "aria-sort": "none"
+      }
+    },
+    {
       text: "County",
       attributes: {
         "aria-sort": "none"


### PR DESCRIPTION
## Context

<!-- Is there a Trello ticket you can link to? -->
https://trello.com/c/M8TfhcMB/520-display-prison-category-in-the-list-of-offerings

<!-- Do you need to add any environment variables? -->
<!-- Is an ADR required? An ADR should be added if this PR introduces a change to the architecture. -->

Prison Category is an important field for POMs to ensure they don't refer people in prison to a programme in a prison of a different category. Until now, it's been unavailable in the Prison Register API, but we've now done the work to add it into the service.

## Changes in this PR

This reverts (and slightly tweaks) the commits made in #105 where we removed the unavailable prison categories.

We now join categories returned from the Prison API with a '/' and display them in the list of offerings.

## Screenshots of UI changes

### Before

<img width="921" alt="image" src="https://github.com/ministryofjustice/hmpps-accredited-programmes-ui/assets/19826940/8a4378af-b440-48c5-9b9f-bac7ab5da6e8">

### After

#### Multiple categories

![image](https://github.com/ministryofjustice/hmpps-accredited-programmes-ui/assets/19826940/7cd7858f-8820-4acb-a78e-d0c3bdb0b745)

#### Category not found

<img width="914" alt="image" src="https://github.com/ministryofjustice/hmpps-accredited-programmes-ui/assets/19826940/c269cfed-aba2-4fb6-af54-ec04a67c96e4">



## Release checklist

[Release process documentation](../doc/how-to/perform-a-release.md)

As part of our continuous deployment strategy we must ensure that this work is
ready to be released once merged.

### Pre-merge

- [ ] There are changes required to the Accredited Programmes API for this change to work...
  - [ ] ... and they have been released to production already

### Post-merge

<!-- The outer checkboxes can be completed pre-merge -->

- [ ] This adds, extends or meaningfully modifies a feature...
  - [ ] ... and I have written or updated an end-to-end test for the happy path in the [Accredited Programmes E2E repo](https://github.com/ministryofjustice/hmpps-accredited-programmes-e2e)
- [ ] This makes new expectations of the API...
  - [ ] ... and I have notified the API developer(s) of changes to the contract tests (Pact), or the API is already compliant
- [ ] [Manually approve](../doc/how-to/perform-a-release.md#releasing-to-the-preprod-environment) release to preprod
- [ ] [Manually approve](../doc/how-to/perform-a-release.md#releasing-to-the-production-environment) release to prod

<!-- Should a release fail at any step, you as the author should now lead the work to
fix it as soon as possible. You can monitor deployment failures in CircleCI
itself and application errors are found in
[Sentry](https://ministryofjustice.sentry.io/projects/hmpps-accredited-programmes-ui/?project=4505330122686464&referrer=sidebar&statsPeriod=24h). -->
