### PR TITLE
(844) Prevent access to check your answers page without referral reason

### DIFF
--- a/server/utils/referralUtils.test.ts
+++ b/server/utils/referralUtils.test.ts
@@ -95,6 +95,15 @@ describe('ReferralUtils', () => {
           heading: 'Referral information',
           items: [
             {
+              statusTag: {
+                attributes: { 'data-testid': 'reason-tag' },
+                classes: 'govuk-tag--grey moj-task-list__task-completed',
+                text: 'not started',
+              },
+              text: 'Add reason for referral and any additional information',
+              url: `/referrals/${referral.id}/reason`,
+            },
+            {
               statusTag: { classes: 'govuk-tag--grey moj-task-list__task-completed', text: 'not started' },
               text: 'Add Accredited Programme history',
               url: '#',
@@ -107,15 +116,6 @@ describe('ReferralUtils', () => {
               },
               text: 'Confirm the OASys information',
               url: `/referrals/${referral.id}/oasys-confirmed`,
-            },
-            {
-              statusTag: {
-                attributes: { 'data-testid': 'reason-tag' },
-                classes: 'govuk-tag--grey moj-task-list__task-completed',
-                text: 'not started',
-              },
-              text: 'Add reason for referral and any additional information',
-              url: `/referrals/${referral.id}/reason`,
             },
           ],
         },
@@ -139,16 +139,16 @@ describe('ReferralUtils', () => {
     it('marks completed sections as completed via their status tags', () => {
       const referralWithCompletedInformation = referralFactory.build({ oasysConfirmed: true, reason: 'Some reason' })
       const taskListSections = ReferralUtils.taskListSections(referralWithCompletedInformation)
-      const oasysConfirmedStatusTag = taskListSections[1].items[1].statusTag
-      const reasonConfirmedStatusTag = taskListSections[1].items[2].statusTag
+      const reasonConfirmedStatusTag = taskListSections[1].items[0].statusTag
+      const oasysConfirmedStatusTag = taskListSections[1].items[2].statusTag
 
-      expect(oasysConfirmedStatusTag).toEqual({
-        attributes: { 'data-testid': 'oasys-confirmed-tag' },
+      expect(reasonConfirmedStatusTag).toEqual({
+        attributes: { 'data-testid': 'reason-tag' },
         classes: 'moj-task-list__task-completed',
         text: 'completed',
       })
-      expect(reasonConfirmedStatusTag).toEqual({
-        attributes: { 'data-testid': 'reason-tag' },
+      expect(oasysConfirmedStatusTag).toEqual({
+        attributes: { 'data-testid': 'oasys-confirmed-tag' },
         classes: 'moj-task-list__task-completed',
         text: 'completed',
       })

--- a/server/utils/referralUtils.test.ts
+++ b/server/utils/referralUtils.test.ts
@@ -60,18 +60,18 @@ describe('ReferralUtils', () => {
   })
 
   describe('isReadyForSubmission', () => {
-    it('returns false for a new referral', () => {
-      const referral = referralFactory.build()
+    const referral = referralFactory.build({ reason: undefined })
 
+    it('returns false for a new referral', () => {
       expect(ReferralUtils.isReadyForSubmission(referral)).toEqual(false)
     })
 
-    describe('when OASys is confirmed', () => {
+    describe('when OASys is confirmed and a reason is provided', () => {
       // to be updated as the referral model is built out
       it('returns true', () => {
-        const referral = referralFactory.build({ oasysConfirmed: true })
+        const updatedReferral = referralFactory.build({ ...referral, oasysConfirmed: true, reason: 'Some reason' })
 
-        expect(ReferralUtils.isReadyForSubmission(referral)).toEqual(true)
+        expect(ReferralUtils.isReadyForSubmission(updatedReferral)).toEqual(true)
       })
     })
   })

--- a/server/utils/referralUtils.ts
+++ b/server/utils/referralUtils.ts
@@ -69,6 +69,11 @@ export default class ReferralUtils {
         heading: 'Referral information',
         items: [
           {
+            statusTag: ReferralUtils.taskListStatus(referral.reason ? 'completed' : 'not started', 'reason-tag'),
+            text: 'Add reason for referral and any additional information',
+            url: referPaths.reason({ referralId: referral.id }),
+          },
+          {
             statusTag: ReferralUtils.taskListStatus('not started'),
             text: 'Add Accredited Programme history',
             url: '#',
@@ -80,11 +85,6 @@ export default class ReferralUtils {
             ),
             text: 'Confirm the OASys information',
             url: referPaths.confirmOasys({ referralId: referral.id }),
-          },
-          {
-            statusTag: ReferralUtils.taskListStatus(referral.reason ? 'completed' : 'not started', 'reason-tag'),
-            text: 'Add reason for referral and any additional information',
-            url: referPaths.reason({ referralId: referral.id }),
           },
         ],
       },

--- a/server/utils/referralUtils.ts
+++ b/server/utils/referralUtils.ts
@@ -45,7 +45,7 @@ export default class ReferralUtils {
   }
 
   static isReadyForSubmission(referral: Referral): boolean {
-    return !!referral.oasysConfirmed
+    return !!referral.oasysConfirmed && !!referral.reason
   }
 
   static taskListSections(referral: Referral): Array<ReferralTaskListSection> {


### PR DESCRIPTION
## Context

https://trello.com/c/wKf9Lq9a/844-prevent-access-to-cya-page-until-reason-for-referral-has-been-filled-in



## Changes in this PR
- Move _Add reason for referral and any additional information_ task to top, beneath Referral Information
- Update `isReadyForSubmission` to check for `referral.reason` to Check Your Answers page cannot be accessed


## Screenshots of UI changes

### Before
![image](https://github.com/ministryofjustice/hmpps-accredited-programmes-ui/assets/1067537/f011e2b6-1777-4ce6-8f52-d3e145dd0233)


### After
![image](https://github.com/ministryofjustice/hmpps-accredited-programmes-ui/assets/1067537/5a7a231d-fd56-4aca-a519-9dacbecf260f)


## Release checklist

[Release process documentation](../doc/how-to/perform-a-release.md)

As part of our continuous deployment strategy we must ensure that this work is
ready to be released once merged.

### Pre-merge

- [ ] There are changes required to the Accredited Programmes API for this change to work...
  - [ ] ... and they have been released to production already

### Post-merge

<!-- The outer checkboxes can be completed pre-merge -->

- [ ] This adds, extends or meaningfully modifies a feature...
  - [ ] ... and I have written or updated an end-to-end test for the happy path in the [Accredited Programmes E2E repo](https://github.com/ministryofjustice/hmpps-accredited-programmes-e2e)
- [ ] This makes new expectations of the API...
  - [ ] ... and I have notified the API developer(s) of changes to the contract tests (Pact), or the API is already compliant
- [ ] [Manually approve](../doc/how-to/perform-a-release.md#releasing-to-the-preprod-environment) release to preprod
- [ ] [Manually approve](../doc/how-to/perform-a-release.md#releasing-to-the-production-environment) release to prod

<!-- Should a release fail at any step, you as the author should now lead the work to
fix it as soon as possible. You can monitor deployment failures in CircleCI
itself and application errors are found in
[Sentry](https://ministryofjustice.sentry.io/projects/hmpps-accredited-programmes-ui/?project=4505330122686464&referrer=sidebar&statsPeriod=24h). -->
