### PR TITLE
(841) Referral factory updates

### DIFF
--- a/integration_tests/e2e/refer.cy.ts
+++ b/integration_tests/e2e/refer.cy.ts
@@ -140,7 +140,9 @@ context('Refer', () => {
     const prison = prisonFactory.build({ prisonId: courseOffering.organisationId })
     const organisation = OrganisationUtils.organisationFromPrison('an-ID', prison)
 
-    const referral = referralFactory.build({ offeringId: courseOffering.id, prisonNumber: person.prisonNumber })
+    const referral = referralFactory
+      .started()
+      .build({ offeringId: courseOffering.id, prisonNumber: person.prisonNumber })
 
     cy.task('stubCourseByOffering', { course, courseOfferingId: courseOffering.id })
     cy.task('stubCourseOffering', { courseOffering })
@@ -179,7 +181,9 @@ context('Refer', () => {
     const prison = prisonFactory.build({ prisonId: courseOffering.organisationId })
     const organisation = OrganisationUtils.organisationFromPrison('an-ID', prison)
 
-    const referral = referralFactory.build({ offeringId: courseOffering.id, prisonNumber: person.prisonNumber })
+    const referral = referralFactory
+      .started()
+      .build({ offeringId: courseOffering.id, prisonNumber: person.prisonNumber })
 
     cy.task('stubCourseByOffering', { course, courseOfferingId: courseOffering.id })
     cy.task('stubCourseOffering', { courseOffering })
@@ -219,7 +223,7 @@ context('Refer', () => {
       setting: 'Custody',
     })
 
-    const referral = referralFactory.build({ prisonNumber: prisoner.prisonerNumber })
+    const referral = referralFactory.started().build({ prisonNumber: prisoner.prisonerNumber })
 
     cy.task('stubPrisoner', prisoner)
     cy.task('stubReferral', referral)
@@ -247,7 +251,7 @@ context('Refer', () => {
       prisonNumber: prisoner.prisonerNumber,
     })
 
-    const referral = referralFactory.build({ prisonNumber: person.prisonNumber })
+    const referral = referralFactory.started().build({ prisonNumber: person.prisonNumber })
 
     cy.task('stubPrisoner', prisoner)
     cy.task('stubReferral', referral)
@@ -284,7 +288,9 @@ context('Refer', () => {
     const prison = prisonFactory.build({ prisonId: courseOffering.organisationId })
     const organisation = OrganisationUtils.organisationFromPrison('an-ID', prison)
 
-    const referral = referralFactory.build({ offeringId: courseOffering.id, prisonNumber: person.prisonNumber })
+    const referral = referralFactory
+      .started()
+      .build({ offeringId: courseOffering.id, prisonNumber: person.prisonNumber })
 
     cy.task('stubCourseByOffering', { course, courseOfferingId: courseOffering.id })
     cy.task('stubCourseOffering', { courseId: course.id, courseOffering })
@@ -316,7 +322,7 @@ context('Refer', () => {
       prisonNumber: prisoner.prisonerNumber,
     })
 
-    const referral = referralFactory.build({ prisonNumber: person.prisonNumber, reason: undefined })
+    const referral = referralFactory.started().build({ prisonNumber: person.prisonNumber, reason: undefined })
 
     cy.task('stubPrisoner', prisoner)
     cy.task('stubReferral', referral)
@@ -351,11 +357,9 @@ context('Refer', () => {
     const prison = prisonFactory.build({ prisonId: courseOffering.organisationId })
     const organisation = OrganisationUtils.organisationFromPrison('an-ID', prison)
 
-    const referral = referralFactory.build({
-      offeringId: courseOffering.id,
-      prisonNumber: person.prisonNumber,
-      reason: undefined,
-    })
+    const referral = referralFactory
+      .started()
+      .build({ offeringId: courseOffering.id, prisonNumber: person.prisonNumber })
 
     cy.task('stubCourseByOffering', { course, courseOfferingId: courseOffering.id })
     cy.task('stubCourseOffering', { courseId: course.id, courseOffering })
@@ -393,11 +397,9 @@ context('Refer', () => {
     const prison = prisonFactory.build({ prisonId: courseOffering.organisationId })
     const organisation = OrganisationUtils.organisationFromPrison('an-ID', prison)
 
-    const referral = referralFactory.build({
-      oasysConfirmed: true,
-      offeringId: courseOffering.id,
-      prisonNumber: person.prisonNumber,
-    })
+    const referral = referralFactory
+      .submittable()
+      .build({ oasysConfirmed: true, offeringId: courseOffering.id, prisonNumber: person.prisonNumber })
 
     cy.task('stubCourseByOffering', { course, courseOfferingId: courseOffering.id })
     cy.task('stubCourseOffering', { courseId: course.id, courseOffering })
@@ -437,11 +439,9 @@ context('Refer', () => {
     const prison = prisonFactory.build({ prisonId: courseOffering.organisationId })
     const organisation = OrganisationUtils.organisationFromPrison('an-ID', prison)
 
-    const referral = referralFactory.build({
-      oasysConfirmed: true,
-      offeringId: courseOffering.id,
-      prisonNumber: person.prisonNumber,
-    })
+    const referral = referralFactory
+      .submittable()
+      .build({ offeringId: courseOffering.id, prisonNumber: person.prisonNumber })
 
     cy.task('stubCourseByOffering', { course, courseOfferingId: courseOffering.id })
     cy.task('stubCourseOffering', { courseId: course.id, courseOffering })
@@ -497,11 +497,9 @@ context('Refer', () => {
     })
 
     it('redirects to the referral complete page when the user confirms the details', () => {
-      const referral = referralFactory.build({
-        oasysConfirmed: true,
-        offeringId: courseOffering.id,
-        prisonNumber: person.prisonNumber,
-      })
+      const referral = referralFactory
+        .submittable()
+        .build({ offeringId: courseOffering.id, prisonNumber: person.prisonNumber })
 
       cy.task('stubReferral', referral)
       cy.task('stubUpdateReferralStatus', referral.id)
@@ -523,11 +521,9 @@ context('Refer', () => {
     })
 
     it('shows an error when the user tries to submit a referral without confirming the details', () => {
-      const referral = referralFactory.build({
-        oasysConfirmed: true,
-        offeringId: courseOffering.id,
-        prisonNumber: person.prisonNumber,
-      })
+      const referral = referralFactory
+        .submittable()
+        .build({ offeringId: courseOffering.id, prisonNumber: person.prisonNumber })
 
       cy.task('stubReferral', referral)
 
@@ -562,7 +558,7 @@ context('Refer', () => {
   it('Shows the complete page for a completed referral', () => {
     cy.signIn()
 
-    const referral = referralFactory.build({ status: 'referral_submitted' })
+    const referral = referralFactory.submitted().build({ status: 'referral_submitted' })
 
     cy.task('stubReferral', referral)
 

--- a/integration_tests/e2eReferDisabled/refer.cy.ts
+++ b/integration_tests/e2eReferDisabled/refer.cy.ts
@@ -71,7 +71,7 @@ context('Refer', () => {
   it("Doesn't show the in-progress referral task list", () => {
     cy.signIn()
 
-    const referral = referralFactory.build()
+    const referral = referralFactory.started().build()
     const course = courseFactory.build()
     const courseOffering = courseOfferingFactory.build({ id: referral.offeringId })
     const prison = prisonFactory.build({ prisonId: courseOffering.organisationId })
@@ -94,7 +94,7 @@ context('Refer', () => {
     cy.signIn()
 
     const prisoner = prisonerFactory.build()
-    const referral = referralFactory.build({ prisonNumber: prisoner.prisonerNumber })
+    const referral = referralFactory.started().build({ prisonNumber: prisoner.prisonerNumber })
 
     cy.task('stubPrisoner', prisoner)
     cy.task('stubReferral', referral)
@@ -110,7 +110,7 @@ context('Refer', () => {
     cy.signIn()
 
     const prisoner = prisonerFactory.build()
-    const referral = referralFactory.build({ prisonNumber: prisoner.prisonerNumber })
+    const referral = referralFactory.started().build({ prisonNumber: prisoner.prisonerNumber })
 
     cy.task('stubPrisoner', prisoner)
     cy.task('stubReferral', referral)
@@ -126,7 +126,7 @@ context('Refer', () => {
     cy.signIn()
 
     const prisoner = prisonerFactory.build()
-    const referral = referralFactory.build({ prisonNumber: prisoner.prisonerNumber })
+    const referral = referralFactory.started().build({ prisonNumber: prisoner.prisonerNumber })
 
     cy.task('stubPrisoner', prisoner)
     cy.task('stubReferral', referral)
@@ -145,7 +145,9 @@ context('Refer', () => {
     const courseOffering = courseOfferingFactory.build()
     const prison = prisonFactory.build({ prisonId: courseOffering.organisationId })
     const prisoner = prisonerFactory.build()
-    const referral = referralFactory.build({ offeringId: courseOffering.id, prisonNumber: prisoner.prisonerNumber })
+    const referral = referralFactory
+      .submittable()
+      .build({ offeringId: courseOffering.id, prisonNumber: prisoner.prisonerNumber })
 
     cy.task('stubCourseByOffering', { course, courseOfferingId: courseOffering.id })
     cy.task('stubCourseOffering', { courseId: course.id, courseOffering })
@@ -163,7 +165,7 @@ context('Refer', () => {
   it("Doesn't show the complete page for a referral", () => {
     cy.signIn()
 
-    const referral = referralFactory.build({ status: 'referral_submitted' })
+    const referral = referralFactory.submitted().build()
 
     cy.task('stubReferral', referral)
 

--- a/server/controllers/find/courseOfferingsController.test.ts
+++ b/server/controllers/find/courseOfferingsController.test.ts
@@ -12,7 +12,7 @@ describe('CoursesOfferingsController', () => {
   describe('show', () => {
     const token = 'SOME_TOKEN'
     let request: DeepMocked<Request>
-    const response: DeepMocked<Response> = createMock<Response>({})
+    let response: DeepMocked<Response>
     const next: DeepMocked<NextFunction> = createMock<NextFunction>({})
     const courseService = createMock<CourseService>({})
     const organisationService = createMock<OrganisationService>({})
@@ -26,6 +26,7 @@ describe('CoursesOfferingsController', () => {
 
     beforeEach(() => {
       request = createMock<Request>({ user: { token } })
+      response = createMock<Response>({})
       courseOfferingsController = new CourseOfferingsController(courseService, organisationService)
     })
 

--- a/server/controllers/find/coursesController.test.ts
+++ b/server/controllers/find/coursesController.test.ts
@@ -13,7 +13,7 @@ import type { OrganisationWithOfferingId } from '@accredited-programmes/ui'
 describe('CoursesController', () => {
   const token = 'SOME_TOKEN'
   let request: DeepMocked<Request>
-  const response: DeepMocked<Response> = createMock<Response>({})
+  let response: DeepMocked<Response>
   const next: DeepMocked<NextFunction> = createMock<NextFunction>({})
   const courseService = createMock<CourseService>({})
   const organisationService = createMock<OrganisationService>({})
@@ -22,6 +22,7 @@ describe('CoursesController', () => {
 
   beforeEach(() => {
     request = createMock<Request>({ user: { token } })
+    response = createMock<Response>({})
     coursesController = new CoursesController(courseService, organisationService)
   })
 

--- a/server/controllers/refer/referralsController.test.ts
+++ b/server/controllers/refer/referralsController.test.ts
@@ -108,7 +108,7 @@ describe('ReferralsController', () => {
 
   describe('create', () => {
     it('asks the service to create a referral and redirects to the show action', async () => {
-      const referral = referralFactory.build()
+      const referral = referralFactory.started().build()
 
       request.body.courseOfferingId = referral.offeringId
       request.body.prisonNumber = referral.prisonNumber
@@ -139,7 +139,9 @@ describe('ReferralsController', () => {
       const person = personFactory.build()
       personService.getPerson.mockResolvedValue(person)
 
-      const referral = referralFactory.build({ offeringId: courseOffering.id, prisonNumber: person.prisonNumber })
+      const referral = referralFactory
+        .started()
+        .build({ offeringId: courseOffering.id, prisonNumber: person.prisonNumber })
       referralService.getReferral.mockResolvedValue(referral)
 
       const requestHandler = referralsController.show()
@@ -164,7 +166,9 @@ describe('ReferralsController', () => {
         const person = personFactory.build()
         personService.getPerson.mockResolvedValue(person)
 
-        const referral = referralFactory.build({ offeringId: courseOffering.id, prisonNumber: person.prisonNumber })
+        const referral = referralFactory
+          .started()
+          .build({ offeringId: courseOffering.id, prisonNumber: person.prisonNumber })
         referralService.getReferral.mockResolvedValue(referral)
 
         const requestHandler = referralsController.show()
@@ -182,7 +186,9 @@ describe('ReferralsController', () => {
         const person = personFactory.build()
         personService.getPerson.mockResolvedValue(null)
 
-        const referral = referralFactory.build({ offeringId: courseOffering.id, prisonNumber: person.prisonNumber })
+        const referral = referralFactory
+          .started()
+          .build({ offeringId: courseOffering.id, prisonNumber: person.prisonNumber })
         referralService.getReferral.mockResolvedValue(referral)
 
         const requestHandler = referralsController.show()
@@ -201,7 +207,7 @@ describe('ReferralsController', () => {
     it("renders the page for viewing a person's details", async () => {
       personService.getPerson.mockResolvedValue(person)
 
-      const referral = referralFactory.build({ prisonNumber: person.prisonNumber })
+      const referral = referralFactory.started().build({ prisonNumber: person.prisonNumber })
       referralService.getReferral.mockResolvedValue(referral)
 
       const requestHandler = referralsController.showPerson()
@@ -219,7 +225,7 @@ describe('ReferralsController', () => {
       it('responds with a 404', async () => {
         personService.getPerson.mockResolvedValue(null)
 
-        const referral = referralFactory.build({ prisonNumber: person.prisonNumber })
+        const referral = referralFactory.started().build({ prisonNumber: person.prisonNumber })
         referralService.getReferral.mockResolvedValue(referral)
 
         const requestHandler = referralsController.showPerson()
@@ -235,7 +241,9 @@ describe('ReferralsController', () => {
       const person = personFactory.build()
       personService.getPerson.mockResolvedValue(person)
 
-      const referral = referralFactory.build({ offeringId: courseOffering.id, prisonNumber: person.prisonNumber })
+      const referral = referralFactory
+        .started()
+        .build({ offeringId: courseOffering.id, prisonNumber: person.prisonNumber })
       referralService.getReferral.mockResolvedValue(referral)
 
       const requestHandler = referralsController.confirmOasys()
@@ -253,7 +261,9 @@ describe('ReferralsController', () => {
         const person = personFactory.build()
         personService.getPerson.mockResolvedValue(null)
 
-        const referral = referralFactory.build({ offeringId: courseOffering.id, prisonNumber: person.prisonNumber })
+        const referral = referralFactory
+          .started()
+          .build({ offeringId: courseOffering.id, prisonNumber: person.prisonNumber })
         referralService.getReferral.mockResolvedValue(referral)
 
         const requestHandler = referralsController.confirmOasys()
@@ -269,11 +279,9 @@ describe('ReferralsController', () => {
       const person = personFactory.build()
       personService.getPerson.mockResolvedValue(person)
 
-      const referral = referralFactory.build({
-        oasysConfirmed: true,
-        offeringId: courseOffering.id,
-        prisonNumber: person.prisonNumber,
-      })
+      const referral = referralFactory
+        .submittable()
+        .build({ offeringId: courseOffering.id, prisonNumber: person.prisonNumber })
       request.params.referralId = referral.id
       referralService.getReferral.mockResolvedValue(referral)
       ;(ReferralUtils.isReadyForSubmission as jest.Mock).mockReturnValue(true)
@@ -317,7 +325,7 @@ describe('ReferralsController', () => {
 
     describe('when the referral is not ready for submission', () => {
       it('redirects to the show referral page', async () => {
-        const referral = referralFactory.build()
+        const referral = referralFactory.started().build()
         request.params.referralId = referral.id
         referralService.getReferral.mockResolvedValue(referral)
         ;(ReferralUtils.isReadyForSubmission as jest.Mock).mockReturnValue(false)
@@ -337,11 +345,9 @@ describe('ReferralsController', () => {
         const person = personFactory.build()
         personService.getPerson.mockResolvedValue(person)
 
-        const referral = referralFactory.build({
-          oasysConfirmed: true,
-          offeringId: courseOffering.id,
-          prisonNumber: person.prisonNumber,
-        })
+        const referral = referralFactory
+          .submittable()
+          .build({ offeringId: courseOffering.id, prisonNumber: person.prisonNumber })
         request.params.referralId = referral.id
         referralService.getReferral.mockResolvedValue(referral)
         ;(ReferralUtils.isReadyForSubmission as jest.Mock).mockReturnValue(true)
@@ -360,10 +366,7 @@ describe('ReferralsController', () => {
 
     describe('when the person service returns `null`', () => {
       it('responds with a 404', async () => {
-        const referral = referralFactory.build({
-          oasysConfirmed: true,
-          offeringId: courseOffering.id,
-        })
+        const referral = referralFactory.submittable().build({ offeringId: courseOffering.id })
         request.params.referralId = referral.id
         referralService.getReferral.mockResolvedValue(referral)
         ;(ReferralUtils.isReadyForSubmission as jest.Mock).mockReturnValue(true)
@@ -386,7 +389,9 @@ describe('ReferralsController', () => {
       const person = personFactory.build()
       personService.getPerson.mockResolvedValue(person)
 
-      const referral = referralFactory.build({ offeringId: courseOffering.id, prisonNumber: person.prisonNumber })
+      const referral = referralFactory
+        .started()
+        .build({ offeringId: courseOffering.id, prisonNumber: person.prisonNumber })
       referralService.getReferral.mockResolvedValue(referral)
 
       const requestHandler = referralsController.reason()
@@ -404,7 +409,9 @@ describe('ReferralsController', () => {
         const person = personFactory.build()
         personService.getPerson.mockResolvedValue(null)
 
-        const referral = referralFactory.build({ offeringId: courseOffering.id, prisonNumber: person.prisonNumber })
+        const referral = referralFactory
+          .started()
+          .build({ offeringId: courseOffering.id, prisonNumber: person.prisonNumber })
         referralService.getReferral.mockResolvedValue(referral)
 
         const requestHandler = referralsController.reason()
@@ -418,7 +425,7 @@ describe('ReferralsController', () => {
   describe('update', () => {
     describe('updating `oasysConfirmed`', () => {
       it('asks the service to update the field and redirects to the show action', async () => {
-        const referral = referralFactory.build({ oasysConfirmed: false })
+        const referral = referralFactory.build({ oasysConfirmed: false, status: 'referral_started' })
         referralService.getReferral.mockResolvedValue(referral)
 
         request.body.oasysConfirmed = true
@@ -436,7 +443,7 @@ describe('ReferralsController', () => {
 
     describe('updating `reason`', () => {
       it('asks the service to update the field and redirects to the show action', async () => {
-        const referral = referralFactory.build({ reason: undefined })
+        const referral = referralFactory.build({ reason: undefined, status: 'referral_started' })
         referralService.getReferral.mockResolvedValue(referral)
 
         request.body.reason = ' Some reason\nAnother paragraph\n '
@@ -456,7 +463,7 @@ describe('ReferralsController', () => {
   describe('complete', () => {
     describe('when the referral status is `referral_submitted`', () => {
       it('renders the referral complete page', async () => {
-        const referral = referralFactory.build({ status: 'referral_submitted' })
+        const referral = referralFactory.submitted().build()
         referralService.getReferral.mockResolvedValue(referral)
 
         request.params.referralId = referral.id
@@ -484,7 +491,7 @@ describe('ReferralsController', () => {
   })
 
   describe('submit', () => {
-    const referral = referralFactory.build()
+    const referral = referralFactory.submittable().build()
 
     beforeEach(() => {
       referralService.getReferral.mockResolvedValue(referral)

--- a/server/controllers/refer/referralsController.test.ts
+++ b/server/controllers/refer/referralsController.test.ts
@@ -468,7 +468,7 @@ describe('ReferralsController', () => {
       })
     })
 
-    describe('when the referral status is not `referral_submitted`', () => {
+    describe('when the referral status is `referral_started`', () => {
       it('responds with a 400', async () => {
         const referral = referralFactory.build({ status: 'referral_started' })
         referralService.getReferral.mockResolvedValue(referral)

--- a/server/data/referralClient.test.ts
+++ b/server/data/referralClient.test.ts
@@ -17,7 +17,7 @@ pactWith({ consumer: 'Accredited Programmes UI', provider: 'Accredited Programme
     config.apis.accreditedProgrammesApi.url = provider.mockService.baseUrl
   })
 
-  const referral = referralFactory.build()
+  const referral = referralFactory.started().build()
   const { offeringId, prisonNumber, referrerId } = referral
   const createdReferralResponse: CreatedReferralResponse = { referralId: referral.id }
 

--- a/server/data/referralClient.test.ts
+++ b/server/data/referralClient.test.ts
@@ -79,7 +79,7 @@ pactWith({ consumer: 'Accredited Programmes UI', provider: 'Accredited Programme
   })
 
   describe('update', () => {
-    const referralUpdate: ReferralUpdate = { oasysConfirmed: true }
+    const referralUpdate: ReferralUpdate = { oasysConfirmed: true, reason: 'A brilliant reason' }
 
     beforeEach(() => {
       provider.addInteraction({

--- a/server/data/referralClient.test.ts
+++ b/server/data/referralClient.test.ts
@@ -83,7 +83,7 @@ pactWith({ consumer: 'Accredited Programmes UI', provider: 'Accredited Programme
 
     beforeEach(() => {
       provider.addInteraction({
-        state: 'Referral can be updates',
+        state: 'Referral can be updated',
         uponReceiving: 'A request to update a referral',
         willRespondWith: {
           status: 204,

--- a/server/services/referralService.test.ts
+++ b/server/services/referralService.test.ts
@@ -22,7 +22,7 @@ describe('ReferralService', () => {
 
   describe('createReferral', () => {
     it('returns a created referral', async () => {
-      const referral = referralFactory.build()
+      const referral = referralFactory.started().build()
       const createdReferralResponse: CreatedReferralResponse = { referralId: referral.id }
 
       when(referralClient.create)

--- a/server/testutils/factories/referral.ts
+++ b/server/testutils/factories/referral.ts
@@ -1,14 +1,45 @@
 import { faker } from '@faker-js/faker'
 import { Factory } from 'fishery'
 
-import type { Referral } from '@accredited-programmes/models'
+import type { Referral, ReferralStatus } from '@accredited-programmes/models'
 
-export default Factory.define<Referral>(() => ({
+class ReferralFactory extends Factory<Referral> {
+  started() {
+    return this.params({
+      oasysConfirmed: false,
+      reason: undefined,
+      status: 'referral_started',
+    })
+  }
+
+  submittable() {
+    return this.params({
+      oasysConfirmed: true,
+      reason: faker.lorem.paragraph({ max: 5, min: 1 }),
+      status: 'referral_started',
+    })
+  }
+
+  submitted() {
+    return this.params({
+      oasysConfirmed: true,
+      reason: faker.lorem.paragraph({ max: 5, min: 1 }),
+      status: 'referral_submitted',
+    })
+  }
+}
+
+export default ReferralFactory.define(() => ({
   id: faker.string.uuid(), // eslint-disable-next-line sort-keys
-  oasysConfirmed: false,
+  oasysConfirmed: faker.datatype.boolean(),
   offeringId: faker.string.uuid(),
   prisonNumber: faker.string.alphanumeric({ length: 7 }),
-  reason: faker.lorem.sentence(),
+  reason: faker.lorem.paragraph({ max: 5, min: 0 }),
   referrerId: faker.string.numeric({ length: 6 }),
-  status: 'referral_started',
+  status: faker.helpers.arrayElement([
+    'awaiting_assesment',
+    'assessment_started',
+    'referral_started',
+    'referral_submitted',
+  ]) as ReferralStatus,
 }))

--- a/server/utils/referralUtils.test.ts
+++ b/server/utils/referralUtils.test.ts
@@ -60,25 +60,23 @@ describe('ReferralUtils', () => {
   })
 
   describe('isReadyForSubmission', () => {
-    const referral = referralFactory.build({ reason: undefined })
-
     it('returns false for a new referral', () => {
-      expect(ReferralUtils.isReadyForSubmission(referral)).toEqual(false)
+      const newReferral = referralFactory.started().build()
+
+      expect(ReferralUtils.isReadyForSubmission(newReferral)).toEqual(false)
     })
 
-    describe('when OASys is confirmed and a reason is provided', () => {
+    it('returns true when OASys is confirmed and a reason is provided', () => {
       // to be updated as the referral model is built out
-      it('returns true', () => {
-        const updatedReferral = { ...referral, oasysConfirmed: true, reason: 'Some reason' }
+      const submittableReferral = referralFactory.submittable().build()
 
-        expect(ReferralUtils.isReadyForSubmission(updatedReferral)).toEqual(true)
-      })
+      expect(ReferralUtils.isReadyForSubmission(submittableReferral)).toEqual(true)
     })
   })
 
   describe('taskListSections', () => {
     it('returns task list sections for a given referral', () => {
-      const referral = referralFactory.build({ reason: undefined })
+      const referral = referralFactory.started().build()
 
       expect(ReferralUtils.taskListSections(referral)).toEqual([
         {
@@ -137,7 +135,7 @@ describe('ReferralUtils', () => {
     })
 
     it('marks completed sections as completed via their status tags', () => {
-      const referralWithCompletedInformation = referralFactory.build({ oasysConfirmed: true, reason: 'Some reason' })
+      const referralWithCompletedInformation = referralFactory.submittable().build()
       const taskListSections = ReferralUtils.taskListSections(referralWithCompletedInformation)
       const referralInformationSection = getTaskListSection('Referral information', taskListSections)
       const reasonStatusTag = getTaskListItem(
@@ -162,7 +160,7 @@ describe('ReferralUtils', () => {
     })
 
     it('updates the check answers task when the referral is ready for submission', () => {
-      const referralWithOasysConfirmed = referralFactory.build({ oasysConfirmed: true })
+      const referralWithOasysConfirmed = referralFactory.submittable().build()
       const taskListSections = ReferralUtils.taskListSections(referralWithOasysConfirmed)
       const checkAnswersSection = getTaskListSection('Check answers and submit', taskListSections)
       const checkAnswersTask = getTaskListItem('Check answers and submit', checkAnswersSection)


### PR DESCRIPTION
## Changes in this PR

- Add traits to referral factory
- Randomise default factory values

## Release checklist

[Release process documentation](../doc/how-to/perform-a-release.md)

As part of our continuous deployment strategy we must ensure that this work is
ready to be released once merged.

### Pre-merge

- [ ] There are changes required to the Accredited Programmes API for this change to work...
  - [ ] ... and they have been released to production already

### Post-merge

<!-- The outer checkboxes can be completed pre-merge -->

- [ ] This adds, extends or meaningfully modifies a feature...
  - [ ] ... and I have written or updated an end-to-end test for the happy path in the [Accredited Programmes E2E repo](https://github.com/ministryofjustice/hmpps-accredited-programmes-e2e)
- [ ] This makes new expectations of the API...
  - [ ] ... and I have notified the API developer(s) of changes to the contract tests (Pact), or the API is already compliant
- [ ] [Manually approve](../doc/how-to/perform-a-release.md#releasing-to-the-preprod-environment) release to preprod
- [ ] [Manually approve](../doc/how-to/perform-a-release.md#releasing-to-the-production-environment) release to prod

<!-- Should a release fail at any step, you as the author should now lead the work to
fix it as soon as possible. You can monitor deployment failures in CircleCI
itself and application errors are found in
[Sentry](https://ministryofjustice.sentry.io/projects/hmpps-accredited-programmes-ui/?project=4505330122686464&referrer=sidebar&statsPeriod=24h). -->
