### PR TITLE
(853a) Delete course participation page

### DIFF
--- a/integration_tests/e2e/refer/programmeHistory.cy.ts
+++ b/integration_tests/e2e/refer/programmeHistory.cy.ts
@@ -70,7 +70,7 @@ context('Programme history', () => {
       programmeHistoryPage.shouldContainNavigation(path)
       programmeHistoryPage.shouldContainBackLink(referPaths.show({ referralId: referral.id }))
       programmeHistoryPage.shouldContainPreHistoryParagraph()
-      programmeHistoryPage.shouldContainHistorySummaryCards()
+      programmeHistoryPage.shouldContainHistorySummaryCards(courseParticipationsWithNames, referral.id)
       programmeHistoryPage.shouldContainButton('Continue')
       programmeHistoryPage.shouldContainButtonLink(
         'Add another',

--- a/integration_tests/e2e/refer/programmeHistory.cy.ts
+++ b/integration_tests/e2e/refer/programmeHistory.cy.ts
@@ -8,7 +8,12 @@ import {
   referralFactory,
 } from '../../../server/testutils/factories'
 import Page from '../../pages/page'
-import { ProgrammeHistoryDetailsPage, ProgrammeHistoryPage, SelectProgrammePage } from '../../pages/refer'
+import {
+  DeleteProgrammeHistoryPage,
+  ProgrammeHistoryDetailsPage,
+  ProgrammeHistoryPage,
+  SelectProgrammePage,
+} from '../../pages/refer'
 import type { CourseParticipation, CourseParticipationWithName } from '@accredited-programmes/models'
 
 context('Programme history', () => {
@@ -314,6 +319,54 @@ context('Programme history', () => {
         programmeHistoryDetailsPage.shouldContainSourceTextArea()
         programmeHistoryDetailsPage.shouldContainButton('Continue')
       })
+    })
+  })
+
+  describe('When removing from the programme history', () => {
+    it('shows the delete page', () => {
+      const prisoner = prisonerFactory.build({
+        firstName: 'Del',
+        lastName: 'Hatton',
+      })
+      const person = personFactory.build({
+        currentPrison: prisoner.prisonName,
+        name: 'Del Hatton',
+        prisonNumber: prisoner.prisonerNumber,
+      })
+
+      const referral = referralFactory.started().build({ prisonNumber: person.prisonNumber })
+      const course = courseFactory.build()
+      const courseParticipation = courseParticipationFactory
+        .withCourseId()
+        .build({ courseId: course.id, prisonNumber: person.prisonNumber })
+      const courseParticipationWithName = { ...courseParticipation, name: course.name }
+
+      cy.task('stubPrisoner', prisoner)
+      cy.task('stubReferral', referral)
+      cy.task('stubParticipation', courseParticipation)
+      cy.task('stubCourse', course)
+
+      cy.signIn()
+
+      const path = referPaths.programmeHistory.delete({
+        courseParticipationId: courseParticipation.id,
+        referralId: referral.id,
+      })
+      cy.visit(path)
+
+      const deleteProgrammeHistoryPage = Page.verifyOnPage(DeleteProgrammeHistoryPage, {
+        participationWithName: courseParticipationWithName,
+        person,
+        referral,
+      })
+      deleteProgrammeHistoryPage.shouldHavePersonDetails(person)
+      deleteProgrammeHistoryPage.shouldContainNavigation(path)
+      deleteProgrammeHistoryPage.shouldContainBackLink(referPaths.programmeHistory.index({ referralId: referral.id }))
+      deleteProgrammeHistoryPage.shouldContainHistorySummaryCards([courseParticipationWithName], referral.id, false)
+      deleteProgrammeHistoryPage.shouldContainWarningText(
+        'You are removing this programme. Once a programme has been removed, it cannot be undone.',
+      )
+      deleteProgrammeHistoryPage.shouldContainButton('Confirm')
     })
   })
 })

--- a/integration_tests/e2eReferDisabled/refer.cy.ts
+++ b/integration_tests/e2eReferDisabled/refer.cy.ts
@@ -208,6 +208,32 @@ context('Refer', () => {
     notFoundPage2.shouldContain404H2()
   })
 
+  it("Doesn't show the delete programme history page", () => {
+    cy.signIn()
+
+    const prisoner = prisonerFactory.build()
+    const referral = referralFactory.started().build({ prisonNumber: prisoner.prisonerNumber })
+    const course = courseFactory.build()
+    const participation = courseParticipationFactory.build({
+      courseId: course.id,
+      prisonNumber: prisoner.prisonerNumber,
+    })
+
+    cy.task('stubPrisoner', prisoner)
+    cy.task('stubReferral', referral)
+    cy.task('stubParticipation', participation)
+    cy.task('stubCourse', course)
+
+    const path = referPaths.programmeHistory.delete({
+      courseParticipationId: participation.id,
+      referralId: referral.id,
+    })
+    cy.visit(path, { failOnStatusCode: false })
+
+    const notFoundPage = Page.verifyOnPage(NotFoundPage)
+    notFoundPage.shouldContain404H2()
+  })
+
   it("Doesn't show the check answers page for a referral", () => {
     cy.signIn()
 

--- a/integration_tests/pages/page.ts
+++ b/integration_tests/pages/page.ts
@@ -236,6 +236,10 @@ export default abstract class Page {
     cy.get(`.govuk-textarea[id="${id}"]`).should('exist')
   }
 
+  shouldContainWarningText(text: GovukFrontendWarningText['text']): void {
+    cy.get('.govuk-warning-text__text').should('contain.text', text)
+  }
+
   shouldHaveErrors(errors: Array<{ field: string; message: string }>): void {
     cy.get('.govuk-error-summary').should('exist')
 

--- a/integration_tests/pages/refer/confirmPerson.ts
+++ b/integration_tests/pages/refer/confirmPerson.ts
@@ -31,8 +31,7 @@ export default class ConfirmPersonPage extends Page {
   shouldHavePersonInformation() {
     this.shouldContainPersonSummaryList(this.person)
 
-    cy.get('.govuk-warning-text__text').should(
-      'contain.text',
+    this.shouldContainWarningText(
       'If this information is out of date or incorrect, you must update the information in NOMIS.',
     )
   }

--- a/integration_tests/pages/refer/deleteProgrammeHistory.ts
+++ b/integration_tests/pages/refer/deleteProgrammeHistory.ts
@@ -1,0 +1,19 @@
+import Page from '../page'
+import type { CourseParticipationWithName, Person, Referral } from '@accredited-programmes/models'
+
+export default class DeleteProgrammeHistoryPage extends Page {
+  participation: CourseParticipationWithName
+
+  person: Person
+
+  referral: Referral
+
+  constructor(args: { participationWithName: CourseParticipationWithName; person: Person; referral: Referral }) {
+    super('Remove programme')
+
+    const { participationWithName, person, referral } = args
+    this.participation = participationWithName
+    this.person = person
+    this.referral = referral
+  }
+}

--- a/integration_tests/pages/refer/index.ts
+++ b/integration_tests/pages/refer/index.ts
@@ -2,6 +2,7 @@ import CheckAnswersPage from './checkAnswers'
 import CompletePage from './complete'
 import ConfirmOasysPage from './confirmOasys'
 import ConfirmPersonPage from './confirmPerson'
+import DeleteProgrammeHistoryPage from './deleteProgrammeHistory'
 import FindPersonPage from './findPerson'
 import ProgrammeHistoryPage from './programmeHistory'
 import ProgrammeHistoryDetailsPage from './programmeHistoryDetails'
@@ -16,6 +17,7 @@ export {
   CompletePage,
   ConfirmOasysPage,
   ConfirmPersonPage,
+  DeleteProgrammeHistoryPage,
   FindPersonPage,
   ProgrammeHistoryDetailsPage,
   ProgrammeHistoryPage,

--- a/integration_tests/pages/refer/programmeHistory.ts
+++ b/integration_tests/pages/refer/programmeHistory.ts
@@ -1,5 +1,3 @@
-import { referPaths } from '../../../server/paths'
-import { CourseParticipationUtils } from '../../../server/utils'
 import Page from '../page'
 import type { CourseParticipationWithName, Person, Referral } from '@accredited-programmes/models'
 
@@ -21,37 +19,6 @@ export default class ProgrammeHistoryPage extends Page {
     this.participations = participationsWithNames
     this.person = person
     this.referral = referral
-  }
-
-  shouldContainHistorySummaryCards() {
-    this.participations.forEach((participation, participationsIndex) => {
-      const { rows } = CourseParticipationUtils.summaryListOptions(participation, this.referral.id)
-
-      cy.get('.govuk-summary-card')
-        .eq(participationsIndex)
-        .then(summaryCardElement => {
-          const actions = [
-            {
-              href: referPaths.programmeHistory.editProgramme({
-                courseParticipationId: participation.id,
-                referralId: this.referral.id,
-              }),
-              text: 'Change',
-              visuallyHiddenText: ` participation for ${participation.name}`,
-            },
-            {
-              href: referPaths.programmeHistory.delete({
-                courseParticipationId: participation.id,
-                referralId: this.referral.id,
-              }),
-              text: 'Remove',
-              visuallyHiddenText: ` participation for ${participation.name}`,
-            },
-          ]
-
-          this.shouldContainSummaryCard(participation.name, actions, rows, summaryCardElement)
-        })
-    })
   }
 
   shouldContainNoHistoryHeading() {

--- a/integration_tests/pages/refer/programmeHistory.ts
+++ b/integration_tests/pages/refer/programmeHistory.ts
@@ -30,16 +30,26 @@ export default class ProgrammeHistoryPage extends Page {
       cy.get('.govuk-summary-card')
         .eq(participationsIndex)
         .then(summaryCardElement => {
-          const action = {
-            href: referPaths.programmeHistory.editProgramme({
-              courseParticipationId: participation.id,
-              referralId: this.referral.id,
-            }),
-            text: 'Change',
-            visuallyHiddenText: ` participation for ${participation.name}`,
-          }
+          const actions = [
+            {
+              href: referPaths.programmeHistory.editProgramme({
+                courseParticipationId: participation.id,
+                referralId: this.referral.id,
+              }),
+              text: 'Change',
+              visuallyHiddenText: ` participation for ${participation.name}`,
+            },
+            {
+              href: referPaths.programmeHistory.delete({
+                courseParticipationId: participation.id,
+                referralId: this.referral.id,
+              }),
+              text: 'Remove',
+              visuallyHiddenText: ` participation for ${participation.name}`,
+            },
+          ]
 
-          this.shouldContainSummaryCard(participation.name, [action], rows, summaryCardElement)
+          this.shouldContainSummaryCard(participation.name, actions, rows, summaryCardElement)
         })
     })
   }

--- a/server/controllers/refer/courseParticipationsController.test.ts
+++ b/server/controllers/refer/courseParticipationsController.test.ts
@@ -142,6 +142,40 @@ describe('CourseParticipationsController', () => {
     })
   })
 
+  describe('delete', () => {
+    it('renders the delete template for a specific course participation', async () => {
+      const person = personFactory.build()
+      const referral = referralFactory.build({ prisonNumber: person.prisonNumber })
+      const course = courseFactory.build()
+      const courseParticipation = courseParticipationFactory.withCourseId().build({
+        courseId: course.id,
+        prisonNumber: person.prisonNumber,
+      })
+
+      personService.getPerson.mockResolvedValue(person)
+      referralService.getReferral.mockResolvedValue(referral)
+      courseService.getCourse.mockResolvedValue(course)
+      courseService.getParticipation.mockResolvedValue(courseParticipation)
+
+      const courseParticipationWithName = { ...courseParticipation, name: course.name }
+      const summaryListsOptions = CourseParticipationUtils.summaryListOptions(
+        courseParticipationWithName,
+        referral.id,
+        false,
+      )
+
+      const requestHandler = courseParticipationsController.delete()
+      await requestHandler(request, response, next)
+
+      expect(response.render).toHaveBeenCalledWith('referrals/courseParticipations/delete', {
+        pageHeading: 'Remove programme',
+        person,
+        referralId: referral.id,
+        summaryListsOptions,
+      })
+    })
+  })
+
   describe('editCourse', () => {
     const courses = courseFactory.buildList(2)
     const person = personFactory.build()

--- a/server/controllers/refer/courseParticipationsController.ts
+++ b/server/controllers/refer/courseParticipationsController.ts
@@ -41,6 +41,39 @@ export default class CourseParticipationsController {
     }
   }
 
+  delete(): TypedRequestHandler<Request, Response> {
+    return async (req: Request, res: Response) => {
+      TypeUtils.assertHasUser(req)
+
+      const { courseParticipationId, referralId } = req.params
+
+      const courseParticipation = await this.courseService.getParticipation(req.user.token, courseParticipationId)
+      const referral = await this.referralService.getReferral(req.user.token, referralId)
+      const person = await this.personService.getPerson(
+        req.user.username,
+        referral.prisonNumber,
+        res.locals.user.caseloads,
+      )
+
+      const courseParticipationWithName = (
+        await this.courseParticipationsWithNames([courseParticipation], req.user.token)
+      )[0]
+
+      const summaryListOptions = CourseParticipationUtils.summaryListOptions(
+        courseParticipationWithName,
+        referralId,
+        false,
+      )
+
+      res.render('referrals/courseParticipations/delete', {
+        pageHeading: 'Remove programme',
+        person,
+        referralId: referral.id,
+        summaryListOptions,
+      })
+    }
+  }
+
   editCourse(): TypedRequestHandler<Request, Response> {
     return async (req: Request, res: Response) => {
       TypeUtils.assertHasUser(req)

--- a/server/paths/refer.ts
+++ b/server/paths/refer.ts
@@ -18,6 +18,7 @@ const newProgrammeHistoryPath = programmeHistoryPath.path('new')
 const showProgrammeHistoryPath = programmeHistoryPath.path(':courseParticipationId')
 const programmeHistoryProgrammePath = showProgrammeHistoryPath.path('programme')
 const programmeHistoryDetailsPath = showProgrammeHistoryPath.path('details')
+const deleteProgrammeHistoryPath = showProgrammeHistoryPath.path('delete')
 const confirmOasysPath = showReferralPath.path('confirm-oasys')
 const reasonForReferralPath = showReferralPath.path('reason')
 const checkAnswersPath = showReferralPath.path('check-answers')
@@ -39,6 +40,7 @@ export default {
   },
   programmeHistory: {
     create: programmeHistoryPath,
+    delete: deleteProgrammeHistoryPath,
     details: programmeHistoryDetailsPath,
     editProgramme: programmeHistoryProgrammePath,
     index: programmeHistoryPath,

--- a/server/routes/refer.ts
+++ b/server/routes/refer.ts
@@ -37,6 +37,7 @@ export default function routes(controllers: Controllers, router: Router): Router
   post(referPaths.programmeHistory.create.pattern, courseParticipationsController.create())
   get(referPaths.programmeHistory.editProgramme.pattern, courseParticipationsController.editCourse())
   put(referPaths.programmeHistory.updateProgramme.pattern, courseParticipationsController.updateCourse())
+  get(referPaths.programmeHistory.delete.pattern, courseParticipationsController.delete())
 
   get(referPaths.programmeHistory.details.pattern, courseParticipationDetailsController.show())
 

--- a/server/utils/courseParticipationUtils.test.ts
+++ b/server/utils/courseParticipationUtils.test.ts
@@ -144,6 +144,17 @@ describe('CourseParticipationUtils', () => {
       })
     })
 
+    describe('when `withActions` is `false`', () => {
+      it('omits the actions', () => {
+        const summaryListOptions = CourseParticipationUtils.summaryListOptions(
+          courseParticipationWithName,
+          referralId,
+          false,
+        )
+        expect(summaryListOptions.card?.actions).toBeUndefined()
+      })
+    })
+
     describe('when rows are missing required data', () => {
       it.each([
         ['Setting', 'setting', undefined],

--- a/server/utils/courseParticipationUtils.test.ts
+++ b/server/utils/courseParticipationUtils.test.ts
@@ -109,6 +109,11 @@ describe('CourseParticipationUtils', () => {
                 text: 'Change',
                 visuallyHiddenText: `participation for ${courseParticipationWithName.name}`,
               },
+              {
+                href: `/referrals/${referralId}/programme-history/${courseParticipationWithName.id}/delete`,
+                text: 'Remove',
+                visuallyHiddenText: `participation for ${courseParticipationWithName.name}`,
+              },
             ],
           },
           title: {

--- a/server/utils/courseParticipationUtils.ts
+++ b/server/utils/courseParticipationUtils.ts
@@ -57,6 +57,14 @@ export default class CourseParticipationUtils {
               text: 'Change',
               visuallyHiddenText: `participation for ${courseParticipationWithName.name}`,
             },
+            {
+              href: referPaths.programmeHistory.delete({
+                courseParticipationId: courseParticipationWithName.id,
+                referralId,
+              }),
+              text: 'Remove',
+              visuallyHiddenText: `participation for ${courseParticipationWithName.name}`,
+            },
           ],
         }
       : undefined

--- a/server/utils/courseParticipationUtils.ts
+++ b/server/utils/courseParticipationUtils.ts
@@ -44,10 +44,10 @@ export default class CourseParticipationUtils {
   static summaryListOptions(
     courseParticipationWithName: CourseParticipationWithName,
     referralId: Referral['id'],
+    withActions = true,
   ): GovukFrontendSummaryListWithRowsWithValues {
-    return {
-      card: {
-        actions: {
+    const actions = withActions
+      ? {
           items: [
             {
               href: referPaths.programmeHistory.editProgramme({
@@ -58,7 +58,12 @@ export default class CourseParticipationUtils {
               visuallyHiddenText: `participation for ${courseParticipationWithName.name}`,
             },
           ],
-        },
+        }
+      : undefined
+
+    return {
+      card: {
+        actions,
         title: {
           text: courseParticipationWithName.name,
         },

--- a/server/views/referrals/courseParticipations/delete.njk
+++ b/server/views/referrals/courseParticipations/delete.njk
@@ -1,0 +1,40 @@
+{% from "govuk/components/back-link/macro.njk" import govukBackLink %}
+{% from "govuk/components/button/macro.njk" import govukButton %}
+{% from "govuk/components/summary-list/macro.njk" import govukSummaryList %}
+{% from "govuk/components/warning-text/macro.njk" import govukWarningText %}
+
+{% extends "../../partials/layout.njk" %}
+
+{% block personBanner %}
+  {% include "../_personBanner.njk" %}
+{% endblock personBanner %}
+
+{% block backLink %}
+  {{ govukBackLink({
+    text: "Back",
+    href: referPaths.programmeHistory.index({ referralId: referralId })
+  }) }}
+{% endblock backLink %}
+
+{% block content %}
+  <h1 class="govuk-heading-l">{{ pageHeading }}</h1>
+
+  <div class="govuk-grid-row">
+    <div class="govuk-grid-column-two-thirds">
+      {{ govukSummaryList(summaryListOptions) }}
+
+      {{ govukWarningText({
+        text: "You are removing this programme. Once a programme has been removed, it cannot be undone.",
+        iconFallbackText: "Warning"
+      }) }}
+
+      <form action="#?_method=PUT" method="post">
+        <input type="hidden" name="_csrf" value="{{ csrfToken }}"/>
+
+        {{ govukButton({
+          text: "Confirm"
+        }) }}
+      </form>
+    </div>
+  </div>
+{% endblock content %}


### PR DESCRIPTION
## Changes in this PR

This adds the delete course participation page. It doesn't implement the destroy action - that will come in another PR

## Screenshots of UI changes

<img width="835" alt="image" src="https://github.com/ministryofjustice/hmpps-accredited-programmes-ui/assets/40244233/38c0d9dc-f283-4485-9b5e-1ed12fd33284">

## Release checklist

[Release process documentation](../doc/how-to/perform-a-release.md)

As part of our continuous deployment strategy we must ensure that this work is
ready to be released once merged.

### Pre-merge

- [ ] There are changes required to the Accredited Programmes API for this change to work...
  - [ ] ... and they have been released to production already

### Post-merge

<!-- The outer checkboxes can be completed pre-merge -->

- [x] This adds, extends or meaningfully modifies a feature...
  - [ ] ... and I have written or updated an end-to-end test for the happy path in the [Accredited Programmes E2E repo](https://github.com/ministryofjustice/hmpps-accredited-programmes-e2e)
- [ ] This makes new expectations of the API...
  - [ ] ... and I have notified the API developer(s) of changes to the contract tests (Pact), or the API is already compliant
- [ ] [Manually approve](../doc/how-to/perform-a-release.md#releasing-to-the-preprod-environment) release to preprod
- [ ] [Manually approve](../doc/how-to/perform-a-release.md#releasing-to-the-production-environment) release to prod

<!-- Should a release fail at any step, you as the author should now lead the work to
fix it as soon as possible. You can monitor deployment failures in CircleCI
itself and application errors are found in
[Sentry](https://ministryofjustice.sentry.io/projects/hmpps-accredited-programmes-ui/?project=4505330122686464&referrer=sidebar&statsPeriod=24h). -->
