### PR TITLE
(851a) Update course client and service for finding and updating course participations 

### DIFF
--- a/server/@types/models/CourseParticipation.ts
+++ b/server/@types/models/CourseParticipation.ts
@@ -25,8 +25,22 @@ type CourseParticipation = {
   source?: string
 }
 
+type CourseParticipationUpdate = {
+  outcome: CourseParticipationOutcome
+  setting: CourseParticipationSetting
+  courseId?: CourseParticipation['courseId']
+  otherCourseName?: CourseParticipation['otherCourseName']
+  source?: CourseParticipation['source']
+}
+
 type CourseParticipationWithName = CourseParticipation & {
   name: string
 }
 
-export type { CourseParticipation, CourseParticipationOutcome, CourseParticipationSetting, CourseParticipationWithName }
+export type {
+  CourseParticipation,
+  CourseParticipationOutcome,
+  CourseParticipationSetting,
+  CourseParticipationUpdate,
+  CourseParticipationWithName,
+}

--- a/server/@types/models/index.d.ts
+++ b/server/@types/models/index.d.ts
@@ -5,6 +5,7 @@ import type {
   CourseParticipation,
   CourseParticipationOutcome,
   CourseParticipationSetting,
+  CourseParticipationUpdate,
   CourseParticipationWithName,
 } from './CourseParticipation'
 import type { CoursePrerequisite } from './CoursePrerequisite'
@@ -20,6 +21,7 @@ export type {
   CourseParticipation,
   CourseParticipationOutcome,
   CourseParticipationSetting,
+  CourseParticipationUpdate,
   CourseParticipationWithName,
   CoursePrerequisite,
   CreatedReferralResponse,

--- a/server/data/courseClient.test.ts
+++ b/server/data/courseClient.test.ts
@@ -234,6 +234,34 @@ pactWith({ consumer: 'Accredited Programmes UI', provider: 'Accredited Programme
     })
   })
 
+  describe('findParticipation', () => {
+    const courseParticipation = courseParticipations[0]
+
+    beforeEach(() => {
+      provider.addInteraction({
+        state: `A course participation exists with ID ${courseParticipation.id}`,
+        uponReceiving: `A request for course participation "${courseParticipation.id}"`,
+        willRespondWith: {
+          body: Matchers.like(courseParticipation),
+          status: 200,
+        },
+        withRequest: {
+          headers: {
+            authorization: `Bearer ${token}`,
+          },
+          method: 'GET',
+          path: apiPaths.participations.show({ courseParticipationId: courseParticipation.id }),
+        },
+      })
+    })
+
+    it('fetches the given course participation', async () => {
+      const result = await courseClient.findParticipation(courseParticipation.id)
+
+      expect(result).toEqual(courseParticipations[0])
+    })
+  })
+
   describe('findParticipationsByPerson', () => {
     beforeEach(() => {
       provider.addInteraction({

--- a/server/data/courseClient.test.ts
+++ b/server/data/courseClient.test.ts
@@ -5,7 +5,7 @@ import CourseClient from './courseClient'
 import config from '../config'
 import { apiPaths } from '../paths'
 import { courseFactory, courseOfferingFactory, courseParticipationFactory, personFactory } from '../testutils/factories'
-import type { CourseParticipation } from '@accredited-programmes/models'
+import type { CourseParticipation, CourseParticipationUpdate } from '@accredited-programmes/models'
 
 pactWith({ consumer: 'Accredited Programmes UI', provider: 'Accredited Programmes API' }, provider => {
   let courseClient: CourseClient
@@ -257,6 +257,48 @@ pactWith({ consumer: 'Accredited Programmes UI', provider: 'Accredited Programme
       const result = await courseClient.findParticipationsByPerson(person.prisonNumber)
 
       expect(result).toEqual(courseParticipations)
+    })
+  })
+
+  describe('updateParticipation', () => {
+    const courseId = 'course-id'
+    const courseParticipation = courseParticipationFactory.withCourseId().build({ courseId })
+    const courseParticipationUpdate: CourseParticipationUpdate = {
+      courseId,
+      outcome: {
+        status: 'complete',
+        yearCompleted: 2023,
+      },
+      setting: {
+        location: 'somewhere',
+        type: 'community',
+      },
+      source: 'somewhere',
+    }
+
+    beforeEach(() => {
+      provider.addInteraction({
+        state: `A course participation exists with ID ${courseParticipation.id}`,
+        uponReceiving: `A request to update course participation "${courseParticipation.id}"`,
+        willRespondWith: {
+          body: Matchers.like(courseParticipation),
+          status: 200,
+        },
+        withRequest: {
+          body: courseParticipationUpdate,
+          headers: {
+            authorization: `Bearer ${token}`,
+          },
+          method: 'PUT',
+          path: apiPaths.participations.update({ courseParticipationId: courseParticipation.id }),
+        },
+      })
+    })
+
+    it('updates the given course participation', async () => {
+      const result = await courseClient.updateParticipation(courseParticipation.id, courseParticipationUpdate)
+
+      expect(result).toEqual(courseParticipation)
     })
   })
 })

--- a/server/data/courseClient.ts
+++ b/server/data/courseClient.ts
@@ -54,6 +54,12 @@ export default class CourseClient {
     })) as Array<CourseOffering>
   }
 
+  async findParticipation(courseParticipationId: CourseParticipation['id']): Promise<CourseParticipation> {
+    return (await this.restClient.get({
+      path: apiPaths.participations.show({ courseParticipationId }),
+    })) as CourseParticipation
+  }
+
   async findParticipationsByPerson(prisonNumber: Person['prisonNumber']): Promise<Array<CourseParticipation>> {
     return (await this.restClient.get({
       path: apiPaths.people.participations({ prisonNumber }),

--- a/server/data/courseClient.ts
+++ b/server/data/courseClient.ts
@@ -2,7 +2,13 @@ import RestClient from './restClient'
 import type { ApiConfig } from '../config'
 import config from '../config'
 import { apiPaths } from '../paths'
-import type { Course, CourseOffering, CourseParticipation, Person } from '@accredited-programmes/models'
+import type {
+  Course,
+  CourseOffering,
+  CourseParticipation,
+  CourseParticipationUpdate,
+  Person,
+} from '@accredited-programmes/models'
 
 export default class CourseClient {
   restClient: RestClient
@@ -52,5 +58,15 @@ export default class CourseClient {
     return (await this.restClient.get({
       path: apiPaths.people.participations({ prisonNumber }),
     })) as Array<CourseParticipation>
+  }
+
+  async updateParticipation(
+    courseParticipationId: CourseParticipation['id'],
+    courseParticipationUpdate: CourseParticipationUpdate,
+  ): Promise<CourseParticipation> {
+    return (await this.restClient.put({
+      data: courseParticipationUpdate,
+      path: apiPaths.participations.update({ courseParticipationId }),
+    })) as CourseParticipation
   }
 }

--- a/server/services/courseService.test.ts
+++ b/server/services/courseService.test.ts
@@ -3,6 +3,7 @@ import { when } from 'jest-when'
 import CourseService from './courseService'
 import { CourseClient } from '../data'
 import { courseFactory, courseOfferingFactory, courseParticipationFactory, personFactory } from '../testutils/factories'
+import type { CourseParticipationUpdate } from '@accredited-programmes/models'
 
 jest.mock('../data/courseClient')
 
@@ -164,6 +165,36 @@ describe('CourseService', () => {
         expect(courseClientBuilder).toHaveBeenCalledWith(token)
         expect(courseClient.findParticipationsByPerson).toHaveBeenCalledWith(person.prisonNumber)
       })
+    })
+  })
+
+  describe('updateParticipation', () => {
+    it('asks the client to update a course participation', async () => {
+      const courseId = 'course-id'
+      const courseParticipation = courseParticipationFactory.withCourseId().build({ courseId })
+      const courseParticipationUpdate: CourseParticipationUpdate = {
+        courseId,
+        outcome: {
+          status: 'complete',
+          yearCompleted: 2023,
+        },
+        setting: {
+          location: 'somewhere',
+          type: 'community',
+        },
+        source: 'somewhere',
+      }
+
+      when(courseClient.updateParticipation)
+        .calledWith(courseParticipation.id, courseParticipationUpdate)
+        .mockResolvedValue(courseParticipation)
+
+      const result = await service.updateParticipation(token, courseParticipation.id, courseParticipationUpdate)
+
+      expect(result).toEqual(courseParticipation)
+
+      expect(courseClientBuilder).toHaveBeenCalledWith(token)
+      expect(courseClient.updateParticipation).toHaveBeenCalledWith(courseParticipation.id, courseParticipationUpdate)
     })
   })
 })

--- a/server/services/courseService.ts
+++ b/server/services/courseService.ts
@@ -1,5 +1,11 @@
 import type { CourseClient, RestClientBuilder } from '../data'
-import type { Course, CourseOffering, CourseParticipation, Person } from '@accredited-programmes/models'
+import type {
+  Course,
+  CourseOffering,
+  CourseParticipation,
+  CourseParticipationUpdate,
+  Person,
+} from '@accredited-programmes/models'
 
 export default class CourseService {
   constructor(private readonly courseClientBuilder: RestClientBuilder<CourseClient>) {}
@@ -45,5 +51,14 @@ export default class CourseService {
   ): Promise<Array<CourseParticipation>> {
     const courseClient = this.courseClientBuilder(token)
     return courseClient.findParticipationsByPerson(prisonNumber)
+  }
+
+  async updateParticipation(
+    token: Express.User['token'],
+    courseParticipationId: CourseParticipation['id'],
+    courseParticipationUpdate: CourseParticipationUpdate,
+  ): Promise<CourseParticipation> {
+    const courseClient = this.courseClientBuilder(token)
+    return courseClient.updateParticipation(courseParticipationId, courseParticipationUpdate)
   }
 }


### PR DESCRIPTION
## Context

https://trello.com/c/oMnAOOLO/851-add-page-for-entering-course-details-ui-m

For the course participation details page we need to make a couple of calls.  One to get the participation and check it exists and then another to update when the form has been filled in.

## Changes in this PR

- Add `CourseParticipationUpdate` type. 
- Add `findParticipation` and `updateParticipation` to `CourseClient`
- Add `getParticipation` and `updateParticipation` to `CourseService`



## Release checklist

[Release process documentation](../doc/how-to/perform-a-release.md)

As part of our continuous deployment strategy we must ensure that this work is
ready to be released once merged.

### Pre-merge

- [ ] There are changes required to the Accredited Programmes API for this change to work...
  - [ ] ... and they have been released to production already

### Post-merge

<!-- The outer checkboxes can be completed pre-merge -->

- [ ] This adds, extends or meaningfully modifies a feature...
  - [ ] ... and I have written or updated an end-to-end test for the happy path in the [Accredited Programmes E2E repo](https://github.com/ministryofjustice/hmpps-accredited-programmes-e2e)
- [ ] This makes new expectations of the API...
  - [ ] ... and I have notified the API developer(s) of changes to the contract tests (Pact), or the API is already compliant
- [ ] [Manually approve](../doc/how-to/perform-a-release.md#releasing-to-the-preprod-environment) release to preprod
- [ ] [Manually approve](../doc/how-to/perform-a-release.md#releasing-to-the-production-environment) release to prod

<!-- Should a release fail at any step, you as the author should now lead the work to
fix it as soon as possible. You can monitor deployment failures in CircleCI
itself and application errors are found in
[Sentry](https://ministryofjustice.sentry.io/projects/hmpps-accredited-programmes-ui/?project=4505330122686464&referrer=sidebar&statsPeriod=24h). -->
