### PR TITLE
Check lib

### DIFF
--- a/integration_tests/pages/page.ts
+++ b/integration_tests/pages/page.ts
@@ -4,10 +4,10 @@ import type { Organisation, Person } from '@accredited-programmes/models'
 import type {
   CoursePresenter,
   GovukFrontendSummaryListRowWithValue,
+  GovukFrontendTagWithText,
   HasHtmlString,
   HasTextString,
 } from '@accredited-programmes/ui'
-import type { GovukFrontendTag } from '@govuk-frontend'
 
 export type PageElement = Cypress.Chainable<JQuery>
 
@@ -154,13 +154,13 @@ export default abstract class Page {
     })
   }
 
-  shouldContainTag(tag: GovukFrontendTag & HasTextString, tagElement: JQuery<HTMLElement>): void {
+  shouldContainTag(tag: GovukFrontendTagWithText, tagElement: JQuery<HTMLElement>): void {
     const { actual, expected } = Helpers.parseHtml(tagElement, tag.text)
     expect(actual).to.equal(expected)
     cy.wrap(tagElement).should('have.class', tag.classes)
   }
 
-  shouldContainTags(tags: Array<GovukFrontendTag & HasTextString>, tagContainerElement: JQuery<HTMLElement>): void {
+  shouldContainTags(tags: Array<GovukFrontendTagWithText>, tagContainerElement: JQuery<HTMLElement>): void {
     cy.wrap(tagContainerElement).within(() => {
       cy.get('.govuk-tag').each((tagElement, tagElementIndex) => {
         const tag = tags[tagElementIndex]

--- a/integration_tests/tsconfig.json
+++ b/integration_tests/tsconfig.json
@@ -6,7 +6,6 @@
     "lib": ["es5", "dom", "es2015.promise"],
     "types": ["cypress", "cypress-axe", "express", "express-session"],
     "esModuleInterop": true,
-    "skipLibCheck": true,
     "paths": {
       "@accredited-programmes/models": ["../server/@types/models/index.d.ts"],
       "@accredited-programmes/ui": ["../server/@types/ui/index.d.ts"],
@@ -15,5 +14,5 @@
       "@prisoner-offender-search": ["../server/@types/prisonerOffenderSearch/index.d.ts"]
     }
   },
-  "include": ["**/*.ts", "../node_modules/cypress"]
+  "include": ["**/*.ts"]
 }

--- a/script/utils/generateGovukFrontendTypes/property.ts
+++ b/script/utils/generateGovukFrontendTypes/property.ts
@@ -181,7 +181,7 @@ ${indentString((this.macroOptions.description ?? '') as string, 4)}
               typeWithoutNullability = `${this.typeIntroduced!.name}[]`
             }
           } else {
-            typeWithoutNullability = 'Array'
+            typeWithoutNullability = 'Array<string>'
           }
           break
         default:

--- a/server/@types/express/index.d.ts
+++ b/server/@types/express/index.d.ts
@@ -1,3 +1,5 @@
+// to fix later = seems that some of the TypeScript here isn't entirely valid, but we don't have time to work out how to rewrite this now
+// @ts-expect-error to fix later: https://github.com/microsoft/TypeScript/issues/16472
 import type { Request as ConnectFlashRequest } from '@types/connect-flash'
 
 declare module 'express-session' {
@@ -9,7 +11,7 @@ declare module 'express-session' {
 }
 
 declare module 'express' {
-  interface TypedRequestHandler<T, U = Response> extends Express.RequestHandler {
+  interface TypedRequestHandler<T, U = Response> extends RequestHandler {
     (req: T, res: U, next: () => void): void
   }
 }
@@ -35,8 +37,10 @@ declare global {
 
 type RequestWithUser = Express.RequestWithUser
 
+// @ts-expect-error to fix later
 export { global }
 
 export type { RequestWithUser }
 
+// @ts-expect-error to fix later
 export default {}

--- a/server/@types/govukFrontend/index.d.ts
+++ b/server/@types/govukFrontend/index.d.ts
@@ -425,7 +425,7 @@ export interface GovukFrontendCheckboxes {
   /*
     Array of values for checkboxes which should be checked when the page loads. Use this as an alternative to setting the `checked` option on each individual item.
   */
-  values?: Array | null
+  values?: Array<string> | null
 
   /*
     Classes to add to the checkboxes container.

--- a/server/@types/ui/index.d.ts
+++ b/server/@types/ui/index.d.ts
@@ -1,7 +1,9 @@
-import type { GovukFrontendSummaryListRow } from '../govukFrontend'
+import type { GovukFrontendSummaryListRow, GovukFrontendSummaryListRowValue, GovukFrontendTag } from '../govukFrontend'
 import type { Course, CourseOffering, Organisation } from '@accredited-programmes/models'
 
 type GovukFrontendSummaryListRowWithValue = GovukFrontendSummaryListRow & { value: GovukFrontendSummaryListRowValue }
+
+type GovukFrontendTagWithText = GovukFrontendTag & { text: string }
 
 type HasTextString = {
   text: string
@@ -14,7 +16,7 @@ type HasHtmlString = {
 type TagColour = 'blue' | 'green' | 'grey' | 'orange' | 'pink' | 'purple' | 'red' | 'turquoise' | 'yellow'
 
 type CoursePresenter = Course & {
-  audienceTags: Array<Tag>
+  audienceTags: Array<GovukFrontendTagWithText>
   nameAndAlternateName: string
   prerequisiteSummaryListRows: Array<GovukFrontendSummaryListRowWithValue>
 }
@@ -29,10 +31,25 @@ type OrganisationWithOfferingEmailsPresenter = Organisation & {
 
 type ReferralTaskListStatusText = 'cannot start yet' | 'completed' | 'not started'
 
+type ReferralTaskListStatusTagCompleted = GovukFrontendTagWithText & {
+  classes: 'govuk-tag--grey moj-task-list__task-completed'
+  text: 'cannot start yet'
+}
+
+type ReferralTaskListStatusTagNotStarted = GovukFrontendTagWithText & {
+  classes: 'govuk-tag--grey moj-task-list__task-completed'
+  text: 'not started'
+}
+
+type ReferralTaskListStatusTagCannotStartYet = GovukFrontendTagWithText & {
+  classes: 'moj-task-list__task-completed'
+  text: 'completed'
+}
+
 type ReferralTaskListStatusTag =
-  | (GovukFrontendTag & { classes: 'govuk-tag--grey moj-task-list__task-completed'; text: 'cannot start yet' })
-  | (GovukFrontendTag & { classes: 'govuk-tag--grey moj-task-list__task-completed'; text: 'not started' })
-  | (GovukFrontendTag & { classes: 'moj-task-list__task-completed'; text: 'completed' })
+  | ReferralTaskListStatusTagCannotStartYet
+  | ReferralTaskListStatusTagCompleted
+  | ReferralTaskListStatusTagNotStarted
 
 type ReferralTaskListItemTestIds = {
   listItem: string
@@ -53,10 +70,10 @@ type ReferralTaskListSection = {
 export type {
   CoursePresenter,
   GovukFrontendSummaryListRowWithValue,
+  GovukFrontendTagWithText,
   HasHtmlString,
   HasTextString,
   OrganisationWithOfferingEmailsPresenter,
-  OrganisationWithOfferingEmailsSummaryListRows,
   OrganisationWithOfferingId,
   ReferralTaskListItem,
   ReferralTaskListSection,

--- a/server/utils/courseUtils.ts
+++ b/server/utils/courseUtils.ts
@@ -2,10 +2,10 @@ import type { Course, CourseAudience, CoursePrerequisite } from '@accredited-pro
 import type {
   CoursePresenter,
   GovukFrontendSummaryListRowWithValue,
+  GovukFrontendTagWithText,
   HasTextString,
   TagColour,
 } from '@accredited-programmes/ui'
-import type { GovukFrontendTag } from '@govuk-frontend'
 
 export default class CourseUtils {
   static presentCourse(course: Course): CoursePresenter {
@@ -19,7 +19,7 @@ export default class CourseUtils {
     }
   }
 
-  private static audienceTags(audiences: Array<CourseAudience>): Array<GovukFrontendTag> {
+  private static audienceTags(audiences: Array<CourseAudience>): Array<GovukFrontendTagWithText> {
     const audienceColourMap: Record<CourseAudience['value'], TagColour> = {
       'Extremism offence': 'turquoise',
       'Gang offence': 'purple',

--- a/server/utils/organisationUtils.ts
+++ b/server/utils/organisationUtils.ts
@@ -1,8 +1,8 @@
 import { findPaths } from '../paths'
 import type { Course, CourseOffering, Organisation, OrganisationAddress } from '@accredited-programmes/models'
 import type {
+  GovukFrontendSummaryListRowWithValue,
   OrganisationWithOfferingEmailsPresenter,
-  OrganisationWithOfferingEmailsSummaryListRows,
   OrganisationWithOfferingId,
 } from '@accredited-programmes/ui'
 import type { GovukFrontendTableRow } from '@govuk-frontend'
@@ -72,8 +72,8 @@ export default class OrganisationUtils {
     organisation: Organisation,
     offering: CourseOffering,
     courseName: Course['name'],
-  ): OrganisationWithOfferingEmailsSummaryListRows {
-    const summaryListRows: OrganisationWithOfferingEmailsSummaryListRows = [
+  ): Array<GovukFrontendSummaryListRowWithValue> {
+    const summaryListRows: Array<GovukFrontendSummaryListRowWithValue> = [
       {
         key: { text: 'Prison category' },
         value: { text: organisation.category },

--- a/server/utils/referralUtils.ts
+++ b/server/utils/referralUtils.ts
@@ -103,13 +103,19 @@ export default class ReferralUtils {
   }
 
   private static taskListStatus(text: ReferralTaskListStatusText, dataTestId?: string): ReferralTaskListStatusTag {
-    let classes = 'moj-task-list__task-completed'
+    const baseClasses = 'moj-task-list__task-completed'
+    const incompleteClasses = `govuk-tag--grey ${baseClasses}`
 
-    if (text !== 'completed') {
-      classes = `govuk-tag--grey ${classes}`
+    let tag: ReferralTaskListStatusTag
+
+    switch (text) {
+      case 'completed':
+        tag = { classes: baseClasses, text }
+        break
+      default:
+        tag = { classes: incompleteClasses, text }
+        break
     }
-
-    const tag: ReferralTaskListStatusTag = { classes, text }
 
     if (dataTestId) {
       tag.attributes = { 'data-testid': dataTestId }

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -7,7 +7,6 @@
     "moduleResolution": "node",
     "outDir": "./dist",
     "sourceMap": true,
-    "skipLibCheck": true,
     "noEmit": false,
     "allowJs": true,
     "checkJs": true,


### PR DESCRIPTION
## Context

<!-- Is there a Trello ticket you can link to? -->
<!-- Do you need to add any environment variables? -->
<!-- Is an ADR required? An ADR should be added if this PR introduces a change to the architecture. -->

Some of the groundwork for the course participation history index pointed me towards some areas of questionable type safety, e.g. where we were importing and using undefined types without error

## Changes in this PR

- Switch from hard mode to harder mode / turn off lib check skipping for better type safety

## Release checklist

[Release process documentation](../doc/how-to/perform-a-release.md)

As part of our continuous deployment strategy we must ensure that this work is
ready to be released once merged.

### Pre-merge

- [ ] There are changes required to the Accredited Programmes API for this change to work...
  - [ ] ... and they have been released to production already

### Post-merge

<!-- The outer checkboxes can be completed pre-merge -->

- [ ] This adds, extends or meaningfully modifies a feature...
  - [ ] ... and I have written or updated an end-to-end test for the happy path in the [Accredited Programmes E2E repo](https://github.com/ministryofjustice/hmpps-accredited-programmes-e2e)
- [ ] This makes new expectations of the API...
  - [ ] ... and I have notified the API developer(s) of changes to the contract tests (Pact), or the API is already compliant
- [ ] [Manually approve](../doc/how-to/perform-a-release.md#releasing-to-the-preprod-environment) release to preprod
- [ ] [Manually approve](../doc/how-to/perform-a-release.md#releasing-to-the-production-environment) release to prod

<!-- Should a release fail at any step, you as the author should now lead the work to
fix it as soon as possible. You can monitor deployment failures in CircleCI
itself and application errors are found in
[Sentry](https://ministryofjustice.sentry.io/projects/hmpps-accredited-programmes-ui/?project=4505330122686464&referrer=sidebar&statsPeriod=24h). -->
