### PR TITLE
Specify `yearStarted` to prevent intermittent test failure

### DIFF
--- a/server/utils/courseParticipationUtils.test.ts
+++ b/server/utils/courseParticipationUtils.test.ts
@@ -20,6 +20,7 @@ describe('CourseParticipationUtils', () => {
           detail: 'Motivation level over 9000!',
           status: 'complete',
           yearCompleted: 2019,
+          yearStarted: undefined,
         },
         setting: {
           location: 'Greater Tharfoot',


### PR DESCRIPTION
## Context

This test was sometimes failing because the course participation related factories randomly provide a `yearStarted` in `outcome` if not specified in `build`.



## Changes in this PR
Provide a `yearStarted` value to problematic test.  


## Screenshots of UI changes

### Before
![image](https://github.com/ministryofjustice/hmpps-accredited-programmes-ui/assets/1067537/8028f235-33c7-4f2f-ac1a-c47ff8ccb688)


### After


## Release checklist

[Release process documentation](../doc/how-to/perform-a-release.md)

As part of our continuous deployment strategy we must ensure that this work is
ready to be released once merged.

### Pre-merge

- [ ] There are changes required to the Accredited Programmes API for this change to work...
  - [ ] ... and they have been released to production already

### Post-merge

<!-- The outer checkboxes can be completed pre-merge -->

- [ ] This adds, extends or meaningfully modifies a feature...
  - [ ] ... and I have written or updated an end-to-end test for the happy path in the [Accredited Programmes E2E repo](https://github.com/ministryofjustice/hmpps-accredited-programmes-e2e)
- [ ] This makes new expectations of the API...
  - [ ] ... and I have notified the API developer(s) of changes to the contract tests (Pact), or the API is already compliant
- [ ] [Manually approve](../doc/how-to/perform-a-release.md#releasing-to-the-preprod-environment) release to preprod
- [ ] [Manually approve](../doc/how-to/perform-a-release.md#releasing-to-the-production-environment) release to prod

<!-- Should a release fail at any step, you as the author should now lead the work to
fix it as soon as possible. You can monitor deployment failures in CircleCI
itself and application errors are found in
[Sentry](https://ministryofjustice.sentry.io/projects/hmpps-accredited-programmes-ui/?project=4505330122686464&referrer=sidebar&statsPeriod=24h). -->
