### PR TITLE
(703a) Add course participations

### DIFF
--- a/integration_tests/mockApis/courses.ts
+++ b/integration_tests/mockApis/courses.ts
@@ -22,7 +22,7 @@ export default {
     stubFor({
       request: {
         method: 'GET',
-        url: apiPaths.courses.offerings.course({ courseOfferingId: args.courseOfferingId }),
+        url: apiPaths.offerings.course({ courseOfferingId: args.courseOfferingId }),
       },
       response: {
         headers: { 'Content-Type': 'application/json;charset=UTF-8' },
@@ -35,7 +35,7 @@ export default {
     stubFor({
       request: {
         method: 'GET',
-        url: apiPaths.courses.offerings.show({ courseOfferingId: args.courseOffering.id }),
+        url: apiPaths.offerings.show({ courseOfferingId: args.courseOffering.id }),
       },
       response: {
         headers: { 'Content-Type': 'application/json;charset=UTF-8' },
@@ -48,7 +48,7 @@ export default {
     stubFor({
       request: {
         method: 'GET',
-        url: apiPaths.courses.offerings.index({ courseId: args.courseId }),
+        url: apiPaths.courses.offerings({ courseId: args.courseId }),
       },
       response: {
         headers: { 'Content-Type': 'application/json;charset=UTF-8' },

--- a/server/@types/models/CourseParticipation.ts
+++ b/server/@types/models/CourseParticipation.ts
@@ -1,0 +1,35 @@
+import type { Course } from './Course'
+import type { Person } from './Person'
+
+type CourseParticipationOutcomeStatus = 'complete' | 'incomplete'
+
+type CourseParticipationOutcome = {
+  detail?: string
+  status?: CourseParticipationOutcomeStatus
+  yearCompleted?: number
+  yearStarted?: number
+}
+
+type CourseParticipationSetting = {
+  type: 'community' | 'custody'
+  location?: string
+}
+
+type CourseParticipation = {
+  id: string // eslint-disable-next-line @typescript-eslint/member-ordering
+  addedBy: string
+  createdAt: string
+  prisonNumber: Person['prisonNumber']
+  courseId?: Course['id']
+  otherCourseName?: string
+  outcome?: CourseParticipationOutcome
+  setting?: CourseParticipationSetting
+  source?: string
+}
+
+export type {
+  CourseParticipation,
+  CourseParticipationOutcome,
+  CourseParticipationOutcomeStatus,
+  CourseParticipationSetting,
+}

--- a/server/@types/models/index.d.ts
+++ b/server/@types/models/index.d.ts
@@ -1,6 +1,12 @@
 import type { Course } from './Course'
 import type { CourseAudience } from './CourseAudience'
 import type { CourseOffering } from './CourseOffering'
+import type {
+  CourseParticipation,
+  CourseParticipationOutcome,
+  CourseParticipationOutcomeStatus,
+  CourseParticipationSetting,
+} from './CourseParticipation'
 import type { CoursePrerequisite } from './CoursePrerequisite'
 import type { Organisation } from './Organisation'
 import type { OrganisationAddress } from './OrganisationAddress'
@@ -11,6 +17,10 @@ export type {
   Course,
   CourseAudience,
   CourseOffering,
+  CourseParticipation,
+  CourseParticipationOutcome,
+  CourseParticipationOutcomeStatus,
+  CourseParticipationSetting,
   CoursePrerequisite,
   CreatedReferralResponse,
   Organisation,

--- a/server/data/courseClient.test.ts
+++ b/server/data/courseClient.test.ts
@@ -101,7 +101,7 @@ pactWith({ consumer: 'Accredited Programmes UI', provider: 'Accredited Programme
             authorization: `Bearer ${token}`,
           },
           method: 'GET',
-          path: apiPaths.courses.offerings.course({ courseOfferingId: courseOffering.id }),
+          path: apiPaths.offerings.course({ courseOfferingId: courseOffering.id }),
         },
       })
     })
@@ -127,7 +127,7 @@ pactWith({ consumer: 'Accredited Programmes UI', provider: 'Accredited Programme
             authorization: `Bearer ${token}`,
           },
           method: 'GET',
-          path: apiPaths.courses.offerings.index({ courseId: course1.id }),
+          path: apiPaths.courses.offerings({ courseId: course1.id }),
         },
       })
     })
@@ -153,7 +153,7 @@ pactWith({ consumer: 'Accredited Programmes UI', provider: 'Accredited Programme
             authorization: `Bearer ${token}`,
           },
           method: 'GET',
-          path: apiPaths.courses.offerings.show({ courseOfferingId: courseOffering.id }),
+          path: apiPaths.offerings.show({ courseOfferingId: courseOffering.id }),
         },
       })
     })

--- a/server/data/courseClient.ts
+++ b/server/data/courseClient.ts
@@ -21,19 +21,19 @@ export default class CourseClient {
 
   async findCourseByOffering(courseOfferingId: CourseOffering['id']): Promise<Course> {
     return (await this.restClient.get({
-      path: apiPaths.courses.offerings.course({ courseOfferingId }),
+      path: apiPaths.offerings.course({ courseOfferingId }),
     })) as Course
   }
 
   async findOffering(courseOfferingId: CourseOffering['id']): Promise<CourseOffering> {
     return (await this.restClient.get({
-      path: apiPaths.courses.offerings.show({ courseOfferingId }),
+      path: apiPaths.offerings.show({ courseOfferingId }),
     })) as CourseOffering
   }
 
   async findOfferings(courseId: Course['id']): Promise<Array<CourseOffering>> {
     return (await this.restClient.get({
-      path: apiPaths.courses.offerings.index({ courseId }),
+      path: apiPaths.courses.offerings({ courseId }),
     })) as Array<CourseOffering>
   }
 }

--- a/server/middleware/index.ts
+++ b/server/middleware/index.ts
@@ -1,4 +1,3 @@
-import asyncMiddleware from './asyncMiddleware'
 import authorisationMiddleware from './authorisationMiddleware'
 import setUpAuthentication from './setUpAuthentication'
 import setUpCsrf from './setUpCsrf'
@@ -11,7 +10,6 @@ import setUpWebSecurity from './setUpWebSecurity'
 import setUpWebSession from './setUpWebSession'
 
 export {
-  asyncMiddleware,
   authorisationMiddleware,
   setUpAuthentication,
   setUpCsrf,

--- a/server/paths/api.ts
+++ b/server/paths/api.ts
@@ -11,6 +11,10 @@ const referralsPath = path('/referrals')
 const referralPath = referralsPath.path(':referralId')
 const updateStatusPath = referralPath.path('status')
 
+const participationsByPersonPath = path('/person/:prisonNumber/course-participations')
+const participationsPath = path('/course-participations')
+const participationPath = participationsPath.path(':courseParticipationId')
+
 export default {
   courses: {
     index: coursesPath,
@@ -20,6 +24,15 @@ export default {
   offerings: {
     course: courseByOfferingPath,
     show: offeringPath,
+  },
+  participations: {
+    create: participationsPath,
+    delete: participationPath,
+    show: participationPath,
+    update: participationPath,
+  },
+  people: {
+    participations: participationsByPersonPath,
   },
   referrals: {
     create: referralsPath,

--- a/server/paths/api.ts
+++ b/server/paths/api.ts
@@ -2,10 +2,10 @@ import { path } from 'static-path'
 
 const coursesPath = path('/courses')
 const coursePath = coursesPath.path(':courseId')
-const courseOfferingsPath = coursePath.path('offerings')
+const offeringsByCoursePath = coursePath.path('offerings')
 
-const courseOfferingPath = path('/offerings/:courseOfferingId')
-const courseByOfferingPath = courseOfferingPath.path('course')
+const offeringPath = path('/offerings/:courseOfferingId')
+const courseByOfferingPath = offeringPath.path('course')
 
 const referralsPath = path('/referrals')
 const referralPath = referralsPath.path(':referralId')
@@ -14,12 +14,12 @@ const updateStatusPath = referralPath.path('status')
 export default {
   courses: {
     index: coursesPath,
-    offerings: {
-      course: courseByOfferingPath,
-      index: courseOfferingsPath,
-      show: courseOfferingPath,
-    },
+    offerings: offeringsByCoursePath,
     show: coursePath,
+  },
+  offerings: {
+    course: courseByOfferingPath,
+    show: offeringPath,
   },
   referrals: {
     create: referralsPath,

--- a/server/testutils/factories/courseParticipation.ts
+++ b/server/testutils/factories/courseParticipation.ts
@@ -1,0 +1,58 @@
+import { faker } from '@faker-js/faker/locale/en_GB'
+import { Factory } from 'fishery'
+
+import courseParticipationOutcomeFactory from './courseParticipationOutcome'
+import courseParticipationSettingFactory from './courseParticipationSetting'
+import FactoryHelpers from './factoryHelpers'
+import { StringUtils } from '../../utils'
+import type { CourseParticipation } from '@accredited-programmes/models'
+
+const courseParticipationTypes = {
+  base() {
+    return {
+      id: faker.string.uuid(), // eslint-disable-next-line sort-keys
+      addedBy: `${faker.person.firstName()} ${faker.person.lastName()}`,
+      createdAt: `${faker.date.between({ from: '2023-09-20T00:00:00.000Z', to: new Date() })}`,
+      outcome: FactoryHelpers.optionalArrayElement(courseParticipationOutcomeFactory.build()),
+      prisonNumber: faker.string.alphanumeric({ length: 7 }),
+      setting: FactoryHelpers.optionalArrayElement(courseParticipationSettingFactory.build()),
+      source: FactoryHelpers.optionalArrayElement(faker.word.words()),
+    }
+  },
+
+  random() {
+    const type = faker.helpers.arrayElement<'withCourseId' | 'withOtherCourseName'>([
+      'withCourseId',
+      'withOtherCourseName',
+    ])
+    return this[type]()
+  },
+
+  withCourseId() {
+    return {
+      ...this.base(),
+      courseId: FactoryHelpers.optionalArrayElement(faker.string.uuid()),
+    }
+  },
+
+  withOtherCourseName() {
+    return {
+      ...this.base(),
+      otherCourseName: FactoryHelpers.optionalArrayElement(
+        `${StringUtils.convertToTitleCase(faker.color.human())} Course`,
+      ),
+    }
+  },
+}
+
+class CourseParticipationFactory extends Factory<CourseParticipation> {
+  withCourseId() {
+    return this.params(courseParticipationTypes.withCourseId())
+  }
+
+  withOtherCourseName() {
+    return this.params(courseParticipationTypes.withOtherCourseName())
+  }
+}
+
+export default CourseParticipationFactory.define(() => courseParticipationTypes.random())

--- a/server/testutils/factories/courseParticipationOutcome.ts
+++ b/server/testutils/factories/courseParticipationOutcome.ts
@@ -1,0 +1,57 @@
+import { faker } from '@faker-js/faker/locale/en_GB'
+import { Factory } from 'fishery'
+
+import FactoryHelpers from './factoryHelpers'
+import type { CourseParticipationOutcome, CourseParticipationOutcomeStatus } from '@accredited-programmes/models'
+
+const randomNonFutureYearFrom = (minimumYear: number): number => {
+  const currentYear = new Date().getFullYear()
+  return faker.number.int({ max: currentYear, min: minimumYear })
+}
+
+const outcomeTypes = {
+  complete() {
+    return {
+      detail: faker.lorem.paragraph({ max: 5, min: 0 }),
+      status: 'complete' as CourseParticipationOutcomeStatus,
+      yearCompleted: FactoryHelpers.optionalArrayElement(randomNonFutureYearFrom(1980)),
+    }
+  },
+
+  incomplete() {
+    return {
+      detail: faker.lorem.paragraph({ max: 5, min: 0 }),
+      status: 'incomplete' as CourseParticipationOutcomeStatus,
+      yearStarted: FactoryHelpers.optionalArrayElement(randomNonFutureYearFrom(1980)),
+    }
+  },
+
+  random() {
+    const type = faker.helpers.arrayElement<'complete' | 'incomplete' | 'unknown'>([
+      'complete',
+      'incomplete',
+      'unknown',
+    ])
+    return this[type]()
+  },
+
+  unknown() {
+    return { detail: faker.lorem.paragraph({ max: 5, min: 0 }) }
+  },
+}
+
+class CourseParticipationOutcomeFactory extends Factory<CourseParticipationOutcome> {
+  complete() {
+    return this.params(outcomeTypes.complete())
+  }
+
+  incomplete() {
+    return this.params(outcomeTypes.incomplete())
+  }
+
+  unknown() {
+    return this.params(outcomeTypes.unknown())
+  }
+}
+
+export default CourseParticipationOutcomeFactory.define(() => outcomeTypes.random())

--- a/server/testutils/factories/courseParticipationSetting.ts
+++ b/server/testutils/factories/courseParticipationSetting.ts
@@ -1,0 +1,10 @@
+import { faker } from '@faker-js/faker/locale/en_GB'
+import { Factory } from 'fishery'
+
+import FactoryHelpers from './factoryHelpers'
+import type { CourseParticipationSetting } from '@accredited-programmes/models'
+
+export default Factory.define<CourseParticipationSetting>(() => ({
+  location: FactoryHelpers.optionalArrayElement(faker.location.city()),
+  type: faker.helpers.arrayElement(['custody', 'community']),
+}))

--- a/server/testutils/factories/factoryHelpers.ts
+++ b/server/testutils/factories/factoryHelpers.ts
@@ -2,7 +2,7 @@ import { faker } from '@faker-js/faker/locale/en_GB'
 import type { Factory } from 'fishery'
 
 export default class FactoryHelpers {
-  static buildListBetween = <T>(factory: Factory<T>, options: { max: number; min?: number }): Array<T> => {
+  static buildListBetween<T>(factory: Factory<T>, options: { max: number; min?: number }): Array<T> {
     const quantity = Math.floor(Math.random() * options.max) + (options.min || 0)
 
     return factory.buildList(quantity)

--- a/server/testutils/factories/factoryHelpers.ts
+++ b/server/testutils/factories/factoryHelpers.ts
@@ -1,3 +1,4 @@
+import { faker } from '@faker-js/faker/locale/en_GB'
 import type { Factory } from 'fishery'
 
 export default class FactoryHelpers {
@@ -5,5 +6,10 @@ export default class FactoryHelpers {
     const quantity = Math.floor(Math.random() * options.max) + (options.min || 0)
 
     return factory.buildList(quantity)
+  }
+
+  static optionalArrayElement<T>(options: Array<T> | T): T | undefined {
+    const fullOptions: Array<T | undefined> = [undefined]
+    return faker.helpers.arrayElement(fullOptions.concat(options))
   }
 }

--- a/server/testutils/factories/index.ts
+++ b/server/testutils/factories/index.ts
@@ -1,6 +1,7 @@
 import courseFactory from './course'
 import courseAudienceFactory from './courseAudience'
 import courseOfferingFactory from './courseOffering'
+import courseParticipationFactory from './courseParticipation'
 import coursePrerequisiteFactory from './coursePrerequisite'
 import organisationFactory from './organisation'
 import organisationAddressFactory from './organisationAddress'
@@ -14,6 +15,7 @@ export {
   courseAudienceFactory,
   courseFactory,
   courseOfferingFactory,
+  courseParticipationFactory,
   coursePrerequisiteFactory,
   organisationAddressFactory,
   organisationFactory,

--- a/server/utils/formUtils.ts
+++ b/server/utils/formUtils.ts
@@ -3,7 +3,7 @@ import type { Request, Response } from 'express'
 import type { GovukFrontendErrorMessage, GovukFrontendErrorSummaryErrorListElement } from '@govuk-frontend'
 
 export default class FormUtils {
-  static setFieldErrors = (req: Request, res: Response, fields: Array<string>): void => {
+  static setFieldErrors(req: Request, res: Response, fields: Array<string>): void {
     const list: Array<GovukFrontendErrorSummaryErrorListElement> = []
     const messages: Record<string, GovukFrontendErrorMessage> = {}
 

--- a/server/utils/organisationUtils.ts
+++ b/server/utils/organisationUtils.ts
@@ -53,7 +53,7 @@ export default class OrganisationUtils {
     }
   }
 
-  private static concatenatedOrganisationAddress = (address: OrganisationAddress): string => {
+  private static concatenatedOrganisationAddress(address: OrganisationAddress): string {
     return [address.addressLine1, address.addressLine2, address.town, address.county, address.postalCode]
       .filter(Boolean)
       .join(', ')

--- a/server/utils/userUtils.ts
+++ b/server/utils/userUtils.ts
@@ -1,7 +1,7 @@
 import jwtDecode from 'jwt-decode'
 
 export default class UserUtils {
-  static getUserRolesFromToken = (token: Express.User['token']): Array<string> | undefined => {
+  static getUserRolesFromToken(token: Express.User['token']): Array<string> | undefined {
     return (jwtDecode(token) as { authorities?: Array<string> }).authorities
   }
 }

--- a/wiremock/scripts/stubApis.ts
+++ b/wiremock/scripts/stubApis.ts
@@ -1,7 +1,7 @@
 /* eslint-disable no-console */
 import { apiPaths } from '../../server/paths'
 import { stubFor } from '../index'
-import { courseOfferings, courses } from '../stubs'
+import { courseOfferings, courseParticipations, courses, prisoners } from '../stubs'
 
 const stubs = []
 
@@ -84,6 +84,20 @@ courseOfferings.forEach(courseOffering => {
     }),
   )
 })
+
+stubs.push(async () =>
+  stubFor({
+    request: {
+      method: 'GET',
+      url: apiPaths.people.participations({ prisonNumber: prisoners[1].prisonerNumber }),
+    },
+    response: {
+      headers: { 'Content-Type': 'application/json;charset=UTF-8' },
+      jsonBody: courseParticipations,
+      status: 200,
+    },
+  }),
+)
 
 console.log('Stubbing APIs')
 

--- a/wiremock/scripts/stubApis.ts
+++ b/wiremock/scripts/stubApis.ts
@@ -42,7 +42,7 @@ courses.forEach(course => {
     stubFor({
       request: {
         method: 'GET',
-        url: apiPaths.courses.offerings.index({ courseId: course.id }),
+        url: apiPaths.courses.offerings({ courseId: course.id }),
       },
       response: {
         headers: {
@@ -60,7 +60,7 @@ courseOfferings.forEach(courseOffering => {
     stubFor({
       request: {
         method: 'GET',
-        url: apiPaths.courses.offerings.show({ courseOfferingId: courseOffering.id }),
+        url: apiPaths.offerings.show({ courseOfferingId: courseOffering.id }),
       },
       response: {
         headers: { 'Content-Type': 'application/json;charset=UTF-8' },
@@ -74,7 +74,7 @@ courseOfferings.forEach(courseOffering => {
     stubFor({
       request: {
         method: 'GET',
-        url: apiPaths.courses.offerings.course({ courseOfferingId: courseOffering.id }),
+        url: apiPaths.offerings.course({ courseOfferingId: courseOffering.id }),
       },
       response: {
         headers: { 'Content-Type': 'application/json;charset=UTF-8' },

--- a/wiremock/stubs/courseParticipations.json
+++ b/wiremock/stubs/courseParticipations.json
@@ -1,0 +1,39 @@
+[
+  {
+    "id": "2da69b41-87a6-4bb3-b07e-6c1e5ec6be5e",
+    "addedBy": "Cedric Daniels",
+    "createdAt": "2023-09-14T10:14:32.047Z",
+    "prisonNumber": "DEF1234",
+    "courseId": "986d6256-5e2c-4792-b93a-568d923cf50c",
+    "outcome": {
+      "detail": "Simply the best outcome",
+      "status": "completed",
+      "yearCompleted": 2022
+    },
+    "setting": {
+      "type": "custody",
+      "location": "Frizinghall (HMP)"
+    },
+    "source": "A very reliable system"
+  },
+  {
+    "id": "57ac20a6-a660-405e-8210-43cb5b4cfc8d",
+    "addedBy": "Roland Pryzbylewski",
+    "createdAt": "2023-09-14T10:46:23.098Z",
+    "prisonNumber": "DEF1234",
+    "otherCourseName": "Opening New Doors"
+  },
+  {
+    "id": "57ac20a6-a660-405e-8210-43cb5b4cfc8d",
+    "addedBy": "Roland Pryzbylewski",
+    "createdAt": "2023-09-14T12:31:57.002Z",
+    "prisonNumber": "DEF1234",
+    "courseId": "197e62b4-4d34-4d30-a51f-e6427100c6c4",
+    "outcome": {
+      "status": "incomplete"
+    },
+    "setting": {
+      "type": "community"
+    }
+  }
+]

--- a/wiremock/stubs/index.ts
+++ b/wiremock/stubs/index.ts
@@ -1,5 +1,6 @@
 import courseOfferings from './courseOfferings.json'
+import courseParticipations from './courseParticipations.json'
 import courses from './courses.json'
 import prisoners from './prisoners.json'
 
-export { courseOfferings, courses, prisoners }
+export { courseOfferings, courseParticipations, courses, prisoners }


### PR DESCRIPTION
## Context

<!-- Is there a Trello ticket you can link to? -->
<!-- Do you need to add any environment variables? -->
<!-- Is an ADR required? An ADR should be added if this PR introduces a change to the architecture. -->

Groundwork for adding the course history index page. The API isn't quite up to date with these changes, but that's being worked on right now, and there aren't any tests this should break

## Changes in this PR

- Add participations types and factories
- Add participations API endpoint paths and stubs
- Two tidy ups

## Release checklist

[Release process documentation](../doc/how-to/perform-a-release.md)

As part of our continuous deployment strategy we must ensure that this work is
ready to be released once merged.

### Pre-merge

- [ ] There are changes required to the Accredited Programmes API for this change to work...
  - [ ] ... and they have been released to production already

### Post-merge

<!-- The outer checkboxes can be completed pre-merge -->

- [ ] This adds, extends or meaningfully modifies a feature...
  - [ ] ... and I have written or updated an end-to-end test for the happy path in the [Accredited Programmes E2E repo](https://github.com/ministryofjustice/hmpps-accredited-programmes-e2e)
- [ ] This makes new expectations of the API...
  - [ ] ... and I have notified the API developer(s) of changes to the contract tests (Pact), or the API is already compliant
- [ ] [Manually approve](../doc/how-to/perform-a-release.md#releasing-to-the-preprod-environment) release to preprod
- [ ] [Manually approve](../doc/how-to/perform-a-release.md#releasing-to-the-production-environment) release to prod

<!-- Should a release fail at any step, you as the author should now lead the work to
fix it as soon as possible. You can monitor deployment failures in CircleCI
itself and application errors are found in
[Sentry](https://ministryofjustice.sentry.io/projects/hmpps-accredited-programmes-ui/?project=4505330122686464&referrer=sidebar&statsPeriod=24h). -->
