### PR TITLE
(888 - take 2) Display unanswered CourseParticipation fields as "Not known"

### DIFF
--- a/server/utils/courseParticipationUtils.ts
+++ b/server/utils/courseParticipationUtils.ts
@@ -15,6 +15,7 @@ import type {
   GovukFrontendSummaryListRowWithValue,
   GovukFrontendSummaryListWithRowsWithValues,
 } from '@accredited-programmes/ui'
+import type { GovukFrontendSummaryListRowKey } from '@govuk-frontend'
 
 interface DetailsBody {
   outcome: {
@@ -152,80 +153,62 @@ export default class CourseParticipationUtils {
   private static summaryListRows(
     courseParticipationWithName: CourseParticipationWithName,
   ): Array<GovukFrontendSummaryListRowWithValue> {
-    const summaryListRows: Array<GovukFrontendSummaryListRowWithValue> = []
+    return [
+      CourseParticipationUtils.summaryListRow('Programme name', [courseParticipationWithName.name]),
+      CourseParticipationUtils.summaryListRowSetting(courseParticipationWithName.setting),
+      CourseParticipationUtils.summaryListRowOutcome(courseParticipationWithName.outcome),
+      CourseParticipationUtils.summaryListRow('Additional detail', [courseParticipationWithName.outcome.detail]),
+      CourseParticipationUtils.summaryListRow('Source of information', [courseParticipationWithName.source]),
+      CourseParticipationUtils.summaryListRow('Added by', [
+        courseParticipationWithName.addedBy,
+        DateUtils.govukFormattedFullDateString(courseParticipationWithName.createdAt),
+      ]),
+    ]
+  }
 
-    summaryListRows.push({
-      key: { text: 'Programme name' },
-      value: { text: courseParticipationWithName.name },
-    })
+  // eslint-disable-next-line @typescript-eslint/member-ordering
+  private static summaryListRow(
+    keyText: GovukFrontendSummaryListRowKey['text'],
+    valueTextItems: Array<string | undefined>,
+  ): GovukFrontendSummaryListRowWithValue {
+    const valueTextItemsWithoutBlanks = valueTextItems.filter(Boolean)
 
-    if (courseParticipationWithName.setting) {
-      const valueTextItems: Array<string> = []
+    return {
+      key: { text: keyText },
+      value: { text: valueTextItemsWithoutBlanks.join(', ') || 'Not known' },
+    }
+  }
 
-      if (courseParticipationWithName.setting.type) {
-        valueTextItems.push(StringUtils.properCase(courseParticipationWithName.setting.type))
-      }
+  private static summaryListRowOutcome(outcome: CourseParticipationOutcome): GovukFrontendSummaryListRowWithValue {
+    const valueTextItems: Array<string> = []
 
-      if (courseParticipationWithName.setting.location) {
-        valueTextItems.push(`${courseParticipationWithName.setting.location}`)
-      }
-
-      const valueText = valueTextItems.join(', ')
-
-      if (valueText) {
-        summaryListRows.push({
-          key: { text: 'Setting' },
-          value: { text: valueText },
-        })
-      }
+    if (outcome.status) {
+      valueTextItems.push(StringUtils.properCase(outcome.status))
     }
 
-    if (courseParticipationWithName.outcome) {
-      if (courseParticipationWithName.outcome.status) {
-        let valueText = ''
-
-        valueText += StringUtils.properCase(courseParticipationWithName.outcome.status)
-
-        if (courseParticipationWithName.outcome.yearStarted) {
-          valueText += ` - started ${courseParticipationWithName.outcome.yearStarted}`
-        }
-
-        if (courseParticipationWithName.outcome.yearCompleted) {
-          valueText += ` - completed in ${courseParticipationWithName.outcome.yearCompleted}`
-        }
-
-        summaryListRows.push({
-          key: { text: 'Outcome' },
-          value: { text: valueText },
-        })
-      }
-
-      if (courseParticipationWithName.outcome.detail) {
-        summaryListRows.push({
-          key: { text: 'Additional detail' },
-          value: { text: courseParticipationWithName.outcome.detail },
-        })
-      }
+    if (outcome.yearStarted) {
+      valueTextItems.push(`Year started ${outcome.yearStarted}`)
     }
 
-    if (courseParticipationWithName.source) {
-      summaryListRows.push({
-        key: { text: 'Source of information' },
-        value: { text: courseParticipationWithName.source },
-      })
+    if (outcome.yearCompleted) {
+      valueTextItems.push(`Year complete ${outcome.yearCompleted}`)
     }
 
-    const addedByValueText = [
-      courseParticipationWithName.addedBy,
-      DateUtils.govukFormattedFullDateString(courseParticipationWithName.createdAt),
-    ].join(', ')
+    return this.summaryListRow('Outcome', valueTextItems)
+  }
 
-    summaryListRows.push({
-      key: { text: 'Added by' },
-      value: { text: addedByValueText },
-    })
+  private static summaryListRowSetting(setting: CourseParticipationSetting): GovukFrontendSummaryListRowWithValue {
+    const valueTextItems: Array<string> = []
 
-    return summaryListRows
+    if (setting.type) {
+      valueTextItems.push(StringUtils.properCase(setting.type))
+    }
+
+    if (setting.location) {
+      valueTextItems.push(`${setting.location}`)
+    }
+
+    return this.summaryListRow('Setting', valueTextItems)
   }
 }
 


### PR DESCRIPTION
## Context

This is a slight refactoring of #249 taking on @yndajas's helpful feedback. It felt easier to start from scratch and handle in one commit, rather than rebase the whole thing to make sense, as this is a more joined-up approach.

<!-- Is there a Trello ticket you can link to? -->
https://trello.com/c/0pCdIJDt/884-display-not-known-on-programme-history-when-the-user-hasnt-answered-a-question

<!-- Do you need to add any environment variables? -->
<!-- Is an ADR required? An ADR should be added if this PR introduces a change to the architecture. -->

Previously, we wouldn't show a row against a field that a user hadn't filled in when creating a CourseParticipation. We now would like to highlight this as "not known" to prompt users to enter any information they do know, rather than ignoring the field. We don't want to make the fields required, as this would prevent people who genuinely don't have this information from being able to add anything.

## Changes in this PR

- Displays "Not known" for rows where the CourseParticipation field is blank.
- Rejigs `CourseParticipationUtils` tests slightly to hopefully be a bit clearer now that this is the case.

## Screenshots of UI changes

### Before

<img width="786" alt="image" src="https://github.com/ministryofjustice/hmpps-accredited-programmes-ui/assets/19826940/474c195f-fec4-47d0-a046-1c66fcb1573c">

### After

<img width="827" alt="Screenshot 2023-10-09 at 16 05 59" src="https://github.com/ministryofjustice/hmpps-accredited-programmes-ui/assets/19826940/1d7eae91-25b6-48bc-8576-ad11aa6c0050">

<img width="843" alt="Screenshot 2023-10-09 at 16 06 05" src="https://github.com/ministryofjustice/hmpps-accredited-programmes-ui/assets/19826940/ad6c7e40-bb4b-45a0-aee7-650a38387683">

## Release checklist

[Release process documentation](../doc/how-to/perform-a-release.md)

As part of our continuous deployment strategy we must ensure that this work is
ready to be released once merged.

### Pre-merge

- [ ] There are changes required to the Accredited Programmes API for this change to work...
  - [ ] ... and they have been released to production already

### Post-merge

<!-- The outer checkboxes can be completed pre-merge -->

- [ ] This adds, extends or meaningfully modifies a feature...
  - [ ] ... and I have written or updated an end-to-end test for the happy path in the [Accredited Programmes E2E repo](https://github.com/ministryofjustice/hmpps-accredited-programmes-e2e)
- [ ] This makes new expectations of the API...
  - [ ] ... and I have notified the API developer(s) of changes to the contract tests (Pact), or the API is already compliant
- [ ] [Manually approve](../doc/how-to/perform-a-release.md#releasing-to-the-preprod-environment) release to preprod
- [ ] [Manually approve](../doc/how-to/perform-a-release.md#releasing-to-the-production-environment) release to prod

<!-- Should a release fail at any step, you as the author should now lead the work to
fix it as soon as possible. You can monitor deployment failures in CircleCI
itself and application errors are found in
[Sentry](https://ministryofjustice.sentry.io/projects/hmpps-accredited-programmes-ui/?project=4505330122686464&referrer=sidebar&statsPeriod=24h). -->
