### PR TITLE
(842) Reason validation

### DIFF
--- a/integration_tests/e2e/refer.cy.ts
+++ b/integration_tests/e2e/refer.cy.ts
@@ -327,7 +327,7 @@ context('Refer', () => {
     cy.task('stubPrisoner', prisoner)
     cy.task('stubReferral', referral)
 
-    const path = referPaths.reason({ referralId: referral.id })
+    const path = referPaths.reason.show({ referralId: referral.id })
     cy.visit(path)
 
     const reasonPage = Page.verifyOnPage(ReasonPage, { referral })
@@ -368,7 +368,7 @@ context('Refer', () => {
     cy.task('stubReferral', referral)
     cy.task('stubUpdateReferral', referral.id)
 
-    const path = referPaths.reason({ referralId: referral.id })
+    const path = referPaths.reason.show({ referralId: referral.id })
     cy.visit(path)
 
     const reasonPage = Page.verifyOnPage(ReasonPage, { referral })

--- a/integration_tests/e2eReferDisabled/refer.cy.ts
+++ b/integration_tests/e2eReferDisabled/refer.cy.ts
@@ -131,7 +131,7 @@ context('Refer', () => {
     cy.task('stubPrisoner', prisoner)
     cy.task('stubReferral', referral)
 
-    const path = referPaths.reason({ referralId: referral.id })
+    const path = referPaths.reason.show({ referralId: referral.id })
     cy.visit(path, { failOnStatusCode: false })
 
     const notFoundPage = Page.verifyOnPage(NotFoundPage)

--- a/server/controllers/refer/index.ts
+++ b/server/controllers/refer/index.ts
@@ -1,9 +1,11 @@
 import OasysConfirmationController from './oasysConfirmationController'
 import PeopleController from './peopleController'
+import ReasonController from './reasonController'
 import ReferralsController from './referralsController'
 import type { Services } from '../../services'
 
 const controllers = (services: Services) => {
+  const reasonController = new ReasonController(services.personService, services.referralService)
   const referralsController = new ReferralsController(
     services.courseService,
     services.organisationService,
@@ -16,6 +18,7 @@ const controllers = (services: Services) => {
   return {
     oasysConfirmationController,
     peopleController,
+    reasonController,
     referralsController,
   }
 }

--- a/server/controllers/refer/reasonController.test.ts
+++ b/server/controllers/refer/reasonController.test.ts
@@ -1,0 +1,71 @@
+import type { DeepMocked } from '@golevelup/ts-jest'
+import { createMock } from '@golevelup/ts-jest'
+import type { NextFunction, Request, Response } from 'express'
+import createError from 'http-errors'
+
+import ReasonController from './reasonController'
+import type { PersonService, ReferralService } from '../../services'
+import { courseOfferingFactory, personFactory, referralFactory } from '../../testutils/factories'
+
+describe('ReasonController', () => {
+  const token = 'SOME_TOKEN'
+
+  let request: DeepMocked<Request>
+  let response: DeepMocked<Response>
+  const next: DeepMocked<NextFunction> = createMock<NextFunction>({})
+
+  const personService = createMock<PersonService>({})
+  const referralService = createMock<ReferralService>({})
+
+  const courseOffering = courseOfferingFactory.build()
+
+  let reasonController: ReasonController
+
+  beforeEach(() => {
+    request = createMock<Request>({ user: { token } })
+    response = createMock<Response>({})
+    reasonController = new ReasonController(personService, referralService)
+  })
+
+  afterEach(() => {
+    jest.resetAllMocks()
+  })
+
+  describe('show', () => {
+    it('renders the reason for referral page', async () => {
+      const person = personFactory.build()
+      personService.getPerson.mockResolvedValue(person)
+
+      const referral = referralFactory
+        .started()
+        .build({ offeringId: courseOffering.id, prisonNumber: person.prisonNumber })
+      referralService.getReferral.mockResolvedValue(referral)
+
+      const requestHandler = reasonController.show()
+      await requestHandler(request, response, next)
+
+      expect(response.render).toHaveBeenCalledWith('referrals/reason', {
+        pageHeading: 'Add reason for referral and any additional information',
+        person,
+        referral,
+      })
+    })
+
+    describe('when the person service returns `null`', () => {
+      it('responds with a 404', async () => {
+        const person = personFactory.build()
+        personService.getPerson.mockResolvedValue(null)
+
+        const referral = referralFactory
+          .started()
+          .build({ offeringId: courseOffering.id, prisonNumber: person.prisonNumber })
+        referralService.getReferral.mockResolvedValue(referral)
+
+        const requestHandler = reasonController.show()
+        const expectedError = createError(404, `Person with prison number ${referral.prisonNumber} not found.`)
+
+        expect(() => requestHandler(request, response, next)).rejects.toThrowError(expectedError)
+      })
+    })
+  })
+})

--- a/server/controllers/refer/reasonController.test.ts
+++ b/server/controllers/refer/reasonController.test.ts
@@ -7,6 +7,9 @@ import ReasonController from './reasonController'
 import { referPaths } from '../../paths'
 import type { PersonService, ReferralService } from '../../services'
 import { courseOfferingFactory, personFactory, referralFactory } from '../../testutils/factories'
+import { FormUtils } from '../../utils'
+
+jest.mock('../../utils/formUtils')
 
 describe('ReasonController', () => {
   const token = 'SOME_TOKEN'
@@ -42,6 +45,11 @@ describe('ReasonController', () => {
         .build({ offeringId: courseOffering.id, prisonNumber: person.prisonNumber })
       referralService.getReferral.mockResolvedValue(referral)
 
+      const emptyErrorsLocal = { list: [], messages: {} }
+      ;(FormUtils.setFieldErrors as jest.Mock).mockImplementation((_request, _response, _fields) => {
+        response.locals.errors = emptyErrorsLocal
+      })
+
       const requestHandler = reasonController.show()
       await requestHandler(request, response, next)
 
@@ -50,6 +58,8 @@ describe('ReasonController', () => {
         person,
         referral,
       })
+
+      expect(FormUtils.setFieldErrors).toHaveBeenCalledWith(request, response, ['reason'])
     })
 
     describe('when the person service returns `null`', () => {

--- a/server/controllers/refer/reasonController.ts
+++ b/server/controllers/refer/reasonController.ts
@@ -1,0 +1,31 @@
+import type { Request, Response, TypedRequestHandler } from 'express'
+import createError from 'http-errors'
+
+import type { PersonService, ReferralService } from '../../services'
+import { TypeUtils } from '../../utils'
+
+export default class ReasonController {
+  constructor(
+    private readonly personService: PersonService,
+    private readonly referralService: ReferralService,
+  ) {}
+
+  show(): TypedRequestHandler<Request, Response> {
+    return async (req, res) => {
+      TypeUtils.assertHasUser(req)
+
+      const referral = await this.referralService.getReferral(req.user.token, req.params.referralId)
+      const person = await this.personService.getPerson(req.user.token, referral.prisonNumber)
+
+      if (!person) {
+        throw createError(404, `Person with prison number ${referral.prisonNumber} not found.`)
+      }
+
+      res.render('referrals/reason', {
+        pageHeading: 'Add reason for referral and any additional information',
+        person,
+        referral,
+      })
+    }
+  }
+}

--- a/server/controllers/refer/reasonController.ts
+++ b/server/controllers/refer/reasonController.ts
@@ -3,7 +3,7 @@ import createError from 'http-errors'
 
 import { referPaths } from '../../paths'
 import type { PersonService, ReferralService } from '../../services'
-import { TypeUtils } from '../../utils'
+import { FormUtils, TypeUtils } from '../../utils'
 import type { ReferralUpdate } from '@accredited-programmes/models'
 
 export default class ReasonController {
@@ -22,6 +22,8 @@ export default class ReasonController {
       if (!person) {
         throw createError(404, `Person with prison number ${referral.prisonNumber} not found.`)
       }
+
+      FormUtils.setFieldErrors(req, res, ['reason'])
 
       res.render('referrals/reason', {
         pageHeading: 'Add reason for referral and any additional information',

--- a/server/controllers/refer/reasonController.ts
+++ b/server/controllers/refer/reasonController.ts
@@ -1,8 +1,10 @@
 import type { Request, Response, TypedRequestHandler } from 'express'
 import createError from 'http-errors'
 
+import { referPaths } from '../../paths'
 import type { PersonService, ReferralService } from '../../services'
 import { TypeUtils } from '../../utils'
+import type { ReferralUpdate } from '@accredited-programmes/models'
 
 export default class ReasonController {
   constructor(
@@ -26,6 +28,31 @@ export default class ReasonController {
         person,
         referral,
       })
+    }
+  }
+
+  update(): TypedRequestHandler<Request, Response> {
+    return async (req, res) => {
+      TypeUtils.assertHasUser(req)
+
+      const formattedReason = req.body.reason?.trim()
+
+      if (!formattedReason) {
+        req.flash('reasonError', 'Enter a reason for the referral')
+
+        return res.redirect(referPaths.reason.show({ referralId: req.params.referralId }))
+      }
+
+      const referral = await this.referralService.getReferral(req.user.token, req.params.referralId)
+
+      const referralUpdate: ReferralUpdate = {
+        oasysConfirmed: referral.oasysConfirmed,
+        reason: formattedReason,
+      }
+
+      await this.referralService.updateReferral(req.user.token, referral.id, referralUpdate)
+
+      return res.redirect(referPaths.show({ referralId: referral.id }))
     }
   }
 }

--- a/server/controllers/refer/referralsController.test.ts
+++ b/server/controllers/refer/referralsController.test.ts
@@ -254,24 +254,6 @@ describe('ReferralsController', () => {
         })
       })
     })
-
-    describe('updating `reason`', () => {
-      it('asks the service to update the field and redirects to the show action', async () => {
-        const referral = referralFactory.build({ reason: undefined, status: 'referral_started' })
-        referralService.getReferral.mockResolvedValue(referral)
-
-        request.body.reason = ' Some reason\nAnother paragraph\n '
-
-        const requestHandler = referralsController.update()
-        await requestHandler(request, response, next)
-
-        expect(response.redirect).toHaveBeenCalledWith(referPaths.show({ referralId: referral.id }))
-        expect(referralService.updateReferral).toHaveBeenCalledWith(token, referral.id, {
-          oasysConfirmed: referral.oasysConfirmed,
-          reason: 'Some reason\nAnother paragraph',
-        })
-      })
-    })
   })
 
   describe('checkAnswers', () => {

--- a/server/controllers/refer/referralsController.test.ts
+++ b/server/controllers/refer/referralsController.test.ts
@@ -236,44 +236,6 @@ describe('ReferralsController', () => {
     })
   })
 
-  describe('reason', () => {
-    it('renders the reason for referral page', async () => {
-      const person = personFactory.build()
-      personService.getPerson.mockResolvedValue(person)
-
-      const referral = referralFactory
-        .started()
-        .build({ offeringId: courseOffering.id, prisonNumber: person.prisonNumber })
-      referralService.getReferral.mockResolvedValue(referral)
-
-      const requestHandler = referralsController.reason()
-      await requestHandler(request, response, next)
-
-      expect(response.render).toHaveBeenCalledWith('referrals/reason', {
-        pageHeading: 'Add reason for referral and any additional information',
-        person,
-        referral,
-      })
-    })
-
-    describe('when the person service returns `null`', () => {
-      it('responds with a 404', async () => {
-        const person = personFactory.build()
-        personService.getPerson.mockResolvedValue(null)
-
-        const referral = referralFactory
-          .started()
-          .build({ offeringId: courseOffering.id, prisonNumber: person.prisonNumber })
-        referralService.getReferral.mockResolvedValue(referral)
-
-        const requestHandler = referralsController.reason()
-        const expectedError = createError(404, `Person with prison number ${referral.prisonNumber} not found.`)
-
-        expect(() => requestHandler(request, response, next)).rejects.toThrowError(expectedError)
-      })
-    })
-  })
-
   describe('update', () => {
     describe('updating `oasysConfirmed`', () => {
       it('asks the service to update the field and redirects to the show action', async () => {

--- a/server/controllers/refer/referralsController.ts
+++ b/server/controllers/refer/referralsController.ts
@@ -119,25 +119,6 @@ export default class ReferralsController {
     }
   }
 
-  reason(): TypedRequestHandler<Request, Response> {
-    return async (req: Request, res: Response) => {
-      TypeUtils.assertHasUser(req)
-
-      const referral = await this.referralService.getReferral(req.user.token, req.params.referralId)
-      const person = await this.personService.getPerson(req.user.token, referral.prisonNumber)
-
-      if (!person) {
-        throw createError(404, `Person with prison number ${referral.prisonNumber} not found.`)
-      }
-
-      res.render('referrals/reason', {
-        pageHeading: 'Add reason for referral and any additional information',
-        person,
-        referral,
-      })
-    }
-  }
-
   show(): TypedRequestHandler<Request, Response> {
     return async (req: Request, res: Response) => {
       TypeUtils.assertHasUser(req)

--- a/server/controllers/refer/referralsController.ts
+++ b/server/controllers/refer/referralsController.ts
@@ -232,11 +232,10 @@ export default class ReferralsController {
       const referral = await this.referralService.getReferral(req.user.token, req.params.referralId)
       const oasysConfirmed =
         typeof req.body.oasysConfirmed === 'undefined' ? referral.oasysConfirmed : req.body.oasysConfirmed
-      const reason = typeof req.body.reason === 'undefined' ? referral.reason : req.body.reason.trim()
 
       const referralUpdate: ReferralUpdate = {
         oasysConfirmed,
-        reason,
+        reason: referral.reason,
       }
 
       await this.referralService.updateReferral(req.user.token, referral.id, referralUpdate)

--- a/server/paths/refer.ts
+++ b/server/paths/refer.ts
@@ -32,7 +32,9 @@ export default {
     find: findPersonPath,
     show: personPath,
   },
-  reason: reasonForReferralPath,
+  reason: {
+    show: reasonForReferralPath,
+  },
   show: showReferralPath,
   showPerson: referralPersonPath,
   start: startReferralPath,

--- a/server/paths/refer.ts
+++ b/server/paths/refer.ts
@@ -34,6 +34,7 @@ export default {
   },
   reason: {
     show: reasonForReferralPath,
+    update: reasonForReferralPath,
   },
   show: showReferralPath,
   showPerson: referralPersonPath,

--- a/server/routes/refer.ts
+++ b/server/routes/refer.ts
@@ -6,7 +6,7 @@ import { RouteUtils } from '../utils'
 
 export default function routes(controllers: Controllers, router: Router): Router {
   const { get, post, put } = RouteUtils.actions(router)
-  const { referralsController, peopleController, oasysConfirmationController } = controllers
+  const { reasonController, referralsController, peopleController, oasysConfirmationController } = controllers
 
   get(referPaths.start.pattern, referralsController.start())
   get(referPaths.new.pattern, referralsController.new())
@@ -20,7 +20,7 @@ export default function routes(controllers: Controllers, router: Router): Router
   get(referPaths.showPerson.pattern, referralsController.showPerson())
   get(referPaths.confirmOasys.show.pattern, oasysConfirmationController.show())
   put(referPaths.confirmOasys.update.pattern, oasysConfirmationController.update())
-  get(referPaths.reason.pattern, referralsController.reason())
+  get(referPaths.reason.show.pattern, reasonController.show())
   get(referPaths.checkAnswers.pattern, referralsController.checkAnswers())
   get(referPaths.complete.pattern, referralsController.complete())
   post(referPaths.submit.pattern, referralsController.submit())

--- a/server/routes/refer.ts
+++ b/server/routes/refer.ts
@@ -21,6 +21,7 @@ export default function routes(controllers: Controllers, router: Router): Router
   get(referPaths.confirmOasys.show.pattern, oasysConfirmationController.show())
   put(referPaths.confirmOasys.update.pattern, oasysConfirmationController.update())
   get(referPaths.reason.show.pattern, reasonController.show())
+  put(referPaths.reason.update.pattern, reasonController.update())
   get(referPaths.checkAnswers.pattern, referralsController.checkAnswers())
   get(referPaths.complete.pattern, referralsController.complete())
   post(referPaths.submit.pattern, referralsController.submit())

--- a/server/utils/referralUtils.ts
+++ b/server/utils/referralUtils.ts
@@ -71,7 +71,7 @@ export default class ReferralUtils {
           {
             statusTag: ReferralUtils.taskListStatus(referral.reason ? 'completed' : 'not started', 'reason-tag'),
             text: 'Add reason for referral and any additional information',
-            url: referPaths.reason({ referralId: referral.id }),
+            url: referPaths.reason.show({ referralId: referral.id }),
           },
           {
             statusTag: ReferralUtils.taskListStatus('not started'),

--- a/server/views/referrals/reason.njk
+++ b/server/views/referrals/reason.njk
@@ -1,6 +1,7 @@
 {% from "govuk/components/back-link/macro.njk" import govukBackLink %}
 {% from "govuk/components/button/macro.njk" import govukButton %}
 {% from "govuk/components/details/macro.njk" import govukDetails %}
+{% from "govuk/components/error-summary/macro.njk" import govukErrorSummary %}
 {% from "govuk/components/textarea/macro.njk" import govukTextarea %}
 
 {% extends "../partials/layout.njk" %}
@@ -19,6 +20,13 @@
 {% block content %}
   <div class="govuk-grid-row">
     <div class="govuk-grid-column-two-thirds">
+      {% if errors.list.length %}
+        {{ govukErrorSummary({
+          titleText: "There is a problem",
+          errorList: errors.list
+        }) }}
+      {% endif %}
+
       {% set detailsHtml %}
       <ul class="govuk-list govuk-list--bullet">
         <li>you can provide information about why you're referring this person to this programme</li>
@@ -50,7 +58,8 @@
           value: referral.reason,
           attributes: {
             "data-testid": "reason-text-area"
-          }
+          },
+          errorMessage: errors.messages.reason
         }) }}
 
         {{ govukButton({

--- a/server/views/referrals/reason.njk
+++ b/server/views/referrals/reason.njk
@@ -19,7 +19,6 @@
 {% block content %}
   <div class="govuk-grid-row">
     <div class="govuk-grid-column-two-thirds">
-
       {% set detailsHtml %}
       <ul class="govuk-list govuk-list--bullet">
         <li>you can provide information about why you're referring this person to this programme</li>
@@ -28,7 +27,7 @@
       </ul>
       {% endset %}
 
-      <form action="{{ referPaths.update({ referralId: referral.id }) }}?_method=PUT" method="post">
+      <form action="{{ referPaths.reason.update({ referralId: referral.id }) }}?_method=PUT" method="post">
         <input type="hidden" name="_csrf" value="{{ csrfToken }}"/>
 
         {{ govukTextarea({


### PR DESCRIPTION
## Context

https://trello.com/c/OkMpaWcU/842-make-reason-for-referral-required-ui

We have decided to create a new controller for each step of a referral to prevent the possibility of the `ReferralsController` becoming too unwieldy.

## Changes in this PR
This extracts the logic for showing, setting and updating the `reason` field on a Referral out of the ReferralsController and into an `ReasonController`.

- Add new `ReasonController`
- Move reason related method and functionality from ReferralsController to new `ReasonController`
- Add new `update` reason method 
- Display error messaging on reason page when no reason submitted


## Screenshots of UI changes

![localhost_3000_referrals_a16f58c0-1c2a-495e-ae8d-823e5e9518c5_reason](https://github.com/ministryofjustice/hmpps-accredited-programmes-ui/assets/1067537/2459d01c-188c-4105-bebd-bb0e6d94a437)



## Release checklist

[Release process documentation](../doc/how-to/perform-a-release.md)

As part of our continuous deployment strategy we must ensure that this work is
ready to be released once merged.

### Pre-merge

- [ ] There are changes required to the Accredited Programmes API for this change to work...
  - [ ] ... and they have been released to production already

### Post-merge

<!-- The outer checkboxes can be completed pre-merge -->

- [ ] This adds, extends or meaningfully modifies a feature...
  - [ ] ... and I have written or updated an end-to-end test for the happy path in the [Accredited Programmes E2E repo](https://github.com/ministryofjustice/hmpps-accredited-programmes-e2e)
- [ ] This makes new expectations of the API...
  - [ ] ... and I have notified the API developer(s) of changes to the contract tests (Pact), or the API is already compliant
- [ ] [Manually approve](../doc/how-to/perform-a-release.md#releasing-to-the-preprod-environment) release to preprod
- [ ] [Manually approve](../doc/how-to/perform-a-release.md#releasing-to-the-production-environment) release to prod

<!-- Should a release fail at any step, you as the author should now lead the work to
fix it as soon as possible. You can monitor deployment failures in CircleCI
itself and application errors are found in
[Sentry](https://ministryofjustice.sentry.io/projects/hmpps-accredited-programmes-ui/?project=4505330122686464&referrer=sidebar&statsPeriod=24h). -->
