### PR TITLE
(650a) Add support for updating the status of a referral

### DIFF
--- a/server/@types/models/Referral.ts
+++ b/server/@types/models/Referral.ts
@@ -18,4 +18,6 @@ type ReferralUpdate = {
   reason?: string
 }
 
-export type { CreatedReferralResponse, Referral, ReferralUpdate }
+type ReferralStatus = 'awaiting_assesment' | 'assessment_started' | 'referral_started' | 'referral_submitted'
+
+export type { CreatedReferralResponse, Referral, ReferralStatus, ReferralUpdate }

--- a/server/@types/models/index.d.ts
+++ b/server/@types/models/index.d.ts
@@ -5,7 +5,7 @@ import type { CoursePrerequisite } from './CoursePrerequisite'
 import type { Organisation } from './Organisation'
 import type { OrganisationAddress } from './OrganisationAddress'
 import type { Person } from './Person'
-import type { CreatedReferralResponse, Referral, ReferralUpdate } from './Referral'
+import type { CreatedReferralResponse, Referral, ReferralStatus, ReferralUpdate } from './Referral'
 
 export type {
   Course,
@@ -17,5 +17,6 @@ export type {
   OrganisationAddress,
   Person,
   Referral,
+  ReferralStatus,
   ReferralUpdate,
 }

--- a/server/data/referralClient.test.ts
+++ b/server/data/referralClient.test.ts
@@ -105,4 +105,32 @@ pactWith({ consumer: 'Accredited Programmes UI', provider: 'Accredited Programme
       await referralClient.update(referral.id, referralUpdate)
     })
   })
+
+  describe('updateStatus', () => {
+    const status = 'referral_submitted'
+
+    beforeEach(() => {
+      provider.addInteraction({
+        state: 'Referral status can be updated',
+        uponReceiving: 'A request to update a referral status',
+        willRespondWith: {
+          status: 204,
+        },
+        withRequest: {
+          body: {
+            status,
+          },
+          headers: {
+            authorization: `Bearer ${token}`,
+          },
+          method: 'PUT',
+          path: apiPaths.referrals.updateStatus({ referralId: referral.id }),
+        },
+      })
+    })
+
+    it('updates a referral status', async () => {
+      await referralClient.updateStatus(referral.id, status)
+    })
+  })
 })

--- a/server/data/referralClient.ts
+++ b/server/data/referralClient.ts
@@ -2,7 +2,7 @@ import RestClient from './restClient'
 import type { ApiConfig } from '../config'
 import config from '../config'
 import { apiPaths } from '../paths'
-import type { CreatedReferralResponse, Referral, ReferralUpdate } from '@accredited-programmes/models'
+import type { CreatedReferralResponse, Referral, ReferralStatus, ReferralUpdate } from '@accredited-programmes/models'
 
 export default class ReferralClient {
   restClient: RestClient
@@ -32,6 +32,13 @@ export default class ReferralClient {
     await this.restClient.put({
       data: referralUpdate,
       path: apiPaths.referrals.update({ referralId }),
+    })
+  }
+
+  async updateStatus(referralId: Referral['id'], status: ReferralStatus): Promise<void> {
+    await this.restClient.put({
+      data: { status },
+      path: apiPaths.referrals.updateStatus({ referralId }),
     })
   }
 }

--- a/server/paths/api.ts
+++ b/server/paths/api.ts
@@ -9,6 +9,7 @@ const courseByOfferingPath = courseOfferingPath.path('course')
 
 const referralsPath = path('/referrals')
 const referralPath = referralsPath.path(':referralId')
+const updateStatusPath = referralPath.path('status')
 
 export default {
   courses: {
@@ -24,5 +25,6 @@ export default {
     create: referralsPath,
     show: referralPath,
     update: referralPath,
+    updateStatus: updateStatusPath,
   },
 }

--- a/server/services/referralService.test.ts
+++ b/server/services/referralService.test.ts
@@ -3,7 +3,7 @@ import { when } from 'jest-when'
 import ReferralService from './referralService'
 import { ReferralClient } from '../data'
 import { referralFactory } from '../testutils/factories'
-import type { CreatedReferralResponse, ReferralUpdate } from '@accredited-programmes/models'
+import type { CreatedReferralResponse, ReferralStatus, ReferralUpdate } from '@accredited-programmes/models'
 
 jest.mock('../data/referralClient')
 
@@ -70,6 +70,18 @@ describe('ReferralService', () => {
 
       expect(referralClientBuilder).toHaveBeenCalledWith(token)
       expect(referralClient.update).toHaveBeenCalledWith(referralId, referralUpdate)
+    })
+  })
+
+  describe('updateReferralStatus', () => {
+    it('asks the client to update the referral status', async () => {
+      const referralId = 'an-ID'
+      const status: ReferralStatus = 'referral_submitted'
+
+      await service.updateReferralStatus(token, referralId, status)
+
+      expect(referralClientBuilder).toHaveBeenCalledWith(token)
+      expect(referralClient.updateStatus).toHaveBeenCalledWith(referralId, status)
     })
   })
 })

--- a/server/services/referralService.ts
+++ b/server/services/referralService.ts
@@ -1,5 +1,5 @@
 import type { ReferralClient, RestClientBuilder } from '../data'
-import type { CreatedReferralResponse, Referral, ReferralUpdate } from '@accredited-programmes/models'
+import type { CreatedReferralResponse, Referral, ReferralStatus, ReferralUpdate } from '@accredited-programmes/models'
 
 export default class ReferralService {
   constructor(private readonly referralClientBuilder: RestClientBuilder<ReferralClient>) {}
@@ -26,5 +26,14 @@ export default class ReferralService {
   ): Promise<void> {
     const referralClient = this.referralClientBuilder(token)
     return referralClient.update(referralId, referralUpdate)
+  }
+
+  async updateReferralStatus(
+    token: Express.User['token'],
+    referralId: Referral['id'],
+    status: ReferralStatus,
+  ): Promise<void> {
+    const referralClient = this.referralClientBuilder(token)
+    return referralClient.updateStatus(referralId, status)
   }
 }


### PR DESCRIPTION
## Context

In anticipation of the referral complete step.

<!-- Is there a Trello ticket you can link to? -->
<!-- Do you need to add any environment variables? -->
<!-- Is an ADR required? An ADR should be added if this PR introduces a change to the architecture. -->



## Changes in this PR
- Add API path for updating status
- Add client and service methods for updating a referral status using the endpoint

## Release checklist

[Release process documentation](../doc/how-to/perform-a-release.md)

As part of our continuous deployment strategy we must ensure that this work is
ready to be released once merged.

### Pre-merge

- [ ] There are changes required to the Accredited Programmes API for this change to work...
  - [ ] ... and they have been released to production already

### Post-merge

<!-- The outer checkboxes can be completed pre-merge -->

- [ ] This adds, extends or meaningfully modifies a feature...
  - [ ] ... and I have written or updated an end-to-end test for the happy path in the [Accredited Programmes E2E repo](https://github.com/ministryofjustice/hmpps-accredited-programmes-e2e)
- [ ] This makes new expectations of the API...
  - [ ] ... and I have notified the API developer(s) of changes to the contract tests (Pact), or the API is already compliant
- [ ] [Manually approve](../doc/how-to/perform-a-release.md#releasing-to-the-preprod-environment) release to preprod
- [ ] [Manually approve](../doc/how-to/perform-a-release.md#releasing-to-the-production-environment) release to prod

<!-- Should a release fail at any step, you as the author should now lead the work to
fix it as soon as possible. You can monitor deployment failures in CircleCI
itself and application errors are found in
[Sentry](https://ministryofjustice.sentry.io/projects/hmpps-accredited-programmes-ui/?project=4505330122686464&referrer=sidebar&statsPeriod=24h). -->
