### PR TITLE
(950a) Update course participation details to pre-populate course participation values

### DIFF
--- a/integration_tests/e2e/refer/programmeHistory.cy.ts
+++ b/integration_tests/e2e/refer/programmeHistory.cy.ts
@@ -287,15 +287,20 @@ context('Programme history', () => {
     })
 
     describe('and adding details', () => {
-      const courseParticipation = courseParticipationFactory
-        .withCourseId()
-        .build({ courseId: courses[0].id, prisonNumber: person.prisonNumber })
-      const path = referPaths.programmeHistory.details.show({
-        courseParticipationId: courseParticipation.id,
-        referralId: referral.id,
-      })
+      let courseParticipation: CourseParticipation
+      let path: string
 
       beforeEach(() => {
+        courseParticipation = courseParticipationFactory.new().build({
+          courseId: courses[0].id,
+          otherCourseName: undefined,
+          prisonNumber: person.prisonNumber,
+        })
+        path = referPaths.programmeHistory.details.show({
+          courseParticipationId: courseParticipation.id,
+          referralId: referral.id,
+        })
+
         cy.task('stubParticipation', courseParticipation)
         cy.task('stubPrisoner', prisoner)
         cy.task('stubReferral', referral)
@@ -316,6 +321,7 @@ context('Programme history', () => {
         programmeHistoryDetailsPage.shouldContainBackLink(
           referPaths.programmeHistory.index({ referralId: referral.id }),
         )
+        programmeHistoryDetailsPage.shouldHaveCorrectFormValues()
         programmeHistoryDetailsPage.shouldContainSettingRadioItems()
         programmeHistoryDetailsPage.shouldNotDisplayCommunityLocationInput()
         programmeHistoryDetailsPage.shouldDisplayCommunityLocationInput()
@@ -426,6 +432,32 @@ context('Programme history', () => {
             message: 'Enter a year using numbers only',
           },
         ])
+      })
+
+      describe('for a participation with existing details', () => {
+        beforeEach(() => {
+          courseParticipation = courseParticipationFactory.withCourseId().build()
+          path = referPaths.programmeHistory.details.show({
+            courseParticipationId: courseParticipation.id,
+            referralId: referral.id,
+          })
+
+          cy.task('stubParticipation', courseParticipation)
+          cy.task('stubPrisoner', prisoner)
+          cy.task('stubReferral', referral)
+
+          cy.visit(path)
+        })
+
+        it('shows the details page with the form fields pre-populated', () => {
+          const programmeHistoryDetailsPage = Page.verifyOnPage(ProgrammeHistoryDetailsPage, {
+            course: courses[0],
+            courseParticipation,
+            person,
+          })
+
+          programmeHistoryDetailsPage.shouldHaveCorrectFormValues()
+        })
       })
     })
   })

--- a/integration_tests/e2e/refer/programmeHistory.cy.ts
+++ b/integration_tests/e2e/refer/programmeHistory.cy.ts
@@ -164,7 +164,7 @@ context('Programme history', () => {
           selectProgrammePage.selectCourse(courses[0].id)
           selectProgrammePage.submitSelection(courseParticipation, courses[0].id)
 
-          Page.verifyOnPage(ProgrammeHistoryDetailsPage)
+          Page.verifyOnPage(ProgrammeHistoryDetailsPage, { course: courses[0], courseParticipation, person })
         })
 
         it('displays an error when no programme is selected', () => {
@@ -260,7 +260,11 @@ context('Programme history', () => {
           selectProgrammePage.selectCourse(newCourseId)
           selectProgrammePage.submitSelection(courseParticipationWithCourseId, newCourseId)
 
-          Page.verifyOnPage(ProgrammeHistoryDetailsPage)
+          Page.verifyOnPage(ProgrammeHistoryDetailsPage, {
+            course: courses[0],
+            courseParticipation: updatedParticipation,
+            person,
+          })
         })
 
         it('displays an error when "Other" is selected but a programme name is not provided', () => {
@@ -302,7 +306,11 @@ context('Programme history', () => {
       })
 
       it('shows the details page', () => {
-        const programmeHistoryDetailsPage = Page.verifyOnPage(ProgrammeHistoryDetailsPage)
+        const programmeHistoryDetailsPage = Page.verifyOnPage(ProgrammeHistoryDetailsPage, {
+          course: courses[0],
+          courseParticipation,
+          person,
+        })
         programmeHistoryDetailsPage.shouldContainNavigation(path)
         programmeHistoryDetailsPage.shouldHavePersonDetails(person)
         programmeHistoryDetailsPage.shouldContainBackLink(
@@ -353,14 +361,18 @@ context('Programme history', () => {
           source: formValues.source,
         })
 
-        const programmeHistoryDetailsPage = Page.verifyOnPage(ProgrammeHistoryDetailsPage)
+        const programmeHistoryDetailsPage = Page.verifyOnPage(ProgrammeHistoryDetailsPage, {
+          course: courses[0],
+          courseParticipation: updatedCourseParticipation,
+          person,
+        })
         programmeHistoryDetailsPage.selectSetting(formValues.setting.type as string)
         programmeHistoryDetailsPage.inputCommunityLocation(formValues.setting.communityLocation)
         programmeHistoryDetailsPage.selectOutcome(formValues.outcome.status as string)
         programmeHistoryDetailsPage.inputOutcomeYearCompleted(formValues.outcome.yearCompleted)
         programmeHistoryDetailsPage.inputOutcomeDetail(formValues.outcome.detail)
         programmeHistoryDetailsPage.inputSource(formValues.source)
-        programmeHistoryDetailsPage.submitDetails(updatedCourseParticipation, courses[0], person)
+        programmeHistoryDetailsPage.submitDetails()
 
         const programmeHistoryPage = Page.verifyOnPage(ProgrammeHistoryPage, {
           participationsWithNames: [{ ...updatedCourseParticipation, name: courses[0].name }],
@@ -371,12 +383,20 @@ context('Programme history', () => {
       })
 
       it('displays an error when inputting a non numeric value for `yearCompleted`', () => {
-        const programmeHistoryDetailsPage = Page.verifyOnPage(ProgrammeHistoryDetailsPage)
+        const programmeHistoryDetailsPage = Page.verifyOnPage(ProgrammeHistoryDetailsPage, {
+          course: courses[0],
+          courseParticipation,
+          person,
+        })
         programmeHistoryDetailsPage.selectOutcome('complete')
         programmeHistoryDetailsPage.inputOutcomeYearCompleted('not a number')
         programmeHistoryDetailsPage.shouldContainButton('Continue').click()
 
-        const programmeHistoryDetailsPageWithError = Page.verifyOnPage(ProgrammeHistoryDetailsPage)
+        const programmeHistoryDetailsPageWithError = Page.verifyOnPage(ProgrammeHistoryDetailsPage, {
+          course: courses[0],
+          courseParticipation,
+          person,
+        })
         programmeHistoryDetailsPageWithError.shouldHaveErrors([
           {
             field: 'yearCompleted',
@@ -386,12 +406,20 @@ context('Programme history', () => {
       })
 
       it('displays an error when inputting a non numeric value for `yearStarted`', () => {
-        const programmeHistoryDetailsPage = Page.verifyOnPage(ProgrammeHistoryDetailsPage)
+        const programmeHistoryDetailsPage = Page.verifyOnPage(ProgrammeHistoryDetailsPage, {
+          course: courses[0],
+          courseParticipation,
+          person,
+        })
         programmeHistoryDetailsPage.selectOutcome('incomplete')
         programmeHistoryDetailsPage.inputOutcomeYearStarted('not a number')
         programmeHistoryDetailsPage.shouldContainButton('Continue').click()
 
-        const programmeHistoryDetailsPageWithError = Page.verifyOnPage(ProgrammeHistoryDetailsPage)
+        const programmeHistoryDetailsPageWithError = Page.verifyOnPage(ProgrammeHistoryDetailsPage, {
+          course: courses[0],
+          courseParticipation,
+          person,
+        })
         programmeHistoryDetailsPageWithError.shouldHaveErrors([
           {
             field: 'yearStarted',

--- a/integration_tests/pages/refer/programmeHistoryDetails.ts
+++ b/integration_tests/pages/refer/programmeHistoryDetails.ts
@@ -2,10 +2,21 @@ import Page from '../page'
 import type { Course, CourseParticipation, Person } from '@accredited-programmes/models'
 
 export default class ProgrammeHistoryDetailsPage extends Page {
-  constructor() {
+  course: Course
+
+  courseParticipation: CourseParticipation
+
+  person: Person
+
+  constructor(args: { course: Course; courseParticipation: CourseParticipation; person: Person }) {
     // Conditional radio buttons add an additional `aria-expanded` field,
     // so ignore that rule on this page
     super('Add Accredited Programme details', { accessibilityRules: { 'aria-allowed-attr': { enabled: false } } })
+
+    const { course, courseParticipation, person } = args
+    this.course = course
+    this.courseParticipation = courseParticipation
+    this.person = person
   }
 
   inputCommunityLocation(value: string) {
@@ -82,6 +93,50 @@ export default class ProgrammeHistoryDetailsPage extends Page {
     cy.get('input[id="yearStarted"]').should('be.visible')
   }
 
+  shouldHaveCorrectFormValues() {
+    const { setting, outcome, source } = this.courseParticipation
+
+    if (setting.type === 'community') {
+      cy.get('[data-testid="community-setting-option"]').should('be.checked')
+
+      if (setting.location) {
+        cy.get('input[id="communityLocation"]').should('have.value', setting.location)
+      }
+    }
+
+    if (setting.type === 'custody') {
+      cy.get('[data-testid="custody-setting-option"]').should('be.checked')
+
+      if (setting.location) {
+        cy.get('input[id="custodyLocation"]').should('have.value', setting.location)
+      }
+    }
+
+    if (outcome.status === 'complete') {
+      cy.get('[data-testid="complete-outcome-option"]').should('be.checked')
+
+      if (outcome.yearCompleted) {
+        cy.get('input[id="yearCompleted"]').should('have.value', outcome.yearCompleted)
+      }
+    }
+
+    if (outcome.status === 'incomplete') {
+      cy.get('[data-testid="incomplete-outcome-option"]').should('be.checked')
+
+      if (outcome.yearStarted) {
+        cy.get('input[id="yearStarted"]').should('have.value', outcome.yearStarted)
+      }
+    }
+
+    if (outcome.detail) {
+      cy.get('textarea[id="outcomeDetail"]').should('have.value', outcome.detail)
+    }
+
+    if (source) {
+      cy.get('textarea[id="source"]').should('have.value', source)
+    }
+  }
+
   shouldNotDisplayCommunityLocationInput() {
     cy.get('input[id="communityLocation"]').should('not.be.visible')
   }
@@ -98,12 +153,12 @@ export default class ProgrammeHistoryDetailsPage extends Page {
     cy.get('input[id="yearStarted"]').should('not.be.visible')
   }
 
-  submitDetails(courseParticipation: CourseParticipation, course: Course, person: Person) {
-    cy.task('stubUpdateParticipation', courseParticipation)
-    cy.task('stubCourse', course)
+  submitDetails() {
+    cy.task('stubUpdateParticipation', this.courseParticipation)
+    cy.task('stubCourse', this.course)
     cy.task('stubParticipationsByPerson', {
-      courseParticipations: [courseParticipation],
-      prisonNumber: person.prisonNumber,
+      courseParticipations: [this.courseParticipation],
+      prisonNumber: this.person.prisonNumber,
     })
     this.shouldContainButton('Continue').click()
   }

--- a/server/controllers/refer/courseParticipationDetailsController.ts
+++ b/server/controllers/refer/courseParticipationDetailsController.ts
@@ -16,7 +16,10 @@ export default class CourseParticipationDetailsController {
       TypeUtils.assertHasUser(req)
       const { courseParticipationId, referralId } = req.params
 
-      await this.courseService.getParticipation(req.user.token, courseParticipationId)
+      const { outcome, setting, source } = await this.courseService.getParticipation(
+        req.user.token,
+        courseParticipationId,
+      )
 
       const referral = await this.referralService.getReferral(req.user.token, referralId)
       const person = await this.personService.getPerson(
@@ -26,7 +29,15 @@ export default class CourseParticipationDetailsController {
       )
 
       FormUtils.setFieldErrors(req, res, ['yearCompleted', 'yearStarted'])
-      FormUtils.setFormValues(req, res)
+      FormUtils.setFormValues(req, res, {
+        outcome,
+        setting: {
+          ...setting,
+          communityLocation: setting.type === 'community' ? setting.location : '',
+          custodyLocation: setting.type === 'custody' ? setting.location : '',
+        },
+        source,
+      })
 
       res.render('referrals/courseParticipations/details/show', {
         action: `${referPaths.programmeHistory.details.update({ courseParticipationId, referralId })}?_method=PUT`,

--- a/server/testutils/factories/courseParticipation.ts
+++ b/server/testutils/factories/courseParticipation.ts
@@ -22,6 +22,23 @@ const courseParticipationTypes = {
     }
   },
 
+  new() {
+    return {
+      ...this.random(),
+      outcome: {
+        detail: undefined,
+        status: undefined,
+        yearCompleted: undefined,
+        yearStarted: undefined,
+      },
+      setting: {
+        location: undefined,
+        type: undefined,
+      },
+      source: undefined,
+    }
+  },
+
   random() {
     const type = faker.helpers.arrayElement<'withCourseId' | 'withOtherCourseName'>([
       'withCourseId',
@@ -46,6 +63,10 @@ const courseParticipationTypes = {
 }
 
 class CourseParticipationFactory extends Factory<CourseParticipation> {
+  new() {
+    return this.params(courseParticipationTypes.new())
+  }
+
   withCourseId() {
     return this.params(courseParticipationTypes.withCourseId())
   }

--- a/server/utils/formUtils.test.ts
+++ b/server/utils/formUtils.test.ts
@@ -60,17 +60,30 @@ describe('FormUtils', () => {
   })
 
   describe('setFormValues', () => {
-    it("adds form values to a response's locals for displaying in the UI", () => {
-      const formValues = { someField: 'some value', someOtherField: 'some other value' }
-      ;(request.flash as jest.Mock).mockImplementation(() => [JSON.stringify(formValues)])
+    describe('when there are default values', () => {
+      const defaultFormValues = { someField: 'some original value', someOtherField: 'some other original value' }
 
-      FormUtils.setFormValues(request, response)
+      it('adds the default values to response locals', () => {
+        ;(request.flash as jest.Mock).mockImplementation(() => [])
+        FormUtils.setFormValues(request, response, defaultFormValues)
 
-      expect(response.locals.formValues).toEqual(formValues)
+        expect(response.locals.formValues).toEqual(defaultFormValues)
+      })
+
+      describe('but there are also flashed form values', () => {
+        it('adds the flashed form values instead of the default values to the response locals', () => {
+          const formValues = { someField: 'some updated value', someOtherField: 'some other updated value' }
+          ;(request.flash as jest.Mock).mockImplementation(() => [JSON.stringify(formValues)])
+
+          FormUtils.setFormValues(request, response, defaultFormValues)
+
+          expect(response.locals.formValues).toEqual(formValues)
+        })
+      })
     })
 
-    describe('when there are no flashed form values', () => {
-      it("doesn't add any form values to a response's locals", () => {
+    describe('when there are no flashed form or default values', () => {
+      it("doesn't add any form values to the response locals", () => {
         ;(request.flash as jest.Mock).mockImplementation(() => [])
 
         FormUtils.setFormValues(request, response)

--- a/server/utils/formUtils.ts
+++ b/server/utils/formUtils.ts
@@ -19,11 +19,11 @@ export default class FormUtils {
     res.locals.errors = { list, messages }
   }
 
-  static setFormValues(req: Request, res: Response): void {
-    const formValuesAsString = req.flash('formValues')[0]
+  static setFormValues(req: Request, res: Response, defaultValues = {}): void {
+    const flashedValuesAsString = req.flash('formValues')[0]
 
-    const formValues = formValuesAsString ? JSON.parse(formValuesAsString) : {}
+    const flashedValues = flashedValuesAsString ? JSON.parse(flashedValuesAsString) : {}
 
-    res.locals.formValues = formValues
+    res.locals.formValues = { ...defaultValues, ...flashedValues }
   }
 }


### PR DESCRIPTION
## Context

The course participation details form needs to be able to display current values when being visited as part of the **Change** journey.

## Changes in this PR
Updated `FormUtils.setFormValues` so it can take a `defaultValues` param.  These values then get set in `res.locals.formValues` but will get overwritten by the newly inputted values if `req.flash('formValues')` is called when there is an error on the form.

Also added `shouldHaveCorrectFormValues` to the Programme history page for integration tests to use to check that form values are correctly displayed.

## Release checklist

[Release process documentation](../doc/how-to/perform-a-release.md)

As part of our continuous deployment strategy we must ensure that this work is
ready to be released once merged.

### Pre-merge

- [ ] There are changes required to the Accredited Programmes API for this change to work...
  - [ ] ... and they have been released to production already

### Post-merge

<!-- The outer checkboxes can be completed pre-merge -->

- [ ] This adds, extends or meaningfully modifies a feature...
  - [ ] ... and I have written or updated an end-to-end test for the happy path in the [Accredited Programmes E2E repo](https://github.com/ministryofjustice/hmpps-accredited-programmes-e2e)
- [ ] This makes new expectations of the API...
  - [ ] ... and I have notified the API developer(s) of changes to the contract tests (Pact), or the API is already compliant
- [ ] [Manually approve](../doc/how-to/perform-a-release.md#releasing-to-the-preprod-environment) release to preprod
- [ ] [Manually approve](../doc/how-to/perform-a-release.md#releasing-to-the-production-environment) release to prod

<!-- Should a release fail at any step, you as the author should now lead the work to
fix it as soon as possible. You can monitor deployment failures in CircleCI
itself and application errors are found in
[Sentry](https://ministryofjustice.sentry.io/projects/hmpps-accredited-programmes-ui/?project=4505330122686464&referrer=sidebar&statsPeriod=24h). -->
