### PR TITLE
(655b) Update course client and service for creating a participation

### DIFF
--- a/server/data/courseClient.ts
+++ b/server/data/courseClient.ts
@@ -15,6 +15,17 @@ export default class CourseClient {
     return (await this.restClient.get({ path: apiPaths.courses.index({}) })) as Array<Course>
   }
 
+  async createParticipation(
+    prisonNumber: CourseParticipation['prisonNumber'],
+    courseId?: CourseParticipation['id'],
+    otherCourseName?: CourseParticipation['otherCourseName'],
+  ): Promise<CourseParticipation> {
+    return (await this.restClient.post({
+      data: { courseId, otherCourseName, prisonNumber },
+      path: apiPaths.participations.create({}),
+    })) as CourseParticipation
+  }
+
   async find(courseId: Course['id']): Promise<Course> {
     return (await this.restClient.get({ path: apiPaths.courses.show({ courseId }) })) as Course
   }

--- a/server/services/courseService.test.ts
+++ b/server/services/courseService.test.ts
@@ -19,6 +19,46 @@ describe('CourseService', () => {
     courseClientBuilder.mockReturnValue(courseClient)
   })
 
+  describe('createParticipation', () => {
+    const person = personFactory.build()
+
+    describe('when `courseId` is provided', () => {
+      it('creates a course participation using the `courseId` value', async () => {
+        const courseParticipation = courseParticipationFactory.withCourseId().build()
+        const { courseId } = courseParticipation
+
+        when(courseClient.createParticipation)
+          .calledWith(person.prisonNumber, courseId, undefined)
+          .mockResolvedValue(courseParticipation)
+
+        const result = await service.createParticipation(token, person.prisonNumber, courseId)
+
+        expect(result).toEqual(courseParticipation)
+
+        expect(courseClientBuilder).toHaveBeenCalledWith(token)
+        expect(courseClient.createParticipation).toHaveBeenCalledWith(person.prisonNumber, courseId, undefined)
+      })
+    })
+
+    describe('when `otherCourseName` is provided and `courseId` is not', () => {
+      it('creates a course participation using the `otherCourseName` value', async () => {
+        const courseParticipation = courseParticipationFactory.withOtherCourseName().build()
+        const { otherCourseName } = courseParticipation
+
+        when(courseClient.createParticipation)
+          .calledWith(person.prisonNumber, undefined, otherCourseName)
+          .mockResolvedValue(courseParticipation)
+
+        const result = await service.createParticipation(token, person.prisonNumber, undefined, otherCourseName)
+
+        expect(result).toEqual(courseParticipation)
+
+        expect(courseClientBuilder).toHaveBeenCalledWith(token)
+        expect(courseClient.createParticipation).toHaveBeenCalledWith(person.prisonNumber, undefined, otherCourseName)
+      })
+    })
+  })
+
   describe('getCourses', () => {
     it('returns a list of all courses', async () => {
       const courses = courseFactory.buildList(3)

--- a/server/services/courseService.ts
+++ b/server/services/courseService.ts
@@ -4,6 +4,16 @@ import type { Course, CourseOffering, CourseParticipation, Person } from '@accre
 export default class CourseService {
   constructor(private readonly courseClientBuilder: RestClientBuilder<CourseClient>) {}
 
+  async createParticipation(
+    token: Express.User['token'],
+    prisonNumber: CourseParticipation['prisonNumber'],
+    courseId?: CourseParticipation['id'],
+    otherCourseName?: CourseParticipation['otherCourseName'],
+  ): Promise<CourseParticipation> {
+    const courseClient = this.courseClientBuilder(token)
+    return courseClient.createParticipation(prisonNumber, courseId, otherCourseName)
+  }
+
   async getCourse(token: Express.User['token'], courseId: Course['id']): Promise<Course> {
     const courseClient = this.courseClientBuilder(token)
     return courseClient.find(courseId)


### PR DESCRIPTION
## Context

https://trello.com/c/i2gzZOoW/655-add-page-for-selecting-course-name-ui

## Changes in this PR
Adds new methods to the course client and course service to create a new course participation.


## Release checklist

[Release process documentation](../doc/how-to/perform-a-release.md)

As part of our continuous deployment strategy we must ensure that this work is
ready to be released once merged.

### Pre-merge

- [ ] There are changes required to the Accredited Programmes API for this change to work...
  - [ ] ... and they have been released to production already

### Post-merge

<!-- The outer checkboxes can be completed pre-merge -->

- [ ] This adds, extends or meaningfully modifies a feature...
  - [ ] ... and I have written or updated an end-to-end test for the happy path in the [Accredited Programmes E2E repo](https://github.com/ministryofjustice/hmpps-accredited-programmes-e2e)
- [ ] This makes new expectations of the API...
  - [ ] ... and I have notified the API developer(s) of changes to the contract tests (Pact), or the API is already compliant
- [ ] [Manually approve](../doc/how-to/perform-a-release.md#releasing-to-the-preprod-environment) release to preprod
- [ ] [Manually approve](../doc/how-to/perform-a-release.md#releasing-to-the-production-environment) release to prod

<!-- Should a release fail at any step, you as the author should now lead the work to
fix it as soon as possible. You can monitor deployment failures in CircleCI
itself and application errors are found in
[Sentry](https://ministryofjustice.sentry.io/projects/hmpps-accredited-programmes-ui/?project=4505330122686464&referrer=sidebar&statsPeriod=24h). -->
