### PR TITLE
(795) Confirm OASys validation

### DIFF
--- a/integration_tests/e2e/refer.cy.ts
+++ b/integration_tests/e2e/refer.cy.ts
@@ -269,44 +269,79 @@ context('Refer', () => {
     confirmOasysPage.shouldContainSaveAndContinueButton()
   })
 
-  it('On confirming OASys information, updates the referral and redirects to the task list', () => {
-    cy.signIn()
+  describe('When confirming OASys information', () => {
+    it('updates the referral and redirects to the task list', () => {
+      cy.signIn()
 
-    const course = courseFactory.build()
-    const courseOffering = courseOfferingFactory.build()
+      const course = courseFactory.build()
+      const courseOffering = courseOfferingFactory.build()
 
-    const prisoner = prisonerFactory.build({
-      firstName: 'Del',
-      lastName: 'Hatton',
+      const prisoner = prisonerFactory.build({
+        firstName: 'Del',
+        lastName: 'Hatton',
+      })
+      const person = personFactory.build({
+        currentPrison: prisoner.prisonName,
+        name: 'Del Hatton',
+        prisonNumber: prisoner.prisonerNumber,
+      })
+
+      const prison = prisonFactory.build({ prisonId: courseOffering.organisationId })
+      const organisation = OrganisationUtils.organisationFromPrison('an-ID', prison)
+
+      const referral = referralFactory
+        .started()
+        .build({ offeringId: courseOffering.id, prisonNumber: person.prisonNumber })
+
+      cy.task('stubCourseByOffering', { course, courseOfferingId: courseOffering.id })
+      cy.task('stubCourseOffering', { courseId: course.id, courseOffering })
+      cy.task('stubPrison', prison)
+      cy.task('stubPrisoner', prisoner)
+      cy.task('stubReferral', referral)
+      cy.task('stubUpdateReferral', referral.id)
+
+      const path = referPaths.confirmOasys.show({ referralId: referral.id })
+      cy.visit(path)
+
+      const confirmOasysPage = Page.verifyOnPage(ConfirmOasysPage, { person, referral })
+      confirmOasysPage.confirmOasys()
+
+      const taskListPage = Page.verifyOnPage(TaskListPage, { course, courseOffering, organisation, referral })
+      taskListPage.shouldHaveConfirmedOasys()
     })
-    const person = personFactory.build({
-      currentPrison: prisoner.prisonName,
-      name: 'Del Hatton',
-      prisonNumber: prisoner.prisonerNumber,
+
+    it('displays an error when the checkbox is not checked', () => {
+      cy.signIn()
+
+      const prisoner = prisonerFactory.build({
+        firstName: 'Del',
+        lastName: 'Hatton',
+      })
+      const person = personFactory.build({
+        currentPrison: prisoner.prisonName,
+        name: 'Del Hatton',
+        prisonNumber: prisoner.prisonerNumber,
+      })
+
+      const referral = referralFactory.started().build({ prisonNumber: person.prisonNumber })
+
+      cy.task('stubPrisoner', prisoner)
+      cy.task('stubReferral', referral)
+
+      const path = referPaths.confirmOasys.show({ referralId: referral.id })
+      cy.visit(path)
+
+      const confirmOasysPage = Page.verifyOnPage(ConfirmOasysPage, { person, referral })
+      confirmOasysPage.shouldContainButton('Save and continue').click()
+
+      const confirmOasysPageWithError = Page.verifyOnPage(ConfirmOasysPage, { person, referral })
+      confirmOasysPageWithError.shouldHaveErrors([
+        {
+          field: 'oasysConfirmed',
+          message: 'Confirm the OASys information is up to date',
+        },
+      ])
     })
-
-    const prison = prisonFactory.build({ prisonId: courseOffering.organisationId })
-    const organisation = OrganisationUtils.organisationFromPrison('an-ID', prison)
-
-    const referral = referralFactory
-      .started()
-      .build({ offeringId: courseOffering.id, prisonNumber: person.prisonNumber })
-
-    cy.task('stubCourseByOffering', { course, courseOfferingId: courseOffering.id })
-    cy.task('stubCourseOffering', { courseId: course.id, courseOffering })
-    cy.task('stubPrison', prison)
-    cy.task('stubPrisoner', prisoner)
-    cy.task('stubReferral', referral)
-    cy.task('stubUpdateReferral', referral.id)
-
-    const path = referPaths.confirmOasys.show({ referralId: referral.id })
-    cy.visit(path)
-
-    const confirmOasysPage = Page.verifyOnPage(ConfirmOasysPage, { person, referral })
-    confirmOasysPage.confirmOasys()
-
-    const taskListPage = Page.verifyOnPage(TaskListPage, { course, courseOffering, organisation, referral })
-    taskListPage.shouldHaveConfirmedOasys()
   })
 
   it('Shows the reason form page', () => {

--- a/server/controllers/refer/oasysConfirmationController.test.ts
+++ b/server/controllers/refer/oasysConfirmationController.test.ts
@@ -7,6 +7,9 @@ import OasysConfirmationController from './oasysConfirmationController'
 import { referPaths } from '../../paths'
 import type { PersonService, ReferralService } from '../../services'
 import { courseOfferingFactory, personFactory, referralFactory } from '../../testutils/factories'
+import { FormUtils } from '../../utils'
+
+jest.mock('../../utils/formUtils')
 
 describe('OasysConfirmationController', () => {
   const token = 'SOME_TOKEN'
@@ -41,6 +44,11 @@ describe('OasysConfirmationController', () => {
         .build({ offeringId: courseOffering.id, prisonNumber: person.prisonNumber })
       referralService.getReferral.mockResolvedValue(referral)
 
+      const emptyErrorsLocal = { list: [], messages: {} }
+      ;(FormUtils.setFieldErrors as jest.Mock).mockImplementation((_request, _response, _fields) => {
+        response.locals.errors = emptyErrorsLocal
+      })
+
       const requestHandler = oasysConfirmationController.show()
       await requestHandler(request, response, next)
 
@@ -49,6 +57,7 @@ describe('OasysConfirmationController', () => {
         person,
         referral,
       })
+      expect(FormUtils.setFieldErrors).toHaveBeenCalledWith(request, response, ['oasysConfirmed'])
     })
 
     describe('when the person service returns `null`', () => {

--- a/server/controllers/refer/oasysConfirmationController.test.ts
+++ b/server/controllers/refer/oasysConfirmationController.test.ts
@@ -70,10 +70,13 @@ describe('OasysConfirmationController', () => {
   })
 
   describe('update', () => {
-    it("asks the service to update the field and redirects to the ReferralController's show action", async () => {
-      const referral = referralFactory.build({ oasysConfirmed: false, status: 'referral_started' })
-      referralService.getReferral.mockResolvedValue(referral)
+    const referral = referralFactory.build({ oasysConfirmed: false, status: 'referral_started' })
 
+    beforeEach(() => {
+      referralService.getReferral.mockResolvedValue(referral)
+    })
+
+    it("asks the service to update the field and redirects to the ReferralController's show action", async () => {
       request.body.oasysConfirmed = true
 
       const requestHandler = oasysConfirmationController.update()
@@ -83,6 +86,18 @@ describe('OasysConfirmationController', () => {
       expect(referralService.updateReferral).toHaveBeenCalledWith(token, referral.id, {
         oasysConfirmed: true,
         reason: referral.reason,
+      })
+    })
+
+    describe('when the `oasysConfirmed` field is not set', () => {
+      it('redirects back to the confirm oasys page with an error', async () => {
+        request.params.referralId = referral.id
+
+        const requestHandler = oasysConfirmationController.update()
+        await requestHandler(request, response, next)
+
+        expect(response.redirect).toHaveBeenCalledWith(referPaths.confirmOasys.show({ referralId: referral.id }))
+        expect(request.flash).toHaveBeenCalledWith('oasysConfirmedError', 'Confirm the OASys information is up to date')
       })
     })
   })

--- a/server/controllers/refer/oasysConfirmationController.ts
+++ b/server/controllers/refer/oasysConfirmationController.ts
@@ -37,9 +37,15 @@ export default class OasysConfirmationController {
     return async (req: Request, res: Response) => {
       TypeUtils.assertHasUser(req)
 
+      const { oasysConfirmed } = req.body
+
+      if (!oasysConfirmed) {
+        req.flash('oasysConfirmedError', 'Confirm the OASys information is up to date')
+
+        return res.redirect(referPaths.confirmOasys.show({ referralId: req.params.referralId }))
+      }
+
       const referral = await this.referralService.getReferral(req.user.token, req.params.referralId)
-      const oasysConfirmed =
-        typeof req.body.oasysConfirmed === 'undefined' ? referral.oasysConfirmed : req.body.oasysConfirmed
 
       const referralUpdate: ReferralUpdate = {
         oasysConfirmed,
@@ -48,7 +54,7 @@ export default class OasysConfirmationController {
 
       await this.referralService.updateReferral(req.user.token, referral.id, referralUpdate)
 
-      res.redirect(referPaths.show({ referralId: referral.id }))
+      return res.redirect(referPaths.show({ referralId: referral.id }))
     }
   }
 }

--- a/server/controllers/refer/oasysConfirmationController.ts
+++ b/server/controllers/refer/oasysConfirmationController.ts
@@ -3,7 +3,7 @@ import createError from 'http-errors'
 
 import { referPaths } from '../../paths'
 import type { PersonService, ReferralService } from '../../services'
-import { TypeUtils } from '../../utils'
+import { FormUtils, TypeUtils } from '../../utils'
 import type { ReferralUpdate } from '@accredited-programmes/models'
 
 export default class OasysConfirmationController {
@@ -24,6 +24,8 @@ export default class OasysConfirmationController {
           userMessage: `Person with prison number ${req.params.prisonNumber} not found.`,
         })
       }
+
+      FormUtils.setFieldErrors(req, res, ['oasysConfirmed'])
 
       res.render('referrals/oasysConfirmation/show', {
         pageHeading: 'Confirm the OASys information',

--- a/server/views/referrals/oasysConfirmation/show.njk
+++ b/server/views/referrals/oasysConfirmation/show.njk
@@ -2,6 +2,7 @@
 {% from "govuk/components/button/macro.njk" import govukButton %}
 {% from "govuk/components/checkboxes/macro.njk" import govukCheckboxes %}
 {% from "govuk/components/details/macro.njk" import govukDetails %}
+{% from "govuk/components/error-summary/macro.njk" import govukErrorSummary %}
 {% from "govuk/components/notification-banner/macro.njk" import govukNotificationBanner %}
 
 {% extends "../../partials/layout.njk" %}
@@ -18,6 +19,17 @@
 {% endblock backLink %}
 
 {% block content %}
+  <div class="govuk-grid-row">
+    <div class="govuk-grid-column-two-thirds">
+      {% if errors.list.length %}
+        {{ govukErrorSummary({
+          titleText: "There is a problem",
+          errorList: errors.list
+        }) }}
+      {% endif %}
+    </div>
+  </div>
+
   <h1 class="govuk-heading-l">{{ pageHeading }}</h1>
 
   <div class="govuk-grid-row">
@@ -60,7 +72,8 @@
               text: "I confirm that the OASys information is up to date.",
               checked: referral.oasysConfirmed
             }
-          ]
+          ],
+          errorMessage: errors.messages.oasysConfirmed
         }) }}
 
         {{ govukButton({ text: "Save and continue" }) }}


### PR DESCRIPTION
## Context

On the Confirm the OASys information step, we need to prevent the form from being submitted and display an error summary and an error message.

https://trello.com/c/k1Wzzrpe/795-prevent-users-being-able-to-submit-the-oasys-confirmation-page-without-checking-the-confirmation-checkbox-ui


## Changes in this PR
Updated both `show` and `update` methods in the `OasysConfirmationController` to handle validation messaging when a user tries to continue without checking the confirmation checkbox.


## Screenshots of UI changes
![localhost_3000_referrals_c11fab18-dc8d-420c-9c82-d0edd373732d_confirm-oasys](https://github.com/ministryofjustice/hmpps-accredited-programmes-ui/assets/1067537/10736a42-e332-40ff-ac89-ff879edff8a1)




## Release checklist

[Release process documentation](../doc/how-to/perform-a-release.md)

As part of our continuous deployment strategy we must ensure that this work is
ready to be released once merged.

### Pre-merge

- [ ] There are changes required to the Accredited Programmes API for this change to work...
  - [ ] ... and they have been released to production already

### Post-merge

<!-- The outer checkboxes can be completed pre-merge -->

- [ ] This adds, extends or meaningfully modifies a feature...
  - [ ] ... and I have written or updated an end-to-end test for the happy path in the [Accredited Programmes E2E repo](https://github.com/ministryofjustice/hmpps-accredited-programmes-e2e)
- [ ] This makes new expectations of the API...
  - [ ] ... and I have notified the API developer(s) of changes to the contract tests (Pact), or the API is already compliant
- [ ] [Manually approve](../doc/how-to/perform-a-release.md#releasing-to-the-preprod-environment) release to preprod
- [ ] [Manually approve](../doc/how-to/perform-a-release.md#releasing-to-the-production-environment) release to prod

<!-- Should a release fail at any step, you as the author should now lead the work to
fix it as soon as possible. You can monitor deployment failures in CircleCI
itself and application errors are found in
[Sentry](https://ministryofjustice.sentry.io/projects/hmpps-accredited-programmes-ui/?project=4505330122686464&referrer=sidebar&statsPeriod=24h). -->
