### PR TITLE
(650c) Submit referral

### DIFF
--- a/integration_tests/e2e/refer.cy.ts
+++ b/integration_tests/e2e/refer.cy.ts
@@ -19,6 +19,7 @@ import {
   StartReferralPage,
   TaskListPage,
 } from '../pages/refer'
+import CompletePage from '../pages/refer/complete'
 
 context('Refer', () => {
   beforeEach(() => {
@@ -326,5 +327,19 @@ context('Refer', () => {
     checkAnswersPage.shouldHaveConfirmationCheckbox()
     checkAnswersPage.shouldContainButton('Submit referral')
     checkAnswersPage.shouldContainButtonLink('Return to tasklist', referPaths.show({ referralId: referral.id }))
+  })
+
+  it('Shows the complete page for a completed referral', () => {
+    cy.signIn()
+
+    const referral = referralFactory.build({ status: 'referral_submitted' })
+
+    cy.task('stubReferral', referral)
+
+    const path = referPaths.complete({ referralId: referral.id })
+    cy.visit(path)
+
+    const completePage = Page.verifyOnPage(CompletePage)
+    completePage.shouldContainPanel('Referral complete')
   })
 })

--- a/integration_tests/mockApis/referrals.ts
+++ b/integration_tests/mockApis/referrals.ts
@@ -42,4 +42,16 @@ export default {
         status: 204,
       },
     }),
+
+  stubUpdateReferralStatus: (referralId: Referral['id']): SuperAgentRequest =>
+    stubFor({
+      request: {
+        method: 'PUT',
+        url: apiPaths.referrals.updateStatus({ referralId }),
+      },
+      response: {
+        headers: { 'Content-Type': 'application/json;charset=UTF-8' },
+        status: 204,
+      },
+    }),
 }

--- a/integration_tests/pages/page.ts
+++ b/integration_tests/pages/page.ts
@@ -72,6 +72,18 @@ export default abstract class Page {
     })
   }
 
+  shouldContainErrorSummary(errors: Array<{ href: string; text: string }>): void {
+    cy.get('.govuk-error-summary').should('exist')
+    cy.get('.govuk-error-summary__list').within(() => {
+      cy.get('li').should('have.length', errors.length)
+      cy.get('li').each((errorElement, errorElementIndex) => {
+        const { actual, expected } = Helpers.parseHtml(errorElement, errors[errorElementIndex].text)
+        expect(actual).to.equal(expected)
+        cy.get('a').should('have.attr', 'href', errors[errorElementIndex].href)
+      })
+    })
+  }
+
   shouldContainLink(text: string, href: string): void {
     cy.contains('.govuk-link', text).should('have.attr', 'href', href)
   }

--- a/integration_tests/pages/page.ts
+++ b/integration_tests/pages/page.ts
@@ -119,6 +119,10 @@ export default abstract class Page {
     })
   }
 
+  shouldContainPanel(text: string): void {
+    cy.contains('.govuk-panel', text)
+  }
+
   shouldContainPersonSummaryList(person: Person): void {
     cy.get('[data-testid="person-summary-list"]').then(summaryListElement => {
       this.shouldContainSummaryListRows(PersonUtils.summaryListRows(person), summaryListElement)

--- a/integration_tests/pages/page.ts
+++ b/integration_tests/pages/page.ts
@@ -191,7 +191,7 @@ export default abstract class Page {
   signOut = (): PageElement => cy.get('[data-qa=signOut]')
 
   private checkHeading(): void {
-    cy.get('.govuk-heading-l').contains(this.pageHeading)
+    cy.get('h1').contains(this.pageHeading)
   }
 
   private checkOnPage(): void {

--- a/integration_tests/pages/refer/checkAnswers.ts
+++ b/integration_tests/pages/refer/checkAnswers.ts
@@ -31,6 +31,11 @@ export default class CheckAnswersPage extends Page {
     this.username = username
   }
 
+  confirmDetailsAndSubmitReferral() {
+    cy.get('[name="confirmation"]').check()
+    this.shouldContainButton('Submit referral').click()
+  }
+
   shouldHaveApplicationSummary() {
     cy.get('[data-testid="application-summary-list"]').then(summaryListElement => {
       this.shouldContainSummaryListRows(

--- a/integration_tests/pages/refer/complete.ts
+++ b/integration_tests/pages/refer/complete.ts
@@ -1,0 +1,7 @@
+import Page from '../page'
+
+export default class CompletePage extends Page {
+  constructor() {
+    super('Referral complete')
+  }
+}

--- a/server/controllers/refer/referralsController.test.ts
+++ b/server/controllers/refer/referralsController.test.ts
@@ -255,6 +255,8 @@ describe('ReferralsController', () => {
 
   describe('checkAnswers', () => {
     it('renders the referral check answers page', async () => {
+      const errors: Array<string> = []
+
       const organisation = organisationFactory.build({ id: courseOffering.organisationId })
       organisationService.getOrganisation.mockResolvedValue(organisation)
 
@@ -265,6 +267,7 @@ describe('ReferralsController', () => {
       referralService.getReferral.mockResolvedValue(referral)
 
       request.params.referralId = referral.id
+      request.flash = jest.fn().mockReturnValue(errors)
 
       TypeUtils.assertHasUser(request)
       request.user.username = 'BOBBY_BROWN'
@@ -286,6 +289,7 @@ describe('ReferralsController', () => {
           person,
           request.user.username,
         ),
+        errors,
         pageHeading: 'Check your answers',
         person,
         personSummaryListRows: PersonUtils.summaryListRows(person),

--- a/server/controllers/refer/referralsController.ts
+++ b/server/controllers/refer/referralsController.ts
@@ -213,6 +213,27 @@ export default class ReferralsController {
     }
   }
 
+  submit(): TypedRequestHandler<Request, Response> {
+    return async (req: Request, res: Response) => {
+      TypeUtils.assertHasUser(req)
+
+      if (req.body.confirmation !== 'true') {
+        req.flash('errors', [
+          {
+            href: '#confirmation',
+            text: 'Please confirm that the information you have provided is complete, accurate and up to date',
+          } as unknown as string,
+        ])
+
+        return res.redirect(referPaths.checkAnswers({ referralId: req.params.referralId }))
+      }
+
+      await this.referralService.updateReferralStatus(req.user.token, req.params.referralId, 'referral_submitted')
+
+      return res.redirect(referPaths.complete({ referralId: req.params.referralId }))
+    }
+  }
+
   update(): TypedRequestHandler<Request, Response> {
     return async (req: Request, res: Response) => {
       TypeUtils.assertHasUser(req)

--- a/server/controllers/refer/referralsController.ts
+++ b/server/controllers/refer/referralsController.ts
@@ -18,6 +18,7 @@ export default class ReferralsController {
     return async (req: Request, res: Response) => {
       TypeUtils.assertHasUser(req)
 
+      const errors = req.flash('errors')
       const { referralId } = req.params
       const { username } = req.user
 
@@ -49,6 +50,7 @@ export default class ReferralsController {
           person,
           username,
         ),
+        errors,
         pageHeading: 'Check your answers',
         person,
         personSummaryListRows: PersonUtils.summaryListRows(person),

--- a/server/paths/refer.ts
+++ b/server/paths/refer.ts
@@ -16,6 +16,7 @@ const referralPersonPath = showReferralPath.path('person')
 const confirmOasysPath = showReferralPath.path('oasys-confirmed')
 const checkAnswersPath = showReferralPath.path('check-answers')
 const completeReferralPath = showReferralPath.path('complete')
+const submitReferralPath = showReferralPath.path('submit')
 
 export default {
   checkAnswers: checkAnswersPath,
@@ -30,5 +31,6 @@ export default {
   show: showReferralPath,
   showPerson: referralPersonPath,
   start: startReferralPath,
+  submit: submitReferralPath,
   update: showReferralPath,
 }

--- a/server/routes/refer.ts
+++ b/server/routes/refer.ts
@@ -21,6 +21,7 @@ export default function routes(controllers: Controllers, router: Router): Router
   get(referPaths.confirmOasys.pattern, referralsController.confirmOasys())
   get(referPaths.checkAnswers.pattern, referralsController.checkAnswers())
   get(referPaths.complete.pattern, referralsController.complete())
+  post(referPaths.submit.pattern, referralsController.submit())
 
   return router
 }

--- a/server/views/referrals/checkAnswers.njk
+++ b/server/views/referrals/checkAnswers.njk
@@ -52,20 +52,20 @@
       <h2 class="govuk-heading-m">Referral details</h2>
 
       {{ govukSummaryList({
-        card: {
-          title: {
-            text: "Personal details"
-          }
-        },
-        rows: personSummaryListRows,
-        attributes: {
-          "data-testid": "person-summary-list"
+      card: {
+        title: {
+          text: "Personal details"
         }
-      }) }}
+      },
+      rows: personSummaryListRows,
+      attributes: {
+        "data-testid": "person-summary-list"
+      }
+    }) }}
 
       <hr class="govuk-section-break govuk-section-break--visible govuk-!-margin-bottom-6">
 
-      <form action="">
+      <form action="{{ referPaths.submit({ referralId: referralId }) }}" method="post">
         <input type="hidden" name="_csrf" value="{{ csrfToken }}"/>
 
         {{ govukCheckboxes({
@@ -78,7 +78,7 @@
           },
           items: [
             {
-              value: "confirm",
+              value: "true",
               text: "I confirm the information I have provided is complete, accurate and up to date."
             }
           ]
@@ -97,5 +97,4 @@
         </div>
       </form>
     </div>
-  </div>
-{% endblock content %}
+  {% endblock content %}

--- a/server/views/referrals/checkAnswers.njk
+++ b/server/views/referrals/checkAnswers.njk
@@ -1,6 +1,7 @@
 {% from "govuk/components/back-link/macro.njk" import govukBackLink %}
 {% from "govuk/components/button/macro.njk" import govukButton %}
 {% from "govuk/components/checkboxes/macro.njk" import govukCheckboxes %}
+{% from "govuk/components/error-summary/macro.njk" import govukErrorSummary %}
 {% from "govuk/components/summary-list/macro.njk" import govukSummaryList %}
 
 {% extends "../partials/layout.njk" %}
@@ -17,6 +18,17 @@
 {% endblock backLink %}
 
 {% block content %}
+  <div class="govuk-grid-row">
+    <div class="govuk-grid-column-two-thirds">
+      {% if errors.length %}
+        {{ govukErrorSummary({
+          titleText: "There is a problem",
+          errorList: errors
+        }) }}
+      {% endif %}
+    </div>
+  </div>
+
   <h1 class="govuk-heading-l">{{ pageHeading }}</h1>
 
   <div class="govuk-grid-row">


### PR DESCRIPTION
## Context

Updates the form functionality on the check answers page to update the referral status to `referral_submitted` when the confirm checkbox is selected and then redirect to the referral complete page when successful. 

Also shows an error if the checkbox is not selected.

## Changes in this PR

- Use `req.flash` for error messages on check answers page
- Use `govukErrorSummary` component to display errors on check answers page
- Add `submit` method to referrals controller to handle `POST` request.
- Update check answers page to use new `/submit` endpoint

## Screenshots of UI changes

With form error message
![localhost_3000_referrals_c11fab18-dc8d-420c-9c82-d0edd373732d_check-answers](https://github.com/ministryofjustice/hmpps-accredited-programmes-ui/assets/1067537/4a687bb2-eff5-4533-be4b-44ad740c3d53)

## Release checklist

[Release process documentation](../doc/how-to/perform-a-release.md)

As part of our continuous deployment strategy we must ensure that this work is
ready to be released once merged.

### Pre-merge

- [ ] There are changes required to the Accredited Programmes API for this change to work...
  - [ ] ... and they have been released to production already

### Post-merge

<!-- The outer checkboxes can be completed pre-merge -->

- [x] This adds, extends or meaningfully modifies a feature...
  - [ ] ... and I have written or updated an end-to-end test for the happy path in the [Accredited Programmes E2E repo](https://github.com/ministryofjustice/hmpps-accredited-programmes-e2e)
- [ ] This makes new expectations of the API...
  - [ ] ... and I have notified the API developer(s) of changes to the contract tests (Pact), or the API is already compliant
- [ ] [Manually approve](../doc/how-to/perform-a-release.md#releasing-to-the-preprod-environment) release to preprod
- [ ] [Manually approve](../doc/how-to/perform-a-release.md#releasing-to-the-production-environment) release to prod

<!-- Should a release fail at any step, you as the author should now lead the work to
fix it as soon as possible. You can monitor deployment failures in CircleCI
itself and application errors are found in
[Sentry](https://ministryofjustice.sentry.io/projects/hmpps-accredited-programmes-ui/?project=4505330122686464&referrer=sidebar&statsPeriod=24h). -->
