### PR TITLE
(814d) Use Prisoner Offender Search `match-prisoners`endpoint

### DIFF
--- a/integration_tests/e2e/refer.cy.ts
+++ b/integration_tests/e2e/refer.cy.ts
@@ -119,6 +119,7 @@ context('Refer', () => {
       })
 
       it('displays an error when the person cannot be found', () => {
+        cy.task('stubPrisoner', undefined)
         const fakeId = 'NOT-A-REAL-ID'
 
         const findPersonPage = Page.verifyOnPage(FindPersonPage)

--- a/integration_tests/mockApis/caseloads.ts
+++ b/integration_tests/mockApis/caseloads.ts
@@ -27,9 +27,7 @@ export default {
       },
       response: {
         headers: { 'Content-Type': 'application/json;charset=UTF-8' },
-        jsonBody: {
-          caseloads: defaultCaseloads,
-        },
+        jsonBody: defaultCaseloads,
         status: 200,
       },
     }),

--- a/integration_tests/mockApis/prisoners.ts
+++ b/integration_tests/mockApis/prisoners.ts
@@ -5,15 +5,23 @@ import { stubFor } from '../../wiremock'
 import type { Prisoner } from '@prisoner-offender-search'
 
 export default {
-  stubPrisoner: (prisoner: Prisoner): SuperAgentRequest =>
+  stubPrisoner: (prisoner: Prisoner | undefined): SuperAgentRequest =>
     stubFor({
       request: {
-        method: 'GET',
-        url: prisonerOffenderSearchPaths.prisoner.show({ prisonNumber: prisoner.prisonerNumber }),
+        bodyPatterns: [
+          {
+            equalToJson: {
+              prisonerIdentifier: prisoner?.prisonerNumber,
+            },
+            ignoreExtraElements: true,
+          },
+        ],
+        method: 'POST',
+        url: prisonerOffenderSearchPaths.prisoner.search({}),
       },
       response: {
         headers: { 'Content-Type': 'application/json;charset=UTF-8' },
-        jsonBody: prisoner,
+        jsonBody: prisoner ? [prisoner] : [],
         status: 200,
       },
     }),

--- a/server/controllers/refer/courseParticipationsController.test.ts
+++ b/server/controllers/refer/courseParticipationsController.test.ts
@@ -7,6 +7,7 @@ import CourseParticipationsController from './courseParticipationsController'
 import { referPaths } from '../../paths'
 import type { CourseService, PersonService, ReferralService } from '../../services'
 import { courseFactory, courseParticipationFactory, personFactory, referralFactory } from '../../testutils/factories'
+import Helpers from '../../testutils/helpers'
 import { CourseParticipationUtils, CourseUtils, FormUtils } from '../../utils'
 
 jest.mock('../../utils/formUtils')
@@ -25,7 +26,7 @@ describe('CourseParticipationsController', () => {
 
   beforeEach(() => {
     request = createMock<Request>({ user: { token } })
-    response = createMock<Response>({})
+    response = Helpers.createMockResponseWithCaseloads()
     courseParticipationsController = new CourseParticipationsController(courseService, personService, referralService)
   })
 

--- a/server/controllers/refer/courseParticipationsController.ts
+++ b/server/controllers/refer/courseParticipationsController.ts
@@ -53,7 +53,11 @@ export default class CourseParticipationsController {
       TypeUtils.assertHasUser(req)
 
       const referral = await this.referralService.getReferral(req.user.token, req.params.referralId)
-      const person = await this.personService.getPerson(req.user.token, referral.prisonNumber)
+      const person = await this.personService.getPerson(
+        req.user.username,
+        referral.prisonNumber,
+        res.locals.user.caseloads,
+      )
 
       if (!person) {
         throw createError(404, {
@@ -88,7 +92,11 @@ export default class CourseParticipationsController {
 
       const courses = await this.courseService.getCourses(req.user.token)
       const referral = await this.referralService.getReferral(req.user.token, req.params.referralId)
-      const person = await this.personService.getPerson(req.user.username, referral.prisonNumber)
+      const person = await this.personService.getPerson(
+        req.user.username,
+        referral.prisonNumber,
+        res.locals.user.caseloads,
+      )
 
       if (!person) {
         throw createError(404, `Person with prison number ${referral.prisonNumber} not found.`)

--- a/server/controllers/refer/oasysConfirmationController.test.ts
+++ b/server/controllers/refer/oasysConfirmationController.test.ts
@@ -7,6 +7,7 @@ import OasysConfirmationController from './oasysConfirmationController'
 import { referPaths } from '../../paths'
 import type { PersonService, ReferralService } from '../../services'
 import { courseOfferingFactory, personFactory, referralFactory } from '../../testutils/factories'
+import Helpers from '../../testutils/helpers'
 import { FormUtils } from '../../utils'
 
 jest.mock('../../utils/formUtils')
@@ -26,7 +27,7 @@ describe('OasysConfirmationController', () => {
 
   beforeEach(() => {
     request = createMock<Request>({ user: { token } })
-    response = createMock<Response>({})
+    response = Helpers.createMockResponseWithCaseloads()
     oasysConfirmationController = new OasysConfirmationController(personService, referralService)
   })
 

--- a/server/controllers/refer/oasysConfirmationController.ts
+++ b/server/controllers/refer/oasysConfirmationController.ts
@@ -17,7 +17,11 @@ export default class OasysConfirmationController {
       TypeUtils.assertHasUser(req)
 
       const referral = await this.referralService.getReferral(req.user.token, req.params.referralId)
-      const person = await this.personService.getPerson(req.user.username, referral.prisonNumber)
+      const person = await this.personService.getPerson(
+        req.user.username,
+        referral.prisonNumber,
+        res.locals.user.caseloads,
+      )
 
       if (!person) {
         throw createError(404, {

--- a/server/controllers/refer/peopleController.test.ts
+++ b/server/controllers/refer/peopleController.test.ts
@@ -6,6 +6,7 @@ import PeopleController from './peopleController'
 import { referPaths } from '../../paths'
 import type PersonService from '../../services/personService'
 import { personFactory } from '../../testutils/factories'
+import Helpers from '../../testutils/helpers'
 import PersonUtils from '../../utils/personUtils'
 
 jest.mock('../../utils/personUtils')
@@ -22,7 +23,7 @@ describe('PeopleController', () => {
 
   beforeEach(() => {
     request = createMock<Request>({ user: { token } })
-    response = createMock<Response>({})
+    response = Helpers.createMockResponseWithCaseloads()
     peopleController = new PeopleController(personService)
   })
 

--- a/server/controllers/refer/peopleController.ts
+++ b/server/controllers/refer/peopleController.ts
@@ -28,7 +28,11 @@ export default class PeopleController {
       TypeUtils.assertHasUser(req)
 
       const { courseOfferingId } = req.params
-      const person = await this.personService.getPerson(req.user.username, req.params.prisonNumber)
+      const person = await this.personService.getPerson(
+        req.user.username,
+        req.params.prisonNumber,
+        res.locals.user.caseloads,
+      )
 
       if (!person) {
         req.flash('prisonNumberError', `No person with a prison number '${req.params.prisonNumber}' was found`)

--- a/server/controllers/refer/reasonController.test.ts
+++ b/server/controllers/refer/reasonController.test.ts
@@ -7,6 +7,7 @@ import ReasonController from './reasonController'
 import { referPaths } from '../../paths'
 import type { PersonService, ReferralService } from '../../services'
 import { courseOfferingFactory, personFactory, referralFactory } from '../../testutils/factories'
+import Helpers from '../../testutils/helpers'
 import { FormUtils } from '../../utils'
 
 jest.mock('../../utils/formUtils')
@@ -27,7 +28,7 @@ describe('ReasonController', () => {
 
   beforeEach(() => {
     request = createMock<Request>({ user: { token } })
-    response = createMock<Response>({})
+    response = Helpers.createMockResponseWithCaseloads()
     reasonController = new ReasonController(personService, referralService)
   })
 

--- a/server/controllers/refer/reasonController.ts
+++ b/server/controllers/refer/reasonController.ts
@@ -17,7 +17,11 @@ export default class ReasonController {
       TypeUtils.assertHasUser(req)
 
       const referral = await this.referralService.getReferral(req.user.token, req.params.referralId)
-      const person = await this.personService.getPerson(req.user.username, referral.prisonNumber)
+      const person = await this.personService.getPerson(
+        req.user.username,
+        referral.prisonNumber,
+        res.locals.user.caseloads,
+      )
 
       if (!person) {
         throw createError(404, `Person with prison number ${referral.prisonNumber} not found.`)

--- a/server/controllers/refer/referralsController.test.ts
+++ b/server/controllers/refer/referralsController.test.ts
@@ -14,6 +14,7 @@ import {
   personFactory,
   referralFactory,
 } from '../../testutils/factories'
+import Helpers from '../../testutils/helpers'
 import { CourseUtils, FormUtils, PersonUtils, ReferralUtils, TypeUtils } from '../../utils'
 import type { CoursePresenter } from '@accredited-programmes/ui'
 
@@ -39,7 +40,7 @@ describe('ReferralsController', () => {
 
   beforeEach(() => {
     request = createMock<Request>({ user: { token } })
-    response = createMock<Response>({})
+    response = Helpers.createMockResponseWithCaseloads()
     referralsController = new ReferralsController(courseService, organisationService, personService, referralService)
     courseService.getCourseByOffering.mockResolvedValue(course)
     courseService.getOffering.mockResolvedValue(courseOffering)

--- a/server/controllers/refer/referralsController.ts
+++ b/server/controllers/refer/referralsController.ts
@@ -27,7 +27,11 @@ export default class ReferralsController {
         return res.redirect(referPaths.show({ referralId: referral.id }))
       }
 
-      const person = await this.personService.getPerson(req.user.username, referral.prisonNumber)
+      const person = await this.personService.getPerson(
+        req.user.username,
+        referral.prisonNumber,
+        res.locals.user.caseloads,
+      )
 
       if (!person) {
         throw createError(404, {
@@ -128,7 +132,11 @@ export default class ReferralsController {
       const course = await this.courseService.getCourseByOffering(req.user.token, referral.offeringId)
       const courseOffering = await this.courseService.getOffering(req.user.token, referral.offeringId)
       const organisation = await this.organisationService.getOrganisation(req.user.token, courseOffering.organisationId)
-      const person = await this.personService.getPerson(req.user.username, referral.prisonNumber)
+      const person = await this.personService.getPerson(
+        req.user.username,
+        referral.prisonNumber,
+        res.locals.user.caseloads,
+      )
 
       if (!organisation) {
         throw createError(404, {
@@ -159,7 +167,11 @@ export default class ReferralsController {
       TypeUtils.assertHasUser(req)
 
       const referral = await this.referralService.getReferral(req.user.token, req.params.referralId)
-      const person = await this.personService.getPerson(req.user.username, referral.prisonNumber)
+      const person = await this.personService.getPerson(
+        req.user.username,
+        referral.prisonNumber,
+        res.locals.user.caseloads,
+      )
 
       if (!person) {
         throw createError(404, {

--- a/server/data/prisonerClient.test.ts
+++ b/server/data/prisonerClient.test.ts
@@ -29,14 +29,26 @@ describe('PrisonerClient', () => {
   describe('find', () => {
     const prisoner: Prisoner = prisonerFactory.build()
 
-    it('fetches the given prisoner', async () => {
+    it('searches for a prisoner by prison number and caseload IDs and returns the first match on the assumption that there will never be multiple matches', async () => {
       fakePrisonerOffenderSearch
-        .get(prisonerOffenderSearchPaths.prisoner.show({ prisonNumber: prisoner.prisonerNumber }))
+        .post(prisonerOffenderSearchPaths.prisoner.search({}))
         .matchHeader('authorization', `Bearer ${token}`)
-        .reply(200, prisoner)
+        .reply(200, [prisoner])
 
-      const output = await prisonerClient.find(prisoner.prisonerNumber)
+      const output = await prisonerClient.find(prisoner.prisonerNumber, ['BXI', 'MDI'])
       expect(output).toEqual(prisoner)
+    })
+
+    describe('when no prisoner is found', () => {
+      it('returns null', async () => {
+        fakePrisonerOffenderSearch
+          .post(prisonerOffenderSearchPaths.prisoner.search({}))
+          .matchHeader('authorization', `Bearer ${token}`)
+          .reply(200, [])
+
+        const output = await prisonerClient.find(prisoner.prisonerNumber, ['BXI', 'MDI'])
+        expect(output).toEqual(null)
+      })
     })
   })
 })

--- a/server/data/prisonerClient.ts
+++ b/server/data/prisonerClient.ts
@@ -2,6 +2,7 @@ import RestClient from './restClient'
 import type { ApiConfig } from '../config'
 import config from '../config'
 import { prisonerOffenderSearchPaths } from '../paths'
+import type { Caseload } from '@prison-api'
 import type { Prisoner } from '@prisoner-offender-search'
 
 export default class PrisonerClient {
@@ -11,9 +12,21 @@ export default class PrisonerClient {
     this.restClient = new RestClient('prisonerClient', config.apis.prisonerOffenderSearch as ApiConfig, token)
   }
 
-  async find(prisonNumber: string): Promise<Prisoner> {
-    return (await this.restClient.get({
-      path: prisonerOffenderSearchPaths.prisoner.show({ prisonNumber }),
-    })) as Prisoner
+  async find(
+    prisonNumber: Prisoner['prisonerNumber'],
+    caseloadIds: Array<Caseload['caseLoadId']>,
+  ): Promise<Prisoner | null> {
+    const prisoners: Array<Prisoner> = (await this.restClient.post({
+      data: {
+        prisonIds: caseloadIds,
+        prisonerIdentifier: prisonNumber,
+      },
+      path: prisonerOffenderSearchPaths.prisoner.search({}),
+    })) as Array<Prisoner>
+
+    if (!prisoners.length) {
+      return null
+    }
+    return prisoners[0]
   }
 }

--- a/server/paths/prisonerOffenderSearch.ts
+++ b/server/paths/prisonerOffenderSearch.ts
@@ -1,9 +1,9 @@
 import { path } from 'static-path'
 
-const prisonerPath = path('/prisoner/:prisonNumber')
+const prisonerSearchPath = path('/prisoner-search/match-prisoners')
 
 export default {
   prisoner: {
-    show: prisonerPath,
+    search: prisonerSearchPath,
   },
 }

--- a/server/services/personService.ts
+++ b/server/services/personService.ts
@@ -4,6 +4,7 @@ import type { ResponseError } from 'superagent'
 import type { HmppsAuthClient, PrisonerClient, RestClientBuilder, RestClientBuilderWithoutToken } from '../data'
 import { PersonUtils } from '../utils'
 import type { Person } from '@accredited-programmes/models'
+import type { Caseload } from '@prison-api'
 
 export default class PersonService {
   constructor(
@@ -11,21 +12,27 @@ export default class PersonService {
     private readonly prisonerClientBuilder: RestClientBuilder<PrisonerClient>,
   ) {}
 
-  async getPerson(username: Express.User['username'], prisonNumber: string): Promise<Person | null> {
+  async getPerson(
+    username: Express.User['username'],
+    prisonNumber: Person['prisonNumber'],
+    caseloads: Array<Caseload>,
+  ): Promise<Person | null> {
     const hmppsAuthClient = this.hmppsAuthClientBuilder()
     const systemToken = await hmppsAuthClient.getSystemClientToken(username)
     const prisonerClient = this.prisonerClientBuilder(systemToken)
 
+    const caseloadIds = caseloads.map(caseload => caseload.caseLoadId)
+
     try {
-      const prisoner = await prisonerClient.find(prisonNumber)
+      const prisoner = await prisonerClient.find(prisonNumber, caseloadIds)
+
+      if (!prisoner) {
+        return null
+      }
 
       return PersonUtils.personFromPrisoner(prisoner)
     } catch (error) {
       const knownError = error as ResponseError
-
-      if (knownError.status === 404) {
-        return null
-      }
 
       throw createError(knownError.status || 500, knownError, {
         userMessage: `Error fetching prisoner ${prisonNumber}.`,

--- a/server/testutils/helpers.ts
+++ b/server/testutils/helpers.ts
@@ -1,0 +1,16 @@
+import { type DeepMocked, createMock } from '@golevelup/ts-jest'
+import type { Response } from 'express'
+
+import { caseloadFactory } from './factories'
+
+export default class Helpers {
+  static createMockResponseWithCaseloads(): DeepMocked<Response> {
+    return createMock<Response>({
+      locals: {
+        user: {
+          caseloads: [caseloadFactory.build()],
+        },
+      },
+    })
+  }
+}

--- a/wiremock/scripts/stubPrisoners.ts
+++ b/wiremock/scripts/stubPrisoners.ts
@@ -7,14 +7,15 @@ import { prisoners } from '../stubs'
 prisoners.forEach(async prisoner => {
   const response = await stubFor({
     request: {
-      method: 'GET',
-      url: prisonerOffenderSearchPaths.prisoner.show({ prisonNumber: prisoner.prisonerNumber }),
+      method: 'POST',
+      url: prisonerOffenderSearchPaths.prisoner.search({}),
     },
+
     response: {
       headers: {
         'Content-Type': 'application/json;charset=UTF-8',
       },
-      jsonBody: prisoner,
+      jsonBody: [prisoner],
       status: 200,
     },
   })


### PR DESCRIPTION
## Context

<!-- Is there a Trello ticket you can link to? -->

https://trello.com/c/PeLVF8dJ/814-ensure-referrers-cant-refer-people-outside-their-active-caseload-ui

<!-- Do you need to add any environment variables? -->
<!-- Is an ADR required? An ADR should be added if this PR introduces a change to the architecture. -->
As of #233, we have the user's caseloads stored in the `res.locals.user` variable, fetched from the Prison API.

Now that we have those, we can query the Prisoner Offender Search's `match-prisoners` endpoint with the user's prison number and the logged-in user's caseloads to only allow users to search for people in prisons that are part of their caseload to prevent them seeing any one they shouldn't.

## Changes in this PR

Switches to using the Prisoner Offender Search's POST `match-prisoners` endpoint when looking up a user to refer (as well as in the banner on each page). This has no visible changes to users, as the functionality is the same, but they'll get a "user not found" error if they try to look up a user with a prison number who is outside of their caseload.

This PR touches a lot of files, so I've broken it down into smaller commits (with failing tests) for the purposes of making it easier to review, but I'd like to squash most of them together before merging so as to not have any commits with failing tests on the `main` branch.

## Release checklist

[Release process documentation](../doc/how-to/perform-a-release.md)

As part of our continuous deployment strategy we must ensure that this work is
ready to be released once merged.

### Pre-merge

- [ ] There are changes required to the Accredited Programmes API for this change to work...
  - [ ] ... and they have been released to production already

### Post-merge

<!-- The outer checkboxes can be completed pre-merge -->

- [ ] This adds, extends or meaningfully modifies a feature...
  - [ ] ... and I have written or updated an end-to-end test for the happy path in the [Accredited Programmes E2E repo](https://github.com/ministryofjustice/hmpps-accredited-programmes-e2e)
- [ ] This makes new expectations of the API...
  - [ ] ... and I have notified the API developer(s) of changes to the contract tests (Pact), or the API is already compliant
- [ ] [Manually approve](../doc/how-to/perform-a-release.md#releasing-to-the-preprod-environment) release to preprod
- [ ] [Manually approve](../doc/how-to/perform-a-release.md#releasing-to-the-production-environment) release to prod

<!-- Should a release fail at any step, you as the author should now lead the work to
fix it as soon as possible. You can monitor deployment failures in CircleCI
itself and application errors are found in
[Sentry](https://ministryofjustice.sentry.io/projects/hmpps-accredited-programmes-ui/?project=4505330122686464&referrer=sidebar&statsPeriod=24h). -->
