### PR TITLE
(655c) Create course participation from select programme page

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -112,6 +112,9 @@ jobs:
           command: java -jar wiremock.jar --port 9199
           background: true
       - run:
+          name: Compile sass
+          command: npm run compile-sass
+      - run:
           name: Run the node app
           command: npm run test:integration:ci:server
           background: true
@@ -155,6 +158,9 @@ jobs:
           name: Run wiremock
           command: java -jar wiremock.jar --port 9199
           background: true
+      - run:
+          name: Compile sass
+          command: npm run compile-sass
       - run:
           name: Run the node app
           command: npm run test:integration:refer-disabled:ci:server

--- a/integration_tests/e2eReferDisabled/refer.cy.ts
+++ b/integration_tests/e2eReferDisabled/refer.cy.ts
@@ -139,6 +139,29 @@ context('Refer', () => {
     notFoundPage.shouldContain404H2()
   })
 
+  it("Doesn't show the select programme page", () => {
+    cy.signIn()
+
+    const courses = courseFactory.buildList(4)
+    const prisoner = prisonerFactory.build()
+    const referral = referralFactory.started().build({ prisonNumber: prisoner.prisonerNumber })
+
+    cy.task('stubCourses', courses)
+    cy.task('stubPrisoner', prisoner)
+    cy.task('stubReferral', referral)
+
+    const path = referPaths.programmeHistory.create({ referralId: referral.id })
+    cy.visit(path, { failOnStatusCode: false })
+
+    const notFoundPage = Page.verifyOnPage(NotFoundPage)
+    notFoundPage.shouldContain404H2()
+
+    cy.visit(path, { failOnStatusCode: false })
+
+    const notFoundPage2 = Page.verifyOnPage(NotFoundPage)
+    notFoundPage2.shouldContain404H2()
+  })
+
   it("Doesn't show the programme history index page", () => {
     cy.signIn()
 

--- a/integration_tests/mockApis/courseParticipations.ts
+++ b/integration_tests/mockApis/courseParticipations.ts
@@ -5,6 +5,19 @@ import { stubFor } from '../../wiremock'
 import type { CourseParticipation, Person } from '@accredited-programmes/models'
 
 export default {
+  stubCreateParticipation: (courseParticipation: CourseParticipation): SuperAgentRequest =>
+    stubFor({
+      request: {
+        method: 'POST',
+        url: apiPaths.participations.create({}),
+      },
+      response: {
+        headers: { 'Content-Type': 'application/json;charset=UTF-8' },
+        jsonBody: courseParticipation,
+        status: 201,
+      },
+    }),
+
   stubParticipationsByPerson: (args: {
     courseParticipations: Array<CourseParticipation>
     prisonNumber: Person['prisonNumber']

--- a/integration_tests/pages/page.ts
+++ b/integration_tests/pages/page.ts
@@ -5,6 +5,7 @@ import Helpers from '../support/helpers'
 import type { Organisation, Person } from '@accredited-programmes/models'
 import type {
   CoursePresenter,
+  GovukFrontendRadiosItemWithLabel,
   GovukFrontendSummaryListRowWithValue,
   GovukFrontendTagWithText,
   HasHtmlString,
@@ -43,6 +44,10 @@ export default abstract class Page {
   }
 
   manageDetails = (): PageElement => cy.get('[data-qa=manageDetails]')
+
+  selectRadioButton(name: string, value: string): void {
+    cy.get(`.govuk-radios__input[name="${name}"][value="${value}"]`).check()
+  }
 
   shouldContainAudienceTags(audienceTags: CoursePresenter['audienceTags']) {
     cy.get('.govuk-main-wrapper').within(() => {
@@ -136,6 +141,20 @@ export default abstract class Page {
   shouldContainPersonSummaryList(person: Person): void {
     cy.get('[data-testid="person-summary-list"]').then(summaryListElement => {
       this.shouldContainSummaryListRows(PersonUtils.summaryListRows(person), summaryListElement)
+    })
+  }
+
+  shouldContainRadioItems(options: Array<GovukFrontendRadiosItemWithLabel>): void {
+    options.forEach((option, optionIndex) => {
+      cy.get('.govuk-radios__item')
+        .eq(optionIndex)
+        .within(() => {
+          cy.get('.govuk-radios__label').then(radioButtonLabelElement => {
+            const { actual, expected } = Helpers.parseHtml(radioButtonLabelElement, option.label)
+            expect(actual).to.equal(expected)
+          })
+          cy.get('.govuk-radios__input').should('have.attr', 'value', option.value)
+        })
     })
   }
 

--- a/integration_tests/pages/refer/index.ts
+++ b/integration_tests/pages/refer/index.ts
@@ -3,6 +3,7 @@ import ConfirmOasysPage from './confirmOasys'
 import ConfirmPersonPage from './confirmPerson'
 import FindPersonPage from './findPerson'
 import ProgrammeHistoryPage from './programmeHistory'
+import SelectProgrammePage from './selectProgramme'
 import ShowPersonPage from './showPerson'
 import StartReferralPage from './startReferral'
 import TaskListPage from './taskList'
@@ -13,6 +14,7 @@ export {
   ConfirmPersonPage,
   FindPersonPage,
   ProgrammeHistoryPage,
+  SelectProgrammePage,
   ShowPersonPage,
   StartReferralPage,
   TaskListPage,

--- a/integration_tests/pages/refer/selectProgramme.ts
+++ b/integration_tests/pages/refer/selectProgramme.ts
@@ -18,7 +18,7 @@ export default class SelectProgrammePage extends Page {
   }
 
   shouldContainCourseOptions() {
-    this.shouldContainRadioButtons([
+    this.shouldContainRadioItems([
       ...this.courses.map(course => ({ label: course.name, value: course.id })),
       { label: 'Other', value: 'other' },
     ])

--- a/integration_tests/pages/refer/selectProgramme.ts
+++ b/integration_tests/pages/refer/selectProgramme.ts
@@ -1,0 +1,35 @@
+import Page from '../page'
+import type { Course } from '@accredited-programmes/models'
+
+export default class SelectProgrammePage extends Page {
+  courses: Array<Course>
+
+  constructor(args: { courses: Array<Course> }) {
+    // Conditional radio buttons add an additional `aria-expanded` field,
+    // so ignore that rule on this page
+    super('Add Accredited Programme history', { accessibilityRules: { 'aria-allowed-attr': { enabled: false } } })
+
+    const { courses } = args
+    this.courses = courses
+  }
+
+  selectCourse(value: string) {
+    this.selectRadioButton('courseId', value)
+  }
+
+  shouldContainCourseOptions() {
+    this.shouldContainRadioButtons([
+      ...this.courses.map(course => ({ label: course.name, value: course.id })),
+      { label: 'Other', value: 'other' },
+    ])
+  }
+
+  shouldDisplayOtherCourseInput() {
+    cy.get('[data-testid="other-course-option"]').check()
+    cy.get(`input[name="otherCourseName"]`).should('be.visible')
+  }
+
+  shouldNotDisplayOtherCourseInput() {
+    cy.get(`input[name="otherCourseName"]`).should('not.be.visible')
+  }
+}

--- a/server/@types/ui/index.d.ts
+++ b/server/@types/ui/index.d.ts
@@ -1,10 +1,13 @@
 import type {
+  GovukFrontendRadiosItem,
   GovukFrontendSummaryList,
   GovukFrontendSummaryListRow,
   GovukFrontendSummaryListRowValue,
   GovukFrontendTag,
 } from '../govukFrontend'
 import type { Course, CourseOffering, Organisation } from '@accredited-programmes/models'
+
+type GovukFrontendRadiosItemWithLabel = GovukFrontendRadiosItem & { label: string }
 
 type GovukFrontendSummaryListRowWithValue = GovukFrontendSummaryListRow & { value: GovukFrontendSummaryListRowValue }
 
@@ -78,6 +81,7 @@ type ReferralTaskListSection = {
 
 export type {
   CoursePresenter,
+  GovukFrontendRadiosItemWithLabel,
   GovukFrontendSummaryListRowWithValue,
   GovukFrontendSummaryListWithRowsWithValues,
   GovukFrontendTagWithText,

--- a/server/controllers/refer/courseParticipationsController.test.ts
+++ b/server/controllers/refer/courseParticipationsController.test.ts
@@ -161,6 +161,7 @@ describe('CourseParticipationsController', () => {
         courseRadioOptions: CourseUtils.courseRadioOptions(courses),
         pageHeading: 'Add Accredited Programme history',
         person,
+        referralId: referral.id,
       })
     })
 

--- a/server/controllers/refer/courseParticipationsController.test.ts
+++ b/server/controllers/refer/courseParticipationsController.test.ts
@@ -83,12 +83,34 @@ describe('CourseParticipationsController', () => {
       const courses = courseFactory.buildList(2)
       courseService.getCourses.mockResolvedValue(courses)
 
+      const person = personFactory.build()
+      personService.getPerson.mockResolvedValue(person)
+
+      const referral = referralFactory.started().build({ prisonNumber: person.prisonNumber })
+      referralService.getReferral.mockResolvedValue(referral)
+
       const requestHandler = courseParticipationsController.new()
       await requestHandler(request, response, next)
 
       expect(response.render).toHaveBeenCalledWith('referrals/courseParticipations/new', {
         courseRadioOptions: CourseUtils.courseRadioOptions(courses),
         pageHeading: 'Add Accredited Programme history',
+        person,
+      })
+    })
+
+    describe('when the person service returns `null`', () => {
+      it('responds with a 404', async () => {
+        const person = personFactory.build()
+        personService.getPerson.mockResolvedValue(null)
+
+        const referral = referralFactory.started().build({ prisonNumber: person.prisonNumber })
+        referralService.getReferral.mockResolvedValue(referral)
+
+        const requestHandler = courseParticipationsController.new()
+        const expectedError = createError(404, `Person with prison number ${referral.prisonNumber} not found.`)
+
+        expect(() => requestHandler(request, response, next)).rejects.toThrowError(expectedError)
       })
     })
   })

--- a/server/controllers/refer/courseParticipationsController.test.ts
+++ b/server/controllers/refer/courseParticipationsController.test.ts
@@ -7,7 +7,9 @@ import CourseParticipationsController from './courseParticipationsController'
 import { referPaths } from '../../paths'
 import type { CourseService, PersonService, ReferralService } from '../../services'
 import { courseFactory, courseParticipationFactory, personFactory, referralFactory } from '../../testutils/factories'
-import { CourseParticipationUtils, CourseUtils } from '../../utils'
+import { CourseParticipationUtils, CourseUtils, FormUtils } from '../../utils'
+
+jest.mock('../../utils/formUtils')
 
 describe('CourseParticipationsController', () => {
   const token = 'SOME_TOKEN'
@@ -93,6 +95,94 @@ describe('CourseParticipationsController', () => {
         )
       })
     })
+
+    describe('when the `courseId` value is not provided', () => {
+      it('redirects to the course participation new page with an error', async () => {
+        const requestHandler = courseParticipationsController.create()
+        await requestHandler(request, response, next)
+
+        expect(response.redirect).toHaveBeenCalledWith(
+          referPaths.programmeHistory.new({ referralId: request.params.referralId }),
+        )
+        expect(request.flash).toHaveBeenCalledWith('courseIdError', 'Select a programme')
+      })
+    })
+
+    describe('when the `courseId` value is `other` and the `otherCourseName` value is not provided', () => {
+      it('redirects to the course participation new page with an error', async () => {
+        request.body = { courseId: 'other' }
+
+        const requestHandler = courseParticipationsController.create()
+        await requestHandler(request, response, next)
+
+        expect(response.redirect).toHaveBeenCalledWith(
+          referPaths.programmeHistory.new({ referralId: request.params.referralId }),
+        )
+        expect(request.flash).toHaveBeenCalledWith('otherCourseNameError', 'Enter the programme name')
+      })
+    })
+
+    describe('when the provided `otherCourseName` value is just spaces', () => {
+      it('redirects to the course participation new page with an error', async () => {
+        request.body = { courseId: 'other', otherCourseName: ' \n \n ' }
+
+        const requestHandler = courseParticipationsController.create()
+        await requestHandler(request, response, next)
+
+        expect(response.redirect).toHaveBeenCalledWith(
+          referPaths.programmeHistory.new({ referralId: request.params.referralId }),
+        )
+        expect(request.flash).toHaveBeenCalledWith('otherCourseNameError', 'Enter the programme name')
+      })
+    })
+  })
+
+  describe('index', () => {
+    const referral = referralFactory.build()
+
+    it("renders the index template for a person's programme history", async () => {
+      referralService.getReferral.mockResolvedValue(referral)
+
+      const person = personFactory.build()
+      personService.getPerson.mockResolvedValue(person)
+
+      const courseParticipations = [
+        courseParticipationFactory.build({ courseId: 'an-ID' }),
+        courseParticipationFactory.build({ courseId: undefined, otherCourseName: 'Another course' }),
+      ]
+      courseService.getParticipationsByPerson.mockResolvedValue(courseParticipations)
+
+      const course = courseFactory.build()
+      courseService.getCourse.mockResolvedValue(course)
+
+      const courseParticipationsWithNames = [
+        { ...courseParticipations[0], name: course.name },
+        { ...courseParticipations[1], name: 'Another course' },
+      ]
+      const summaryListsOptions = courseParticipationsWithNames.map(CourseParticipationUtils.summaryListOptions)
+
+      const requestHandler = courseParticipationsController.index()
+      await requestHandler(request, response, next)
+
+      expect(response.render).toHaveBeenCalledWith('referrals/courseParticipations/index', {
+        pageHeading: 'Accredited Programme history',
+        person,
+        referralId: referral.id,
+        summaryListsOptions,
+      })
+    })
+
+    describe('when the person service returns `null`', () => {
+      it('responds with a 404', async () => {
+        referralService.getReferral.mockResolvedValue(referral)
+        personService.getPerson.mockResolvedValue(null)
+
+        const requestHandler = courseParticipationsController.index()
+        const expectedError = createError(404)
+
+        expect(() => requestHandler(request, response, next)).rejects.toThrowError(expectedError)
+      })
+    })
   })
 
   describe('index', () => {
@@ -154,6 +244,11 @@ describe('CourseParticipationsController', () => {
       const referral = referralFactory.started().build({ prisonNumber: person.prisonNumber })
       referralService.getReferral.mockResolvedValue(referral)
 
+      const emptyErrorsLocal = { list: [], messages: {} }
+      ;(FormUtils.setFieldErrors as jest.Mock).mockImplementation((_request, _response, _fields) => {
+        response.locals.errors = emptyErrorsLocal
+      })
+
       const requestHandler = courseParticipationsController.new()
       await requestHandler(request, response, next)
 
@@ -163,6 +258,7 @@ describe('CourseParticipationsController', () => {
         person,
         referralId: referral.id,
       })
+      expect(FormUtils.setFieldErrors).toHaveBeenCalledWith(request, response, ['courseId', 'otherCourseName'])
     })
 
     describe('when the person service returns `null`', () => {

--- a/server/controllers/refer/courseParticipationsController.ts
+++ b/server/controllers/refer/courseParticipationsController.ts
@@ -84,6 +84,7 @@ export default class CourseParticipationsController {
         courseRadioOptions: CourseUtils.courseRadioOptions(courses),
         pageHeading: 'Add Accredited Programme history',
         person,
+        referralId: referral.id,
       })
     }
   }

--- a/server/controllers/refer/courseParticipationsController.ts
+++ b/server/controllers/refer/courseParticipationsController.ts
@@ -51,10 +51,17 @@ export default class CourseParticipationsController {
       TypeUtils.assertHasUser(req)
 
       const courses = await this.courseService.getCourses(req.user.token)
+      const referral = await this.referralService.getReferral(req.user.token, req.params.referralId)
+      const person = await this.personService.getPerson(req.user.username, referral.prisonNumber)
+
+      if (!person) {
+        throw createError(404, `Person with prison number ${referral.prisonNumber} not found.`)
+      }
 
       res.render('referrals/courseParticipations/new', {
         courseRadioOptions: CourseUtils.courseRadioOptions(courses),
         pageHeading: 'Add Accredited Programme history',
+        person,
       })
     }
   }

--- a/server/paths/refer.ts
+++ b/server/paths/refer.ts
@@ -36,7 +36,7 @@ export default {
     show: personPath,
   },
   programmeHistory: {
-    create: newProgrammeHistoryPath,
+    create: programmeHistoryPath,
     details: programmeHistoryDetailsPath,
     index: programmeHistoryPath,
     new: newProgrammeHistoryPath,

--- a/server/paths/refer.ts
+++ b/server/paths/refer.ts
@@ -15,6 +15,7 @@ const showReferralPath = referralsPath.path(':referralId')
 const referralPersonPath = showReferralPath.path('person')
 const programmeHistoryPath = showReferralPath.path('programme-history')
 const newProgrammeHistoryPath = programmeHistoryPath.path('new')
+const programmeHistoryDetailsPath = programmeHistoryPath.path(':courseParticipationId/details')
 const confirmOasysPath = showReferralPath.path('confirm-oasys')
 const reasonForReferralPath = showReferralPath.path('reason')
 const checkAnswersPath = showReferralPath.path('check-answers')
@@ -35,6 +36,8 @@ export default {
     show: personPath,
   },
   programmeHistory: {
+    create: newProgrammeHistoryPath,
+    details: programmeHistoryDetailsPath,
     index: programmeHistoryPath,
     new: newProgrammeHistoryPath,
   },

--- a/server/routes/refer.ts
+++ b/server/routes/refer.ts
@@ -37,10 +37,13 @@ export default function routes(controllers: Controllers, router: Router): Router
   get(referPaths.reason.show.pattern, reasonController.show(), { allowedRoles: [ApplicationRoles.ACP_REFERRER] })
   put(referPaths.reason.update.pattern, reasonController.update(), { allowedRoles: [ApplicationRoles.ACP_REFERRER] })
 
+  get(referPaths.programmeHistory.index.pattern, courseParticipationsController.index(), {
+    allowedRoles: [ApplicationRoles.ACP_REFERRER],
+  })
   get(referPaths.programmeHistory.new.pattern, courseParticipationsController.new(), {
     allowedRoles: [ApplicationRoles.ACP_REFERRER],
   })
-  get(referPaths.programmeHistory.index.pattern, courseParticipationsController.index(), {
+  post(referPaths.programmeHistory.create.pattern, courseParticipationsController.create(), {
     allowedRoles: [ApplicationRoles.ACP_REFERRER],
   })
 

--- a/server/views/referrals/courseParticipations/new.njk
+++ b/server/views/referrals/courseParticipations/new.njk
@@ -1,5 +1,6 @@
 {% from "govuk/components/back-link/macro.njk" import govukBackLink %}
 {% from "govuk/components/button/macro.njk" import govukButton %}
+{% from "govuk/components/error-summary/macro.njk" import govukErrorSummary %}
 {% from "govuk/components/radios/macro.njk" import govukRadios %}
 {% from "govuk/components/input/macro.njk" import govukInput %}
 
@@ -25,12 +26,20 @@
     classes: "govuk-!-width-one-third",
     label: {
       text: "Enter the programme"
-    }
+    },
+    errorMessage: errors.messages.otherCourseName
   }) }}
   {% endset %}
 
   <div class="govuk-grid-row">
     <div class="govuk-grid-column-two-thirds">
+      {% if errors.list.length %}
+        {{ govukErrorSummary({
+          titleText: "There is a problem",
+          errorList: errors.list
+        }) }}
+      {% endif %}
+
       <form action="{{ referPaths.programmeHistory.create({ referralId: referralId }) }}" method="post">
         <input type="hidden" name="_csrf" value="{{ csrfToken }}"/>
 
@@ -51,8 +60,10 @@
             text: "Other",
             conditional: {
               html: otherCourseHtml
-            }
-          })
+            },
+            checked: errors.messages.otherCourseName
+          }),
+          errorMessage: errors.messages.courseId
         }) }}
 
         {{ govukButton({

--- a/server/views/referrals/courseParticipations/new.njk
+++ b/server/views/referrals/courseParticipations/new.njk
@@ -61,7 +61,10 @@
             conditional: {
               html: otherCourseHtml
             },
-            checked: errors.messages.otherCourseName
+            checked: errors.messages.otherCourseName,
+            attributes: {
+              "data-testid": "other-course-option"
+            }
           }),
           errorMessage: errors.messages.courseId
         }) }}

--- a/server/views/referrals/courseParticipations/new.njk
+++ b/server/views/referrals/courseParticipations/new.njk
@@ -5,6 +5,10 @@
 
 {% extends "../../partials/layout.njk" %}
 
+{% block personBanner %}
+  {% include "../_personBanner.njk" %}
+{% endblock personBanner %}
+
 {% block backLink %}
   {{ govukBackLink({
     text: "Back",

--- a/server/views/referrals/courseParticipations/new.njk
+++ b/server/views/referrals/courseParticipations/new.njk
@@ -12,7 +12,7 @@
 {% block backLink %}
   {{ govukBackLink({
     text: "Back",
-    href: "#"
+    href: referPaths.programmeHistory.index({ referralId: referralId })
   }) }}
 {% endblock backLink %}
 
@@ -31,7 +31,9 @@
 
   <div class="govuk-grid-row">
     <div class="govuk-grid-column-two-thirds">
-      <form action="#" method="post">
+      <form action="{{ referPaths.programmeHistory.create({ referralId: referralId }) }}" method="post">
+        <input type="hidden" name="_csrf" value="{{ csrfToken }}"/>
+
         {{ govukRadios({
           name: "courseId",
           fieldset: {


### PR DESCRIPTION
## Context

https://trello.com/c/i2gzZOoW/655-add-page-for-selecting-course-name-ui


## Changes in this PR
Note: Branched off #218 so contains changes to courseClient and courseService until that has been merged. 

Updates the select a programme form page to `POST` to `/course-participations` and redirects to the yet to be created details page. 

Also displays validation for either an unselected programme or missing text in the conditionally displayed Other text input.



## Screenshots of UI changes

![localhost_3000_referrals_c11fab18-dc8d-420c-9c82-d0edd373732d_programme-history_new (7)](https://github.com/ministryofjustice/hmpps-accredited-programmes-ui/assets/1067537/3bfb3a8a-dc72-47e4-83fd-14e8bda43931)

![localhost_3000_referrals_c11fab18-dc8d-420c-9c82-d0edd373732d_programme-history_new (8)](https://github.com/ministryofjustice/hmpps-accredited-programmes-ui/assets/1067537/2cf74a61-3d23-4ee2-8ebd-f980a342782a)

![localhost_3000_referrals_c11fab18-dc8d-420c-9c82-d0edd373732d_programme-history_new (9)](https://github.com/ministryofjustice/hmpps-accredited-programmes-ui/assets/1067537/71ae312e-11dd-4f43-9f72-de4e7a4818a3)

## Release checklist

[Release process documentation](../doc/how-to/perform-a-release.md)

As part of our continuous deployment strategy we must ensure that this work is
ready to be released once merged.

### Pre-merge

- [x] There are changes required to the Accredited Programmes API for this change to work...
  - [ ] ... and they have been released to production already

### Post-merge

<!-- The outer checkboxes can be completed pre-merge -->

- [x] This adds, extends or meaningfully modifies a feature...
  - [ ] ... and I have written or updated an end-to-end test for the happy path in the [Accredited Programmes E2E repo](https://github.com/ministryofjustice/hmpps-accredited-programmes-e2e)
- [ ] This makes new expectations of the API...
  - [ ] ... and I have notified the API developer(s) of changes to the contract tests (Pact), or the API is already compliant
- [ ] [Manually approve](../doc/how-to/perform-a-release.md#releasing-to-the-preprod-environment) release to preprod
- [ ] [Manually approve](../doc/how-to/perform-a-release.md#releasing-to-the-production-environment) release to prod

<!-- Should a release fail at any step, you as the author should now lead the work to
fix it as soon as possible. You can monitor deployment failures in CircleCI
itself and application errors are found in
[Sentry](https://ministryofjustice.sentry.io/projects/hmpps-accredited-programmes-ui/?project=4505330122686464&referrer=sidebar&statsPeriod=24h). -->
