### PR TITLE
(851c) Submit course participation details

### DIFF
--- a/integration_tests/e2e/refer/programmeHistory.cy.ts
+++ b/integration_tests/e2e/refer/programmeHistory.cy.ts
@@ -283,7 +283,7 @@ context('Programme history', () => {
       const courseParticipation = courseParticipationFactory
         .withCourseId()
         .build({ courseId: courses[0].id, prisonNumber: person.prisonNumber })
-      const path = referPaths.programmeHistory.details({
+      const path = referPaths.programmeHistory.details.show({
         courseParticipationId: courseParticipation.id,
         referralId: referral.id,
       })

--- a/integration_tests/e2eReferDisabled/refer.cy.ts
+++ b/integration_tests/e2eReferDisabled/refer.cy.ts
@@ -193,7 +193,7 @@ context('Refer', () => {
     cy.task('stubPrisoner', prisoner)
     cy.task('stubReferral', referral)
 
-    const path = referPaths.programmeHistory.details({
+    const path = referPaths.programmeHistory.details.show({
       courseParticipationId: courseParticipation.id,
       referralId: referral.id,
     })

--- a/integration_tests/pages/refer/programmeHistory.ts
+++ b/integration_tests/pages/refer/programmeHistory.ts
@@ -41,4 +41,12 @@ export default class ProgrammeHistoryPage extends Page {
       `The history below shows ${this.person.name}'s history of Accredited Programmes. Add another programme if you know that they started or completed a programme which is not listed below.`,
     )
   }
+
+  shouldContainSuccessMessage() {
+    cy.get('[data-testid="success-banner"]').should('contain.text', 'You have successfully added a programme.')
+  }
+
+  shouldNotContainSuccessMessage() {
+    cy.get('[data-testid="success-banner"]').should('not.exist')
+  }
 }

--- a/integration_tests/pages/refer/programmeHistoryDetails.ts
+++ b/integration_tests/pages/refer/programmeHistoryDetails.ts
@@ -1,10 +1,39 @@
 import Page from '../page'
+import type { Course, CourseParticipation, Person } from '@accredited-programmes/models'
 
 export default class ProgrammeHistoryDetailsPage extends Page {
   constructor() {
     // Conditional radio buttons add an additional `aria-expanded` field,
     // so ignore that rule on this page
     super('Add Accredited Programme details', { accessibilityRules: { 'aria-allowed-attr': { enabled: false } } })
+  }
+
+  inputCommunityLocation(value: string) {
+    cy.get('input[id="communityLocation"]').type(value)
+  }
+
+  inputOutcomeDetail(value: string) {
+    cy.get('textarea[id="outcomeDetail"]').type(value)
+  }
+
+  inputOutcomeYearCompleted(value: string) {
+    cy.get('input[id="yearCompleted"]').type(value)
+  }
+
+  inputOutcomeYearStarted(value: string) {
+    cy.get('input[id="yearStarted"]').type(value)
+  }
+
+  inputSource(value: string) {
+    cy.get('textarea[id="source"]').type(value)
+  }
+
+  selectOutcome(value: string) {
+    this.selectRadioButton('outcome[status]', value)
+  }
+
+  selectSetting(value: string) {
+    this.selectRadioButton('setting[type]', value)
   }
 
   shouldContainOutcomeDetailTextArea() {
@@ -67,5 +96,15 @@ export default class ProgrammeHistoryDetailsPage extends Page {
 
   shouldNotDisplayYearStartedInput() {
     cy.get('input[id="yearStarted"]').should('not.be.visible')
+  }
+
+  submitDetails(courseParticipation: CourseParticipation, course: Course, person: Person) {
+    cy.task('stubUpdateParticipation', courseParticipation)
+    cy.task('stubCourse', course)
+    cy.task('stubParticipationsByPerson', {
+      courseParticipations: [courseParticipation],
+      prisonNumber: person.prisonNumber,
+    })
+    this.shouldContainButton('Continue').click()
   }
 }

--- a/server/controllers/refer/courseParticipationDetailsController.test.ts
+++ b/server/controllers/refer/courseParticipationDetailsController.test.ts
@@ -73,6 +73,7 @@ describe('CourseParticipationDetailsController', () => {
       await requestHandler(request, response, next)
 
       expect(response.render).toHaveBeenCalledWith('referrals/courseParticipations/details/show', {
+        action: `${referPaths.programmeHistory.details.update({ courseParticipationId, referralId })}?_method=PUT`,
         courseParticipationId,
         pageHeading: 'Add Accredited Programme details',
         person,

--- a/server/controllers/refer/courseParticipationDetailsController.test.ts
+++ b/server/controllers/refer/courseParticipationDetailsController.test.ts
@@ -7,6 +7,9 @@ import CourseParticipationDetailsController from './courseParticipationDetailsCo
 import type { CourseService, PersonService, ReferralService } from '../../services'
 import { courseParticipationFactory, personFactory, referralFactory } from '../../testutils/factories'
 import Helpers from '../../testutils/helpers'
+import { FormUtils } from '../../utils'
+
+jest.mock('../../utils/formUtils')
 
 describe('CourseParticipationDetailsController', () => {
   const token = 'SOME_TOKEN'
@@ -53,6 +56,14 @@ describe('CourseParticipationDetailsController', () => {
       const courseParticipation = courseParticipationFactory.build()
       courseService.getParticipation.mockResolvedValue(courseParticipation)
 
+      const emptyErrorsLocal = { list: [], messages: {} }
+      ;(FormUtils.setFieldErrors as jest.Mock).mockImplementation((_request, _response, _fields) => {
+        response.locals.errors = emptyErrorsLocal
+      })
+      ;(FormUtils.setFormValues as jest.Mock).mockImplementation((_request, _response) => {
+        response.locals.formValues = {}
+      })
+
       const requestHandler = courseParticipationDetailsController.show()
       await requestHandler(request, response, next)
 
@@ -62,6 +73,8 @@ describe('CourseParticipationDetailsController', () => {
         person,
         referralId,
       })
+      expect(FormUtils.setFieldErrors).toHaveBeenCalledWith(request, response, ['yearCompleted', 'yearStarted'])
+      expect(FormUtils.setFormValues).toHaveBeenCalledWith(request, response)
     })
   })
 })

--- a/server/controllers/refer/courseParticipationDetailsController.ts
+++ b/server/controllers/refer/courseParticipationDetailsController.ts
@@ -1,7 +1,7 @@
 import type { Request, Response, TypedRequestHandler } from 'express'
 
 import type { CourseService, PersonService, ReferralService } from '../../services'
-import { TypeUtils } from '../../utils'
+import { FormUtils, TypeUtils } from '../../utils'
 
 export default class CourseParticipationDetailsController {
   constructor(
@@ -23,6 +23,9 @@ export default class CourseParticipationDetailsController {
         referral.prisonNumber,
         res.locals.user.caseloads,
       )
+
+      FormUtils.setFieldErrors(req, res, ['yearCompleted', 'yearStarted'])
+      FormUtils.setFormValues(req, res)
 
       res.render('referrals/courseParticipations/details/show', {
         courseParticipationId,

--- a/server/controllers/refer/courseParticipationDetailsController.ts
+++ b/server/controllers/refer/courseParticipationDetailsController.ts
@@ -29,6 +29,7 @@ export default class CourseParticipationDetailsController {
       FormUtils.setFormValues(req, res)
 
       res.render('referrals/courseParticipations/details/show', {
+        action: `${referPaths.programmeHistory.details.update({ courseParticipationId, referralId })}?_method=PUT`,
         courseParticipationId,
         pageHeading: 'Add Accredited Programme details',
         person,

--- a/server/controllers/refer/courseParticipationsController.test.ts
+++ b/server/controllers/refer/courseParticipationsController.test.ts
@@ -223,11 +223,11 @@ describe('CourseParticipationsController', () => {
               referralId: referral.id,
             })}?_method=PUT`,
             courseRadioOptions: CourseUtils.courseRadioOptions(courses),
+            formValues: { courseId, otherCourseName },
             otherCourseNameChecked: courseIdentifierType === 'an otherCourseName',
             pageHeading: 'Add Accredited Programme history',
             person,
             referralId: referral.id,
-            values: { courseId, otherCourseName },
           })
           expect(FormUtils.setFieldErrors).toHaveBeenCalledWith(request, response, ['courseId', 'otherCourseName'])
         })
@@ -312,11 +312,11 @@ describe('CourseParticipationsController', () => {
       expect(response.render).toHaveBeenCalledWith('referrals/courseParticipations/course', {
         action: referPaths.programmeHistory.create({ referralId: referral.id }),
         courseRadioOptions: CourseUtils.courseRadioOptions(courses),
+        formValues: {},
         otherCourseNameChecked: false,
         pageHeading: 'Add Accredited Programme history',
         person,
         referralId: referral.id,
-        values: {},
       })
       expect(FormUtils.setFieldErrors).toHaveBeenCalledWith(request, response, ['courseId', 'otherCourseName'])
     })

--- a/server/controllers/refer/courseParticipationsController.test.ts
+++ b/server/controllers/refer/courseParticipationsController.test.ts
@@ -72,7 +72,7 @@ describe('CourseParticipationsController', () => {
           undefined,
         )
         expect(response.redirect).toHaveBeenCalledWith(
-          referPaths.programmeHistory.details({
+          referPaths.programmeHistory.details.show({
             courseParticipationId: courseParticipation.id,
             referralId: referral.id,
           }),
@@ -109,7 +109,7 @@ describe('CourseParticipationsController', () => {
           otherCourseName,
         )
         expect(response.redirect).toHaveBeenCalledWith(
-          referPaths.programmeHistory.details({
+          referPaths.programmeHistory.details.show({
             courseParticipationId: courseParticipation.id,
             referralId: referral.id,
           }),
@@ -353,7 +353,7 @@ describe('CourseParticipationsController', () => {
           updatedCourseParticipation,
         )
         expect(response.redirect).toHaveBeenCalledWith(
-          referPaths.programmeHistory.details({
+          referPaths.programmeHistory.details.show({
             courseParticipationId: courseParticipation.id,
             referralId: referral.id,
           }),

--- a/server/controllers/refer/courseParticipationsController.ts
+++ b/server/controllers/refer/courseParticipationsController.ts
@@ -36,7 +36,10 @@ export default class CourseParticipationsController {
       )
 
       return res.redirect(
-        referPaths.programmeHistory.details({ courseParticipationId: courseParticipation.id, referralId: referral.id }),
+        referPaths.programmeHistory.details.show({
+          courseParticipationId: courseParticipation.id,
+          referralId: referral.id,
+        }),
       )
     }
   }
@@ -196,7 +199,7 @@ export default class CourseParticipationsController {
       })
 
       return res.redirect(
-        referPaths.programmeHistory.details({
+        referPaths.programmeHistory.details.show({
           courseParticipationId: req.params.courseParticipationId,
           referralId: req.params.referralId,
         }),

--- a/server/controllers/refer/courseParticipationsController.ts
+++ b/server/controllers/refer/courseParticipationsController.ts
@@ -102,11 +102,11 @@ export default class CourseParticipationsController {
       res.render('referrals/courseParticipations/course', {
         action: `${referPaths.programmeHistory.updateProgramme({ courseParticipationId, referralId })}?_method=PUT`,
         courseRadioOptions: CourseUtils.courseRadioOptions(courses),
+        formValues: { courseId, otherCourseName },
         otherCourseNameChecked: isOtherCourse || hasOtherCourseNameError,
         pageHeading: 'Add Accredited Programme history',
         person,
         referralId: referral.id,
-        values: { courseId, otherCourseName },
       })
     }
   }
@@ -161,11 +161,11 @@ export default class CourseParticipationsController {
       res.render('referrals/courseParticipations/course', {
         action: referPaths.programmeHistory.create({ referralId: referral.id }),
         courseRadioOptions: CourseUtils.courseRadioOptions(courses),
+        formValues: {},
         otherCourseNameChecked: !!res.locals.errors.messages.otherCourseName,
         pageHeading: 'Add Accredited Programme history',
         person,
         referralId: referral.id,
-        values: {},
       })
     }
   }

--- a/server/controllers/refer/courseParticipationsController.ts
+++ b/server/controllers/refer/courseParticipationsController.ts
@@ -115,6 +115,7 @@ export default class CourseParticipationsController {
     return async (req: Request, res: Response) => {
       TypeUtils.assertHasUser(req)
 
+      const successMessage = req.flash('successMessage')[0]
       const referral = await this.referralService.getReferral(req.user.token, req.params.referralId)
       const person = await this.personService.getPerson(
         req.user.username,
@@ -137,6 +138,7 @@ export default class CourseParticipationsController {
         pageHeading: 'Accredited Programme history',
         person,
         referralId: referral.id,
+        successMessage,
         summaryListsOptions,
       })
     }

--- a/server/paths/refer.ts
+++ b/server/paths/refer.ts
@@ -41,7 +41,10 @@ export default {
   programmeHistory: {
     create: programmeHistoryPath,
     delete: deleteProgrammeHistoryPath,
-    details: programmeHistoryDetailsPath,
+    details: {
+      show: programmeHistoryDetailsPath,
+      update: programmeHistoryDetailsPath,
+    },
     editProgramme: programmeHistoryProgrammePath,
     index: programmeHistoryPath,
     new: newProgrammeHistoryPath,

--- a/server/routes/refer.ts
+++ b/server/routes/refer.ts
@@ -40,6 +40,7 @@ export default function routes(controllers: Controllers, router: Router): Router
   get(referPaths.programmeHistory.delete.pattern, courseParticipationsController.delete())
 
   get(referPaths.programmeHistory.details.show.pattern, courseParticipationDetailsController.show())
+  put(referPaths.programmeHistory.details.update.pattern, courseParticipationDetailsController.update())
 
   get(referPaths.checkAnswers.pattern, referralsController.checkAnswers())
   get(referPaths.complete.pattern, referralsController.complete())

--- a/server/routes/refer.ts
+++ b/server/routes/refer.ts
@@ -39,7 +39,7 @@ export default function routes(controllers: Controllers, router: Router): Router
   put(referPaths.programmeHistory.updateProgramme.pattern, courseParticipationsController.updateCourse())
   get(referPaths.programmeHistory.delete.pattern, courseParticipationsController.delete())
 
-  get(referPaths.programmeHistory.details.pattern, courseParticipationDetailsController.show())
+  get(referPaths.programmeHistory.details.show.pattern, courseParticipationDetailsController.show())
 
   get(referPaths.checkAnswers.pattern, referralsController.checkAnswers())
   get(referPaths.complete.pattern, referralsController.complete())

--- a/server/utils/courseParticipationUtils.ts
+++ b/server/utils/courseParticipationUtils.ts
@@ -3,13 +3,82 @@ import type { Request } from 'express'
 import DateUtils from './dateUtils'
 import StringUtils from './stringUtils'
 import { referPaths } from '../paths'
-import type { CourseParticipation, CourseParticipationWithName, Referral } from '@accredited-programmes/models'
+import type {
+  CourseParticipation,
+  CourseParticipationOutcome,
+  CourseParticipationSetting,
+  CourseParticipationUpdate,
+  CourseParticipationWithName,
+  Referral,
+} from '@accredited-programmes/models'
 import type {
   GovukFrontendSummaryListRowWithValue,
   GovukFrontendSummaryListWithRowsWithValues,
 } from '@accredited-programmes/ui'
 
+interface DetailsBody {
+  outcome: {
+    detail: string
+    yearCompleted: string
+    yearStarted: string
+    status?: CourseParticipationOutcome['status']
+  }
+  setting: {
+    communityLocation: string
+    custodyLocation: string
+    type?: CourseParticipationSetting['type']
+  }
+  source: string
+}
+interface RequestWithDetailsBody extends Request {
+  body: DetailsBody
+}
+
 export default class CourseParticipationUtils {
+  static processDetailsFormData(request: RequestWithDetailsBody): {
+    courseParticipationUpdate: CourseParticipationUpdate
+    hasFormErrors: boolean
+  } {
+    const { body } = request
+    let hasFormErrors = false
+
+    const validateYear = (field: string, value: string): number | undefined => {
+      const validatedYear = value ? Number(value) : undefined
+
+      if (value && Number.isNaN(validatedYear)) {
+        request.flash(`${field}Error`, 'Enter a year using numbers only')
+        request.flash('formValues', JSON.stringify(body))
+
+        hasFormErrors = true
+
+        return undefined
+      }
+
+      return validatedYear
+    }
+
+    const { outcome, setting, source } = body
+
+    const courseParticipationUpdate: CourseParticipationUpdate = {
+      outcome: {
+        detail: outcome.detail?.trim() || undefined,
+        status: outcome.status,
+        yearCompleted: outcome.status === 'complete' ? validateYear('yearCompleted', outcome.yearCompleted) : undefined,
+        yearStarted: outcome.status === 'incomplete' ? validateYear('yearStarted', outcome.yearStarted) : undefined,
+      },
+      setting: {
+        location: (setting.type === 'community' ? setting.communityLocation : setting.custodyLocation) || undefined,
+        type: setting.type,
+      },
+      source: source.trim() || undefined,
+    }
+
+    return {
+      courseParticipationUpdate,
+      hasFormErrors,
+    }
+  }
+
   static processedCourseFormData(
     courseId: CourseParticipation['courseId'] | 'other' | undefined,
     otherCourseName: CourseParticipation['otherCourseName'] | undefined,
@@ -159,3 +228,5 @@ export default class CourseParticipationUtils {
     return summaryListRows
   }
 }
+
+export type { DetailsBody, RequestWithDetailsBody }

--- a/server/utils/formUtils.test.ts
+++ b/server/utils/formUtils.test.ts
@@ -1,13 +1,22 @@
-import { createMock } from '@golevelup/ts-jest'
+import { type DeepMocked, createMock } from '@golevelup/ts-jest'
 import type { Request, Response } from 'express'
 
 import FormUtils from './formUtils'
 
 describe('FormUtils', () => {
-  describe('setFieldErrors', () => {
-    const request = createMock<Request>({})
-    const response = createMock<Response>({})
+  let request: DeepMocked<Request>
+  let response: DeepMocked<Response>
 
+  beforeEach(() => {
+    request = createMock<Request>({})
+    response = createMock<Response>({})
+  })
+
+  afterEach(() => {
+    jest.resetAllMocks()
+  })
+
+  describe('setFieldErrors', () => {
     it("adds errors to a response's locals for displaying in the UI", () => {
       const someFieldErrorMessage = 'You must fill in some field'
       const someOtherFieldErrorMessage = 'Some other field is invalid'
@@ -46,6 +55,27 @@ describe('FormUtils', () => {
           list: [],
           messages: {},
         })
+      })
+    })
+  })
+
+  describe('setFormValues', () => {
+    it("adds form values to a response's locals for displaying in the UI", () => {
+      const formValues = { someField: 'some value', someOtherField: 'some other value' }
+      ;(request.flash as jest.Mock).mockImplementation(() => [JSON.stringify(formValues)])
+
+      FormUtils.setFormValues(request, response)
+
+      expect(response.locals.formValues).toEqual(formValues)
+    })
+
+    describe('when there are no flashed form values', () => {
+      it("doesn't add any form values to a response's locals", () => {
+        ;(request.flash as jest.Mock).mockImplementation(() => [])
+
+        FormUtils.setFormValues(request, response)
+
+        expect(response.locals.formValues).toEqual({})
       })
     })
   })

--- a/server/utils/formUtils.ts
+++ b/server/utils/formUtils.ts
@@ -18,4 +18,12 @@ export default class FormUtils {
 
     res.locals.errors = { list, messages }
   }
+
+  static setFormValues(req: Request, res: Response): void {
+    const formValuesAsString = req.flash('formValues')[0]
+
+    const formValues = formValuesAsString ? JSON.parse(formValuesAsString) : {}
+
+    res.locals.formValues = formValues
+  }
 }

--- a/server/views/referrals/courseParticipations/course.njk
+++ b/server/views/referrals/courseParticipations/course.njk
@@ -22,7 +22,7 @@
   {{ govukInput({
     id: "otherCourseName",
     name: "otherCourseName",
-    value: values.otherCourseName,
+    value: formValues.otherCourseName,
     type: "text",
     classes: "govuk-!-width-one-third",
     label: {
@@ -67,7 +67,7 @@
               "data-testid": "other-course-option"
             }
           }),
-          value: values.courseId,
+          value: formValues.courseId,
           errorMessage: errors.messages.courseId
         }) }}
 

--- a/server/views/referrals/courseParticipations/details/show.njk
+++ b/server/views/referrals/courseParticipations/details/show.njk
@@ -1,5 +1,6 @@
 {% from "govuk/components/back-link/macro.njk" import govukBackLink %}
 {% from "govuk/components/button/macro.njk" import govukButton %}
+{% from "govuk/components/error-summary/macro.njk" import govukErrorSummary %}
 {% from "govuk/components/input/macro.njk" import govukInput %}
 {% from "govuk/components/radios/macro.njk" import govukRadios %}
 {% from "govuk/components/textarea/macro.njk" import govukTextarea %}
@@ -20,22 +21,24 @@
 {% set communityLocationHtml %}
 {{ govukInput({
   id: "communityLocation",
-  name: "setting[location]",
+  name: "setting[communityLocation]",
   classes: "govuk-!-width-one-third",
   label: {
     text: "Enter the location (if known)"
-  }
+  },
+  value: formValues.setting.communityLocation
 }) }}
 {% endset %}
 
 {% set custodyLocationHtml %}
 {{ govukInput({
   id: "custodyLocation",
-  name: "setting[location]",
+  name: "setting[custodyLocation]",
   classes: "govuk-!-width-one-third",
   label: {
     text: "Enter the prison (if known)"
-  }
+  },
+  value: formValues.setting.custodyLocation
 }) }}
 {% endset %}
 
@@ -48,7 +51,9 @@
   classes: "govuk-!-width-one-third",
   label: {
     text: "Enter the year completed (if known)"
-  }
+  },
+  errorMessage: errors.messages.yearCompleted,
+  value: formValues.outcome.yearCompleted
 }) }}
 {% endset %}
 
@@ -61,11 +66,24 @@
   classes: "govuk-!-width-one-third",
   label: {
     text: "Enter the year started (if known)"
-  }
+  },
+  errorMessage: errors.messages.yearStarted,
+  value: formValues.outcome.yearStarted
 }) }}
 {% endset %}
 
 {% block content %}
+  <div class="govuk-grid-row">
+    <div class="govuk-grid-column-two-thirds">
+      {% if errors.list.length %}
+        {{ govukErrorSummary({
+          titleText: "There is a problem",
+          errorList: errors.list
+        }) }}
+      {% endif %}
+    </div>
+  </div>
+
   <h1 class="govuk-heading-l">{{ pageHeading }}</h1>
 
   <div class="govuk-grid-row">
@@ -87,6 +105,7 @@
               conditional: {
                 html: communityLocationHtml
               },
+              checked: formValues.setting.type === "community",
               attributes: {
                 "data-testid": "community-setting-option"
               }
@@ -97,6 +116,7 @@
               conditional: {
                 html: custodyLocationHtml
               },
+              checked: formValues.setting.type === "custody",
               attributes: {
                 "data-testid": "custody-setting-option"
               }
@@ -121,6 +141,7 @@
               conditional: {
                 html: yearCompletedHtml
               },
+              checked: formValues.outcome.status === "complete",
               attributes: {
                 "data-testid": "complete-outcome-option"
               }
@@ -131,6 +152,7 @@
               conditional: {
                 html: yearStartedHtml
               },
+              checked: formValues.outcome.status === "incomplete",
               attributes: {
                 "data-testid": "incomplete-outcome-option"
               }
@@ -149,7 +171,8 @@
           },
           hint: {
             text: "Include information about the outcome"
-          }
+          },
+          value: formValues.outcome.detail
         }) }}
 
         {{ govukTextarea({
@@ -160,7 +183,8 @@
           },
           hint: {
             text: "Include where you got this information from"
-          }
+          },
+          value: formValues.source
         }) }}
 
         {{ govukButton({

--- a/server/views/referrals/courseParticipations/details/show.njk
+++ b/server/views/referrals/courseParticipations/details/show.njk
@@ -70,7 +70,7 @@
 
   <div class="govuk-grid-row">
     <div class="govuk-grid-column-two-thirds">
-      <form action="#" method="post">
+      <form action="{{ action }}" method="post">
         <input type="hidden" name="_csrf" value="{{ csrfToken }}"/>
 
         {{ govukRadios({

--- a/server/views/referrals/courseParticipations/index.njk
+++ b/server/views/referrals/courseParticipations/index.njk
@@ -1,6 +1,7 @@
 {% from "govuk/components/back-link/macro.njk" import govukBackLink %}
 {% from "govuk/components/button/macro.njk" import govukButton %}
 {% from "govuk/components/summary-list/macro.njk" import govukSummaryList %}
+{% from "moj/components/banner/macro.njk" import mojBanner %}
 
 {% extends "../../partials/layout.njk" %}
 
@@ -20,6 +21,17 @@
 
   <div class="govuk-grid-row">
     <div class="govuk-grid-column-two-thirds">
+      {% if successMessage %}
+        {{ mojBanner({
+          type: "success",
+          text: successMessage,
+          iconFallbackText: "Success",
+          attributes: {
+            "data-testid": "success-banner"
+          }
+        }) }}
+      {% endif %}
+
       {% if summaryListsOptions.length %}
         <p class="govuk-body" data-testid="pre-history-paragraph">The history below shows {{ person.name }}'s history of Accredited Programmes. Add another programme if you know that they started or completed a programme which is not listed below.</p>
 


### PR DESCRIPTION
## Context

https://trello.com/c/oMnAOOLO/851-add-page-for-entering-course-details-ui-m


## Changes in this PR
This PR now allows the course participation detail form to be submitted to update a course participation with further details and redirects to the programme history index page with success message when successful.  

It also displays an error message for both year started and year completed if a non numeric value is entered.

## Screenshots
![image](https://github.com/ministryofjustice/hmpps-accredited-programmes-ui/assets/1067537/e48110fe-67f7-4068-90fd-aeed569df72d)


## Release checklist

[Release process documentation](../doc/how-to/perform-a-release.md)

As part of our continuous deployment strategy we must ensure that this work is
ready to be released once merged.

### Pre-merge

- [ ] There are changes required to the Accredited Programmes API for this change to work...
  - [ ] ... and they have been released to production already

### Post-merge

<!-- The outer checkboxes can be completed pre-merge -->

- [ ] This adds, extends or meaningfully modifies a feature...
  - [ ] ... and I have written or updated an end-to-end test for the happy path in the [Accredited Programmes E2E repo](https://github.com/ministryofjustice/hmpps-accredited-programmes-e2e)
- [ ] This makes new expectations of the API...
  - [ ] ... and I have notified the API developer(s) of changes to the contract tests (Pact), or the API is already compliant
- [ ] [Manually approve](../doc/how-to/perform-a-release.md#releasing-to-the-preprod-environment) release to preprod
- [ ] [Manually approve](../doc/how-to/perform-a-release.md#releasing-to-the-production-environment) release to prod

<!-- Should a release fail at any step, you as the author should now lead the work to
fix it as soon as possible. You can monitor deployment failures in CircleCI
itself and application errors are found in
[Sentry](https://ministryofjustice.sentry.io/projects/hmpps-accredited-programmes-ui/?project=4505330122686464&referrer=sidebar&statsPeriod=24h). -->
