### PR TITLE
(641) Add missing `.govuk-body` classes

### DIFF
--- a/server/views/autherror.njk
+++ b/server/views/autherror.njk
@@ -4,7 +4,7 @@
   <h1 class="govuk-heading-l">
     Authorisation Error
   </h1>
-  <p>
+  <p class="govuk-body">
     You are not authorised to use this application.
   </p>
 {% endblock content %}

--- a/server/views/courses/_audienceTags.njk
+++ b/server/views/courses/_audienceTags.njk
@@ -1,7 +1,7 @@
 {% from "govuk/components/tag/macro.njk" import govukTag %}
 
 {% macro audienceTags(audienceTagData) %}
-  <p>
+  <p class="govuk-body">
     {% for tag in audienceTagData %}
       {{ govukTag({text: tag.text, classes: tag.classes}) }}
     {% endfor %}

--- a/server/views/courses/_indexCourseSummary.njk
+++ b/server/views/courses/_indexCourseSummary.njk
@@ -11,7 +11,7 @@
 
       {{ audienceTags(course.audienceTags) }}
 
-      <p>{{ course.description }}</p>
+      <p class="govuk-body">{{ course.description }}</p>
 
       {{ govukSummaryList({
         classes: 'govuk-summary-list--no-border',

--- a/server/views/courses/show.njk
+++ b/server/views/courses/show.njk
@@ -29,7 +29,7 @@
 
       <h2 class="govuk-heading-m">Programme description</h2>
 
-      <p>{{ course.description }}</p>
+      <p class="govuk-body">{{ course.description }}</p>
 
       <h2 class="govuk-heading-m">Locations</h2>
 


### PR DESCRIPTION
## Context

<!-- Is there a Trello ticket you can link to? -->
<!-- Do you need to add any environment variables? -->
<!-- Is an ADR required? An ADR should be added if this PR introduces a change to the architecture. -->

Some paragraph classes were missed when writing earlier PRs

## Changes in this PR

Add `govuk-body` class to paragraphs where missing

## Screenshots of UI changes

No noticeable change

## Release checklist

[Release process documentation](../doc/how-to/perform-a-release.md)

As part of our continuous deployment strategy we must ensure that this work is
ready to be released once merged.

### Pre-merge

- [ ] There are changes required to the Accredited Programmes API for this change to work...
  - [ ] ... and they have been released to production already

### Post-merge

<!-- The outer checkboxes can be completed pre-merge -->

- [ ] This adds, extends or meaningfully modifies a feature...
  - [ ] ... and I have written or updated an end-to-end test for the happy path in the [Accredited Programmes E2E repo](https://github.com/ministryofjustice/hmpps-accredited-programmes-e2e)
- [ ] This makes new expectations of the API...
  - [ ] ... and I have notified the API developer(s) of changes to the contract tests (Pact), or the API is already compliant
- [ ] [Manually approve](../doc/how-to/perform-a-release.md#releasing-to-the-preprod-environment) release to preprod
- [ ] [Manually approve](../doc/how-to/perform-a-release.md#releasing-to-the-production-environment) release to prod

<!-- Should a release fail at any step, you as the author should now lead the work to
fix it as soon as possible. You can monitor deployment failures in CircleCI
itself and application errors are found in
[Sentry](https://ministryofjustice.sentry.io/projects/hmpps-accredited-programmes-ui/?project=4505330122686464&referrer=sidebar&statsPeriod=24h). -->
