### PR TITLE
(650d) Update check your answers page validation

### DIFF
--- a/integration_tests/e2e/refer.cy.ts
+++ b/integration_tests/e2e/refer.cy.ts
@@ -550,10 +550,10 @@ context('Refer', () => {
         person,
         username: auth.mockedUsername(),
       })
-      checkAnswersPageWithErrors.shouldContainErrorSummary([
+      checkAnswersPageWithErrors.shouldHaveErrors([
         {
-          href: '#confirmation',
-          text: 'Please confirm that the information you have provided is complete, accurate and up to date',
+          field: 'confirmation',
+          message: 'Please confirm that the information you have provided is complete, accurate and up to date',
         },
       ])
     })

--- a/integration_tests/e2e/refer.cy.ts
+++ b/integration_tests/e2e/refer.cy.ts
@@ -553,7 +553,7 @@ context('Refer', () => {
       checkAnswersPageWithErrors.shouldHaveErrors([
         {
           field: 'confirmation',
-          message: 'Please confirm that the information you have provided is complete, accurate and up to date',
+          message: 'Confirm that the information you have provided is complete, accurate and up to date',
         },
       ])
     })

--- a/integration_tests/pages/page.ts
+++ b/integration_tests/pages/page.ts
@@ -203,8 +203,6 @@ export default abstract class Page {
         const { actual, expected } = Helpers.parseHtml(fieldErrorElement, `Error: ${error.message}`)
         expect(actual).to.equal(expected)
       })
-
-      cy.get(`[name="${error.field}"]`).should('have.class', 'govuk-input--error')
     })
   }
 

--- a/integration_tests/pages/page.ts
+++ b/integration_tests/pages/page.ts
@@ -72,18 +72,6 @@ export default abstract class Page {
     })
   }
 
-  shouldContainErrorSummary(errors: Array<{ href: string; text: string }>): void {
-    cy.get('.govuk-error-summary').should('exist')
-    cy.get('.govuk-error-summary__list').within(() => {
-      cy.get('li').should('have.length', errors.length)
-      cy.get('li').each((errorElement, errorElementIndex) => {
-        const { actual, expected } = Helpers.parseHtml(errorElement, errors[errorElementIndex].text)
-        expect(actual).to.equal(expected)
-        cy.get('a').should('have.attr', 'href', errors[errorElementIndex].href)
-      })
-    })
-  }
-
   shouldContainLink(text: string, href: string): void {
     cy.contains('.govuk-link', text).should('have.attr', 'href', href)
   }

--- a/server/controllers/refer/peopleController.test.ts
+++ b/server/controllers/refer/peopleController.test.ts
@@ -13,7 +13,7 @@ jest.mock('../../utils/personUtils')
 describe('PeopleController', () => {
   const token = 'SOME_TOKEN'
   let request: DeepMocked<Request>
-  const response: DeepMocked<Response> = createMock<Response>({})
+  let response: DeepMocked<Response>
   const next: DeepMocked<NextFunction> = createMock<NextFunction>({})
   const personService = createMock<PersonService>({})
   const courseOfferingId = 'A-COURSE-OFFERING-ID'
@@ -22,6 +22,7 @@ describe('PeopleController', () => {
 
   beforeEach(() => {
     request = createMock<Request>({ user: { token } })
+    response = createMock<Response>({})
     peopleController = new PeopleController(personService)
   })
 

--- a/server/controllers/refer/referralsController.test.ts
+++ b/server/controllers/refer/referralsController.test.ts
@@ -515,7 +515,7 @@ describe('ReferralsController', () => {
 
         expect(request.flash).toHaveBeenCalledWith(
           'confirmationError',
-          'Please confirm that the information you have provided is complete, accurate and up to date',
+          'Confirm that the information you have provided is complete, accurate and up to date',
         )
         expect(response.redirect).toHaveBeenCalledWith(referPaths.checkAnswers({ referralId: referral.id }))
       })

--- a/server/controllers/refer/referralsController.test.ts
+++ b/server/controllers/refer/referralsController.test.ts
@@ -317,9 +317,6 @@ describe('ReferralsController', () => {
 
     describe('when the referral is not ready for submission', () => {
       it('redirects to the show referral page', async () => {
-        const errors: Array<string> = []
-        request.flash = jest.fn().mockReturnValue(errors)
-
         const referral = referralFactory.build()
         request.params.referralId = referral.id
         referralService.getReferral.mockResolvedValue(referral)
@@ -337,9 +334,6 @@ describe('ReferralsController', () => {
 
     describe('when the organisation service returns `null`', () => {
       it('responds with a 404', async () => {
-        const errors: Array<string> = []
-        request.flash = jest.fn().mockReturnValue(errors)
-
         const person = personFactory.build()
         personService.getPerson.mockResolvedValue(person)
 
@@ -366,9 +360,6 @@ describe('ReferralsController', () => {
 
     describe('when the person service returns `null`', () => {
       it('responds with a 404', async () => {
-        const errors: Array<string> = []
-        request.flash = jest.fn().mockReturnValue(errors)
-
         const referral = referralFactory.build({
           oasysConfirmed: true,
           offeringId: courseOffering.id,

--- a/server/controllers/refer/referralsController.test.ts
+++ b/server/controllers/refer/referralsController.test.ts
@@ -24,7 +24,7 @@ jest.mock('../../utils/referralUtils')
 describe('ReferralsController', () => {
   const token = 'SOME_TOKEN'
   let request: DeepMocked<Request>
-  const response: DeepMocked<Response> = createMock<Response>({})
+  let response: DeepMocked<Response>
   const next: DeepMocked<NextFunction> = createMock<NextFunction>({})
 
   const courseService = createMock<CourseService>({})
@@ -39,6 +39,7 @@ describe('ReferralsController', () => {
 
   beforeEach(() => {
     request = createMock<Request>({ user: { token } })
+    response = createMock<Response>({})
     referralsController = new ReferralsController(courseService, organisationService, personService, referralService)
     courseService.getCourseByOffering.mockResolvedValue(course)
     courseService.getOffering.mockResolvedValue(courseOffering)

--- a/server/controllers/refer/referralsController.ts
+++ b/server/controllers/refer/referralsController.ts
@@ -247,7 +247,7 @@ export default class ReferralsController {
       if (req.body.confirmation !== 'true') {
         req.flash(
           'confirmationError',
-          'Please confirm that the information you have provided is complete, accurate and up to date',
+          'Confirm that the information you have provided is complete, accurate and up to date',
         )
 
         return res.redirect(referPaths.checkAnswers({ referralId: req.params.referralId }))

--- a/server/controllers/refer/referralsController.ts
+++ b/server/controllers/refer/referralsController.ts
@@ -18,7 +18,6 @@ export default class ReferralsController {
     return async (req: Request, res: Response) => {
       TypeUtils.assertHasUser(req)
 
-      const errors = req.flash('errors')
       const { referralId } = req.params
       const { username } = req.user
 
@@ -48,6 +47,8 @@ export default class ReferralsController {
       const course = await this.courseService.getCourseByOffering(req.user.token, referral.offeringId)
       const coursePresenter = CourseUtils.presentCourse(course)
 
+      FormUtils.setFieldErrors(req, res, ['confirmation'])
+
       return res.render('referrals/checkAnswers', {
         applicationSummaryListRows: ReferralUtils.applicationSummaryListRows(
           courseOffering,
@@ -56,7 +57,6 @@ export default class ReferralsController {
           person,
           username,
         ),
-        errors,
         pageHeading: 'Check your answers',
         person,
         personSummaryListRows: PersonUtils.summaryListRows(person),
@@ -245,12 +245,10 @@ export default class ReferralsController {
       TypeUtils.assertHasUser(req)
 
       if (req.body.confirmation !== 'true') {
-        req.flash('errors', [
-          {
-            href: '#confirmation',
-            text: 'Please confirm that the information you have provided is complete, accurate and up to date',
-          } as unknown as string,
-        ])
+        req.flash(
+          'confirmationError',
+          'Please confirm that the information you have provided is complete, accurate and up to date',
+        )
 
         return res.redirect(referPaths.checkAnswers({ referralId: req.params.referralId }))
       }

--- a/server/views/referrals/checkAnswers.njk
+++ b/server/views/referrals/checkAnswers.njk
@@ -20,10 +20,10 @@
 {% block content %}
   <div class="govuk-grid-row">
     <div class="govuk-grid-column-two-thirds">
-      {% if errors.length %}
+      {% if errors.list.length %}
         {{ govukErrorSummary({
           titleText: "There is a problem",
-          errorList: errors
+          errorList: errors.list
         }) }}
       {% endif %}
     </div>
@@ -81,7 +81,8 @@
               value: "true",
               text: "I confirm the information I have provided is complete, accurate and up to date."
             }
-          ]
+          ],
+          errorMessage: errors.messages.confirmation
         }) }}
 
         <div class="govuk-button-group">


### PR DESCRIPTION
## Context

Utilise `setFieldErrors` from `FormUtils` to set the validation for the check your answers page.


## Changes in this PR
- Use `FormUtils.setFieldErrors` for the `confirmation` checkbox on check your answers page
- Updated the referrals controller test to reset the response value between each test to avoid unexpected test behaviour.


## Screenshots of UI changes
![localhost_3000_referrals_e38891f9-033b-412c-96f1-60b6689a8109_check-answers](https://github.com/ministryofjustice/hmpps-accredited-programmes-ui/assets/1067537/ae210c2b-c1d5-4a25-9dbf-f258f59d132d)



## Release checklist

[Release process documentation](../doc/how-to/perform-a-release.md)

As part of our continuous deployment strategy we must ensure that this work is
ready to be released once merged.

### Pre-merge

- [ ] There are changes required to the Accredited Programmes API for this change to work...
  - [ ] ... and they have been released to production already

### Post-merge

<!-- The outer checkboxes can be completed pre-merge -->

- [ ] This adds, extends or meaningfully modifies a feature...
  - [ ] ... and I have written or updated an end-to-end test for the happy path in the [Accredited Programmes E2E repo](https://github.com/ministryofjustice/hmpps-accredited-programmes-e2e)
- [ ] This makes new expectations of the API...
  - [ ] ... and I have notified the API developer(s) of changes to the contract tests (Pact), or the API is already compliant
- [ ] [Manually approve](../doc/how-to/perform-a-release.md#releasing-to-the-preprod-environment) release to preprod
- [ ] [Manually approve](../doc/how-to/perform-a-release.md#releasing-to-the-production-environment) release to prod

<!-- Should a release fail at any step, you as the author should now lead the work to
fix it as soon as possible. You can monitor deployment failures in CircleCI
itself and application errors are found in
[Sentry](https://ministryofjustice.sentry.io/projects/hmpps-accredited-programmes-ui/?project=4505330122686464&referrer=sidebar&statsPeriod=24h). -->
