### PR TITLE
(797) Make check answers task dynamic

### DIFF
--- a/integration_tests/e2e/refer.cy.ts
+++ b/integration_tests/e2e/refer.cy.ts
@@ -398,20 +398,6 @@ context('Refer', () => {
     checkAnswersPage.shouldContainButtonLink('Return to tasklist', referPaths.show({ referralId: referral.id }))
   })
 
-  it('Shows the complete page for a completed referral', () => {
-    cy.signIn()
-
-    const referral = referralFactory.build({ status: 'referral_submitted' })
-
-    cy.task('stubReferral', referral)
-
-    const path = referPaths.complete({ referralId: referral.id })
-    cy.visit(path)
-
-    const completePage = Page.verifyOnPage(CompletePage)
-    completePage.shouldContainPanel('Referral complete')
-  })
-
   describe('Submitting a referral', () => {
     const course = courseFactory.build()
     const courseOffering = courseOfferingFactory.build()
@@ -499,5 +485,19 @@ context('Refer', () => {
         },
       ])
     })
+  })
+
+  it('Shows the complete page for a completed referral', () => {
+    cy.signIn()
+
+    const referral = referralFactory.build({ status: 'referral_submitted' })
+
+    cy.task('stubReferral', referral)
+
+    const path = referPaths.complete({ referralId: referral.id })
+    cy.visit(path)
+
+    const completePage = Page.verifyOnPage(CompletePage)
+    completePage.shouldContainPanel('Referral complete')
   })
 })

--- a/integration_tests/e2e/refer.cy.ts
+++ b/integration_tests/e2e/refer.cy.ts
@@ -398,7 +398,7 @@ context('Refer', () => {
     checkAnswersPage.shouldContainButtonLink('Return to tasklist', referPaths.show({ referralId: referral.id }))
   })
 
-  describe('Submitting a referral', () => {
+  describe('When submitting a referral', () => {
     const course = courseFactory.build()
     const courseOffering = courseOfferingFactory.build()
 

--- a/integration_tests/e2e/refer.cy.ts
+++ b/integration_tests/e2e/refer.cy.ts
@@ -196,6 +196,7 @@ context('Refer', () => {
     taskListPage.shouldContainOrganisationAndCourseHeading(taskListPage)
     taskListPage.shouldContainAudienceTags(taskListPage.course.audienceTags)
     taskListPage.shouldContainTaskList()
+    taskListPage.shouldNotBeReadyForSubmission()
   })
 
   it('Shows the person page for a referral', () => {
@@ -299,6 +300,44 @@ context('Refer', () => {
 
     const taskListPage = Page.verifyOnPage(TaskListPage, { course, courseOffering, organisation, referral })
     taskListPage.shouldHaveConfirmedOasys()
+  })
+
+  it('Links to the check answers page when the referral is ready for submission', () => {
+    cy.signIn()
+
+    const course = courseFactory.build()
+    const courseOffering = courseOfferingFactory.build()
+
+    const prisoner = prisonerFactory.build({
+      firstName: 'Del',
+      lastName: 'Hatton',
+    })
+    const person = personFactory.build({
+      currentPrison: prisoner.prisonName,
+      name: 'Del Hatton',
+      prisonNumber: prisoner.prisonerNumber,
+    })
+
+    const prison = prisonFactory.build({ prisonId: courseOffering.organisationId })
+    const organisation = OrganisationUtils.organisationFromPrison('an-ID', prison)
+
+    const referral = referralFactory.build({
+      oasysConfirmed: true,
+      offeringId: courseOffering.id,
+      prisonNumber: person.prisonNumber,
+    })
+
+    cy.task('stubCourseByOffering', { course, courseOfferingId: courseOffering.id })
+    cy.task('stubCourseOffering', { courseId: course.id, courseOffering })
+    cy.task('stubPrison', prison)
+    cy.task('stubPrisoner', prisoner)
+    cy.task('stubReferral', referral)
+
+    const path = referPaths.show({ referralId: referral.id })
+    cy.visit(path)
+
+    const taskListPage = Page.verifyOnPage(TaskListPage, { course, courseOffering, organisation, referral })
+    taskListPage.shouldBeReadyForSubmission()
   })
 
   it('Shows the correct information on the Check answers and submit task page', () => {

--- a/integration_tests/e2eReferDisabled/refer.cy.ts
+++ b/integration_tests/e2eReferDisabled/refer.cy.ts
@@ -143,4 +143,18 @@ context('Refer', () => {
     const notFoundPage = Page.verifyOnPage(NotFoundPage)
     notFoundPage.shouldContain404H2()
   })
+
+  it("Doesn't show the complete page for a referral", () => {
+    cy.signIn()
+
+    const referral = referralFactory.build({ status: 'referral_submitted' })
+
+    cy.task('stubReferral', referral)
+
+    const path = referPaths.complete({ referralId: referral.id })
+    cy.visit(path, { failOnStatusCode: false })
+
+    const notFoundPage = Page.verifyOnPage(NotFoundPage)
+    notFoundPage.shouldContain404H2()
+  })
 })

--- a/integration_tests/pages/refer/checkAnswers.ts
+++ b/integration_tests/pages/refer/checkAnswers.ts
@@ -1,6 +1,6 @@
 import { CourseUtils, ReferralUtils } from '../../../server/utils'
 import Page from '../page'
-import type { Course, CourseOffering, Organisation, Person } from '@accredited-programmes/models'
+import type { Course, CourseOffering, Organisation, Person, Referral } from '@accredited-programmes/models'
 import type { CoursePresenter } from '@accredited-programmes/ui'
 
 export default class CheckAnswersPage extends Page {
@@ -31,8 +31,9 @@ export default class CheckAnswersPage extends Page {
     this.username = username
   }
 
-  confirmDetailsAndSubmitReferral() {
+  confirmDetailsAndSubmitReferral(referral: Referral) {
     cy.get('[name="confirmation"]').check()
+    cy.task('stubReferral', { ...referral, status: 'referral_submitted' })
     this.shouldContainButton('Submit referral').click()
   }
 

--- a/integration_tests/pages/refer/taskList.ts
+++ b/integration_tests/pages/refer/taskList.ts
@@ -1,4 +1,5 @@
 import { CourseUtils, ReferralUtils } from '../../../server/utils'
+import Helpers from '../../support/helpers'
 import Page from '../page'
 import type { Course, CourseOffering, Organisation, Referral } from '@accredited-programmes/models'
 import type { CoursePresenter } from '@accredited-programmes/ui'
@@ -25,6 +26,16 @@ export default class TaskListPage extends Page {
     this.courseOffering = courseOffering
     this.organisation = organisation
     this.referral = referral
+  }
+
+  shouldBeReadyForSubmission() {
+    cy.get('[data-testid="check-answers-list-item"]').within(() => {
+      cy.get('a').should('have.attr', 'href', `/referrals/${this.referral.id}/check-answers`)
+      cy.get('.govuk-tag').then(tagElement => {
+        const { actual, expected } = Helpers.parseHtml(tagElement, 'not started')
+        expect(actual).to.equal(expected)
+      })
+    })
   }
 
   shouldContainTaskList() {
@@ -57,6 +68,16 @@ export default class TaskListPage extends Page {
         { classes: 'govuk-tag moj-task-list__task-completed', text: 'completed' },
         oasysConfirmedTagElement,
       )
+    })
+  }
+
+  shouldNotBeReadyForSubmission() {
+    cy.get('[data-testid="check-answers-list-item"]').within(() => {
+      cy.get('a').should('not.exist')
+      cy.get('.govuk-tag').then(tagElement => {
+        const { actual, expected } = Helpers.parseHtml(tagElement, 'cannot start yet')
+        expect(actual).to.equal(expected)
+      })
     })
   }
 }

--- a/server/@types/ui/index.d.ts
+++ b/server/@types/ui/index.d.ts
@@ -34,9 +34,14 @@ type ReferralTaskListStatusTag =
   | (GovukFrontendTag & { classes: 'govuk-tag--grey moj-task-list__task-completed'; text: 'not started' })
   | (GovukFrontendTag & { classes: 'govuk-tag--grey moj-task-list__task-completed'; text: 'cannot start yet' })
 
+type ReferralTaskListItemTestIds = {
+  listItem: string
+}
+
 type ReferralTaskListItem = {
   statusTag: ReferralTaskListStatusTag
   text: string
+  testIds?: ReferralTaskListItemTestIds
   url?: string
 }
 

--- a/server/controllers/refer/referralsController.test.ts
+++ b/server/controllers/refer/referralsController.test.ts
@@ -354,7 +354,7 @@ describe('ReferralsController', () => {
   })
 
   describe('submit', () => {
-    const referral = referralFactory.build({ status: 'referral_started' })
+    const referral = referralFactory.build()
 
     beforeEach(() => {
       referralService.getReferral.mockResolvedValue(referral)

--- a/server/controllers/refer/referralsController.test.ts
+++ b/server/controllers/refer/referralsController.test.ts
@@ -329,6 +329,60 @@ describe('ReferralsController', () => {
         expect(response.redirect).toHaveBeenCalledWith(referPaths.show({ referralId: referral.id }))
       })
     })
+
+    describe('when the organisation service returns `null`', () => {
+      it('responds with a 404', async () => {
+        const errors: Array<string> = []
+        request.flash = jest.fn().mockReturnValue(errors)
+
+        const person = personFactory.build()
+        personService.getPerson.mockResolvedValue(person)
+
+        const referral = referralFactory.build({
+          oasysConfirmed: true,
+          offeringId: courseOffering.id,
+          prisonNumber: person.prisonNumber,
+        })
+        request.params.referralId = referral.id
+        referralService.getReferral.mockResolvedValue(referral)
+        ;(ReferralUtils.isReadyForSubmission as jest.Mock).mockReturnValue(true)
+
+        TypeUtils.assertHasUser(request)
+        request.user.username = 'BOBBY_BROWN'
+
+        organisationService.getOrganisation.mockResolvedValue(null)
+
+        const requestHandler = referralsController.show()
+        const expectedError = createError(404)
+
+        expect(() => requestHandler(request, response, next)).rejects.toThrowError(expectedError)
+      })
+    })
+
+    describe('when the person service returns `null`', () => {
+      it('responds with a 404', async () => {
+        const errors: Array<string> = []
+        request.flash = jest.fn().mockReturnValue(errors)
+
+        const referral = referralFactory.build({
+          oasysConfirmed: true,
+          offeringId: courseOffering.id,
+        })
+        request.params.referralId = referral.id
+        referralService.getReferral.mockResolvedValue(referral)
+        ;(ReferralUtils.isReadyForSubmission as jest.Mock).mockReturnValue(true)
+
+        TypeUtils.assertHasUser(request)
+        request.user.username = 'BOBBY_BROWN'
+
+        personService.getPerson.mockResolvedValue(null)
+
+        const requestHandler = referralsController.show()
+        const expectedError = createError(404)
+
+        expect(() => requestHandler(request, response, next)).rejects.toThrowError(expectedError)
+      })
+    })
   })
 
   describe('update', () => {

--- a/server/controllers/refer/referralsController.test.ts
+++ b/server/controllers/refer/referralsController.test.ts
@@ -265,22 +265,25 @@ describe('ReferralsController', () => {
   describe('checkAnswers', () => {
     it('renders the referral check answers page', async () => {
       const errors: Array<string> = []
-
-      const organisation = organisationFactory.build({ id: courseOffering.organisationId })
-      organisationService.getOrganisation.mockResolvedValue(organisation)
+      request.flash = jest.fn().mockReturnValue(errors)
 
       const person = personFactory.build()
       personService.getPerson.mockResolvedValue(person)
 
-      const referral = referralFactory.build({ offeringId: courseOffering.id, prisonNumber: person.prisonNumber })
-      referralService.getReferral.mockResolvedValue(referral)
-
+      const referral = referralFactory.build({
+        oasysConfirmed: true,
+        offeringId: courseOffering.id,
+        prisonNumber: person.prisonNumber,
+      })
       request.params.referralId = referral.id
-      request.flash = jest.fn().mockReturnValue(errors)
+      referralService.getReferral.mockResolvedValue(referral)
+      ;(ReferralUtils.isReadyForSubmission as jest.Mock).mockReturnValue(true)
 
       TypeUtils.assertHasUser(request)
       request.user.username = 'BOBBY_BROWN'
-      ;(ReferralUtils.isReadyForSubmission as jest.Mock).mockReturnValue(true)
+
+      const organisation = organisationFactory.build({ id: courseOffering.organisationId })
+      organisationService.getOrganisation.mockResolvedValue(organisation)
 
       const coursePresenter = createMock<CoursePresenter>({
         audiences: courseAudienceFactory.buildList(1),

--- a/server/controllers/refer/referralsController.test.ts
+++ b/server/controllers/refer/referralsController.test.ts
@@ -383,8 +383,13 @@ describe('ReferralsController', () => {
       request.params.referralId = referral.id
     })
 
-    it('asks the service to update the referral as submitted and redirect to the complete page', async () => {
+    it('asks the service to update the referral status to submitted and redirects to the complete page', async () => {
       request.body.confirmation = 'true'
+
+      referralService.getReferral.mockResolvedValue(referral)
+
+      request.params.referralId = referral.id
+      ;(ReferralUtils.isReadyForSubmission as jest.Mock).mockReturnValue(true)
 
       const requestHandler = referralsController.submit()
       await requestHandler(request, response, next)
@@ -407,6 +412,22 @@ describe('ReferralsController', () => {
           },
         ])
         expect(response.redirect).toHaveBeenCalledWith(referPaths.checkAnswers({ referralId: referral.id }))
+      })
+    })
+
+    describe('when the referral is not ready for submission', () => {
+      it('redirects to the show referral page', async () => {
+        request.body.confirmation = 'true'
+
+        referralService.getReferral.mockResolvedValue(referral)
+
+        request.params.referralId = referral.id
+        ;(ReferralUtils.isReadyForSubmission as jest.Mock).mockReturnValue(false)
+
+        const requestHandler = referralsController.submit()
+        await requestHandler(request, response, next)
+
+        expect(response.redirect).toHaveBeenCalledWith(referPaths.show({ referralId: referral.id }))
       })
     })
   })

--- a/server/controllers/refer/referralsController.ts
+++ b/server/controllers/refer/referralsController.ts
@@ -28,16 +28,7 @@ export default class ReferralsController {
         return res.redirect(referPaths.show({ referralId: referral.id }))
       }
 
-      const course = await this.courseService.getCourseByOffering(req.user.token, referral.offeringId)
-      const courseOffering = await this.courseService.getOffering(req.user.token, referral.offeringId)
-      const organisation = await this.organisationService.getOrganisation(req.user.token, courseOffering.organisationId)
       const person = await this.personService.getPerson(req.user.token, referral.prisonNumber)
-
-      if (!organisation) {
-        throw createError(404, {
-          userMessage: 'Organisation not found.',
-        })
-      }
 
       if (!person) {
         throw createError(404, {
@@ -45,6 +36,16 @@ export default class ReferralsController {
         })
       }
 
+      const courseOffering = await this.courseService.getOffering(req.user.token, referral.offeringId)
+      const organisation = await this.organisationService.getOrganisation(req.user.token, courseOffering.organisationId)
+
+      if (!organisation) {
+        throw createError(404, {
+          userMessage: 'Organisation not found.',
+        })
+      }
+
+      const course = await this.courseService.getCourseByOffering(req.user.token, referral.offeringId)
       const coursePresenter = CourseUtils.presentCourse(course)
 
       return res.render('referrals/checkAnswers', {

--- a/server/controllers/refer/referralsController.ts
+++ b/server/controllers/refer/referralsController.ts
@@ -235,6 +235,12 @@ export default class ReferralsController {
         return res.redirect(referPaths.checkAnswers({ referralId: req.params.referralId }))
       }
 
+      const referral = await this.referralService.getReferral(req.user.token, req.params.referralId)
+
+      if (!ReferralUtils.isReadyForSubmission(referral)) {
+        return res.redirect(referPaths.show({ referralId: referral.id }))
+      }
+
       await this.referralService.updateReferralStatus(req.user.token, req.params.referralId, 'referral_submitted')
 
       return res.redirect(referPaths.complete({ referralId: req.params.referralId }))

--- a/server/controllers/refer/referralsController.ts
+++ b/server/controllers/refer/referralsController.ts
@@ -23,6 +23,11 @@ export default class ReferralsController {
       const { username } = req.user
 
       const referral = await this.referralService.getReferral(req.user.token, referralId)
+
+      if (!ReferralUtils.isReadyForSubmission(referral)) {
+        return res.redirect(referPaths.show({ referralId: referral.id }))
+      }
+
       const course = await this.courseService.getCourseByOffering(req.user.token, referral.offeringId)
       const courseOffering = await this.courseService.getOffering(req.user.token, referral.offeringId)
       const organisation = await this.organisationService.getOrganisation(req.user.token, courseOffering.organisationId)
@@ -42,7 +47,7 @@ export default class ReferralsController {
 
       const coursePresenter = CourseUtils.presentCourse(course)
 
-      res.render('referrals/checkAnswers', {
+      return res.render('referrals/checkAnswers', {
         applicationSummaryListRows: ReferralUtils.applicationSummaryListRows(
           courseOffering,
           coursePresenter,

--- a/server/testutils/factories/referral.ts
+++ b/server/testutils/factories/referral.ts
@@ -9,10 +9,5 @@ export default Factory.define<Referral>(() => ({
   offeringId: faker.string.uuid(),
   prisonNumber: faker.string.alphanumeric({ length: 7 }),
   referrerId: faker.string.numeric({ length: 6 }),
-  status: faker.helpers.arrayElement([
-    'awaiting_assesment',
-    'assessment_started',
-    'referral_started',
-    'referral_submitted',
-  ]),
+  status: 'referral_started',
 }))

--- a/server/utils/referralUtils.test.ts
+++ b/server/utils/referralUtils.test.ts
@@ -106,6 +106,7 @@ describe('ReferralUtils', () => {
                 classes: 'govuk-tag--grey moj-task-list__task-completed',
                 text: 'cannot start yet',
               },
+              testIds: { listItem: 'check-answers-list-item' },
               text: 'Check answers and submit',
               url: '',
             },

--- a/server/utils/referralUtils.test.ts
+++ b/server/utils/referralUtils.test.ts
@@ -59,6 +59,23 @@ describe('ReferralUtils', () => {
     })
   })
 
+  describe('isReadyForSubmission', () => {
+    it('returns false for a new referral', () => {
+      const referral = referralFactory.build()
+
+      expect(ReferralUtils.isReadyForSubmission(referral)).toEqual(false)
+    })
+
+    describe('when OASys is confirmed', () => {
+      // to be updated as the referral model is built out
+      it('returns true', () => {
+        const referral = referralFactory.build({ oasysConfirmed: true })
+
+        expect(ReferralUtils.isReadyForSubmission(referral)).toEqual(true)
+      })
+    })
+  })
+
   describe('taskListSections', () => {
     it('returns task list sections for a given referral', () => {
       const referral = referralFactory.build()

--- a/server/utils/referralUtils.test.ts
+++ b/server/utils/referralUtils.test.ts
@@ -7,6 +7,7 @@ import {
   personFactory,
   referralFactory,
 } from '../testutils/factories'
+import type { ReferralTaskListSection } from '@accredited-programmes/ui'
 
 describe('ReferralUtils', () => {
   describe('applicationSummaryListRows', () => {
@@ -106,7 +107,7 @@ describe('ReferralUtils', () => {
                 text: 'cannot start yet',
               },
               text: 'Check answers and submit',
-              url: `/referrals/${referral.id}/check-answers`,
+              url: '',
             },
           ],
         },
@@ -123,6 +124,17 @@ describe('ReferralUtils', () => {
         classes: 'moj-task-list__task-completed',
         text: 'completed',
       })
+    })
+
+    it('updates the check answers task when the referral is ready for submission', () => {
+      const referralWithOasysConfirmed = referralFactory.build({ oasysConfirmed: true })
+      const taskListSections = ReferralUtils.taskListSections(referralWithOasysConfirmed)
+      const checkAnswersTask = (
+        taskListSections.find(section => section.heading === 'Check answers and submit') as ReferralTaskListSection
+      ).items[0]
+
+      expect(checkAnswersTask.url).toEqual(`/referrals/${referralWithOasysConfirmed.id}/check-answers`)
+      expect(checkAnswersTask.statusTag.text).toEqual('not started')
     })
   })
 })

--- a/server/utils/referralUtils.ts
+++ b/server/utils/referralUtils.ts
@@ -45,6 +45,11 @@ export default class ReferralUtils {
   }
 
   static taskListSections(referral: Referral): Array<ReferralTaskListSection> {
+    const checkAnswersStatus = ReferralUtils.isReadyForSubmission(referral) ? 'not started' : 'cannot start yet'
+    const checkAnswersUrl = ReferralUtils.isReadyForSubmission(referral)
+      ? referPaths.checkAnswers({ referralId: referral.id })
+      : ''
+
     return [
       {
         heading: 'Personal details',
@@ -83,13 +88,17 @@ export default class ReferralUtils {
         heading: 'Check answers and submit',
         items: [
           {
-            statusTag: ReferralUtils.taskListStatus('cannot start yet'),
+            statusTag: ReferralUtils.taskListStatus(checkAnswersStatus),
             text: 'Check answers and submit',
-            url: referPaths.checkAnswers({ referralId: referral.id }),
+            url: checkAnswersUrl,
           },
         ],
       },
     ]
+  }
+
+  private static isReadyForSubmission(referral: Referral): boolean {
+    return !!referral.oasysConfirmed
   }
 
   private static taskListStatus(text: ReferralTaskListStatusText, dataTestId?: string): ReferralTaskListStatusTag {

--- a/server/utils/referralUtils.ts
+++ b/server/utils/referralUtils.ts
@@ -44,6 +44,10 @@ export default class ReferralUtils {
     ]
   }
 
+  static isReadyForSubmission(referral: Referral): boolean {
+    return !!referral.oasysConfirmed
+  }
+
   static taskListSections(referral: Referral): Array<ReferralTaskListSection> {
     const checkAnswersStatus = ReferralUtils.isReadyForSubmission(referral) ? 'not started' : 'cannot start yet'
     const checkAnswersUrl = ReferralUtils.isReadyForSubmission(referral)
@@ -96,10 +100,6 @@ export default class ReferralUtils {
         ],
       },
     ]
-  }
-
-  private static isReadyForSubmission(referral: Referral): boolean {
-    return !!referral.oasysConfirmed
   }
 
   private static taskListStatus(text: ReferralTaskListStatusText, dataTestId?: string): ReferralTaskListStatusTag {

--- a/server/utils/referralUtils.ts
+++ b/server/utils/referralUtils.ts
@@ -89,6 +89,7 @@ export default class ReferralUtils {
         items: [
           {
             statusTag: ReferralUtils.taskListStatus(checkAnswersStatus),
+            testIds: ReferralUtils.testIds('check-answers'),
             text: 'Check answers and submit',
             url: checkAnswersUrl,
           },
@@ -115,5 +116,9 @@ export default class ReferralUtils {
     }
 
     return tag
+  }
+
+  private static testIds(base: string): { listItem: string } {
+    return { listItem: `${base}-list-item` }
   }
 }

--- a/server/views/referrals/_taskListSection.njk
+++ b/server/views/referrals/_taskListSection.njk
@@ -5,7 +5,7 @@
     <h2 class="moj-task-list__section">{{ section.heading }}</h2>
     <ul class="moj-task-list__items">
       {% for item in section.items %}
-        <li class="moj-task-list__item">
+        <li class="moj-task-list__item" data-testid="{{ item.testIds.listItem }}">
           {% if item.url %}
             <a class="moj-task-list__task-name" href="{{ item.url }}">{{ item.text }}</a>
           {% else %}


### PR DESCRIPTION
## Context

<!-- Is there a Trello ticket you can link to? -->
<!-- Do you need to add any environment variables? -->
<!-- Is an ADR required? An ADR should be added if this PR introduces a change to the architecture. -->

The check answers task list section is currently hardcoded to show the URL and a 'cannot start yet' tag

## Changes in this PR

- Make the check answers task list section dynamic, only showing the URL when ready, and updating the tag to reflect the actual status
- Redirect from check answers/submit when the referral is not ready for submission
- Tidy ups

Currently it only checks for `oasysConfirmed` since the `Referral` model is incomplete

## Screenshots of UI changes

### Before

<img width="814" alt="image" src="https://github.com/ministryofjustice/hmpps-accredited-programmes-ui/assets/40244233/576a996a-ae3d-4a32-be66-908987878120">

### After

#### Unready

<img width="807" alt="image" src="https://github.com/ministryofjustice/hmpps-accredited-programmes-ui/assets/40244233/8981391d-c131-453a-81dc-d5241f6a56e3">

#### Ready

<img width="821" alt="image" src="https://github.com/ministryofjustice/hmpps-accredited-programmes-ui/assets/40244233/7eed8037-17c1-42f8-8e34-37891fc8f5e4">

## Release checklist

[Release process documentation](../doc/how-to/perform-a-release.md)

As part of our continuous deployment strategy we must ensure that this work is
ready to be released once merged.

### Pre-merge

- [ ] There are changes required to the Accredited Programmes API for this change to work...
  - [ ] ... and they have been released to production already

### Post-merge

<!-- The outer checkboxes can be completed pre-merge -->

- [ ] This adds, extends or meaningfully modifies a feature...
  - [ ] ... and I have written or updated an end-to-end test for the happy path in the [Accredited Programmes E2E repo](https://github.com/ministryofjustice/hmpps-accredited-programmes-e2e)
- [ ] This makes new expectations of the API...
  - [ ] ... and I have notified the API developer(s) of changes to the contract tests (Pact), or the API is already compliant
- [ ] [Manually approve](../doc/how-to/perform-a-release.md#releasing-to-the-preprod-environment) release to preprod
- [ ] [Manually approve](../doc/how-to/perform-a-release.md#releasing-to-the-production-environment) release to prod

<!-- Should a release fail at any step, you as the author should now lead the work to
fix it as soon as possible. You can monitor deployment failures in CircleCI
itself and application errors are found in
[Sentry](https://ministryofjustice.sentry.io/projects/hmpps-accredited-programmes-ui/?project=4505330122686464&referrer=sidebar&statsPeriod=24h). -->
