### PR TITLE
(653) Reason for referral

### DIFF
--- a/integration_tests/e2eReferDisabled/refer.cy.ts
+++ b/integration_tests/e2eReferDisabled/refer.cy.ts
@@ -122,6 +122,22 @@ context('Refer', () => {
     notFoundPage.shouldContain404H2()
   })
 
+  it("Doesn't show the reason for referral form page", () => {
+    cy.signIn()
+
+    const prisoner = prisonerFactory.build()
+    const referral = referralFactory.build({ prisonNumber: prisoner.prisonerNumber })
+
+    cy.task('stubPrisoner', prisoner)
+    cy.task('stubReferral', referral)
+
+    const path = referPaths.reason({ referralId: referral.id })
+    cy.visit(path, { failOnStatusCode: false })
+
+    const notFoundPage = Page.verifyOnPage(NotFoundPage)
+    notFoundPage.shouldContain404H2()
+  })
+
   it("Doesn't show the check answers page for a referral", () => {
     cy.signIn()
 

--- a/integration_tests/pages/page.ts
+++ b/integration_tests/pages/page.ts
@@ -181,6 +181,11 @@ export default abstract class Page {
     })
   }
 
+  shouldContainTextArea(name: string, label: string): void {
+    cy.get(`.govuk-label[for="${name}"]`).should('contain.text', label)
+    cy.get(`.govuk-textarea[name="${name}"]`).should('exist')
+  }
+
   shouldHaveErrors(errors: Array<{ field: string; message: string }>): void {
     cy.get('.govuk-error-summary').should('exist')
 

--- a/integration_tests/pages/refer/reason.ts
+++ b/integration_tests/pages/refer/reason.ts
@@ -1,0 +1,43 @@
+import Page from '../page'
+import type { Referral } from '@accredited-programmes/models'
+
+export default class ReasonPage extends Page {
+  referral: Referral
+
+  constructor(args: { referral: Referral }) {
+    super('Add reason for referral and supporting information')
+
+    const { referral } = args
+
+    this.referral = referral
+  }
+
+  shouldContainInformationTypeDetails() {
+    cy.get('[data-testid="information-type-details"]').then(informationTypeDetailsElement => {
+      this.shouldContainDetails(
+        'What type of information can I add?',
+        "you can provide information about why you're referring this person to this programme" +
+          'you can add supporting information that would be useful for the programme team to know' +
+          'you can add any other information that would be useful for the programme team to know',
+        informationTypeDetailsElement,
+      )
+    })
+  }
+
+  shouldContainReasonTextArea() {
+    this.shouldContainTextArea('reason', 'Add reason for referral and supporting information')
+  }
+
+  shouldContainSaveAndContinueButton() {
+    this.shouldContainButton('Save and continue')
+  }
+
+  submitReason() {
+    const reason = 'This is the reason for the referral'
+    cy.get('[data-testid="reason-text-area"]').type(reason)
+    this.referral = { ...this.referral, reason }
+    // We're stubbing the referral here to make sure the updated referral is available on the task list page
+    cy.task('stubReferral', this.referral)
+    this.shouldContainButton('Save and continue').click()
+  }
+}

--- a/integration_tests/pages/refer/taskList.ts
+++ b/integration_tests/pages/refer/taskList.ts
@@ -71,6 +71,12 @@ export default class TaskListPage extends Page {
     })
   }
 
+  shouldHaveReason() {
+    cy.get('[data-testid="reason-tag"]').then(reasonTagElement => {
+      this.shouldContainTag({ classes: 'govuk-tag moj-task-list__task-completed', text: 'completed' }, reasonTagElement)
+    })
+  }
+
   shouldNotBeReadyForSubmission() {
     cy.get('[data-testid="check-answers-list-item"]').within(() => {
       cy.get('a').should('not.exist')

--- a/server/@types/models/Referral.ts
+++ b/server/@types/models/Referral.ts
@@ -6,6 +6,7 @@ type Referral = {
   oasysConfirmed: boolean
   offeringId: CourseOffering['id']
   prisonNumber: Person['prisonNumber']
+  reason: string
   referrerId: Express.User['userId']
   status: ReferralStatus
 }

--- a/server/controllers/refer/referralsController.test.ts
+++ b/server/controllers/refer/referralsController.test.ts
@@ -397,7 +397,28 @@ describe('ReferralsController', () => {
         await requestHandler(request, response, next)
 
         expect(response.redirect).toHaveBeenCalledWith(referPaths.show({ referralId: referral.id }))
-        expect(referralService.updateReferral).toHaveBeenCalledWith(token, referral.id, { oasysConfirmed: true })
+        expect(referralService.updateReferral).toHaveBeenCalledWith(token, referral.id, {
+          oasysConfirmed: true,
+          reason: referral.reason,
+        })
+      })
+    })
+
+    describe('updating `reason`', () => {
+      it('asks the service to update the field and redirects to the show action', async () => {
+        const referral = referralFactory.build({ oasysConfirmed: true, reason: undefined })
+        referralService.getReferral.mockResolvedValue(referral)
+
+        request.body.reason = ' Some reason\nAnother paragraph\n '
+
+        const requestHandler = referralsController.update()
+        await requestHandler(request, response, next)
+
+        expect(response.redirect).toHaveBeenCalledWith(referPaths.show({ referralId: referral.id }))
+        expect(referralService.updateReferral).toHaveBeenCalledWith(token, referral.id, {
+          oasysConfirmed: true,
+          reason: 'Some reason\nAnother paragraph',
+        })
       })
     })
   })

--- a/server/controllers/refer/referralsController.test.ts
+++ b/server/controllers/refer/referralsController.test.ts
@@ -488,4 +488,38 @@ describe('ReferralsController', () => {
       })
     })
   })
+
+  describe('reason', () => {
+    it('renders the reason for referral page', async () => {
+      const person = personFactory.build()
+      personService.getPerson.mockResolvedValue(person)
+
+      const referral = referralFactory.build({ offeringId: courseOffering.id, prisonNumber: person.prisonNumber })
+      referralService.getReferral.mockResolvedValue(referral)
+
+      const requestHandler = referralsController.reason()
+      await requestHandler(request, response, next)
+
+      expect(response.render).toHaveBeenCalledWith('referrals/reason', {
+        pageHeading: 'Add reason for referral and supporting information',
+        person,
+        referral,
+      })
+    })
+
+    describe('when the person service returns `null`', () => {
+      it('responds with a 404', async () => {
+        const person = personFactory.build()
+        personService.getPerson.mockResolvedValue(null)
+
+        const referral = referralFactory.build({ offeringId: courseOffering.id, prisonNumber: person.prisonNumber })
+        referralService.getReferral.mockResolvedValue(referral)
+
+        const requestHandler = referralsController.reason()
+        const expectedError = createError(404, `Person with prison number ${referral.prisonNumber} not found.`)
+
+        expect(() => requestHandler(request, response, next)).rejects.toThrowError(expectedError)
+      })
+    })
+  })
 })

--- a/server/controllers/refer/referralsController.ts
+++ b/server/controllers/refer/referralsController.ts
@@ -140,6 +140,25 @@ export default class ReferralsController {
     }
   }
 
+  reason(): TypedRequestHandler<Request, Response> {
+    return async (req: Request, res: Response) => {
+      TypeUtils.assertHasUser(req)
+
+      const referral = await this.referralService.getReferral(req.user.token, req.params.referralId)
+      const person = await this.personService.getPerson(req.user.token, referral.prisonNumber)
+
+      if (!person) {
+        throw createError(404, `Person with prison number ${referral.prisonNumber} not found.`)
+      }
+
+      res.render('referrals/reason', {
+        pageHeading: 'Add reason for referral and supporting information',
+        person,
+        referral,
+      })
+    }
+  }
+
   show(): TypedRequestHandler<Request, Response> {
     return async (req: Request, res: Response) => {
       TypeUtils.assertHasUser(req)

--- a/server/controllers/refer/referralsController.ts
+++ b/server/controllers/refer/referralsController.ts
@@ -274,9 +274,11 @@ export default class ReferralsController {
       const referral = await this.referralService.getReferral(req.user.token, req.params.referralId)
       const oasysConfirmed =
         typeof req.body.oasysConfirmed === 'undefined' ? referral.oasysConfirmed : req.body.oasysConfirmed
+      const reason = typeof req.body.reason === 'undefined' ? referral.reason : req.body.reason.trim()
 
       const referralUpdate: ReferralUpdate = {
         oasysConfirmed,
+        reason,
       }
 
       await this.referralService.updateReferral(req.user.token, referral.id, referralUpdate)

--- a/server/paths/refer.ts
+++ b/server/paths/refer.ts
@@ -14,6 +14,7 @@ const referralsPath = path('/referrals')
 const showReferralPath = referralsPath.path(':referralId')
 const referralPersonPath = showReferralPath.path('person')
 const confirmOasysPath = showReferralPath.path('oasys-confirmed')
+const reasonForReferralPath = showReferralPath.path('reason')
 const checkAnswersPath = showReferralPath.path('check-answers')
 const completeReferralPath = showReferralPath.path('complete')
 const submitReferralPath = showReferralPath.path('submit')
@@ -28,6 +29,7 @@ export default {
     find: findPersonPath,
     show: personPath,
   },
+  reason: reasonForReferralPath,
   show: showReferralPath,
   showPerson: referralPersonPath,
   start: startReferralPath,

--- a/server/routes/refer.ts
+++ b/server/routes/refer.ts
@@ -19,6 +19,7 @@ export default function routes(controllers: Controllers, router: Router): Router
   put(referPaths.update.pattern, referralsController.update())
   get(referPaths.showPerson.pattern, referralsController.showPerson())
   get(referPaths.confirmOasys.pattern, referralsController.confirmOasys())
+  get(referPaths.reason.pattern, referralsController.reason())
   get(referPaths.checkAnswers.pattern, referralsController.checkAnswers())
   get(referPaths.complete.pattern, referralsController.complete())
   post(referPaths.submit.pattern, referralsController.submit())

--- a/server/testutils/factories/referral.ts
+++ b/server/testutils/factories/referral.ts
@@ -8,6 +8,7 @@ export default Factory.define<Referral>(() => ({
   oasysConfirmed: false,
   offeringId: faker.string.uuid(),
   prisonNumber: faker.string.alphanumeric({ length: 7 }),
+  reason: faker.lorem.sentence(),
   referrerId: faker.string.numeric({ length: 6 }),
   status: 'referral_started',
 }))

--- a/server/utils/referralUtils.test.ts
+++ b/server/utils/referralUtils.test.ts
@@ -78,7 +78,7 @@ describe('ReferralUtils', () => {
 
   describe('taskListSections', () => {
     it('returns task list sections for a given referral', () => {
-      const referral = referralFactory.build()
+      const referral = referralFactory.build({ reason: undefined })
 
       expect(ReferralUtils.taskListSections(referral)).toEqual([
         {
@@ -109,7 +109,11 @@ describe('ReferralUtils', () => {
               url: `/referrals/${referral.id}/oasys-confirmed`,
             },
             {
-              statusTag: { classes: 'govuk-tag--grey moj-task-list__task-completed', text: 'not started' },
+              statusTag: {
+                attributes: { 'data-testid': 'reason-tag' },
+                classes: 'govuk-tag--grey moj-task-list__task-completed',
+                text: 'not started',
+              },
               text: 'Add reason for referral and any additional information',
               url: `/referrals/${referral.id}/reason`,
             },
@@ -133,12 +137,18 @@ describe('ReferralUtils', () => {
     })
 
     it('marks completed sections as completed via their status tags', () => {
-      const referralWithOasysConfirmed = referralFactory.build({ oasysConfirmed: true })
-      const taskListSections = ReferralUtils.taskListSections(referralWithOasysConfirmed)
+      const referralWithCompletedInformation = referralFactory.build({ oasysConfirmed: true, reason: 'Some reason' })
+      const taskListSections = ReferralUtils.taskListSections(referralWithCompletedInformation)
       const oasysConfirmedStatusTag = taskListSections[1].items[1].statusTag
+      const reasonConfirmedStatusTag = taskListSections[1].items[2].statusTag
 
       expect(oasysConfirmedStatusTag).toEqual({
         attributes: { 'data-testid': 'oasys-confirmed-tag' },
+        classes: 'moj-task-list__task-completed',
+        text: 'completed',
+      })
+      expect(reasonConfirmedStatusTag).toEqual({
+        attributes: { 'data-testid': 'reason-tag' },
         classes: 'moj-task-list__task-completed',
         text: 'completed',
       })

--- a/server/utils/referralUtils.test.ts
+++ b/server/utils/referralUtils.test.ts
@@ -111,7 +111,7 @@ describe('ReferralUtils', () => {
             {
               statusTag: { classes: 'govuk-tag--grey moj-task-list__task-completed', text: 'not started' },
               text: 'Add reason for referral and any additional information',
-              url: '#',
+              url: `/referrals/${referral.id}/reason`,
             },
           ],
         },

--- a/server/utils/referralUtils.ts
+++ b/server/utils/referralUtils.ts
@@ -82,7 +82,7 @@ export default class ReferralUtils {
             url: referPaths.confirmOasys({ referralId: referral.id }),
           },
           {
-            statusTag: ReferralUtils.taskListStatus('not started'),
+            statusTag: ReferralUtils.taskListStatus(referral.reason ? 'completed' : 'not started', 'reason-tag'),
             text: 'Add reason for referral and any additional information',
             url: referPaths.reason({ referralId: referral.id }),
           },

--- a/server/utils/referralUtils.ts
+++ b/server/utils/referralUtils.ts
@@ -84,7 +84,7 @@ export default class ReferralUtils {
           {
             statusTag: ReferralUtils.taskListStatus('not started'),
             text: 'Add reason for referral and any additional information',
-            url: '#',
+            url: referPaths.reason({ referralId: referral.id }),
           },
         ],
       },

--- a/server/views/referrals/reason.njk
+++ b/server/views/referrals/reason.njk
@@ -1,0 +1,60 @@
+{% from "govuk/components/back-link/macro.njk" import govukBackLink %}
+{% from "govuk/components/button/macro.njk" import govukButton %}
+{% from "govuk/components/details/macro.njk" import govukDetails %}
+{% from "govuk/components/textarea/macro.njk" import govukTextarea %}
+
+{% extends "../partials/layout.njk" %}
+
+{% block personBanner %}
+  {% include "./_personBanner.njk" %}
+{% endblock personBanner %}
+
+{% block backLink %}
+  {{ govukBackLink({
+    text: "Back",
+    href: referPaths.show({ referralId: referral.id })
+  }) }}
+{% endblock backLink %}
+
+{% block content %}
+  <div class="govuk-grid-row">
+    <div class="govuk-grid-column-two-thirds">
+
+      {% set detailsHtml %}
+      <ul class="govuk-list govuk-list--bullet">
+        <li>you can provide information about why you're referring this person to this programme</li>
+        <li>you can add supporting information that would be useful for the programme team to know</li>
+        <li>you can add any other information that would be useful for the programme team to know</li>
+      </ul>
+      {% endset %}
+
+      <form action="{{ referPaths.update({ referralId: referral.id }) }}?_method=PUT" method="post">
+        <input type="hidden" name="_csrf" value="{{ csrfToken }}"/>
+
+        {{ govukTextarea({
+          name: "reason",
+          id: "reason",
+          label: {
+            text: pageHeading,
+            classes: "govuk-label--l",
+            isPageHeading: true
+          },
+          hint: {
+            html: govukDetails({
+              summaryText: "What type of information can I add?",
+              html: detailsHtml,
+              attributes: {
+                "data-testid": "information-type-details"
+              }
+            }) 
+          },
+          value: referral.reason
+        }) }}
+
+        {{ govukButton({
+          text: "Save and continue"
+        }) }}
+      </form>
+    </div>
+  </div>
+{% endblock %}

--- a/server/views/referrals/reason.njk
+++ b/server/views/referrals/reason.njk
@@ -48,7 +48,10 @@
               }
             }) 
           },
-          value: referral.reason
+          value: referral.reason,
+          attributes: {
+            "data-testid": "reason-text-area"
+          }
         }) }}
 
         {{ govukButton({


### PR DESCRIPTION
## Context

https://trello.com/c/LSccMbIN/653-add-reason-for-the-referral-form-step-ui

## Changes in this PR
- Added page template for referral reason form step
- Added `/reason-for-referral` path
- Added `reason` method to `ReferralsController`
- Update `update` method to handle `reason`
- Add url to link to new page from task list


## Screenshots of UI changes
![localhost_3000_referrals_778ad55f-aa95-48b7-9f4b-96a58c068c7e_reason](https://github.com/ministryofjustice/hmpps-accredited-programmes-ui/assets/1067537/ee7dfc8d-761c-4ee7-ad2f-1cfb8d2c4e0a)




## Release checklist

[Release process documentation](../doc/how-to/perform-a-release.md)

As part of our continuous deployment strategy we must ensure that this work is
ready to be released once merged.

### Pre-merge

- [ ] There are changes required to the Accredited Programmes API for this change to work...
  - [ ] ... and they have been released to production already

### Post-merge

<!-- The outer checkboxes can be completed pre-merge -->

- [x] This adds, extends or meaningfully modifies a feature...
  - [ ] ... and I have written or updated an end-to-end test for the happy path in the [Accredited Programmes E2E repo](https://github.com/ministryofjustice/hmpps-accredited-programmes-e2e)
- [ ] This makes new expectations of the API...
  - [ ] ... and I have notified the API developer(s) of changes to the contract tests (Pact), or the API is already compliant
- [ ] [Manually approve](../doc/how-to/perform-a-release.md#releasing-to-the-preprod-environment) release to preprod
- [ ] [Manually approve](../doc/how-to/perform-a-release.md#releasing-to-the-production-environment) release to prod

<!-- Should a release fail at any step, you as the author should now lead the work to
fix it as soon as possible. You can monitor deployment failures in CircleCI
itself and application errors are found in
[Sentry](https://ministryofjustice.sentry.io/projects/hmpps-accredited-programmes-ui/?project=4505330122686464&referrer=sidebar&statsPeriod=24h). -->
