### PR TITLE
(610) Display empty row for no Prison Category

### DIFF
--- a/server/utils/organisationUtils.test.ts
+++ b/server/utils/organisationUtils.test.ts
@@ -28,10 +28,10 @@ describe('organisationUtils', () => {
       })
     })
 
-    it('returns "Not available"" for the category if one cannot be found', () => {
+    it('returns an empty string for the category if one cannot be found', () => {
       const prison = prisonFactory.build({ categories: [] })
 
-      expect(organisationFromPrison('an-ID', prison).category).toEqual('Not available')
+      expect(organisationFromPrison('an-ID', prison).category).toEqual('')
     })
   })
 

--- a/server/utils/organisationUtils.ts
+++ b/server/utils/organisationUtils.ts
@@ -10,7 +10,7 @@ import type { Prison } from '@prison-register-api'
 
 const organisationFromPrison = (organisationId: Organisation['id'], prison: Prison): Organisation => {
   const { addressLine1, addressLine2, town, county, postcode, country } = prison.addresses[0]
-  const categories = prison.categories.length > 0 ? prison.categories.sort().join('/') : 'Not available'
+  const categories = prison.categories.sort().join('/')
 
   return {
     id: organisationId,


### PR DESCRIPTION
## Context

<!-- Is there a Trello ticket you can link to? -->
https://trello.com/c/P1bccynd/610-display-empty-cell-in-table-rather-than-not-available-where-no-prison-category-is-found
<!-- Do you need to add any environment variables? -->
<!-- Is an ADR required? An ADR should be added if this PR introduces a change to the architecture. -->

Some prisons don't have categories (i.e. women's prison, YOI), so showing "Not available" feels misleading.

## Changes in this PR

We now show an empty row instead of "not found" where there's no prison category available.


## Screenshots of UI changes

### Before

![image](https://github.com/ministryofjustice/hmpps-accredited-programmes-ui/assets/19826940/3b9ef300-8119-47b2-8f19-dd4cf5cd2fdd)

### After

![image](https://github.com/ministryofjustice/hmpps-accredited-programmes-ui/assets/19826940/3e5bc7fa-93f7-4754-aa48-4da1940f6ba6)

## Release checklist

[Release process documentation](../doc/how-to/perform-a-release.md)

As part of our continuous deployment strategy we must ensure that this work is
ready to be released once merged.

### Pre-merge

- [ ] There are changes required to the Accredited Programmes API for this change to work...
  - [ ] ... and they have been released to production already

### Post-merge

<!-- The outer checkboxes can be completed pre-merge -->

- [ ] This adds, extends or meaningfully modifies a feature...
  - [ ] ... and I have written or updated an end-to-end test for the happy path in the [Accredited Programmes E2E repo](https://github.com/ministryofjustice/hmpps-accredited-programmes-e2e)
- [ ] This makes new expectations of the API...
  - [ ] ... and I have notified the API developer(s) of changes to the contract tests (Pact), or the API is already compliant
- [ ] [Manually approve](../doc/how-to/perform-a-release.md#releasing-to-the-preprod-environment) release to preprod
- [ ] [Manually approve](../doc/how-to/perform-a-release.md#releasing-to-the-production-environment) release to prod

<!-- Should a release fail at any step, you as the author should now lead the work to
fix it as soon as possible. You can monitor deployment failures in CircleCI
itself and application errors are found in
[Sentry](https://ministryofjustice.sentry.io/projects/hmpps-accredited-programmes-ui/?project=4505330122686464&referrer=sidebar&statsPeriod=24h). -->
