### PR TITLE
(814b) Switch endpoint for fetching user's caseloads

### DIFF
--- a/server/data/caseloadClient.test.ts
+++ b/server/data/caseloadClient.test.ts
@@ -26,17 +26,16 @@ describe('caseloadClient', () => {
     nock.cleanAll()
   })
 
-  describe('findAll', () => {
-    const staffId = '123123'
+  describe('allByCurrentUser', () => {
     const caseloads: Array<Caseload> = [caseloadFactory.active().build(), caseloadFactory.inactive().build()]
 
-    it('fetches all Caseloads for the given staff ID', async () => {
+    it('fetches all Caseloads for the logged in user', async () => {
       fakePrisonApi
-        .get(prisonApiPaths.staff.caseloads.index({ staffId }))
+        .get(prisonApiPaths.users.current.caseloads({}))
         .matchHeader('authorization', `Bearer ${token}`)
         .reply(200, caseloads)
 
-      const output = await caseloadClient.findAll(staffId)
+      const output = await caseloadClient.allByCurrentUser()
       expect(output).toEqual(caseloads)
     })
   })

--- a/server/data/caseloadClient.ts
+++ b/server/data/caseloadClient.ts
@@ -11,9 +11,9 @@ export default class CaseloadClient {
     this.restClient = new RestClient('caseloadClient', config.apis.prisonApi as ApiConfig, token)
   }
 
-  async findAll(staffId: string): Promise<Array<Caseload>> {
+  async allByCurrentUser(): Promise<Array<Caseload>> {
     return (await this.restClient.get({
-      path: prisonApiPaths.staff.caseloads.index({ staffId }),
+      path: prisonApiPaths.users.current.caseloads({}),
     })) as Array<Caseload>
   }
 }

--- a/server/paths/prisonApi.ts
+++ b/server/paths/prisonApi.ts
@@ -1,11 +1,11 @@
 import { path } from 'static-path'
 
-const caseloadsPath = path('/api/staff/:staffId/caseloads')
+const caseloadsPath = path('/api/users/me/caseLoads')
 
 export default {
-  staff: {
-    caseloads: {
-      index: caseloadsPath,
+  users: {
+    current: {
+      caseloads: caseloadsPath,
     },
   },
 }


### PR DESCRIPTION
## Context
<!-- Is there a Trello ticket you can link to? -->
<!-- Do you need to add any environment variables? -->
<!-- Is an ADR required? An ADR should be added if this PR introduces a change to the architecture. -->

The previous endpoint (`/api/staff/:staffId/caseloads`) wouldn't return any caseloads for admin users (e.g. my own). It also meant we had to do a slightly roundabout journey reading the logged-in-user's staffID.

## Changes in this PR

Switches to using the (apparently case-sensitive) `/api/users/me/caseLoads` endpoint and passing the logged-in user's token. This seems to allow us to fetch caseloads even if the user is an admin.

We'll be passing these caseloads to the request to the Prisoner Offender Search for a prisoner to ensure we're only searching by the logged in user's caseloads.

## Release checklist

[Release process documentation](../doc/how-to/perform-a-release.md)

As part of our continuous deployment strategy we must ensure that this work is
ready to be released once merged.

### Pre-merge

- [ ] There are changes required to the Accredited Programmes API for this change to work...
  - [ ] ... and they have been released to production already

### Post-merge

<!-- The outer checkboxes can be completed pre-merge -->

- [ ] This adds, extends or meaningfully modifies a feature...
  - [ ] ... and I have written or updated an end-to-end test for the happy path in the [Accredited Programmes E2E repo](https://github.com/ministryofjustice/hmpps-accredited-programmes-e2e)
- [ ] This makes new expectations of the API...
  - [ ] ... and I have notified the API developer(s) of changes to the contract tests (Pact), or the API is already compliant
- [ ] [Manually approve](../doc/how-to/perform-a-release.md#releasing-to-the-preprod-environment) release to preprod
- [ ] [Manually approve](../doc/how-to/perform-a-release.md#releasing-to-the-production-environment) release to prod

<!-- Should a release fail at any step, you as the author should now lead the work to
fix it as soon as possible. You can monitor deployment failures in CircleCI
itself and application errors are found in
[Sentry](https://ministryofjustice.sentry.io/projects/hmpps-accredited-programmes-ui/?project=4505330122686464&referrer=sidebar&statsPeriod=24h). -->
