### PR TITLE
(718c) Remove `courseId` from `stubCourseOffering`

### DIFF
--- a/integration_tests/e2e/find.cy.ts
+++ b/integration_tests/e2e/find.cy.ts
@@ -79,7 +79,7 @@ context('Find', () => {
       const organisation = OrganisationUtils.organisationFromPrison('an-ID', prison)
 
       cy.task('stubCourseByOffering', { course, courseOfferingId: courseOffering.id })
-      cy.task('stubCourseOffering', { courseId: course.id, courseOffering })
+      cy.task('stubCourseOffering', { courseOffering })
       cy.task('stubPrison', prison)
 
       const path = findPaths.offerings.show({ courseOfferingId: courseOffering.id })
@@ -105,7 +105,7 @@ context('Find', () => {
       const organisation = OrganisationUtils.organisationFromPrison('an-ID', prison)
 
       cy.task('stubCourseByOffering', { course, courseOfferingId: courseOffering.id })
-      cy.task('stubCourseOffering', { courseId: course.id, courseOffering })
+      cy.task('stubCourseOffering', { courseOffering })
       cy.task('stubPrison', prison)
 
       const path = findPaths.offerings.show({ courseOfferingId: courseOffering.id })

--- a/integration_tests/e2e/refer.cy.ts
+++ b/integration_tests/e2e/refer.cy.ts
@@ -27,7 +27,7 @@ context('Refer', () => {
     const organisation = OrganisationUtils.organisationFromPrison('an-ID', prison)
 
     cy.task('stubCourseByOffering', { course, courseOfferingId: courseOffering.id })
-    cy.task('stubCourseOffering', { courseId: course.id, courseOffering })
+    cy.task('stubCourseOffering', { courseOffering })
     cy.task('stubPrison', prison)
 
     const path = referPaths.start({ courseOfferingId: courseOffering.id })
@@ -54,7 +54,7 @@ context('Refer', () => {
     })
 
     cy.task('stubCourseByOffering', { course, courseOfferingId: courseOffering.id })
-    cy.task('stubCourseOffering', { courseId: course.id, courseOffering })
+    cy.task('stubCourseOffering', { courseOffering })
     cy.task('stubPrisoner', prisoner)
 
     const path = referPaths.new({ courseOfferingId: courseOffering.id })
@@ -116,7 +116,7 @@ context('Refer', () => {
     const referral = referralFactory.build({ offeringId: courseOffering.id, prisonNumber: person.prisonNumber })
 
     cy.task('stubCourseByOffering', { course, courseOfferingId: courseOffering.id })
-    cy.task('stubCourseOffering', { courseId: course.id, courseOffering })
+    cy.task('stubCourseOffering', { courseOffering })
     cy.task('stubPrison', prison)
     cy.task('stubPrisoner', prisoner)
     cy.task('stubCreateReferral', referral)
@@ -161,7 +161,7 @@ context('Refer', () => {
     const referral = referralFactory.build({ offeringId: courseOffering.id, prisonNumber: person.prisonNumber })
 
     cy.task('stubCourseByOffering', { course, courseOfferingId: courseOffering.id })
-    cy.task('stubCourseOffering', { courseId: course.id, courseOffering })
+    cy.task('stubCourseOffering', { courseOffering })
     cy.task('stubPrison', prison)
     cy.task('stubPrisoner', prisoner)
     cy.task('stubReferral', referral)

--- a/integration_tests/e2eReferDisabled/find.cy.ts
+++ b/integration_tests/e2eReferDisabled/find.cy.ts
@@ -22,7 +22,7 @@ context('Find', () => {
     const organisation = OrganisationUtils.organisationFromPrison('an-ID', prison)
 
     cy.task('stubCourseByOffering', { course, courseOfferingId: courseOffering.id })
-    cy.task('stubCourseOffering', { courseId: course.id, courseOffering })
+    cy.task('stubCourseOffering', { courseOffering })
     cy.task('stubPrison', prison)
 
     const path = findPaths.offerings.show({ courseOfferingId: courseOffering.id })

--- a/integration_tests/e2eReferDisabled/refer.cy.ts
+++ b/integration_tests/e2eReferDisabled/refer.cy.ts
@@ -24,7 +24,7 @@ context('Refer', () => {
     const prison = prisonFactory.build({ prisonId: courseOffering.organisationId })
 
     cy.task('stubCourseByOffering', { course, courseOfferingId: courseOffering.id })
-    cy.task('stubCourseOffering', { courseId: course.id, courseOffering })
+    cy.task('stubCourseOffering', { courseOffering })
     cy.task('stubPrison', prison)
 
     const path = referPaths.start({ courseOfferingId: courseOffering.id })
@@ -77,7 +77,7 @@ context('Refer', () => {
     const referral = referralFactory.build()
 
     cy.task('stubCourseByOffering', { course, courseOfferingId: courseOffering.id })
-    cy.task('stubCourseOffering', { courseId: course.id, courseOffering })
+    cy.task('stubCourseOffering', { courseOffering })
     cy.task('stubPrison', prison)
 
     const path = referPaths.show({ referralId: referral.id })

--- a/integration_tests/mockApis/courses.ts
+++ b/integration_tests/mockApis/courses.ts
@@ -31,7 +31,7 @@ export default {
       },
     }),
 
-  stubCourseOffering: (args: { courseId: Course['id']; courseOffering: CourseOffering }): SuperAgentRequest =>
+  stubCourseOffering: (args: { courseOffering: CourseOffering }): SuperAgentRequest =>
     stubFor({
       request: {
         method: 'GET',


### PR DESCRIPTION
## Context

<!-- Is there a Trello ticket you can link to? -->
<!-- Do you need to add any environment variables? -->
<!-- Is an ADR required? An ADR should be added if this PR introduces a change to the architecture. -->

We simplified the offering endpoint in https://github.com/ministryofjustice/hmpps-accredited-programmes-ui/pull/169 but missed `stubCourseOffering` in the integration tests

## Changes in this PR

- Remove `courseId` from `stubCourseOffering

## Release checklist

[Release process documentation](../doc/how-to/perform-a-release.md)

As part of our continuous deployment strategy we must ensure that this work is
ready to be released once merged.

### Pre-merge

- [ ] There are changes required to the Accredited Programmes API for this change to work...
  - [ ] ... and they have been released to production already

### Post-merge

<!-- The outer checkboxes can be completed pre-merge -->

- [ ] This adds, extends or meaningfully modifies a feature...
  - [ ] ... and I have written or updated an end-to-end test for the happy path in the [Accredited Programmes E2E repo](https://github.com/ministryofjustice/hmpps-accredited-programmes-e2e)
- [ ] This makes new expectations of the API...
  - [ ] ... and I have notified the API developer(s) of changes to the contract tests (Pact), or the API is already compliant
- [ ] [Manually approve](../doc/how-to/perform-a-release.md#releasing-to-the-preprod-environment) release to preprod
- [ ] [Manually approve](../doc/how-to/perform-a-release.md#releasing-to-the-production-environment) release to prod

<!-- Should a release fail at any step, you as the author should now lead the work to
fix it as soon as possible. You can monitor deployment failures in CircleCI
itself and application errors are found in
[Sentry](https://ministryofjustice.sentry.io/projects/hmpps-accredited-programmes-ui/?project=4505330122686464&referrer=sidebar&statsPeriod=24h). -->
