### PR TITLE
Make course participation setting type optional; require setting and outcome (942/pre-856)

### DIFF
--- a/server/@types/models/CourseParticipation.ts
+++ b/server/@types/models/CourseParticipation.ts
@@ -17,11 +17,11 @@ type CourseParticipation = {
   id: string // eslint-disable-next-line @typescript-eslint/member-ordering
   addedBy: string
   createdAt: string
+  outcome: CourseParticipationOutcome
   prisonNumber: Person['prisonNumber']
+  setting: CourseParticipationSetting
   courseId?: Course['id']
   otherCourseName?: string
-  outcome?: CourseParticipationOutcome
-  setting?: CourseParticipationSetting
   source?: string
 }
 

--- a/server/@types/models/CourseParticipation.ts
+++ b/server/@types/models/CourseParticipation.ts
@@ -9,8 +9,8 @@ type CourseParticipationOutcome = {
 }
 
 type CourseParticipationSetting = {
-  type: 'community' | 'custody'
   location?: string
+  type?: 'community' | 'custody'
 }
 
 type CourseParticipation = {

--- a/server/data/courseClient.test.ts
+++ b/server/data/courseClient.test.ts
@@ -70,7 +70,9 @@ pactWith({ consumer: 'Accredited Programmes UI', provider: 'Accredited Programme
 
   describe('createParticipation', () => {
     describe('when `courseId` is provided', () => {
-      const courseParticipation = courseParticipationFactory.withCourseId().build()
+      const courseParticipation = courseParticipationFactory.withCourseId().build() as CourseParticipation & {
+        courseId: string
+      }
       const { courseId, prisonNumber } = courseParticipation
 
       beforeEach(() => {
@@ -82,7 +84,7 @@ pactWith({ consumer: 'Accredited Programmes UI', provider: 'Accredited Programme
             status: 201,
           },
           withRequest: {
-            body: { courseId, prisonNumber } as CourseParticipation & { courseId: string },
+            body: { courseId, prisonNumber },
             headers: {
               authorization: `Bearer ${token}`,
             },
@@ -100,7 +102,9 @@ pactWith({ consumer: 'Accredited Programmes UI', provider: 'Accredited Programme
     })
 
     describe('when `otherCourseName` is provided and `courseId` is not', () => {
-      const courseParticipation = courseParticipationFactory.withOtherCourseName().build()
+      const courseParticipation = courseParticipationFactory.withOtherCourseName().build() as CourseParticipation & {
+        otherCourseName: string
+      }
       const { otherCourseName, prisonNumber } = courseParticipation
 
       beforeEach(() => {
@@ -112,7 +116,7 @@ pactWith({ consumer: 'Accredited Programmes UI', provider: 'Accredited Programme
             status: 201,
           },
           withRequest: {
-            body: { otherCourseName, prisonNumber } as CourseParticipation & { otherCourseName: string },
+            body: { otherCourseName, prisonNumber },
             headers: {
               authorization: `Bearer ${token}`,
             },

--- a/server/data/courseClient.test.ts
+++ b/server/data/courseClient.test.ts
@@ -84,7 +84,7 @@ pactWith({ consumer: 'Accredited Programmes UI', provider: 'Accredited Programme
             status: 201,
           },
           withRequest: {
-            body: { courseId, prisonNumber },
+            body: { courseId, outcome: {}, prisonNumber, setting: {} },
             headers: {
               authorization: `Bearer ${token}`,
             },
@@ -116,7 +116,7 @@ pactWith({ consumer: 'Accredited Programmes UI', provider: 'Accredited Programme
             status: 201,
           },
           withRequest: {
-            body: { otherCourseName, prisonNumber },
+            body: { otherCourseName, outcome: {}, prisonNumber, setting: {} },
             headers: {
               authorization: `Bearer ${token}`,
             },

--- a/server/data/courseClient.ts
+++ b/server/data/courseClient.ts
@@ -27,7 +27,7 @@ export default class CourseClient {
     otherCourseName?: CourseParticipation['otherCourseName'],
   ): Promise<CourseParticipation> {
     return (await this.restClient.post({
-      data: { courseId, otherCourseName, prisonNumber },
+      data: { courseId, otherCourseName, outcome: {}, prisonNumber, setting: {} },
       path: apiPaths.participations.create({}),
     })) as CourseParticipation
   }

--- a/server/testutils/factories/courseParticipation.ts
+++ b/server/testutils/factories/courseParticipation.ts
@@ -15,9 +15,9 @@ const courseParticipationTypes = {
       courseId: undefined,
       createdAt: `${faker.date.between({ from: '2023-09-20T00:00:00.000Z', to: new Date() })}`,
       otherCourseName: undefined,
-      outcome: FactoryHelpers.optionalArrayElement(courseParticipationOutcomeFactory.build()),
+      outcome: courseParticipationOutcomeFactory.build(),
       prisonNumber: faker.string.alphanumeric({ length: 7 }),
-      setting: FactoryHelpers.optionalArrayElement(courseParticipationSettingFactory.build()),
+      setting: courseParticipationSettingFactory.build(),
       source: FactoryHelpers.optionalArrayElement(faker.word.words()),
     }
   },

--- a/server/utils/courseParticipationUtils.test.ts
+++ b/server/utils/courseParticipationUtils.test.ts
@@ -83,6 +83,18 @@ describe('CourseParticipationUtils', () => {
         expect(fieldRow).toBeUndefined()
       })
 
+      it('only shows the location in the Setting row when setting location is undefined', () => {
+        const withoutSettingType = {
+          ...courseParticipationWithName,
+          setting: { location: 'Stockport', type: undefined },
+        }
+
+        const { rows } = CourseParticipationUtils.summaryListOptions(withoutSettingType)
+        const settingRow = getRow(rows, 'Setting')
+
+        expect(settingRow).toEqual({ key: { text: 'Setting' }, value: { text: 'Stockport' } })
+      })
+
       it('only shows the type in the Setting row when setting location is undefined', () => {
         const withoutSettingLocation = {
           ...courseParticipationWithName,

--- a/server/utils/courseParticipationUtils.ts
+++ b/server/utils/courseParticipationUtils.ts
@@ -31,22 +31,30 @@ export default class CourseParticipationUtils {
     })
 
     if (courseParticipationWithName.setting) {
-      let valueText = StringUtils.properCase(courseParticipationWithName.setting.type)
+      const valueTextItems: Array<string> = []
 
-      if (courseParticipationWithName.setting.location) {
-        valueText += `, ${courseParticipationWithName.setting.location}`
+      if (courseParticipationWithName.setting.type) {
+        valueTextItems.push(StringUtils.properCase(courseParticipationWithName.setting.type))
       }
 
-      summaryListRows.push({
-        key: { text: 'Setting' },
-        value: { text: valueText },
-      })
+      if (courseParticipationWithName.setting.location) {
+        valueTextItems.push(`${courseParticipationWithName.setting.location}`)
+      }
+
+      const valueText = valueTextItems.join(', ')
+
+      if (valueText) {
+        summaryListRows.push({
+          key: { text: 'Setting' },
+          value: { text: valueText },
+        })
+      }
     }
 
     if (courseParticipationWithName.outcome) {
-      let valueText = ''
-
       if (courseParticipationWithName.outcome.status) {
+        let valueText = ''
+
         valueText += StringUtils.properCase(courseParticipationWithName.outcome.status)
 
         if (courseParticipationWithName.outcome.yearStarted) {

--- a/wiremock/stubs/courseParticipations.json
+++ b/wiremock/stubs/courseParticipations.json
@@ -21,7 +21,9 @@
     "addedBy": "Roland Pryzbylewski",
     "createdAt": "2023-09-14T10:46:23.098Z",
     "prisonNumber": "DEF1234",
-    "otherCourseName": "Opening New Doors"
+    "otherCourseName": "Opening New Doors",
+    "outcome": {},
+    "setting": {}
   },
   {
     "id": "57ac20a6-a660-405e-8210-43cb5b4cfc8d",


### PR DESCRIPTION
## Changes in this PR

- Use more accurate type casting
- Update `CourseParticipationSetting` so that `type` is optional - this has been changed on the API and needs changing here in anticipation of work to allow updates to the course name/ID
- Require `setting` and `outcome` on `CourseParticipation`

## Release checklist

[Release process documentation](../doc/how-to/perform-a-release.md)

As part of our continuous deployment strategy we must ensure that this work is
ready to be released once merged.

### Pre-merge

- [x] There are changes required to the Accredited Programmes API for this change to work...
  - [x] ... and they have been released to production already

### Post-merge

<!-- The outer checkboxes can be completed pre-merge -->

- [ ] This adds, extends or meaningfully modifies a feature...
  - [ ] ... and I have written or updated an end-to-end test for the happy path in the [Accredited Programmes E2E repo](https://github.com/ministryofjustice/hmpps-accredited-programmes-e2e)
- [x] This makes new expectations of the API...
  - [x] ... and I have notified the API developer(s) of changes to the contract tests (Pact), or the API is already compliant
- [ ] [Manually approve](../doc/how-to/perform-a-release.md#releasing-to-the-preprod-environment) release to preprod
- [ ] [Manually approve](../doc/how-to/perform-a-release.md#releasing-to-the-production-environment) release to prod

<!-- Should a release fail at any step, you as the author should now lead the work to
fix it as soon as possible. You can monitor deployment failures in CircleCI
itself and application errors are found in
[Sentry](https://ministryofjustice.sentry.io/projects/hmpps-accredited-programmes-ui/?project=4505330122686464&referrer=sidebar&statsPeriod=24h). -->
