### PR TITLE
(730) Simplify post creation actions

### DIFF
--- a/integration_tests/e2e/refer.cy.ts
+++ b/integration_tests/e2e/refer.cy.ts
@@ -88,7 +88,7 @@ context('Refer', () => {
     confirmPersonPage.shouldHavePersonInformation()
   })
 
-  it("On confirming a person's details, creates a referral and redirects to the tasklist", () => {
+  it("On confirming a person's details, creates a referral and redirects to the task list", () => {
     cy.signIn()
 
     const course = courseFactory.build()

--- a/integration_tests/e2e/refer.cy.ts
+++ b/integration_tests/e2e/refer.cy.ts
@@ -113,13 +113,14 @@ context('Refer', () => {
     const prison = prisonFactory.build({ prisonId: courseOffering.organisationId })
     const organisation = OrganisationUtils.organisationFromPrison('an-ID', prison)
 
-    const referral = referralFactory.build()
+    const referral = referralFactory.build({ offeringId: courseOffering.id, prisonNumber: person.prisonNumber })
 
     cy.task('stubCourseByOffering', { course, courseOfferingId: courseOffering.id })
     cy.task('stubCourseOffering', { courseId: course.id, courseOffering })
     cy.task('stubPrison', prison)
     cy.task('stubPrisoner', prisoner)
     cy.task('stubCreateReferral', referral)
+    cy.task('stubReferral', referral)
 
     const path = referPaths.people.show({
       courseOfferingId: courseOffering.id,
@@ -139,13 +140,14 @@ context('Refer', () => {
     const courseOffering = courseOfferingFactory.build()
     const prison = prisonFactory.build({ prisonId: courseOffering.organisationId })
     const organisation = OrganisationUtils.organisationFromPrison('an-ID', prison)
-    const referral = referralFactory.build()
+    const referral = referralFactory.build({ offeringId: courseOffering.id })
 
     cy.task('stubCourseByOffering', { course, courseOfferingId: courseOffering.id })
     cy.task('stubCourseOffering', { courseId: course.id, courseOffering })
     cy.task('stubPrison', prison)
+    cy.task('stubReferral', referral)
 
-    const path = referPaths.show({ courseOfferingId: courseOffering.id, referralId: referral.id })
+    const path = referPaths.show({ referralId: referral.id })
     cy.visit(path)
 
     const taskListPage = Page.verifyOnPage(TaskListPage, { course, courseOffering, organisation })

--- a/integration_tests/e2eReferDisabled/refer.cy.ts
+++ b/integration_tests/e2eReferDisabled/refer.cy.ts
@@ -80,7 +80,7 @@ context('Refer', () => {
     cy.task('stubCourseOffering', { courseId: course.id, courseOffering })
     cy.task('stubPrison', prison)
 
-    const path = referPaths.show({ courseOfferingId: courseOffering.id, referralId: referral.id })
+    const path = referPaths.show({ referralId: referral.id })
     cy.visit(path, { failOnStatusCode: false })
 
     const notFoundPage = Page.verifyOnPage(NotFoundPage)

--- a/integration_tests/e2eReferDisabled/refer.cy.ts
+++ b/integration_tests/e2eReferDisabled/refer.cy.ts
@@ -68,7 +68,7 @@ context('Refer', () => {
     notFoundPage.shouldContain404H2()
   })
 
-  it("Doesn't show the the in-progress referral form page", () => {
+  it("Doesn't show the the in-progress referral task list", () => {
     cy.signIn()
 
     const course = courseFactory.build()

--- a/integration_tests/mockApis/referrals.ts
+++ b/integration_tests/mockApis/referrals.ts
@@ -17,4 +17,17 @@ export default {
         status: 201,
       },
     }),
+
+  stubReferral: (referral: Referral): SuperAgentRequest =>
+    stubFor({
+      request: {
+        method: 'GET',
+        url: apiPaths.referrals.show({ referralId: referral.id }),
+      },
+      response: {
+        headers: { 'Content-Type': 'application/json;charset=UTF-8' },
+        jsonBody: referral,
+        status: 200,
+      },
+    }),
 }

--- a/server/controllers/refer/referralsController.test.ts
+++ b/server/controllers/refer/referralsController.test.ts
@@ -102,9 +102,7 @@ describe('ReferralsController', () => {
       const requestHandler = referralsController.create()
       await requestHandler(request, response, next)
 
-      expect(response.redirect).toHaveBeenCalledWith(
-        referPaths.show({ courseOfferingId: referral.offeringId, referralId: referral.id }),
-      )
+      expect(response.redirect).toHaveBeenCalledWith(referPaths.show({ referralId: referral.id }))
       expect(referralService.createReferral).toHaveBeenCalledWith(
         token,
         referral.offeringId,
@@ -127,7 +125,6 @@ describe('ReferralsController', () => {
 
       expect(response.render).toHaveBeenCalledWith('referrals/show', {
         course: coursePresenter,
-        courseOffering,
         organisation,
         pageHeading: 'Make a referral',
       })

--- a/server/controllers/refer/referralsController.ts
+++ b/server/controllers/refer/referralsController.ts
@@ -27,7 +27,7 @@ export default class ReferralsController {
         userId,
       )
 
-      res.redirect(referPaths.show({ courseOfferingId, referralId: createdReferralResponse.referralId }))
+      res.redirect(referPaths.show({ referralId: createdReferralResponse.referralId }))
     }
   }
 
@@ -49,12 +49,9 @@ export default class ReferralsController {
     return async (req: Request, res: Response) => {
       TypeUtils.assertHasUser(req)
 
-      const course = await this.courseService.getCourseByOffering(req.user.token, req.params.courseOfferingId)
-      const courseOffering = await this.courseService.getOffering(
-        req.user.token,
-        course.id,
-        req.params.courseOfferingId,
-      )
+      const referral = await this.referralService.getReferral(req.user.token, req.params.referralId)
+      const course = await this.courseService.getCourseByOffering(req.user.token, referral.offeringId)
+      const courseOffering = await this.courseService.getOffering(req.user.token, course.id, referral.offeringId)
       const organisation = await this.organisationService.getOrganisation(req.user.token, courseOffering.organisationId)
 
       if (!organisation) {
@@ -67,7 +64,6 @@ export default class ReferralsController {
 
       res.render('referrals/show', {
         course: coursePresenter,
-        courseOffering,
         organisation,
         pageHeading: 'Make a referral',
       })

--- a/server/data/referralClient.test.ts
+++ b/server/data/referralClient.test.ts
@@ -51,4 +51,30 @@ pactWith({ consumer: 'Accredited Programmes UI', provider: 'Accredited Programme
       expect(result).toEqual(createdReferralResponse)
     })
   })
+
+  describe('find', () => {
+    beforeEach(() => {
+      provider.addInteraction({
+        state: `A referral exists with ID ${referral.id}`,
+        uponReceiving: `A request for referral "${referral.id}"`,
+        willRespondWith: {
+          body: Matchers.like(referral),
+          status: 200,
+        },
+        withRequest: {
+          headers: {
+            authorization: `Bearer ${token}`,
+          },
+          method: 'GET',
+          path: apiPaths.referrals.show({ referralId: referral.id }),
+        },
+      })
+    })
+
+    it('fetches the given referral', async () => {
+      const result = await referralClient.find(referral.id)
+
+      expect(result).toEqual(referral)
+    })
+  })
 })

--- a/server/data/referralClient.ts
+++ b/server/data/referralClient.ts
@@ -21,4 +21,10 @@ export default class ReferralClient {
       path: apiPaths.referrals.create({}),
     })) as CreatedReferralResponse
   }
+
+  async find(referralId: Referral['id']): Promise<Referral> {
+    return (await this.restClient.get({
+      path: apiPaths.referrals.show({ referralId }),
+    })) as Referral
+  }
 }

--- a/server/paths/api.ts
+++ b/server/paths/api.ts
@@ -9,6 +9,7 @@ const courseOfferingPath = courseOfferingsPath.path(':courseOfferingId')
 const courseByOfferingPath = path('/offerings/:courseOfferingId/course')
 
 const referralsPath = path('/referrals')
+const referralPath = referralsPath.path(':referralId')
 
 export default {
   courses: {
@@ -22,5 +23,6 @@ export default {
   },
   referrals: {
     create: referralsPath,
+    show: referralPath,
   },
 }

--- a/server/paths/refer.ts
+++ b/server/paths/refer.ts
@@ -2,12 +2,13 @@ import { path } from 'static-path'
 
 import findPaths from './find'
 
-const startReferralPath = findPaths.offerings.show.path('refer')
-const newReferralPath = startReferralPath.path('new')
+const offeringReferralPathBase = findPaths.offerings.show.path('referrals')
+const startReferralPath = offeringReferralPathBase.path('start')
+const newReferralPath = offeringReferralPathBase.path('new')
 
-const peoplePath = startReferralPath.path('people')
-const findPersonPath = peoplePath.path('search')
-const personPath = peoplePath.path(':prisonNumber')
+const peoplePathBase = offeringReferralPathBase.path('people')
+const findPersonPath = peoplePathBase.path('search')
+const personPath = peoplePathBase.path(':prisonNumber')
 
 const referralsPath = path('/referrals')
 const showReferralPath = referralsPath.path(':referralId')

--- a/server/paths/refer.ts
+++ b/server/paths/refer.ts
@@ -4,13 +4,13 @@ import findPaths from './find'
 
 const startReferralPath = findPaths.offerings.show.path('refer')
 const newReferralPath = startReferralPath.path('new')
-const showReferralPath = findPaths.offerings.show.path('referrals/:referralId')
 
 const peoplePath = startReferralPath.path('people')
 const findPersonPath = peoplePath.path('search')
 const personPath = peoplePath.path(':prisonNumber')
 
 const referralsPath = path('/referrals')
+const showReferralPath = referralsPath.path(':referralId')
 
 export default {
   create: referralsPath,

--- a/server/services/referralService.test.ts
+++ b/server/services/referralService.test.ts
@@ -46,4 +46,18 @@ describe('ReferralService', () => {
       )
     })
   })
+
+  describe('getReferral', () => {
+    it('returns a given referral', async () => {
+      const referral = referralFactory.build()
+      when(referralClient.find).calledWith(referral.id).mockResolvedValue(referral)
+
+      const result = await service.getReferral(token, referral.id)
+
+      expect(result).toEqual(referral)
+
+      expect(referralClientBuilder).toHaveBeenCalledWith(token)
+      expect(referralClient.find).toHaveBeenCalledWith(referral.id)
+    })
+  })
 })

--- a/server/services/referralService.ts
+++ b/server/services/referralService.ts
@@ -13,4 +13,9 @@ export default class ReferralService {
     const referralClient = this.referralClientBuilder(token)
     return referralClient.create(courseOfferingId, prisonNumber, referrerId)
   }
+
+  async getReferral(token: Express.User['token'], referralId: Referral['id']): Promise<Referral> {
+    const referralClient = this.referralClientBuilder(token)
+    return referralClient.find(referralId)
+  }
 }


### PR DESCRIPTION
## Context

<!-- Is there a Trello ticket you can link to? -->
<!-- Do you need to add any environment variables? -->
<!-- Is an ADR required? An ADR should be added if this PR introduces a change to the architecture. -->

We currently have the course offering in all Refer paths, but we can get this from the referral once created

## Changes in this PR

- Simplify post-creation Refer paths to remove redundant course offering ID
- Clean up paths
- Update test descriptions

## Release checklist

[Release process documentation](../doc/how-to/perform-a-release.md)

As part of our continuous deployment strategy we must ensure that this work is
ready to be released once merged.

### Pre-merge

- [x] There are changes required to the Accredited Programmes API for this change to work...
  - [x] ... and they have been released to production already

### Post-merge

<!-- The outer checkboxes can be completed pre-merge -->

- [x] This adds, extends or meaningfully modifies a feature...
  - [ ] ... and I have written or updated an end-to-end test for the happy path in the [Accredited Programmes E2E repo](https://github.com/ministryofjustice/hmpps-accredited-programmes-e2e)
- [x] This makes new expectations of the API...
  - [x] ... and I have notified the API developer(s) of changes to the contract tests (Pact), or the API is already compliant
- [ ] [Manually approve](../doc/how-to/perform-a-release.md#releasing-to-the-preprod-environment) release to preprod
- [ ] [Manually approve](../doc/how-to/perform-a-release.md#releasing-to-the-production-environment) release to prod

<!-- Should a release fail at any step, you as the author should now lead the work to
fix it as soon as possible. You can monitor deployment failures in CircleCI
itself and application errors are found in
[Sentry](https://ministryofjustice.sentry.io/projects/hmpps-accredited-programmes-ui/?project=4505330122686464&referrer=sidebar&statsPeriod=24h). -->
