### PR TITLE
Update eslint-plugin-import

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -105,10 +105,7 @@
       "error",
       {
         "alphabetize": { "order": "asc", "orderImportKind": "asc" },
-        "groups": [
-          ["builtin", "external"],
-          ["internal", "parent", "sibling"]
-        ],
+        "groups": [["builtin", "external"]],
         "newlines-between": "always"
       }
     ],

--- a/package-lock.json
+++ b/package-lock.json
@@ -79,7 +79,7 @@
         "eslint-config-prettier": "^9.0.0",
         "eslint-import-resolver-typescript": "^3.5.5",
         "eslint-plugin-cypress": "^2.13.2",
-        "eslint-plugin-import": "^2.27.5",
+        "eslint-plugin-import": "^2.28.1",
         "eslint-plugin-no-only-tests": "^3.1.0",
         "eslint-plugin-prettier": "^5.0.0",
         "eslint-plugin-sort-exports": "^0.8.0",

--- a/package.json
+++ b/package.json
@@ -121,7 +121,7 @@
     "eslint-config-prettier": "^9.0.0",
     "eslint-import-resolver-typescript": "^3.5.5",
     "eslint-plugin-cypress": "^2.13.2",
-    "eslint-plugin-import": "^2.27.5",
+    "eslint-plugin-import": "^2.28.1",
     "eslint-plugin-no-only-tests": "^3.1.0",
     "eslint-plugin-prettier": "^5.0.0",
     "eslint-plugin-sort-exports": "^0.8.0",


### PR DESCRIPTION
## Context

<!-- Is there a Trello ticket you can link to? -->
<!-- Do you need to add any environment variables? -->
<!-- Is an ADR required? An ADR should be added if this PR introduces a change to the architecture. -->

`eslint-plugin-import` introduced a breaking change to `import/order` where single nested groups were effectively denested. I (hopefully) fixed this in https://github.com/import-js/eslint-plugin-import/pull/2854, which has been released

## Changes in this PR

- Update `eslint-plugin-import` and revert complication of rule

## Release checklist

[Release process documentation](../doc/how-to/perform-a-release.md)

As part of our continuous deployment strategy we must ensure that this work is
ready to be released once merged.

### Pre-merge

- [ ] There are changes required to the Accredited Programmes API for this change to work...
  - [ ] ... and they have been released to production already

### Post-merge

<!-- The outer checkboxes can be completed pre-merge -->

- [ ] This adds, extends or meaningfully modifies a feature...
  - [ ] ... and I have written or updated an end-to-end test for the happy path in the [Accredited Programmes E2E repo](https://github.com/ministryofjustice/hmpps-accredited-programmes-e2e)
- [ ] This makes new expectations of the API...
  - [ ] ... and I have notified the API developer(s) of changes to the contract tests (Pact), or the API is already compliant
- [ ] [Manually approve](../doc/how-to/perform-a-release.md#releasing-to-the-preprod-environment) release to preprod
- [ ] [Manually approve](../doc/how-to/perform-a-release.md#releasing-to-the-production-environment) release to prod

<!-- Should a release fail at any step, you as the author should now lead the work to
fix it as soon as possible. You can monitor deployment failures in CircleCI
itself and application errors are found in
[Sentry](https://ministryofjustice.sentry.io/projects/hmpps-accredited-programmes-ui/?project=4505330122686464&referrer=sidebar&statsPeriod=24h). -->
