### PR TITLE
Update checkAccessibility cypress command to accept optional accessibilityRules

### DIFF
--- a/integration_tests/@types/index.d.ts
+++ b/integration_tests/@types/index.d.ts
@@ -1,0 +1,1 @@
+export type AxeRules = Record<string, { enabled: boolean }> | undefined

--- a/integration_tests/index.d.ts
+++ b/integration_tests/index.d.ts
@@ -1,10 +1,14 @@
-declare namespace Cypress {
-  interface Chainable {
-    checkAccessibility(): void
-    /**
-     * Custom command to signIn. Set failOnStatusCode to false if you expect and non 200 return code
-     * @example cy.signIn({ failOnStatusCode: boolean })
-     */
-    signIn(options?: { failOnStatusCode: boolean }): Chainable<AUTWindow>
+import type { AxeRules } from '@accredited-programmes/integration-tests'
+
+declare global {
+  namespace Cypress {
+    interface Chainable {
+      checkAccessibility(rules?: AxeRules): void
+      /**
+       * Custom command to signIn. Set failOnStatusCode to false if you expect and non 200 return code
+       * @example cy.signIn({ failOnStatusCode: boolean })
+       */
+      signIn(options?: { failOnStatusCode: boolean }): Chainable<AUTWindow>
+    }
   }
 }

--- a/integration_tests/pages/page.ts
+++ b/integration_tests/pages/page.ts
@@ -1,3 +1,5 @@
+import type { AxeRules } from '@accredited-programmes/integration-tests'
+
 import { PersonUtils } from '../../server/utils'
 import Helpers from '../support/helpers'
 import type { Organisation, Person } from '@accredited-programmes/models'
@@ -16,19 +18,26 @@ export default abstract class Page {
     return new constructor(...args)
   }
 
+  accessibilityRules: AxeRules | undefined
+
   customPageTitleEnd: string | undefined
 
   external: boolean
 
   constructor(
     private readonly pageHeading: string,
-    options?: { customPageTitleEnd?: string; external?: boolean },
+    options?: {
+      accessibilityRules?: AxeRules
+      customPageTitleEnd?: string
+      external?: boolean
+    },
   ) {
+    this.accessibilityRules = options?.accessibilityRules
     this.customPageTitleEnd = options?.customPageTitleEnd
     this.external = options?.external || false
     this.checkOnPage()
     if (!this.external) {
-      cy.checkAccessibility()
+      cy.checkAccessibility(this.accessibilityRules)
     }
   }
 

--- a/integration_tests/support/commands.ts
+++ b/integration_tests/support/commands.ts
@@ -1,3 +1,4 @@
+import type { AxeRules } from '@accredited-programmes/integration-tests'
 import type { Result } from 'axe-core'
 
 Cypress.Commands.add('signIn', (options = { failOnStatusCode: true }) => {
@@ -23,8 +24,8 @@ const logAccessibilityViolations = (violations: Array<Result>) => {
   cy.task('table', violationsData)
 }
 
-Cypress.Commands.add('checkAccessibility', () => {
+Cypress.Commands.add('checkAccessibility', (rules: AxeRules = undefined) => {
   cy.injectAxe()
   cy.configureAxe({ rules: [{ enabled: false, id: 'region', selector: '.govuk-phase-banner' }] })
-  cy.checkA11y(undefined, undefined, logAccessibilityViolations)
+  cy.checkA11y(undefined, { rules }, logAccessibilityViolations)
 })

--- a/integration_tests/tsconfig.json
+++ b/integration_tests/tsconfig.json
@@ -7,6 +7,7 @@
     "types": ["cypress", "cypress-axe", "express", "express-session"],
     "esModuleInterop": true,
     "paths": {
+      "@accredited-programmes/integration-tests": ["./@types/index.d.ts"],
       "@accredited-programmes/models": ["../server/@types/models/index.d.ts"],
       "@accredited-programmes/ui": ["../server/@types/ui/index.d.ts"],
       "@govuk-frontend": ["../server/@types/govukFrontend/index.d.ts"],


### PR DESCRIPTION
## Context

Now we plan to use conditional radio buttons from govuk-frontend, we were getting an accessibility error which were preventing the tests from passing.


## Changes in this PR

Updated the cypress `checkAccessibility` command to accept some rules, which we can then use on a page by page basis.
 
For example in page which has conditional radio buttons we can do:
`super('Add Accredited Programme history', { accessibilityRules: { 'aria-allowed-attr': { enabled: false } } })`

## Release checklist

[Release process documentation](../doc/how-to/perform-a-release.md)

As part of our continuous deployment strategy we must ensure that this work is
ready to be released once merged.

### Pre-merge

- [ ] There are changes required to the Accredited Programmes API for this change to work...
  - [ ] ... and they have been released to production already

### Post-merge

<!-- The outer checkboxes can be completed pre-merge -->

- [ ] This adds, extends or meaningfully modifies a feature...
  - [ ] ... and I have written or updated an end-to-end test for the happy path in the [Accredited Programmes E2E repo](https://github.com/ministryofjustice/hmpps-accredited-programmes-e2e)
- [ ] This makes new expectations of the API...
  - [ ] ... and I have notified the API developer(s) of changes to the contract tests (Pact), or the API is already compliant
- [ ] [Manually approve](../doc/how-to/perform-a-release.md#releasing-to-the-preprod-environment) release to preprod
- [ ] [Manually approve](../doc/how-to/perform-a-release.md#releasing-to-the-production-environment) release to prod

<!-- Should a release fail at any step, you as the author should now lead the work to
fix it as soon as possible. You can monitor deployment failures in CircleCI
itself and application errors are found in
[Sentry](https://ministryofjustice.sentry.io/projects/hmpps-accredited-programmes-ui/?project=4505330122686464&referrer=sidebar&statsPeriod=24h). -->
