### PR TITLE
(703b) Add course participation client and service methods

### DIFF
--- a/server/data/courseClient.ts
+++ b/server/data/courseClient.ts
@@ -2,7 +2,7 @@ import RestClient from './restClient'
 import type { ApiConfig } from '../config'
 import config from '../config'
 import { apiPaths } from '../paths'
-import type { Course, CourseOffering } from '@accredited-programmes/models'
+import type { Course, CourseOffering, CourseParticipation, Person } from '@accredited-programmes/models'
 
 export default class CourseClient {
   restClient: RestClient
@@ -35,5 +35,11 @@ export default class CourseClient {
     return (await this.restClient.get({
       path: apiPaths.courses.offerings({ courseId }),
     })) as Array<CourseOffering>
+  }
+
+  async findParticipationsByPerson(prisonNumber: Person['prisonNumber']): Promise<Array<CourseParticipation>> {
+    return (await this.restClient.get({
+      path: apiPaths.people.participations({ prisonNumber }),
+    })) as Array<CourseParticipation>
   }
 }

--- a/server/services/courseService.test.ts
+++ b/server/services/courseService.test.ts
@@ -2,7 +2,7 @@ import { when } from 'jest-when'
 
 import CourseService from './courseService'
 import { CourseClient } from '../data'
-import { courseFactory, courseOfferingFactory } from '../testutils/factories'
+import { courseFactory, courseOfferingFactory, courseParticipationFactory, personFactory } from '../testutils/factories'
 
 jest.mock('../data/courseClient')
 
@@ -89,6 +89,41 @@ describe('CourseService', () => {
 
       expect(courseClientBuilder).toHaveBeenCalledWith(token)
       expect(courseClient.findOffering).toHaveBeenCalledWith(courseOffering.id)
+    })
+  })
+
+  describe('getParticipationsByPerson', () => {
+    const person = personFactory.build()
+
+    it('returns a list of participations for a given person', async () => {
+      const courseParticipations = [
+        courseParticipationFactory.build({ prisonNumber: person.prisonNumber }),
+        courseParticipationFactory.build({ prisonNumber: person.prisonNumber }),
+      ]
+
+      when(courseClient.findParticipationsByPerson)
+        .calledWith(person.prisonNumber)
+        .mockResolvedValue(courseParticipations)
+
+      const result = await service.getParticipationsByPerson(token, person.prisonNumber)
+
+      expect(result).toEqual(courseParticipations)
+
+      expect(courseClientBuilder).toHaveBeenCalledWith(token)
+      expect(courseClient.findParticipationsByPerson).toHaveBeenCalledWith(person.prisonNumber)
+    })
+
+    describe('when the person has no previous course participations', () => {
+      it('returns an empty array', async () => {
+        when(courseClient.findParticipationsByPerson).calledWith(person.prisonNumber).mockResolvedValue([])
+
+        const result = await service.getParticipationsByPerson(token, person.prisonNumber)
+
+        expect(result).toEqual([])
+
+        expect(courseClientBuilder).toHaveBeenCalledWith(token)
+        expect(courseClient.findParticipationsByPerson).toHaveBeenCalledWith(person.prisonNumber)
+      })
     })
   })
 })

--- a/server/services/courseService.ts
+++ b/server/services/courseService.ts
@@ -1,5 +1,5 @@
 import type { CourseClient, RestClientBuilder } from '../data'
-import type { Course, CourseOffering } from '@accredited-programmes/models'
+import type { Course, CourseOffering, CourseParticipation, Person } from '@accredited-programmes/models'
 
 export default class CourseService {
   constructor(private readonly courseClientBuilder: RestClientBuilder<CourseClient>) {}
@@ -27,5 +27,13 @@ export default class CourseService {
   async getOfferingsByCourse(token: Express.User['token'], courseId: Course['id']): Promise<Array<CourseOffering>> {
     const courseClient = this.courseClientBuilder(token)
     return courseClient.findOfferings(courseId)
+  }
+
+  async getParticipationsByPerson(
+    token: Express.User['token'],
+    prisonNumber: Person['prisonNumber'],
+  ): Promise<Array<CourseParticipation>> {
+    const courseClient = this.courseClientBuilder(token)
+    return courseClient.findParticipationsByPerson(prisonNumber)
   }
 }


### PR DESCRIPTION
## Context

<!-- Is there a Trello ticket you can link to? -->
<!-- Do you need to add any environment variables? -->
<!-- Is an ADR required? An ADR should be added if this PR introduces a change to the architecture. -->

#214 added the course participation types, factories and paths

## Changes in this PR

- Add client and service methods to get participations by person

## Release checklist

[Release process documentation](../doc/how-to/perform-a-release.md)

As part of our continuous deployment strategy we must ensure that this work is
ready to be released once merged.

### Pre-merge

- [x] There are changes required to the Accredited Programmes API for this change to work...
  - [x] ... and they have been released to production already

### Post-merge

<!-- The outer checkboxes can be completed pre-merge -->

- [ ] This adds, extends or meaningfully modifies a feature...
  - [ ] ... and I have written or updated an end-to-end test for the happy path in the [Accredited Programmes E2E repo](https://github.com/ministryofjustice/hmpps-accredited-programmes-e2e)
- [ ] This makes new expectations of the API...
  - [ ] ... and I have notified the API developer(s) of changes to the contract tests (Pact), or the API is already compliant
- [ ] [Manually approve](../doc/how-to/perform-a-release.md#releasing-to-the-preprod-environment) release to preprod
- [ ] [Manually approve](../doc/how-to/perform-a-release.md#releasing-to-the-production-environment) release to prod

<!-- Should a release fail at any step, you as the author should now lead the work to
fix it as soon as possible. You can monitor deployment failures in CircleCI
itself and application errors are found in
[Sentry](https://ministryofjustice.sentry.io/projects/hmpps-accredited-programmes-ui/?project=4505330122686464&referrer=sidebar&statsPeriod=24h). -->
