### PR TITLE
Add `test_results` dir to eslintignore and tsconfig

### DIFF
--- a/.eslintignore
+++ b/.eslintignore
@@ -6,3 +6,4 @@ reporter-config.json
 dist/
 script/build/
 server/@types/govukFrontend/index.d.ts
+test_results

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -32,7 +32,8 @@
     "dist",
     "integration_tests",
     "node_modules",
-    "script"
+    "script",
+    "test_results"
   ],
   "include": ["**/*.js", "**/*.ts"]
 }


### PR DESCRIPTION
## Changes in this PR

Added `test_results` directory to eslintignore and tsconfig files as it was causing problems.


## Release checklist

[Release process documentation](../doc/how-to/perform-a-release.md)

As part of our continuous deployment strategy we must ensure that this work is
ready to be released once merged.

### Pre-merge

- [ ] There are changes required to the Accredited Programmes API for this change to work...
  - [ ] ... and they have been released to production already

### Post-merge

<!-- The outer checkboxes can be completed pre-merge -->

- [ ] This adds, extends or meaningfully modifies a feature...
  - [ ] ... and I have written or updated an end-to-end test for the happy path in the [Accredited Programmes E2E repo](https://github.com/ministryofjustice/hmpps-accredited-programmes-e2e)
- [ ] This makes new expectations of the API...
  - [ ] ... and I have notified the API developer(s) of changes to the contract tests (Pact), or the API is already compliant
- [ ] [Manually approve](../doc/how-to/perform-a-release.md#releasing-to-the-preprod-environment) release to preprod
- [ ] [Manually approve](../doc/how-to/perform-a-release.md#releasing-to-the-production-environment) release to prod

<!-- Should a release fail at any step, you as the author should now lead the work to
fix it as soon as possible. You can monitor deployment failures in CircleCI
itself and application errors are found in
[Sentry](https://ministryofjustice.sentry.io/projects/hmpps-accredited-programmes-ui/?project=4505330122686464&referrer=sidebar&statsPeriod=24h). -->
