### PR TITLE
Collect coverage

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -75,7 +75,7 @@ jobs:
           name: unit tests
           command: npm run test:unit:ci
       - store_test_results:
-          path: test_results/unit
+          path: test_results/unit/xml
       - store_artifacts:
           path: test_results/unit
       - store_artifacts:

--- a/jest.config.ts
+++ b/jest.config.ts
@@ -1,6 +1,7 @@
 import type { Config } from 'jest'
 
 const config: Config = {
+  collectCoverage: true,
   collectCoverageFrom: [
     'server/**/*.{ts,js,jsx,mjs}',
     '!server/authentication/*.ts',
@@ -8,6 +9,12 @@ const config: Config = {
     '!server/routes/*.ts',
     '!server/testutils/factories/*.ts',
   ],
+  coverageDirectory: 'test_results/unit/coverage',
+  coverageThreshold: {
+    global: {
+      functions: 100,
+    },
+  },
   moduleFileExtensions: ['web.js', 'js', 'json', 'node', 'ts'],
   reporters: [
     'default',

--- a/jest.config.ts
+++ b/jest.config.ts
@@ -1,7 +1,13 @@
 import type { Config } from 'jest'
 
 const config: Config = {
-  collectCoverageFrom: ['server/**/*.{ts,js,jsx,mjs}'],
+  collectCoverageFrom: [
+    'server/**/*.{ts,js,jsx,mjs}',
+    '!server/authentication/*.ts',
+    '!server/middleware/*.ts',
+    '!server/routes/*.ts',
+    '!server/testutils/factories/*.ts',
+  ],
   moduleFileExtensions: ['web.js', 'js', 'json', 'node', 'ts'],
   reporters: [
     'default',

--- a/server/app.ts
+++ b/server/app.ts
@@ -1,3 +1,5 @@
+/* istanbul ignore file */
+
 import express from 'express'
 import createError from 'http-errors'
 import methodOverride from 'method-override'

--- a/server/applicationVersion.ts
+++ b/server/applicationVersion.ts
@@ -1,4 +1,3 @@
-// eslint-disable import/no-unresolved, global-require
 import fs from 'fs'
 
 const packageData = JSON.parse(fs.readFileSync('./package.json').toString())

--- a/server/controllers/find/index.ts
+++ b/server/controllers/find/index.ts
@@ -1,3 +1,5 @@
+/* istanbul ignore file */
+
 import CourseOfferingsController from './courseOfferingsController'
 import CoursesController from './coursesController'
 import type { Services } from '../../services'

--- a/server/controllers/index.ts
+++ b/server/controllers/index.ts
@@ -1,3 +1,5 @@
+/* istanbul ignore file */
+
 import DashboardController from './dashboardController'
 import findControllers from './find'
 import referControllers from './refer'

--- a/server/controllers/refer/index.ts
+++ b/server/controllers/refer/index.ts
@@ -1,3 +1,5 @@
+/* istanbul ignore file */
+
 import OasysConfirmationController from './oasysConfirmationController'
 import PeopleController from './peopleController'
 import ReasonController from './reasonController'

--- a/server/data/index.ts
+++ b/server/data/index.ts
@@ -1,4 +1,6 @@
+/* istanbul ignore file */
 /* eslint-disable import/first, import/order */
+
 /*
  * Do appinsights first as it does some magic instrumentation work, i.e. it affects other 'require's
  * In particular, applicationinsights automatically collects bunyan logs

--- a/server/data/redisClient.ts
+++ b/server/data/redisClient.ts
@@ -1,3 +1,5 @@
+/* istanbul ignore file */
+
 import { createClient } from 'redis'
 
 import logger from '../../logger'

--- a/server/data/restClient.ts
+++ b/server/data/restClient.ts
@@ -1,3 +1,5 @@
+/* istanbul ignore file */
+
 import Agent, { HttpsAgent } from 'agentkeepalive'
 import { Readable } from 'stream'
 import superagent from 'superagent'

--- a/server/data/restClientMetricsMiddleware.ts
+++ b/server/data/restClientMetricsMiddleware.ts
@@ -1,3 +1,5 @@
+/* istanbul ignore file */
+
 import type { Socket } from 'net'
 import promClient from 'prom-client'
 import type { Response, SuperAgentRequest } from 'superagent'

--- a/server/data/tokenStore.ts
+++ b/server/data/tokenStore.ts
@@ -1,3 +1,5 @@
+/* istanbul ignore file */
+
 import type { RedisClient } from './redisClient'
 import logger from '../../logger'
 

--- a/server/data/tokenVerification.ts
+++ b/server/data/tokenVerification.ts
@@ -1,3 +1,5 @@
+/* istanbul ignore file */
+
 import type { Request } from 'express'
 import superagent from 'superagent'
 

--- a/server/monitoring/metricsApp.ts
+++ b/server/monitoring/metricsApp.ts
@@ -1,3 +1,5 @@
+/* istanbul ignore file */
+
 import express from 'express'
 import promBundle from 'express-prom-bundle'
 

--- a/server/services/healthCheck.ts
+++ b/server/services/healthCheck.ts
@@ -1,3 +1,5 @@
+/* istanbul ignore file */
+
 import promClient from 'prom-client'
 
 import type { AgentConfig } from '../config'

--- a/server/services/index.ts
+++ b/server/services/index.ts
@@ -1,3 +1,5 @@
+/* istanbul ignore file */
+
 import CourseService from './courseService'
 import healthCheck from './healthCheck'
 import OrganisationService from './organisationService'

--- a/server/utils/appInsightsUtils.ts
+++ b/server/utils/appInsightsUtils.ts
@@ -1,3 +1,5 @@
+/* istanbul ignore file */
+
 import type { TelemetryClient } from 'applicationinsights'
 import { Contracts, DistributedTracingModes, defaultClient, setup } from 'applicationinsights'
 import type { EnvelopeTelemetry } from 'applicationinsights/out/Declarations/Contracts'

--- a/server/utils/routeUtils.ts
+++ b/server/utils/routeUtils.ts
@@ -1,3 +1,5 @@
+/* istanbul ignore file */
+
 import type { RequestHandler, Router } from 'express'
 
 import asyncMiddleware from '../middleware/asyncMiddleware'

--- a/wiremock/scripts/resetStubs.ts
+++ b/wiremock/scripts/resetStubs.ts
@@ -1,4 +1,3 @@
-/* eslint-disable no-console */
 import { resetStubs } from '../index'
 
 process.stdout.write('Resetting stubs... ')


### PR DESCRIPTION
## Context

<!-- Is there a Trello ticket you can link to? -->
<!-- Do you need to add any environment variables? -->
<!-- Is an ADR required? An ADR should be added if this PR introduces a change to the architecture. -->

We aren't collecting unit test coverage at the moment, despite the `collectCoverageFrom` Jest setting

## Changes in this PR

- Collect unit test coverage
- Ignore certain files
- Require 100% function coverage in all other files

## Release checklist

[Release process documentation](../doc/how-to/perform-a-release.md)

As part of our continuous deployment strategy we must ensure that this work is
ready to be released once merged.

### Pre-merge

- [ ] There are changes required to the Accredited Programmes API for this change to work...
  - [ ] ... and they have been released to production already

### Post-merge

<!-- The outer checkboxes can be completed pre-merge -->

- [ ] This adds, extends or meaningfully modifies a feature...
  - [ ] ... and I have written or updated an end-to-end test for the happy path in the [Accredited Programmes E2E repo](https://github.com/ministryofjustice/hmpps-accredited-programmes-e2e)
- [ ] This makes new expectations of the API...
  - [ ] ... and I have notified the API developer(s) of changes to the contract tests (Pact), or the API is already compliant
- [ ] [Manually approve](../doc/how-to/perform-a-release.md#releasing-to-the-preprod-environment) release to preprod
- [ ] [Manually approve](../doc/how-to/perform-a-release.md#releasing-to-the-production-environment) release to prod

<!-- Should a release fail at any step, you as the author should now lead the work to
fix it as soon as possible. You can monitor deployment failures in CircleCI
itself and application errors are found in
[Sentry](https://ministryofjustice.sentry.io/projects/hmpps-accredited-programmes-ui/?project=4505330122686464&referrer=sidebar&statsPeriod=24h). -->
