### PR TITLE
(827) Refactor prisoner client to take system token over user token

### DIFF
--- a/server/controllers/refer/oasysConfirmationController.ts
+++ b/server/controllers/refer/oasysConfirmationController.ts
@@ -17,7 +17,7 @@ export default class OasysConfirmationController {
       TypeUtils.assertHasUser(req)
 
       const referral = await this.referralService.getReferral(req.user.token, req.params.referralId)
-      const person = await this.personService.getPerson(req.user.token, referral.prisonNumber)
+      const person = await this.personService.getPerson(req.user.username, referral.prisonNumber)
 
       if (!person) {
         throw createError(404, {

--- a/server/controllers/refer/peopleController.ts
+++ b/server/controllers/refer/peopleController.ts
@@ -28,7 +28,7 @@ export default class PeopleController {
       TypeUtils.assertHasUser(req)
 
       const { courseOfferingId } = req.params
-      const person = await this.personService.getPerson(req.user.token, req.params.prisonNumber)
+      const person = await this.personService.getPerson(req.user.username, req.params.prisonNumber)
 
       if (!person) {
         req.flash('prisonNumberError', `No person with a prison number '${req.params.prisonNumber}' was found`)

--- a/server/controllers/refer/reasonController.ts
+++ b/server/controllers/refer/reasonController.ts
@@ -17,7 +17,7 @@ export default class ReasonController {
       TypeUtils.assertHasUser(req)
 
       const referral = await this.referralService.getReferral(req.user.token, req.params.referralId)
-      const person = await this.personService.getPerson(req.user.token, referral.prisonNumber)
+      const person = await this.personService.getPerson(req.user.username, referral.prisonNumber)
 
       if (!person) {
         throw createError(404, `Person with prison number ${referral.prisonNumber} not found.`)

--- a/server/controllers/refer/referralsController.ts
+++ b/server/controllers/refer/referralsController.ts
@@ -27,7 +27,7 @@ export default class ReferralsController {
         return res.redirect(referPaths.show({ referralId: referral.id }))
       }
 
-      const person = await this.personService.getPerson(req.user.token, referral.prisonNumber)
+      const person = await this.personService.getPerson(req.user.username, referral.prisonNumber)
 
       if (!person) {
         throw createError(404, {
@@ -128,7 +128,7 @@ export default class ReferralsController {
       const course = await this.courseService.getCourseByOffering(req.user.token, referral.offeringId)
       const courseOffering = await this.courseService.getOffering(req.user.token, referral.offeringId)
       const organisation = await this.organisationService.getOrganisation(req.user.token, courseOffering.organisationId)
-      const person = await this.personService.getPerson(req.user.token, referral.prisonNumber)
+      const person = await this.personService.getPerson(req.user.username, referral.prisonNumber)
 
       if (!organisation) {
         throw createError(404, {
@@ -159,7 +159,7 @@ export default class ReferralsController {
       TypeUtils.assertHasUser(req)
 
       const referral = await this.referralService.getReferral(req.user.token, req.params.referralId)
-      const person = await this.personService.getPerson(req.user.token, referral.prisonNumber)
+      const person = await this.personService.getPerson(req.user.username, referral.prisonNumber)
 
       if (!person) {
         throw createError(404, {

--- a/server/services/index.ts
+++ b/server/services/index.ts
@@ -18,7 +18,7 @@ import {
 const services = () => {
   const courseService = new CourseService(courseClientBuilder)
   const organisationService = new OrganisationService(prisonClientBuilder)
-  const personService = new PersonService(prisonerClientBuilder)
+  const personService = new PersonService(hmppsAuthClientBuilder, prisonerClientBuilder)
   const referralService = new ReferralService(referralClientBuilder)
   const userService = new UserService(hmppsAuthClientBuilder)
 


### PR DESCRIPTION
## Context

<!-- Is there a Trello ticket you can link to? -->
<!-- Do you need to add any environment variables? -->
<!-- Is an ADR required? An ADR should be added if this PR introduces a change to the architecture. -->

Up until now, we've passed on the logged-in user's token to the Prisoner Offender Search client to authenticate them when searching for a Person in Prison by their `prisonNumber`. This has worked fine for now, but we've had to add the `ROLE_VIEW_PRISONER_DATA` role to all users to access the specific `prisoner/:id` endpoint.

Because this could potentially mean adding lots of roles to users and introduce a lot of admin overhead, we've now added the `VIEW_PRISONER_DATA` role to our client credentials, meaning users who have access to our service (POMs and Programme Teams) can make use of this role themselves.

## Changes in this PR

This PR refactors the PersonService to pass the system client token generated by HMPPS Auth, rather than the user's own token as we did before. We also send through the user's username through the system client token for auditing purposes on the HMPPS Auth side of things.

This refactor allows us to authenticate with the Prisoner Offender Search with our system client credentials rather than the logged in user's token, meaning we don't need to add the `VIEW_PRISONER_DATA` role to all of our users individually. That role is now on our own client.

There's a lot changing in this single commit here as we call the `PersonService` in a few places so a few tests needed updating. The main functional change here is the update to the `PersonService` to first fetch the system token from HMPPS Auth and pass that (rather than the user's own token) to the `PrisonerClient` to authenticate with the Prisoner Offender Search.

## Release checklist

[Release process documentation](../doc/how-to/perform-a-release.md)

As part of our continuous deployment strategy we must ensure that this work is
ready to be released once merged.

### Pre-merge

- [ ] There are changes required to the Accredited Programmes API for this change to work...
  - [ ] ... and they have been released to production already

### Post-merge

<!-- The outer checkboxes can be completed pre-merge -->

- [ ] This adds, extends or meaningfully modifies a feature...
  - [ ] ... and I have written or updated an end-to-end test for the happy path in the [Accredited Programmes E2E repo](https://github.com/ministryofjustice/hmpps-accredited-programmes-e2e)
- [ ] This makes new expectations of the API...
  - [ ] ... and I have notified the API developer(s) of changes to the contract tests (Pact), or the API is already compliant
- [ ] [Manually approve](../doc/how-to/perform-a-release.md#releasing-to-the-preprod-environment) release to preprod
- [ ] [Manually approve](../doc/how-to/perform-a-release.md#releasing-to-the-production-environment) release to prod

<!-- Should a release fail at any step, you as the author should now lead the work to
fix it as soon as possible. You can monitor deployment failures in CircleCI
itself and application errors are found in
[Sentry](https://ministryofjustice.sentry.io/projects/hmpps-accredited-programmes-ui/?project=4505330122686464&referrer=sidebar&statsPeriod=24h). -->
