### PR TITLE
(853b) Add delete request support

### DIFF
--- a/server/data/restClient.test.ts
+++ b/server/data/restClient.test.ts
@@ -1,0 +1,119 @@
+import nock from 'nock'
+
+import RestClient from './restClient'
+import { AgentConfig } from '../config'
+
+const restClient = new RestClient(
+  'api-name',
+  {
+    agent: new AgentConfig(1000),
+    timeout: {
+      deadline: 1000,
+      response: 1000,
+    },
+    url: 'http://localhost:8080/api',
+  },
+  'token-1',
+)
+
+describe.each(['get', 'post', 'put', 'delete'] as const)('Method: %s', method => {
+  it('should return response body', async () => {
+    nock('http://localhost:8080', {
+      reqheaders: { authorization: 'Bearer token-1' },
+    })
+      [method]('/api/test')
+      .reply(200, { success: true })
+
+    const result = await restClient[method]({
+      path: '/test',
+    })
+
+    expect(nock.isDone()).toBe(true)
+
+    expect(result).toStrictEqual({
+      success: true,
+    })
+  })
+
+  it('should return raw response body', async () => {
+    nock('http://localhost:8080', {
+      reqheaders: { authorization: 'Bearer token-1' },
+    })
+      [method]('/api/test')
+      .reply(200, { success: true })
+
+    const result = await restClient[method]({
+      headers: { header1: 'headerValue1' },
+      path: '/test',
+      raw: true,
+    })
+
+    expect(nock.isDone()).toBe(true)
+
+    expect(result).toMatchObject({
+      req: { method: method.toUpperCase() },
+      status: 200,
+      text: '{"success":true}',
+    })
+  })
+
+  if (method === 'get' || method === 'delete') {
+    it('should retry by default', async () => {
+      nock('http://localhost:8080', {
+        reqheaders: { authorization: 'Bearer token-1' },
+      })
+        [method]('/api/test')
+        .reply(500)
+        [method]('/api/test')
+        .reply(500)
+        [method]('/api/test')
+        .reply(500)
+
+      await expect(() =>
+        restClient[method]({
+          headers: { header1: 'headerValue1' },
+          path: '/test',
+        }),
+      ).rejects.toThrow('Internal Server Error')
+
+      expect(nock.isDone()).toBe(true)
+    })
+
+    it('can recover through retries', async () => {
+      nock('http://localhost:8080', {
+        reqheaders: { authorization: 'Bearer token-1' },
+      })
+        [method]('/api/test')
+        .reply(500)
+        [method]('/api/test')
+        .reply(500)
+        [method]('/api/test')
+        .reply(200, { success: true })
+
+      const result = await restClient[method]({
+        headers: { header1: 'headerValue1' },
+        path: '/test',
+      })
+
+      expect(result).toStrictEqual({ success: true })
+      expect(nock.isDone()).toBe(true)
+    })
+  } else {
+    it('should not retry', async () => {
+      nock('http://localhost:8080', {
+        reqheaders: { authorization: 'Bearer token-1' },
+      })
+        [method]('/api/test')
+        .reply(500)
+
+      await expect(
+        restClient[method]({
+          headers: { header1: 'headerValue1' },
+          path: '/test',
+        }),
+      ).rejects.toThrow('Internal Server Error')
+
+      expect(nock.isDone()).toBe(true)
+    })
+  }
+})

--- a/server/data/restClient.ts
+++ b/server/data/restClient.ts
@@ -160,10 +160,6 @@ export default class RestClient {
         .send(data)
         .agent(this.agent)
         .use(restClientMetricsMiddleware)
-        .retry(2, (err, res) => {
-          if (err) logger.info(`Retry handler found API error with ${err.code} ${err.message}`)
-          return undefined // retry handler only for logging retries, not to influence retry logic
-        })
         .auth(this.token, { type: 'bearer' })
         .set(headers)
         .responseType(responseType)

--- a/server/data/restClient.ts
+++ b/server/data/restClient.ts
@@ -18,6 +18,8 @@ interface GetRequest {
   responseType?: string
 }
 
+interface DeleteRequest extends GetRequest {}
+
 interface PostRequest {
   data?: Record<string, unknown>
   headers?: Record<string, string>
@@ -43,6 +45,37 @@ export default class RestClient {
     private readonly token: Express.User['token'],
   ) {
     this.agent = config.url.startsWith('https') ? new HttpsAgent(config.agent) : new Agent(config.agent)
+  }
+
+  async delete({
+    path = '',
+    query = '',
+    headers = {},
+    responseType = '',
+    raw = false,
+  }: DeleteRequest): Promise<unknown> {
+    logger.info(`Delete using user credentials: calling ${this.name}: ${path} ${query}`)
+    try {
+      const result = await superagent
+        .delete(`${this.apiUrl()}${path}`)
+        .agent(this.agent)
+        .use(restClientMetricsMiddleware)
+        .retry(2, (err, res) => {
+          if (err) logger.info(`Retry handler found API error with ${err.code} ${err.message}`)
+          return undefined // retry handler only for logging retries, not to influence retry logic
+        })
+        .query(query)
+        .auth(this.token, { type: 'bearer' })
+        .set(headers)
+        .responseType(responseType)
+        .timeout(this.timeoutConfig())
+
+      return raw ? result : result.body
+    } catch (error) {
+      const sanitisedError = sanitiseError(error as UnsanitisedError)
+      logger.warn({ ...sanitisedError, query }, `Error calling ${this.name}, path: '${path}', verb: 'DELETE'`)
+      throw sanitisedError
+    }
   }
 
   async get({ path = '', query = '', headers = {}, responseType = '', raw = false }: GetRequest): Promise<unknown> {

--- a/server/sanitisedError.ts
+++ b/server/sanitisedError.ts
@@ -1,6 +1,8 @@
 import type { ResponseError } from 'superagent'
 
-interface SanitisedError {
+type UnsanitisedError = ResponseError
+
+type SanitisedError = Error & {
   message: string
   stack: string | undefined
   data?: unknown
@@ -9,21 +11,19 @@ interface SanitisedError {
   text?: string
 }
 
-export type UnsanitisedError = ResponseError
-
 export default function sanitiseError(error: UnsanitisedError): SanitisedError {
+  const sanitisedError = new Error() as SanitisedError
+  sanitisedError.message = error.message
+  sanitisedError.stack = error.stack
+
   if (error.response) {
-    return {
-      data: error.response.body,
-      headers: error.response.headers,
-      message: error.message,
-      stack: error.stack,
-      status: error.response.status,
-      text: error.response.text,
-    }
+    sanitisedError.data = error.response.body
+    sanitisedError.headers = error.response.headers
+    sanitisedError.status = error.response.status
+    sanitisedError.text = error.response.text
   }
-  return {
-    message: error.message,
-    stack: error.stack,
-  }
+
+  return sanitisedError
 }
+
+export type { SanitisedError, UnsanitisedError }

--- a/server/utils/routeUtils.ts
+++ b/server/utils/routeUtils.ts
@@ -9,6 +9,8 @@ import type { MiddlewareOptions } from '@accredited-programmes/server'
 export default class RouteUtils {
   static actions(router: Router, defaultMiddlewareOptions?: MiddlewareOptions) {
     return {
+      delete: (path: Array<string> | string, handler: RequestHandler, middlewareOptions = defaultMiddlewareOptions) =>
+        router.delete(path, asyncMiddleware(roleBasedAccessMiddleware(handler, middlewareOptions))),
       get: (path: Array<string> | string, handler: RequestHandler, middlewareOptions = defaultMiddlewareOptions) =>
         router.get(path, asyncMiddleware(roleBasedAccessMiddleware(handler, middlewareOptions))),
       post: (path: Array<string> | string, handler: RequestHandler, middlewareOptions = defaultMiddlewareOptions) =>


### PR DESCRIPTION
## Context

<!-- Is there a Trello ticket you can link to? -->
<!-- Do you need to add any environment variables? -->
<!-- Is an ADR required? An ADR should be added if this PR introduces a change to the architecture. -->

#247 added the page for deleting course participations, but not the destroy action. Our codebase doesn't currently support DELETE requests

## Changes in this PR

- Add support for DELETE requests
- Add `RestClient` tests
- Remove retries on POST and PUT requests, per the template and Approved Premises

## Release checklist

[Release process documentation](../doc/how-to/perform-a-release.md)

As part of our continuous deployment strategy we must ensure that this work is
ready to be released once merged.

### Pre-merge

- [ ] There are changes required to the Accredited Programmes API for this change to work...
  - [ ] ... and they have been released to production already

### Post-merge

<!-- The outer checkboxes can be completed pre-merge -->

- [ ] This adds, extends or meaningfully modifies a feature...
  - [ ] ... and I have written or updated an end-to-end test for the happy path in the [Accredited Programmes E2E repo](https://github.com/ministryofjustice/hmpps-accredited-programmes-e2e)
- [ ] This makes new expectations of the API...
  - [ ] ... and I have notified the API developer(s) of changes to the contract tests (Pact), or the API is already compliant
- [ ] [Manually approve](../doc/how-to/perform-a-release.md#releasing-to-the-preprod-environment) release to preprod
- [ ] [Manually approve](../doc/how-to/perform-a-release.md#releasing-to-the-production-environment) release to prod

<!-- Should a release fail at any step, you as the author should now lead the work to
fix it as soon as possible. You can monitor deployment failures in CircleCI
itself and application errors are found in
[Sentry](https://ministryofjustice.sentry.io/projects/hmpps-accredited-programmes-ui/?project=4505330122686464&referrer=sidebar&statsPeriod=24h). -->
