### PR TITLE
(731) Add PUT/update support

### DIFF
--- a/server/@types/models/Referral.ts
+++ b/server/@types/models/Referral.ts
@@ -12,4 +12,9 @@ type CreatedReferralResponse = {
   referralId: Referral['id']
 }
 
-export type { CreatedReferralResponse, Referral }
+type ReferralUpdate = {
+  oasysConfirmed: boolean
+  reason?: string
+}
+
+export type { CreatedReferralResponse, Referral, ReferralUpdate }

--- a/server/@types/models/index.d.ts
+++ b/server/@types/models/index.d.ts
@@ -5,7 +5,7 @@ import type { CoursePrerequisite } from './CoursePrerequisite'
 import type { Organisation } from './Organisation'
 import type { OrganisationAddress } from './OrganisationAddress'
 import type { Person } from './Person'
-import type { CreatedReferralResponse, Referral } from './Referral'
+import type { CreatedReferralResponse, Referral, ReferralUpdate } from './Referral'
 
 export type {
   Course,
@@ -17,4 +17,5 @@ export type {
   OrganisationAddress,
   Person,
   Referral,
+  ReferralUpdate,
 }

--- a/server/data/referralClient.test.ts
+++ b/server/data/referralClient.test.ts
@@ -5,7 +5,7 @@ import ReferralClient from './referralClient'
 import config from '../config'
 import { apiPaths } from '../paths'
 import { referralFactory } from '../testutils/factories'
-import type { CreatedReferralResponse } from '@accredited-programmes/models'
+import type { CreatedReferralResponse, ReferralUpdate } from '@accredited-programmes/models'
 
 pactWith({ consumer: 'Accredited Programmes UI', provider: 'Accredited Programmes API' }, provider => {
   let referralClient: ReferralClient
@@ -75,6 +75,34 @@ pactWith({ consumer: 'Accredited Programmes UI', provider: 'Accredited Programme
       const result = await referralClient.find(referral.id)
 
       expect(result).toEqual(referral)
+    })
+  })
+
+  describe('update', () => {
+    const referralUpdate: ReferralUpdate = { oasysConfirmed: true }
+
+    beforeEach(() => {
+      provider.addInteraction({
+        state: 'Referral can be updates',
+        uponReceiving: 'A request to update a referral',
+        willRespondWith: {
+          status: 204,
+        },
+        withRequest: {
+          body: {
+            ...referralUpdate,
+          },
+          headers: {
+            authorization: `Bearer ${token}`,
+          },
+          method: 'PUT',
+          path: apiPaths.referrals.update({ referralId: referral.id }),
+        },
+      })
+    })
+
+    it('updates a referral', async () => {
+      await referralClient.update(referral.id, referralUpdate)
     })
   })
 })

--- a/server/data/referralClient.ts
+++ b/server/data/referralClient.ts
@@ -2,7 +2,7 @@ import RestClient from './restClient'
 import type { ApiConfig } from '../config'
 import config from '../config'
 import { apiPaths } from '../paths'
-import type { CreatedReferralResponse, Referral } from '@accredited-programmes/models'
+import type { CreatedReferralResponse, Referral, ReferralUpdate } from '@accredited-programmes/models'
 
 export default class ReferralClient {
   restClient: RestClient
@@ -26,5 +26,12 @@ export default class ReferralClient {
     return (await this.restClient.get({
       path: apiPaths.referrals.show({ referralId }),
     })) as Referral
+  }
+
+  async update(referralId: Referral['id'], referralUpdate: ReferralUpdate): Promise<void> {
+    await this.restClient.put({
+      data: referralUpdate,
+      path: apiPaths.referrals.update({ referralId }),
+    })
   }
 }

--- a/server/paths/api.ts
+++ b/server/paths/api.ts
@@ -23,5 +23,6 @@ export default {
   referrals: {
     create: referralsPath,
     show: referralPath,
+    update: referralPath,
   },
 }

--- a/server/services/referralService.test.ts
+++ b/server/services/referralService.test.ts
@@ -3,7 +3,7 @@ import { when } from 'jest-when'
 import ReferralService from './referralService'
 import { ReferralClient } from '../data'
 import { referralFactory } from '../testutils/factories'
-import type { CreatedReferralResponse } from '@accredited-programmes/models'
+import type { CreatedReferralResponse, ReferralUpdate } from '@accredited-programmes/models'
 
 jest.mock('../data/referralClient')
 
@@ -58,6 +58,18 @@ describe('ReferralService', () => {
 
       expect(referralClientBuilder).toHaveBeenCalledWith(token)
       expect(referralClient.find).toHaveBeenCalledWith(referral.id)
+    })
+  })
+
+  describe('updateReferral', () => {
+    it('asks the client to update a referral', async () => {
+      const referralId = 'an-ID'
+      const referralUpdate: ReferralUpdate = { oasysConfirmed: true }
+
+      await service.updateReferral(token, referralId, referralUpdate)
+
+      expect(referralClientBuilder).toHaveBeenCalledWith(token)
+      expect(referralClient.update).toHaveBeenCalledWith(referralId, referralUpdate)
     })
   })
 })

--- a/server/services/referralService.ts
+++ b/server/services/referralService.ts
@@ -1,5 +1,5 @@
 import type { ReferralClient, RestClientBuilder } from '../data'
-import type { CreatedReferralResponse, Referral } from '@accredited-programmes/models'
+import type { CreatedReferralResponse, Referral, ReferralUpdate } from '@accredited-programmes/models'
 
 export default class ReferralService {
   constructor(private readonly referralClientBuilder: RestClientBuilder<ReferralClient>) {}
@@ -17,5 +17,14 @@ export default class ReferralService {
   async getReferral(token: Express.User['token'], referralId: Referral['id']): Promise<Referral> {
     const referralClient = this.referralClientBuilder(token)
     return referralClient.find(referralId)
+  }
+
+  async updateReferral(
+    token: Express.User['token'],
+    referralId: Referral['id'],
+    referralUpdate: ReferralUpdate,
+  ): Promise<void> {
+    const referralClient = this.referralClientBuilder(token)
+    return referralClient.update(referralId, referralUpdate)
   }
 }

--- a/server/utils/routeUtils.ts
+++ b/server/utils/routeUtils.ts
@@ -7,6 +7,7 @@ export default class RouteUtils {
     return {
       get: (path: string | Array<string>, handler: RequestHandler) => router.get(path, asyncMiddleware(handler)),
       post: (path: string | Array<string>, handler: RequestHandler) => router.post(path, asyncMiddleware(handler)),
+      put: (path: string | Array<string>, handler: RequestHandler) => router.put(path, asyncMiddleware(handler)),
     }
   }
 }


### PR DESCRIPTION
## Context

<!-- Is there a Trello ticket you can link to? -->
<!-- Do you need to add any environment variables? -->
<!-- Is an ADR required? An ADR should be added if this PR introduces a change to the architecture. -->

The API now has support for updating a referral via a PUT request

## Changes in this PR

- Add PUT request support
- Add API path
- Add client and service methods for updating a referral using the endpoint

## Release checklist

[Release process documentation](../doc/how-to/perform-a-release.md)

As part of our continuous deployment strategy we must ensure that this work is
ready to be released once merged.

### Pre-merge

- [x] There are changes required to the Accredited Programmes API for this change to work...
  - [x] ... and they have been released to production already

### Post-merge

<!-- The outer checkboxes can be completed pre-merge -->

- [ ] This adds, extends or meaningfully modifies a feature...
  - [ ] ... and I have written or updated an end-to-end test for the happy path in the [Accredited Programmes E2E repo](https://github.com/ministryofjustice/hmpps-accredited-programmes-e2e)
- [x] This makes new expectations of the API...
  - [x] ... and I have notified the API developer(s) of changes to the contract tests (Pact), or the API is already compliant
- [ ] [Manually approve](../doc/how-to/perform-a-release.md#releasing-to-the-preprod-environment) release to preprod
- [ ] [Manually approve](../doc/how-to/perform-a-release.md#releasing-to-the-production-environment) release to prod

<!-- Should a release fail at any step, you as the author should now lead the work to
fix it as soon as possible. You can monitor deployment failures in CircleCI
itself and application errors are found in
[Sentry](https://ministryofjustice.sentry.io/projects/hmpps-accredited-programmes-ui/?project=4505330122686464&referrer=sidebar&statsPeriod=24h). -->
