### PR TITLE
(655a) Select programme for adding accredited programme history

### DIFF
--- a/server/controllers/refer/courseParticipationsController.test.ts
+++ b/server/controllers/refer/courseParticipationsController.test.ts
@@ -1,0 +1,44 @@
+import type { DeepMocked } from '@golevelup/ts-jest'
+import { createMock } from '@golevelup/ts-jest'
+import type { NextFunction, Request, Response } from 'express'
+
+import CourseParticipationsController from './courseParticipationsController'
+import type { CourseService } from '../../services'
+import { courseFactory } from '../../testutils/factories'
+import { CourseUtils } from '../../utils'
+
+describe('CourseParticipationsController', () => {
+  const token = 'SOME_TOKEN'
+  let request: DeepMocked<Request>
+  let response: DeepMocked<Response>
+  const next: DeepMocked<NextFunction> = createMock<NextFunction>({})
+
+  const courseService = createMock<CourseService>({})
+
+  let courseParticipationsController: CourseParticipationsController
+
+  beforeEach(() => {
+    request = createMock<Request>({ user: { token } })
+    response = createMock<Response>({})
+    courseParticipationsController = new CourseParticipationsController(courseService)
+  })
+
+  afterEach(() => {
+    jest.resetAllMocks()
+  })
+
+  describe('new', () => {
+    it('renders the new template for selecting a course/programme', async () => {
+      const courses = courseFactory.buildList(2)
+      courseService.getCourses.mockResolvedValue(courses)
+
+      const requestHandler = courseParticipationsController.new()
+      await requestHandler(request, response, next)
+
+      expect(response.render).toHaveBeenCalledWith('referrals/courseParticipations/new', {
+        courseRadioOptions: CourseUtils.courseRadioOptions(courses),
+        pageHeading: 'Add Accredited Programme history',
+      })
+    })
+  })
+})

--- a/server/controllers/refer/courseParticipationsController.ts
+++ b/server/controllers/refer/courseParticipationsController.ts
@@ -1,0 +1,21 @@
+import type { Request, Response, TypedRequestHandler } from 'express'
+
+import type { CourseService } from '../../services'
+import { CourseUtils, TypeUtils } from '../../utils'
+
+export default class CourseParticipationsController {
+  constructor(private readonly courseService: CourseService) {}
+
+  new(): TypedRequestHandler<Request, Response> {
+    return async (req, res) => {
+      TypeUtils.assertHasUser(req)
+
+      const courses = await this.courseService.getCourses(req.user.token)
+
+      res.render('referrals/courseParticipations/new', {
+        courseRadioOptions: CourseUtils.courseRadioOptions(courses),
+        pageHeading: 'Add Accredited Programme history',
+      })
+    }
+  }
+}

--- a/server/controllers/refer/index.ts
+++ b/server/controllers/refer/index.ts
@@ -1,5 +1,6 @@
 /* istanbul ignore file */
 
+import CourseParticipationsController from './courseParticipationsController'
 import OasysConfirmationController from './oasysConfirmationController'
 import PeopleController from './peopleController'
 import ReasonController from './reasonController'
@@ -7,6 +8,7 @@ import ReferralsController from './referralsController'
 import type { Services } from '../../services'
 
 const controllers = (services: Services) => {
+  const courseParticipationsController = new CourseParticipationsController(services.courseService)
   const reasonController = new ReasonController(services.personService, services.referralService)
   const referralsController = new ReferralsController(
     services.courseService,
@@ -18,6 +20,7 @@ const controllers = (services: Services) => {
   const oasysConfirmationController = new OasysConfirmationController(services.personService, services.referralService)
 
   return {
+    courseParticipationsController,
     oasysConfirmationController,
     peopleController,
     reasonController,

--- a/server/paths/refer.ts
+++ b/server/paths/refer.ts
@@ -13,6 +13,8 @@ const personPath = peoplePathBase.path(':prisonNumber')
 const referralsPath = path('/referrals')
 const showReferralPath = referralsPath.path(':referralId')
 const referralPersonPath = showReferralPath.path('person')
+const programmeHistoryBasePath = showReferralPath.path('programme-history')
+const newProgrammeHistoryPath = programmeHistoryBasePath.path('new')
 const confirmOasysPath = showReferralPath.path('confirm-oasys')
 const reasonForReferralPath = showReferralPath.path('reason')
 const checkAnswersPath = showReferralPath.path('check-answers')
@@ -31,6 +33,9 @@ export default {
   people: {
     find: findPersonPath,
     show: personPath,
+  },
+  programmeHistory: {
+    new: newProgrammeHistoryPath,
   },
   reason: {
     show: reasonForReferralPath,

--- a/server/routes/refer.ts
+++ b/server/routes/refer.ts
@@ -6,7 +6,13 @@ import { RouteUtils } from '../utils'
 
 export default function routes(controllers: Controllers, router: Router): Router {
   const { get, post, put } = RouteUtils.actions(router)
-  const { reasonController, referralsController, peopleController, oasysConfirmationController } = controllers
+  const {
+    courseParticipationsController,
+    reasonController,
+    referralsController,
+    peopleController,
+    oasysConfirmationController,
+  } = controllers
 
   get(referPaths.start.pattern, referralsController.start())
   get(referPaths.new.pattern, referralsController.new())
@@ -21,6 +27,7 @@ export default function routes(controllers: Controllers, router: Router): Router
   put(referPaths.confirmOasys.update.pattern, oasysConfirmationController.update())
   get(referPaths.reason.show.pattern, reasonController.show())
   put(referPaths.reason.update.pattern, reasonController.update())
+  get(referPaths.programmeHistory.new.pattern, courseParticipationsController.new())
   get(referPaths.checkAnswers.pattern, referralsController.checkAnswers())
   get(referPaths.complete.pattern, referralsController.complete())
   post(referPaths.submit.pattern, referralsController.submit())

--- a/server/utils/courseUtils.test.ts
+++ b/server/utils/courseUtils.test.ts
@@ -2,6 +2,17 @@ import CourseUtils from './courseUtils'
 import { courseAudienceFactory, courseFactory, coursePrerequisiteFactory } from '../testutils/factories'
 
 describe('CourseUtils', () => {
+  describe('courseRadioOptions', () => {
+    it('returns a formatted array of courses to use with UI radios', () => {
+      const courses = courseFactory.buildList(2)
+
+      expect(CourseUtils.courseRadioOptions(courses)).toEqual([
+        { text: courses[0].name, value: courses[0].id },
+        { text: courses[1].name, value: courses[1].id },
+      ])
+    })
+  })
+
   describe('presentCourse', () => {
     it('returns course details with UI-formatted audience and prerequisite data', () => {
       const course = courseFactory.build({

--- a/server/utils/courseUtils.ts
+++ b/server/utils/courseUtils.ts
@@ -8,6 +8,15 @@ import type {
 } from '@accredited-programmes/ui'
 
 export default class CourseUtils {
+  static courseRadioOptions(courses: Array<Course>): Array<GovukFrontendTagWithText> {
+    return courses.map(course => {
+      return {
+        text: course.name,
+        value: course.id,
+      }
+    })
+  }
+
   static presentCourse(course: Course): CoursePresenter {
     const nameAndAlternateName = course.alternateName ? `${course.name} (${course.alternateName})` : course.name
 

--- a/server/views/referrals/courseParticipations/new.njk
+++ b/server/views/referrals/courseParticipations/new.njk
@@ -1,0 +1,58 @@
+{% from "govuk/components/back-link/macro.njk" import govukBackLink %}
+{% from "govuk/components/button/macro.njk" import govukButton %}
+{% from "govuk/components/radios/macro.njk" import govukRadios %}
+{% from "govuk/components/input/macro.njk" import govukInput %}
+
+{% extends "../../partials/layout.njk" %}
+
+{% block backLink %}
+  {{ govukBackLink({
+    text: "Back",
+    href: "#"
+  }) }}
+{% endblock backLink %}
+
+{% block content %}
+  {% set otherCourseHtml %}
+  {{ govukInput({
+    id: "otherCourseName",
+    name: "otherCourseName",
+    type: "text",
+    classes: "govuk-!-width-one-third",
+    label: {
+      text: "Enter the programme"
+    }
+  }) }}
+  {% endset %}
+
+  <div class="govuk-grid-row">
+    <div class="govuk-grid-column-two-thirds">
+      <form action="#" method="post">
+        {{ govukRadios({
+          name: "courseId",
+          fieldset: {
+            legend: {
+              text: pageHeading,
+              isPageHeading: true,
+              classes: "govuk-fieldset__legend--l"
+            }
+          },
+          hint: {
+            text: "Select the programme"
+          },
+          items: courseRadioOptions.concat({
+            value: "other",
+            text: "Other",
+            conditional: {
+              html: otherCourseHtml
+            }
+          })
+        }) }}
+
+        {{ govukButton({
+          text: "Continue"
+        }) }}
+      </form>
+    </div>
+  </div>
+{% endblock %}


### PR DESCRIPTION
## Context
https://trello.com/c/i2gzZOoW/655-add-page-for-selecting-course-name-ui


## Changes in this PR

- Adds the form page for selecting a course to add a programme history to a referral. 
- Adds new `ProgrammeHistoryController` with `new` method to render the form page.

A follow on PR will add `create` method to create to `POST` to `/course-participations` and the functionality to submit the form (with validation).

## Screenshots of UI changes
![localhost_3000_referrals_c11fab18-dc8d-420c-9c82-d0edd373732d_programme-history_new](https://github.com/ministryofjustice/hmpps-accredited-programmes-ui/assets/1067537/fcc43840-b6e7-402a-b878-d27ac6b19cdd)


## Release checklist

[Release process documentation](../doc/how-to/perform-a-release.md)

As part of our continuous deployment strategy we must ensure that this work is
ready to be released once merged.

### Pre-merge

- [ ] There are changes required to the Accredited Programmes API for this change to work...
  - [ ] ... and they have been released to production already

### Post-merge

<!-- The outer checkboxes can be completed pre-merge -->

- [x] This adds, extends or meaningfully modifies a feature...
  - [ ] ... and I have written or updated an end-to-end test for the happy path in the [Accredited Programmes E2E repo](https://github.com/ministryofjustice/hmpps-accredited-programmes-e2e)
- [ ] This makes new expectations of the API...
  - [ ] ... and I have notified the API developer(s) of changes to the contract tests (Pact), or the API is already compliant
- [ ] [Manually approve](../doc/how-to/perform-a-release.md#releasing-to-the-preprod-environment) release to preprod
- [ ] [Manually approve](../doc/how-to/perform-a-release.md#releasing-to-the-production-environment) release to prod

<!-- Should a release fail at any step, you as the author should now lead the work to
fix it as soon as possible. You can monitor deployment failures in CircleCI
itself and application errors are found in
[Sentry](https://ministryofjustice.sentry.io/projects/hmpps-accredited-programmes-ui/?project=4505330122686464&referrer=sidebar&statsPeriod=24h). -->
