### PR TITLE
(853d) Destroy course participations

### DIFF
--- a/integration_tests/mockApis/courseParticipations.ts
+++ b/integration_tests/mockApis/courseParticipations.ts
@@ -18,6 +18,18 @@ export default {
       },
     }),
 
+  stubDeleteParticipation: (courseParticipationId: CourseParticipation['id']): SuperAgentRequest =>
+    stubFor({
+      request: {
+        method: 'DELETE',
+        url: apiPaths.participations.delete({ courseParticipationId }),
+      },
+      response: {
+        headers: { 'Content-Type': 'application/json;charset=UTF-8' },
+        status: 200,
+      },
+    }),
+
   stubParticipation: (courseParticipation: CourseParticipation): SuperAgentRequest =>
     stubFor({
       request: {

--- a/integration_tests/pages/refer/deleteProgrammeHistory.ts
+++ b/integration_tests/pages/refer/deleteProgrammeHistory.ts
@@ -16,4 +16,9 @@ export default class DeleteProgrammeHistoryPage extends Page {
     this.person = person
     this.referral = referral
   }
+
+  confirm() {
+    cy.task('stubParticipationsByPerson', { courseParticipations: [], prisonNumber: this.person.prisonNumber })
+    this.shouldContainButton('Confirm').click()
+  }
 }

--- a/server/controllers/refer/courseParticipationsController.test.ts
+++ b/server/controllers/refer/courseParticipationsController.test.ts
@@ -176,6 +176,22 @@ describe('CourseParticipationsController', () => {
     })
   })
 
+  describe('destroy', () => {
+    it('asks the service to delete the participation and redirects to the index action', async () => {
+      const courseParticipationId = 'aCourseParticipationId'
+      const referralId = 'aReferralId'
+
+      request.params.courseParticipationId = courseParticipationId
+      request.params.referralId = referralId
+
+      const requestHandler = courseParticipationsController.destroy()
+      await requestHandler(request, response, next)
+
+      expect(courseService.deleteParticipation).toHaveBeenCalledWith(token, courseParticipationId)
+      expect(response.redirect).toHaveBeenCalledWith(referPaths.programmeHistory.index({ referralId }))
+    })
+  })
+
   describe('editCourse', () => {
     const courses = courseFactory.buildList(2)
     const person = personFactory.build()

--- a/server/controllers/refer/courseParticipationsController.test.ts
+++ b/server/controllers/refer/courseParticipationsController.test.ts
@@ -151,6 +151,11 @@ describe('CourseParticipationsController', () => {
         courseId: course.id,
         prisonNumber: person.prisonNumber,
       })
+      const courseParticipationId = courseParticipation.id
+      const referralId = referral.id
+
+      request.params.courseParticipationId = courseParticipationId
+      request.params.referralId = referralId
 
       personService.getPerson.mockResolvedValue(person)
       referralService.getReferral.mockResolvedValue(referral)
@@ -168,6 +173,7 @@ describe('CourseParticipationsController', () => {
       await requestHandler(request, response, next)
 
       expect(response.render).toHaveBeenCalledWith('referrals/courseParticipations/delete', {
+        action: `${referPaths.programmeHistory.destroy({ courseParticipationId, referralId })}?_method=DELETE`,
         pageHeading: 'Remove programme',
         person,
         referralId: referral.id,

--- a/server/controllers/refer/courseParticipationsController.test.ts
+++ b/server/controllers/refer/courseParticipationsController.test.ts
@@ -194,6 +194,7 @@ describe('CourseParticipationsController', () => {
       await requestHandler(request, response, next)
 
       expect(courseService.deleteParticipation).toHaveBeenCalledWith(token, courseParticipationId)
+      expect(request.flash).toHaveBeenCalledWith('successMessage', 'You have successfully removed a programme.')
       expect(response.redirect).toHaveBeenCalledWith(referPaths.programmeHistory.index({ referralId }))
     })
   })

--- a/server/controllers/refer/courseParticipationsController.ts
+++ b/server/controllers/refer/courseParticipationsController.ts
@@ -69,6 +69,7 @@ export default class CourseParticipationsController {
       )
 
       res.render('referrals/courseParticipations/delete', {
+        action: `${referPaths.programmeHistory.destroy({ courseParticipationId, referralId })}?_method=DELETE`,
         pageHeading: 'Remove programme',
         person,
         referralId: referral.id,

--- a/server/controllers/refer/courseParticipationsController.ts
+++ b/server/controllers/refer/courseParticipationsController.ts
@@ -86,6 +86,8 @@ export default class CourseParticipationsController {
 
       await this.courseService.deleteParticipation(req.user.token, courseParticipationId)
 
+      req.flash('successMessage', 'You have successfully removed a programme.')
+
       return res.redirect(
         referPaths.programmeHistory.index({
           referralId,

--- a/server/controllers/refer/courseParticipationsController.ts
+++ b/server/controllers/refer/courseParticipationsController.ts
@@ -77,6 +77,22 @@ export default class CourseParticipationsController {
     }
   }
 
+  destroy(): TypedRequestHandler<Request, Response> {
+    return async (req: Request, res: Response) => {
+      TypeUtils.assertHasUser(req)
+
+      const { courseParticipationId, referralId } = req.params
+
+      await this.courseService.deleteParticipation(req.user.token, courseParticipationId)
+
+      return res.redirect(
+        referPaths.programmeHistory.index({
+          referralId,
+        }),
+      )
+    }
+  }
+
   editCourse(): TypedRequestHandler<Request, Response> {
     return async (req: Request, res: Response) => {
       TypeUtils.assertHasUser(req)

--- a/server/data/courseClient.test.ts
+++ b/server/data/courseClient.test.ts
@@ -134,6 +134,31 @@ pactWith({ consumer: 'Accredited Programmes UI', provider: 'Accredited Programme
     })
   })
 
+  describe('destroyParticipation', () => {
+    const courseParticipation = courseParticipations[0]
+
+    beforeEach(() => {
+      provider.addInteraction({
+        state: `A course exists with ID ${course1.id}`,
+        uponReceiving: `A request to destroy course participation "${courseParticipation.id}"`,
+        willRespondWith: {
+          status: 200,
+        },
+        withRequest: {
+          headers: {
+            authorization: `Bearer ${token}`,
+          },
+          method: 'DELETE',
+          path: apiPaths.participations.delete({ courseParticipationId: courseParticipation.id }),
+        },
+      })
+    })
+
+    it('destroys a course participation', async () => {
+      await courseClient.destroyParticipation(courseParticipation.id)
+    })
+  })
+
   describe('find', () => {
     beforeEach(() => {
       provider.addInteraction({
@@ -262,7 +287,7 @@ pactWith({ consumer: 'Accredited Programmes UI', provider: 'Accredited Programme
     it('fetches the given course participation', async () => {
       const result = await courseClient.findParticipation(courseParticipation.id)
 
-      expect(result).toEqual(courseParticipations[0])
+      expect(result).toEqual(courseParticipation)
     })
   })
 

--- a/server/data/courseClient.ts
+++ b/server/data/courseClient.ts
@@ -32,6 +32,12 @@ export default class CourseClient {
     })) as CourseParticipation
   }
 
+  async destroyParticipation(courseParticipationId: CourseParticipation['id']): Promise<void> {
+    await this.restClient.delete({
+      path: apiPaths.participations.delete({ courseParticipationId }),
+    })
+  }
+
   async find(courseId: Course['id']): Promise<Course> {
     return (await this.restClient.get({ path: apiPaths.courses.show({ courseId }) })) as Course
   }

--- a/server/paths/refer.ts
+++ b/server/paths/refer.ts
@@ -41,6 +41,7 @@ export default {
   programmeHistory: {
     create: programmeHistoryPath,
     delete: deleteProgrammeHistoryPath,
+    destroy: showProgrammeHistoryPath,
     details: {
       show: programmeHistoryDetailsPath,
       update: programmeHistoryDetailsPath,

--- a/server/routes/refer.ts
+++ b/server/routes/refer.ts
@@ -6,7 +6,12 @@ import { referPaths } from '../paths'
 import { RouteUtils } from '../utils'
 
 export default function routes(controllers: Controllers, router: Router): Router {
-  const { get, post, put } = RouteUtils.actions(router, { allowedRoles: [ApplicationRoles.ACP_REFERRER] })
+  const {
+    get,
+    delete: deleteAction,
+    post,
+    put,
+  } = RouteUtils.actions(router, { allowedRoles: [ApplicationRoles.ACP_REFERRER] })
   const {
     courseParticipationDetailsController,
     courseParticipationsController,
@@ -38,6 +43,7 @@ export default function routes(controllers: Controllers, router: Router): Router
   get(referPaths.programmeHistory.editProgramme.pattern, courseParticipationsController.editCourse())
   put(referPaths.programmeHistory.updateProgramme.pattern, courseParticipationsController.updateCourse())
   get(referPaths.programmeHistory.delete.pattern, courseParticipationsController.delete())
+  deleteAction(referPaths.programmeHistory.destroy.pattern, courseParticipationsController.destroy())
 
   get(referPaths.programmeHistory.details.show.pattern, courseParticipationDetailsController.show())
   put(referPaths.programmeHistory.details.update.pattern, courseParticipationDetailsController.update())

--- a/server/services/courseService.test.ts
+++ b/server/services/courseService.test.ts
@@ -62,6 +62,17 @@ describe('CourseService', () => {
     })
   })
 
+  describe('deleteParticipation', () => {
+    it('asks the client to delete a course participation', async () => {
+      const courseParticipation = courseParticipationFactory.build()
+
+      await service.deleteParticipation(token, courseParticipation.id)
+
+      expect(courseClientBuilder).toHaveBeenCalledWith(token)
+      expect(courseClient.destroyParticipation).toHaveBeenCalledWith(courseParticipation.id)
+    })
+  })
+
   describe('getCourses', () => {
     it('returns a list of all courses', async () => {
       const courses = courseFactory.buildList(3)

--- a/server/services/courseService.ts
+++ b/server/services/courseService.ts
@@ -23,6 +23,14 @@ export default class CourseService {
     return courseClient.createParticipation(prisonNumber, courseId, otherCourseName)
   }
 
+  async deleteParticipation(
+    token: Express.User['token'],
+    courseParticipationId: CourseParticipation['id'],
+  ): Promise<void> {
+    const courseClient = this.courseClientBuilder(token)
+    return courseClient.destroyParticipation(courseParticipationId)
+  }
+
   async getCourse(token: Express.User['token'], courseId: Course['id']): Promise<Course> {
     const courseClient = this.courseClientBuilder(token)
     return courseClient.find(courseId)

--- a/server/views/referrals/courseParticipations/delete.njk
+++ b/server/views/referrals/courseParticipations/delete.njk
@@ -28,7 +28,7 @@
         iconFallbackText: "Warning"
       }) }}
 
-      <form action="#?_method=PUT" method="post">
+      <form action="{{ action }}" method="post">
         <input type="hidden" name="_csrf" value="{{ csrfToken }}"/>
 
         {{ govukButton({


### PR DESCRIPTION
## Context

<!-- Is there a Trello ticket you can link to? -->
<!-- Do you need to add any environment variables? -->
<!-- Is an ADR required? An ADR should be added if this PR introduces a change to the architecture. -->

A delete page now exists and generic delete functionality has been added to the app

## Changes in this PR

- Destroy participation on confirmation from delete page and redirect to participation index with a flashed message

Note the uncertainty about naming here mentioned in the commits: delete vs destroy outside the controller

## Release checklist

[Release process documentation](../doc/how-to/perform-a-release.md)

As part of our continuous deployment strategy we must ensure that this work is
ready to be released once merged.

### Pre-merge

- [ ] There are changes required to the Accredited Programmes API for this change to work...
  - [ ] ... and they have been released to production already

### Post-merge

<!-- The outer checkboxes can be completed pre-merge -->

- [ ] This adds, extends or meaningfully modifies a feature...
  - [ ] ... and I have written or updated an end-to-end test for the happy path in the [Accredited Programmes E2E repo](https://github.com/ministryofjustice/hmpps-accredited-programmes-e2e)
- [ ] This makes new expectations of the API...
  - [ ] ... and I have notified the API developer(s) of changes to the contract tests (Pact), or the API is already compliant
- [ ] [Manually approve](../doc/how-to/perform-a-release.md#releasing-to-the-preprod-environment) release to preprod
- [ ] [Manually approve](../doc/how-to/perform-a-release.md#releasing-to-the-production-environment) release to prod

<!-- Should a release fail at any step, you as the author should now lead the work to
fix it as soon as possible. You can monitor deployment failures in CircleCI
itself and application errors are found in
[Sentry](https://ministryofjustice.sentry.io/projects/hmpps-accredited-programmes-ui/?project=4505330122686464&referrer=sidebar&statsPeriod=24h). -->
