### PR TITLE
(888) Display not known against empty Course Participation values

### DIFF
--- a/server/utils/courseParticipationUtils.test.ts
+++ b/server/utils/courseParticipationUtils.test.ts
@@ -168,18 +168,6 @@ describe('CourseParticipationUtils', () => {
     })
 
     describe('when rows are missing required data', () => {
-      it.each([['Source of information', 'source', undefined]])(
-        'omits the %s row when %s is %s',
-        (keyText: GovukFrontendSummaryListRowKey['text'], field: string, value) => {
-          const withoutField = { ...courseParticipationWithName, [field]: value }
-
-          const { rows } = CourseParticipationUtils.summaryListOptions(withoutField, referralId)
-          const fieldRow = getRow(rows, keyText)
-
-          expect(fieldRow).toBeUndefined()
-        },
-      )
-
       describe('setting', () => {
         describe('when the setting has no location', () => {
           const withoutSettingLocation: CourseParticipationWithName = {
@@ -302,6 +290,20 @@ describe('CourseParticipationUtils', () => {
           it('displays "Not known"', () => {
             const { rows } = CourseParticipationUtils.summaryListOptions(withoutOutcomeAdditionalDetail, referralId)
             expect(getRowValueText(rows, 'Additional detail')).toEqual('Not known')
+          })
+        })
+      })
+
+      describe('source of information', () => {
+        describe('when there is no source of information set', () => {
+          const withoutSource: CourseParticipationWithName = {
+            ...courseParticipationWithName,
+            source: undefined,
+          }
+
+          it('displays "Not known"', () => {
+            const { rows } = CourseParticipationUtils.summaryListOptions(withoutSource, referralId)
+            expect(getRowValueText(rows, 'Source of information')).toEqual('Not known')
           })
         })
       })

--- a/server/utils/courseParticipationUtils.test.ts
+++ b/server/utils/courseParticipationUtils.test.ts
@@ -8,18 +8,11 @@ import { courseParticipationFactory } from '../testutils/factories'
 import type { CourseParticipationOutcome, CourseParticipationWithName } from '@accredited-programmes/models'
 import type { GovukFrontendSummaryListRow, GovukFrontendSummaryListRowKey } from '@govuk-frontend'
 
-const getRow = (
-  rows: Array<GovukFrontendSummaryListRow>,
-  keyText: GovukFrontendSummaryListRowKey['text'],
-): GovukFrontendSummaryListRow | undefined => {
-  return rows.find(row => (row.key as GovukFrontendSummaryListRowKey).text === keyText)
-}
-
 const getRowValueText = (
   rows: Array<GovukFrontendSummaryListRow>,
   keyText: GovukFrontendSummaryListRowKey['text'],
 ): string => {
-  return getRow(rows, keyText)!.value!.text!
+  return rows.find(row => (row.key as GovukFrontendSummaryListRowKey).text === keyText)!.value!.text!
 }
 
 describe('CourseParticipationUtils', () => {

--- a/server/utils/courseParticipationUtils.test.ts
+++ b/server/utils/courseParticipationUtils.test.ts
@@ -168,17 +168,17 @@ describe('CourseParticipationUtils', () => {
     })
 
     describe('when rows are missing required data', () => {
-      it.each([
-        ['Additional detail', 'outcome', { detail: undefined }],
-        ['Source of information', 'source', undefined],
-      ])('omits the %s row when %s is %s', (keyText: GovukFrontendSummaryListRowKey['text'], field: string, value) => {
-        const withoutField = { ...courseParticipationWithName, [field]: value }
+      it.each([['Source of information', 'source', undefined]])(
+        'omits the %s row when %s is %s',
+        (keyText: GovukFrontendSummaryListRowKey['text'], field: string, value) => {
+          const withoutField = { ...courseParticipationWithName, [field]: value }
 
-        const { rows } = CourseParticipationUtils.summaryListOptions(withoutField, referralId)
-        const fieldRow = getRow(rows, keyText)
+          const { rows } = CourseParticipationUtils.summaryListOptions(withoutField, referralId)
+          const fieldRow = getRow(rows, keyText)
 
-        expect(fieldRow).toBeUndefined()
-      })
+          expect(fieldRow).toBeUndefined()
+        },
+      )
 
       describe('setting', () => {
         describe('when the setting has no location', () => {
@@ -271,6 +271,37 @@ describe('CourseParticipationUtils', () => {
           it('displays "Not known"', () => {
             const { rows } = CourseParticipationUtils.summaryListOptions(withoutOutcome, referralId)
             expect(getRowValueText(rows, 'Outcome')).toEqual('Not known')
+          })
+        })
+      })
+
+      describe('additional detail', () => {
+        describe('when there is no outcome', () => {
+          const withoutOutcome: CourseParticipationWithName = {
+            ...courseParticipationWithName,
+            outcome: {},
+          }
+
+          it('displays "Not known"', () => {
+            const { rows } = CourseParticipationUtils.summaryListOptions(withoutOutcome, referralId)
+            expect(getRowValueText(rows, 'Additional detail')).toEqual('Not known')
+          })
+        })
+
+        describe('when there is no additional detail set on the outcome', () => {
+          const withoutOutcomeAdditionalDetail: CourseParticipationWithName = {
+            ...courseParticipationWithName,
+            outcome: {
+              detail: undefined,
+              status: 'complete',
+              yearCompleted: 2019,
+              yearStarted: undefined,
+            },
+          }
+
+          it('displays "Not known"', () => {
+            const { rows } = CourseParticipationUtils.summaryListOptions(withoutOutcomeAdditionalDetail, referralId)
+            expect(getRowValueText(rows, 'Additional detail')).toEqual('Not known')
           })
         })
       })

--- a/server/utils/courseParticipationUtils.test.ts
+++ b/server/utils/courseParticipationUtils.test.ts
@@ -99,53 +99,55 @@ describe('CourseParticipationUtils', () => {
       name: 'A mediocre course name (aMCN)',
     }
 
-    it('generates an object to pass into a Nunjucks macro for a GOV.UK summary list with card', () => {
-      expect(CourseParticipationUtils.summaryListOptions(courseParticipationWithName, referralId)).toEqual({
-        card: {
-          actions: {
-            items: [
-              {
-                href: `/referrals/${referralId}/programme-history/${courseParticipationWithName.id}/programme`,
-                text: 'Change',
-                visuallyHiddenText: `participation for ${courseParticipationWithName.name}`,
-              },
-              {
-                href: `/referrals/${referralId}/programme-history/${courseParticipationWithName.id}/delete`,
-                text: 'Remove',
-                visuallyHiddenText: `participation for ${courseParticipationWithName.name}`,
-              },
-            ],
+    describe('when all fields are present on the CourseParticipationWithName', () => {
+      it('generates an object to pass into a Nunjucks macro for a GOV.UK summary list with card', () => {
+        expect(CourseParticipationUtils.summaryListOptions(courseParticipationWithName, referralId)).toEqual({
+          card: {
+            actions: {
+              items: [
+                {
+                  href: `/referrals/${referralId}/programme-history/${courseParticipationWithName.id}/programme`,
+                  text: 'Change',
+                  visuallyHiddenText: `participation for ${courseParticipationWithName.name}`,
+                },
+                {
+                  href: `/referrals/${referralId}/programme-history/${courseParticipationWithName.id}/delete`,
+                  text: 'Remove',
+                  visuallyHiddenText: `participation for ${courseParticipationWithName.name}`,
+                },
+              ],
+            },
+            title: {
+              text: 'A mediocre course name (aMCN)',
+            },
           },
-          title: {
-            text: 'A mediocre course name (aMCN)',
-          },
-        },
-        rows: [
-          {
-            key: { text: 'Programme name' },
-            value: { text: 'A mediocre course name (aMCN)' },
-          },
-          {
-            key: { text: 'Setting' },
-            value: { text: 'Community, Greater Tharfoot' },
-          },
-          {
-            key: { text: 'Outcome' },
-            value: { text: 'Complete, year completed 2019' },
-          },
-          {
-            key: { text: 'Additional detail' },
-            value: { text: 'Motivation level over 9000!' },
-          },
-          {
-            key: { text: 'Source of information' },
-            value: { text: 'Word of mouth' },
-          },
-          {
-            key: { text: 'Added by' },
-            value: { text: 'Eric McNally, 20 April 2023' },
-          },
-        ],
+          rows: [
+            {
+              key: { text: 'Programme name' },
+              value: { text: 'A mediocre course name (aMCN)' },
+            },
+            {
+              key: { text: 'Setting' },
+              value: { text: 'Community, Greater Tharfoot' },
+            },
+            {
+              key: { text: 'Outcome' },
+              value: { text: 'Complete, year completed 2019' },
+            },
+            {
+              key: { text: 'Additional detail' },
+              value: { text: 'Motivation level over 9000!' },
+            },
+            {
+              key: { text: 'Source of information' },
+              value: { text: 'Word of mouth' },
+            },
+            {
+              key: { text: 'Added by' },
+              value: { text: 'Eric McNally, 20 April 2023' },
+            },
+          ],
+        })
       })
     })
 
@@ -160,7 +162,7 @@ describe('CourseParticipationUtils', () => {
       })
     })
 
-    describe('when rows are missing required data', () => {
+    describe('rows with optional values', () => {
       describe('setting', () => {
         describe('when the setting has no location', () => {
           const withoutSettingLocation: CourseParticipationWithName = {

--- a/server/utils/courseParticipationUtils.test.ts
+++ b/server/utils/courseParticipationUtils.test.ts
@@ -138,7 +138,7 @@ describe('CourseParticipationUtils', () => {
           },
           {
             key: { text: 'Outcome' },
-            value: { text: 'Complete - completed in 2019' },
+            value: { text: 'Complete, year completed 2019' },
           },
           {
             key: { text: 'Additional detail' },
@@ -169,8 +169,6 @@ describe('CourseParticipationUtils', () => {
 
     describe('when rows are missing required data', () => {
       it.each([
-        ['Outcome', 'outcome', undefined],
-        ['Outcome', 'outcome', { status: undefined }],
         ['Additional detail', 'outcome', { detail: undefined }],
         ['Source of information', 'source', undefined],
       ])('omits the %s row when %s is %s', (keyText: GovukFrontendSummaryListRowKey['text'], field: string, value) => {
@@ -211,28 +209,70 @@ describe('CourseParticipationUtils', () => {
         })
       })
 
-      it('only shows the status in the Outcome row when yearStarted is undefined on an incomplete outcome', () => {
-        const withoutOutcomeYearStarted = {
-          ...courseParticipationWithName,
-          outcome: { status: 'incomplete' as CourseParticipationOutcome['status'], yearStarted: undefined },
-        }
+      describe('outcome', () => {
+        describe('when the outcome is incomplete', () => {
+          describe('and there is a yearStarted value', () => {
+            const withOutcomeYearStarted = {
+              ...courseParticipationWithName,
+              outcome: { status: 'incomplete' as CourseParticipationOutcome['status'], yearStarted: 2019 },
+            }
 
-        const { rows } = CourseParticipationUtils.summaryListOptions(withoutOutcomeYearStarted, referralId)
-        const outcomeRow = getRow(rows, 'Outcome')
+            it('displays the outcome and yearStarted value', () => {
+              const { rows } = CourseParticipationUtils.summaryListOptions(withOutcomeYearStarted, referralId)
+              expect(getRowValueText(rows, 'Outcome')).toEqual('Incomplete, year started 2019')
+            })
+          })
 
-        expect(outcomeRow).toEqual({ key: { text: 'Outcome' }, value: { text: 'Incomplete' } })
-      })
+          describe('and there is no yearStarted value', () => {
+            const withoutOutcomeYearStarted = {
+              ...courseParticipationWithName,
+              outcome: { status: 'incomplete' as CourseParticipationOutcome['status'], yearStarted: undefined },
+            }
 
-      it('only shows the status in the Outcome row when yearCompleted is undefined on a complete outcome', () => {
-        const withoutOutcomeYearCompleted = {
-          ...courseParticipationWithName,
-          outcome: { status: 'complete' as CourseParticipationOutcome['status'], yearCompleted: undefined },
-        }
+            it('displays the outcome on its own', () => {
+              const { rows } = CourseParticipationUtils.summaryListOptions(withoutOutcomeYearStarted, referralId)
+              expect(getRowValueText(rows, 'Outcome')).toEqual('Incomplete')
+            })
+          })
+        })
 
-        const { rows } = CourseParticipationUtils.summaryListOptions(withoutOutcomeYearCompleted, referralId)
-        const outcomeRow = getRow(rows, 'Outcome')
+        describe('when the outcome is complete', () => {
+          describe('and there is a yearCompleted value', () => {
+            const withOutcomeYearCompleted = {
+              ...courseParticipationWithName,
+              outcome: { status: 'complete' as CourseParticipationOutcome['status'], yearCompleted: 2019 },
+            }
 
-        expect(outcomeRow).toEqual({ key: { text: 'Outcome' }, value: { text: 'Complete' } })
+            it('displays the outcome and yearCompleted value', () => {
+              const { rows } = CourseParticipationUtils.summaryListOptions(withOutcomeYearCompleted, referralId)
+              expect(getRowValueText(rows, 'Outcome')).toEqual('Complete, year completed 2019')
+            })
+          })
+
+          describe('and there is no yearCompleted value', () => {
+            const withoutOutcomeYearCompleted = {
+              ...courseParticipationWithName,
+              outcome: { status: 'complete' as CourseParticipationOutcome['status'], yearCompleted: undefined },
+            }
+
+            it('displays the outcome and yearStarted value', () => {
+              const { rows } = CourseParticipationUtils.summaryListOptions(withoutOutcomeYearCompleted, referralId)
+              expect(getRowValueText(rows, 'Outcome')).toEqual('Complete')
+            })
+          })
+        })
+
+        describe('when there is no outcome', () => {
+          const withoutOutcome: CourseParticipationWithName = {
+            ...courseParticipationWithName,
+            outcome: {},
+          }
+
+          it('displays "Not known"', () => {
+            const { rows } = CourseParticipationUtils.summaryListOptions(withoutOutcome, referralId)
+            expect(getRowValueText(rows, 'Outcome')).toEqual('Not known')
+          })
+        })
       })
     })
   })

--- a/server/utils/courseParticipationUtils.ts
+++ b/server/utils/courseParticipationUtils.ts
@@ -94,16 +94,7 @@ export default class CourseParticipationUtils {
     summaryListRows.push(CourseParticipationUtils.outcomeSummaryListRow(courseParticipationWithName))
     summaryListRows.push(CourseParticipationUtils.outcomeAdditionalDetailSummaryListRow(courseParticipationWithName))
     summaryListRows.push(CourseParticipationUtils.sourceSummaryListRow(courseParticipationWithName))
-
-    const addedByValueText = [
-      courseParticipationWithName.addedBy,
-      DateUtils.govukFormattedFullDateString(courseParticipationWithName.createdAt),
-    ].join(', ')
-
-    summaryListRows.push({
-      key: { text: 'Added by' },
-      value: { text: addedByValueText },
-    })
+    summaryListRows.push(CourseParticipationUtils.addedBySummaryListRow(courseParticipationWithName))
 
     return summaryListRows
   }
@@ -169,6 +160,21 @@ export default class CourseParticipationUtils {
     return {
       key: { text: 'Source of information' },
       value: { text: courseParticipationWithName.source || 'Not known' },
+    }
+  }
+
+  // eslint-disable-next-line @typescript-eslint/member-ordering
+  private static addedBySummaryListRow(
+    courseParticipationWithName: CourseParticipationWithName,
+  ): GovukFrontendSummaryListRowWithValue {
+    const addedByValueText = [
+      courseParticipationWithName.addedBy,
+      DateUtils.govukFormattedFullDateString(courseParticipationWithName.createdAt),
+    ].join(', ')
+
+    return {
+      key: { text: 'Added by' },
+      value: { text: addedByValueText },
     }
   }
 }

--- a/server/utils/courseParticipationUtils.ts
+++ b/server/utils/courseParticipationUtils.ts
@@ -93,13 +93,7 @@ export default class CourseParticipationUtils {
     summaryListRows.push(CourseParticipationUtils.settingSummaryListRow(courseParticipationWithName))
     summaryListRows.push(CourseParticipationUtils.outcomeSummaryListRow(courseParticipationWithName))
     summaryListRows.push(CourseParticipationUtils.outcomeAdditionalDetailSummaryListRow(courseParticipationWithName))
-
-    if (courseParticipationWithName.source) {
-      summaryListRows.push({
-        key: { text: 'Source of information' },
-        value: { text: courseParticipationWithName.source },
-      })
-    }
+    summaryListRows.push(CourseParticipationUtils.sourceSummaryListRow(courseParticipationWithName))
 
     const addedByValueText = [
       courseParticipationWithName.addedBy,
@@ -165,6 +159,16 @@ export default class CourseParticipationUtils {
     return {
       key: { text: 'Additional detail' },
       value: { text: courseParticipationWithName.outcome.detail || 'Not known' },
+    }
+  }
+
+  // eslint-disable-next-line @typescript-eslint/member-ordering
+  private static sourceSummaryListRow(
+    courseParticipationWithName: CourseParticipationWithName,
+  ): GovukFrontendSummaryListRowWithValue {
+    return {
+      key: { text: 'Source of information' },
+      value: { text: courseParticipationWithName.source || 'Not known' },
     }
   }
 }

--- a/server/utils/courseParticipationUtils.ts
+++ b/server/utils/courseParticipationUtils.ts
@@ -83,20 +83,17 @@ export default class CourseParticipationUtils {
   private static summaryListRows(
     courseParticipationWithName: CourseParticipationWithName,
   ): Array<GovukFrontendSummaryListRowWithValue> {
-    const summaryListRows: Array<GovukFrontendSummaryListRowWithValue> = []
-
-    summaryListRows.push({
-      key: { text: 'Programme name' },
-      value: { text: courseParticipationWithName.name },
-    })
-
-    summaryListRows.push(CourseParticipationUtils.settingSummaryListRow(courseParticipationWithName))
-    summaryListRows.push(CourseParticipationUtils.outcomeSummaryListRow(courseParticipationWithName))
-    summaryListRows.push(CourseParticipationUtils.outcomeAdditionalDetailSummaryListRow(courseParticipationWithName))
-    summaryListRows.push(CourseParticipationUtils.sourceSummaryListRow(courseParticipationWithName))
-    summaryListRows.push(CourseParticipationUtils.addedBySummaryListRow(courseParticipationWithName))
-
-    return summaryListRows
+    return [
+      {
+        key: { text: 'Programme name' },
+        value: { text: courseParticipationWithName.name },
+      },
+      CourseParticipationUtils.settingSummaryListRow(courseParticipationWithName),
+      CourseParticipationUtils.outcomeSummaryListRow(courseParticipationWithName),
+      CourseParticipationUtils.outcomeAdditionalDetailSummaryListRow(courseParticipationWithName),
+      CourseParticipationUtils.sourceSummaryListRow(courseParticipationWithName),
+      CourseParticipationUtils.addedBySummaryListRow(courseParticipationWithName),
+    ]
   }
 
   // eslint-disable-next-line @typescript-eslint/member-ordering

--- a/server/utils/courseParticipationUtils.ts
+++ b/server/utils/courseParticipationUtils.ts
@@ -92,15 +92,7 @@ export default class CourseParticipationUtils {
 
     summaryListRows.push(CourseParticipationUtils.settingSummaryListRow(courseParticipationWithName))
     summaryListRows.push(CourseParticipationUtils.outcomeSummaryListRow(courseParticipationWithName))
-
-    if (courseParticipationWithName.outcome) {
-      if (courseParticipationWithName.outcome.detail) {
-        summaryListRows.push({
-          key: { text: 'Additional detail' },
-          value: { text: courseParticipationWithName.outcome.detail },
-        })
-      }
-    }
+    summaryListRows.push(CourseParticipationUtils.outcomeAdditionalDetailSummaryListRow(courseParticipationWithName))
 
     if (courseParticipationWithName.source) {
       summaryListRows.push({
@@ -163,6 +155,16 @@ export default class CourseParticipationUtils {
     return {
       key: { text: 'Outcome' },
       value: { text: valueTextItems.join(', ') || 'Not known' },
+    }
+  }
+
+  // eslint-disable-next-line @typescript-eslint/member-ordering
+  private static outcomeAdditionalDetailSummaryListRow(
+    courseParticipationWithName: CourseParticipationWithName,
+  ): GovukFrontendSummaryListRowWithValue {
+    return {
+      key: { text: 'Additional detail' },
+      value: { text: courseParticipationWithName.outcome.detail || 'Not known' },
     }
   }
 }

--- a/server/utils/courseParticipationUtils.ts
+++ b/server/utils/courseParticipationUtils.ts
@@ -91,27 +91,9 @@ export default class CourseParticipationUtils {
     })
 
     summaryListRows.push(CourseParticipationUtils.settingSummaryListRow(courseParticipationWithName))
+    summaryListRows.push(CourseParticipationUtils.outcomeSummaryListRow(courseParticipationWithName))
 
     if (courseParticipationWithName.outcome) {
-      if (courseParticipationWithName.outcome.status) {
-        let valueText = ''
-
-        valueText += StringUtils.properCase(courseParticipationWithName.outcome.status)
-
-        if (courseParticipationWithName.outcome.yearStarted) {
-          valueText += ` - started ${courseParticipationWithName.outcome.yearStarted}`
-        }
-
-        if (courseParticipationWithName.outcome.yearCompleted) {
-          valueText += ` - completed in ${courseParticipationWithName.outcome.yearCompleted}`
-        }
-
-        summaryListRows.push({
-          key: { text: 'Outcome' },
-          value: { text: valueText },
-        })
-      }
-
       if (courseParticipationWithName.outcome.detail) {
         summaryListRows.push({
           key: { text: 'Additional detail' },
@@ -156,6 +138,30 @@ export default class CourseParticipationUtils {
 
     return {
       key: { text: 'Setting' },
+      value: { text: valueTextItems.join(', ') || 'Not known' },
+    }
+  }
+
+  // eslint-disable-next-line @typescript-eslint/member-ordering
+  private static outcomeSummaryListRow(
+    courseParticipationWithName: CourseParticipationWithName,
+  ): GovukFrontendSummaryListRowWithValue {
+    const valueTextItems: Array<string> = []
+
+    if (courseParticipationWithName.outcome?.status) {
+      valueTextItems.push(StringUtils.properCase(courseParticipationWithName.outcome.status))
+    }
+
+    if (courseParticipationWithName.outcome?.yearStarted) {
+      valueTextItems.push(`year started ${courseParticipationWithName.outcome.yearStarted}`)
+    }
+
+    if (courseParticipationWithName.outcome?.yearCompleted) {
+      valueTextItems.push(`year completed ${courseParticipationWithName.outcome.yearCompleted}`)
+    }
+
+    return {
+      key: { text: 'Outcome' },
       value: { text: valueTextItems.join(', ') || 'Not known' },
     }
   }

--- a/server/utils/courseParticipationUtils.ts
+++ b/server/utils/courseParticipationUtils.ts
@@ -90,26 +90,7 @@ export default class CourseParticipationUtils {
       value: { text: courseParticipationWithName.name },
     })
 
-    if (courseParticipationWithName.setting) {
-      const valueTextItems: Array<string> = []
-
-      if (courseParticipationWithName.setting.type) {
-        valueTextItems.push(StringUtils.properCase(courseParticipationWithName.setting.type))
-      }
-
-      if (courseParticipationWithName.setting.location) {
-        valueTextItems.push(`${courseParticipationWithName.setting.location}`)
-      }
-
-      const valueText = valueTextItems.join(', ')
-
-      if (valueText) {
-        summaryListRows.push({
-          key: { text: 'Setting' },
-          value: { text: valueText },
-        })
-      }
-    }
+    summaryListRows.push(CourseParticipationUtils.settingSummaryListRow(courseParticipationWithName))
 
     if (courseParticipationWithName.outcome) {
       if (courseParticipationWithName.outcome.status) {
@@ -157,5 +138,25 @@ export default class CourseParticipationUtils {
     })
 
     return summaryListRows
+  }
+
+  // eslint-disable-next-line @typescript-eslint/member-ordering
+  private static settingSummaryListRow(
+    courseParticipationWithName: CourseParticipationWithName,
+  ): GovukFrontendSummaryListRowWithValue {
+    const valueTextItems: Array<string> = []
+
+    if (courseParticipationWithName.setting.type) {
+      valueTextItems.push(StringUtils.properCase(courseParticipationWithName.setting.type))
+    }
+
+    if (courseParticipationWithName.setting.location) {
+      valueTextItems.push(`${courseParticipationWithName.setting.location}`)
+    }
+
+    return {
+      key: { text: 'Setting' },
+      value: { text: valueTextItems.join(', ') || 'Not known' },
+    }
   }
 }


### PR DESCRIPTION
## Context

<!-- Is there a Trello ticket you can link to? -->

https://trello.com/c/0pCdIJDt/884-display-not-known-on-programme-history-when-the-user-hasnt-answered-a-question

<!-- Do you need to add any environment variables? -->
<!-- Is an ADR required? An ADR should be added if this PR introduces a change to the architecture. -->

Previously, we wouldn't show a row against a field that a user hadn't filled in when creating a CourseParticipation. We now would like to highlight this as "not known" to prompt users to enter any information they do know, rather than ignoring the field. We don't want to make the fields required, as this would prevent people who genuinely don't have this information from being able to add anything.

## Changes in this PR

- Displays "Not known" for rows where the CourseParticipation field is blank.
- Rejigs `CourseParticipationUtils` tests slightly to hopefully be a bit clearer now that this is the case.

## Screenshots of UI changes

### Before

<img width="857" alt="Screenshot 2023-10-05 at 16 20 06" src="https://github.com/ministryofjustice/hmpps-accredited-programmes-ui/assets/19826940/fc01f146-a6ea-49f9-9fb7-d23d2efaa3a9">

### After

<img width="929" alt="image" src="https://github.com/ministryofjustice/hmpps-accredited-programmes-ui/assets/19826940/20d93373-b20e-47e3-9ed1-e485a373d7d0">


## Release checklist

[Release process documentation](../doc/how-to/perform-a-release.md)

As part of our continuous deployment strategy we must ensure that this work is
ready to be released once merged.

### Pre-merge

- [ ] There are changes required to the Accredited Programmes API for this change to work...
  - [ ] ... and they have been released to production already

### Post-merge

<!-- The outer checkboxes can be completed pre-merge -->

- [ ] This adds, extends or meaningfully modifies a feature...
  - [ ] ... and I have written or updated an end-to-end test for the happy path in the [Accredited Programmes E2E repo](https://github.com/ministryofjustice/hmpps-accredited-programmes-e2e)
- [ ] This makes new expectations of the API...
  - [ ] ... and I have notified the API developer(s) of changes to the contract tests (Pact), or the API is already compliant
- [ ] [Manually approve](../doc/how-to/perform-a-release.md#releasing-to-the-preprod-environment) release to preprod
- [ ] [Manually approve](../doc/how-to/perform-a-release.md#releasing-to-the-production-environment) release to prod

<!-- Should a release fail at any step, you as the author should now lead the work to
fix it as soon as possible. You can monitor deployment failures in CircleCI
itself and application errors are found in
[Sentry](https://ministryofjustice.sentry.io/projects/hmpps-accredited-programmes-ui/?project=4505330122686464&referrer=sidebar&statsPeriod=24h). -->
