### PR TITLE
(954) Move to new participation `detail` field

### DIFF
--- a/integration_tests/e2e/refer/programmeHistory.cy.ts
+++ b/integration_tests/e2e/refer/programmeHistory.cy.ts
@@ -335,15 +335,15 @@ context('Programme history', () => {
         programmeHistoryDetailsPage.shouldDisplayYearCompletedInput()
         programmeHistoryDetailsPage.shouldNotDisplayYearStartedInput()
         programmeHistoryDetailsPage.shouldDisplayYearStartedInput()
-        programmeHistoryDetailsPage.shouldContainOutcomeDetailTextArea()
+        programmeHistoryDetailsPage.shouldContainDetailTextArea()
         programmeHistoryDetailsPage.shouldContainSourceTextArea()
         programmeHistoryDetailsPage.shouldContainButton('Continue')
       })
 
       it('updates the entry and redirects to the programme history page', () => {
         const formValues: DetailsBody = {
+          detail: 'Some outcome details',
           outcome: {
-            detail: 'Some outcome details',
             status: 'complete',
             yearCompleted: '2023',
             yearStarted: '',
@@ -358,8 +358,8 @@ context('Programme history', () => {
 
         const updatedCourseParticipation = courseParticipationFactory.build({
           ...courseParticipation,
+          detail: formValues.detail,
           outcome: {
-            detail: formValues.outcome.detail,
             status: formValues.outcome.status,
             yearCompleted: Number(formValues.outcome),
           },
@@ -379,7 +379,7 @@ context('Programme history', () => {
         programmeHistoryDetailsPage.inputCommunityLocation(formValues.setting.communityLocation)
         programmeHistoryDetailsPage.selectOutcome(formValues.outcome.status as string)
         programmeHistoryDetailsPage.inputOutcomeYearCompleted(formValues.outcome.yearCompleted)
-        programmeHistoryDetailsPage.inputOutcomeDetail(formValues.outcome.detail)
+        programmeHistoryDetailsPage.inputDetail(formValues.detail)
         programmeHistoryDetailsPage.inputSource(formValues.source)
         programmeHistoryDetailsPage.submitDetails()
 

--- a/integration_tests/pages/refer/programmeHistoryDetails.ts
+++ b/integration_tests/pages/refer/programmeHistoryDetails.ts
@@ -23,8 +23,8 @@ export default class ProgrammeHistoryDetailsPage extends Page {
     cy.get('input[id="communityLocation"]').type(value)
   }
 
-  inputOutcomeDetail(value: string) {
-    cy.get('textarea[id="outcomeDetail"]').type(value)
+  inputDetail(value: string) {
+    cy.get('textarea[id="detail"]').type(value)
   }
 
   inputOutcomeYearCompleted(value: string) {
@@ -47,8 +47,8 @@ export default class ProgrammeHistoryDetailsPage extends Page {
     this.selectRadioButton('setting[type]', value)
   }
 
-  shouldContainOutcomeDetailTextArea() {
-    this.shouldContainTextArea('outcomeDetail', 'Provide additional detail (if known)')
+  shouldContainDetailTextArea() {
+    this.shouldContainTextArea('detail', 'Provide additional detail (if known)')
   }
 
   shouldContainOutcomeRadioItems() {
@@ -94,7 +94,7 @@ export default class ProgrammeHistoryDetailsPage extends Page {
   }
 
   shouldHaveCorrectFormValues() {
-    const { setting, outcome, source } = this.courseParticipation
+    const { detail, setting, outcome, source } = this.courseParticipation
 
     if (setting.type === 'community') {
       cy.get('[data-testid="community-setting-option"]').should('be.checked')
@@ -128,8 +128,8 @@ export default class ProgrammeHistoryDetailsPage extends Page {
       }
     }
 
-    if (outcome.detail) {
-      cy.get('textarea[id="outcomeDetail"]').should('have.value', outcome.detail)
+    if (detail) {
+      cy.get('textarea[id="detail"]').should('have.value', detail)
     }
 
     if (source) {

--- a/server/@types/models/CourseParticipation.ts
+++ b/server/@types/models/CourseParticipation.ts
@@ -2,7 +2,6 @@ import type { Course } from './Course'
 import type { Person } from './Person'
 
 type CourseParticipationOutcome = {
-  detail?: string
   status?: 'complete' | 'incomplete'
   yearCompleted?: number
   yearStarted?: number
@@ -21,6 +20,7 @@ type CourseParticipation = {
   prisonNumber: Person['prisonNumber']
   setting: CourseParticipationSetting
   courseId?: Course['id']
+  detail?: string
   otherCourseName?: string
   source?: string
 }
@@ -29,6 +29,7 @@ type CourseParticipationUpdate = {
   outcome: CourseParticipationOutcome
   setting: CourseParticipationSetting
   courseId?: CourseParticipation['courseId']
+  detail?: CourseParticipation['detail']
   otherCourseName?: CourseParticipation['otherCourseName']
   source?: CourseParticipation['source']
 }

--- a/server/controllers/refer/courseParticipationDetailsController.test.ts
+++ b/server/controllers/refer/courseParticipationDetailsController.test.ts
@@ -82,6 +82,7 @@ describe('CourseParticipationDetailsController', () => {
       })
       expect(FormUtils.setFieldErrors).toHaveBeenCalledWith(request, response, ['yearCompleted', 'yearStarted'])
       expect(FormUtils.setFormValues).toHaveBeenCalledWith(request, response, {
+        detail: courseParticipation.detail,
         outcome: courseParticipation.outcome,
         setting: {
           ...courseParticipation.setting,
@@ -105,6 +106,7 @@ describe('CourseParticipationDetailsController', () => {
           await requestHandler(request, response, next)
 
           expect(FormUtils.setFormValues).toHaveBeenCalledWith(request, response, {
+            detail: courseParticipationWithCommunitySetting.detail,
             outcome: courseParticipationWithCommunitySetting.outcome,
             setting: {
               ...courseParticipationWithCommunitySetting.setting,
@@ -128,6 +130,7 @@ describe('CourseParticipationDetailsController', () => {
           await requestHandler(request, response, next)
 
           expect(FormUtils.setFormValues).toHaveBeenCalledWith(request, response, {
+            detail: courseParticipationWithCustodySetting.detail,
             outcome: courseParticipationWithCustodySetting.outcome,
             setting: {
               ...courseParticipationWithCustodySetting.setting,
@@ -144,8 +147,8 @@ describe('CourseParticipationDetailsController', () => {
   describe('update', () => {
     it('asks the service to update the given course participation details and redirects to the `CourseParticipationsController` `index` action', async () => {
       const courseParticipationUpdate: CourseParticipationUpdate = {
+        detail: 'Some additional detail',
         outcome: {
-          detail: 'Some additional detail',
           status: 'complete',
           yearCompleted: 2019,
         },

--- a/server/controllers/refer/courseParticipationDetailsController.ts
+++ b/server/controllers/refer/courseParticipationDetailsController.ts
@@ -16,7 +16,7 @@ export default class CourseParticipationDetailsController {
       TypeUtils.assertHasUser(req)
       const { courseParticipationId, referralId } = req.params
 
-      const { outcome, setting, source } = await this.courseService.getParticipation(
+      const { detail, outcome, setting, source } = await this.courseService.getParticipation(
         req.user.token,
         courseParticipationId,
       )
@@ -30,6 +30,7 @@ export default class CourseParticipationDetailsController {
 
       FormUtils.setFieldErrors(req, res, ['yearCompleted', 'yearStarted'])
       FormUtils.setFormValues(req, res, {
+        detail,
         outcome,
         setting: {
           ...setting,

--- a/server/testutils/factories/courseParticipation.ts
+++ b/server/testutils/factories/courseParticipation.ts
@@ -14,6 +14,7 @@ const courseParticipationTypes = {
       addedBy: `${faker.person.firstName()} ${faker.person.lastName()}`,
       courseId: undefined,
       createdAt: `${faker.date.between({ from: '2023-09-20T00:00:00.000Z', to: new Date() })}`,
+      detail: faker.lorem.paragraph({ max: 5, min: 0 }),
       otherCourseName: undefined,
       outcome: courseParticipationOutcomeFactory.build(),
       prisonNumber: faker.string.alphanumeric({ length: 7 }),
@@ -25,8 +26,8 @@ const courseParticipationTypes = {
   new() {
     return {
       ...this.random(),
+      detail: undefined,
       outcome: {
-        detail: undefined,
         status: undefined,
         yearCompleted: undefined,
         yearStarted: undefined,

--- a/server/testutils/factories/courseParticipationOutcome.ts
+++ b/server/testutils/factories/courseParticipationOutcome.ts
@@ -12,7 +12,6 @@ const randomNonFutureYearFrom = (minimumYear: number): number => {
 const outcomeTypes = {
   complete(): CourseParticipationOutcome {
     return {
-      detail: faker.lorem.paragraph({ max: 5, min: 0 }),
       status: 'complete',
       yearCompleted: FactoryHelpers.optionalArrayElement(randomNonFutureYearFrom(1980)),
     }
@@ -20,7 +19,6 @@ const outcomeTypes = {
 
   incomplete(): CourseParticipationOutcome {
     return {
-      detail: faker.lorem.paragraph({ max: 5, min: 0 }),
       status: 'incomplete',
       yearStarted: FactoryHelpers.optionalArrayElement(randomNonFutureYearFrom(1980)),
     }
@@ -36,7 +34,7 @@ const outcomeTypes = {
   },
 
   unknown() {
-    return { detail: faker.lorem.paragraph({ max: 5, min: 0 }) }
+    return {}
   },
 }
 

--- a/server/utils/courseParticipationUtils.test.ts
+++ b/server/utils/courseParticipationUtils.test.ts
@@ -28,8 +28,8 @@ describe('CourseParticipationUtils', () => {
       request = createMock<RequestWithDetailsBody>({})
 
       request.body = {
+        detail: 'Some additional detail',
         outcome: {
-          detail: 'Some additional detail',
           status: 'complete',
           yearCompleted: '2019',
           yearStarted: '',
@@ -43,8 +43,8 @@ describe('CourseParticipationUtils', () => {
       }
 
       expectedCourseParticipationUpdate = {
+        detail: request.body.detail,
         outcome: {
-          detail: request.body.outcome.detail,
           status: request.body.outcome.status,
           yearCompleted: Number(request.body.outcome.yearCompleted),
           yearStarted: undefined,
@@ -66,10 +66,10 @@ describe('CourseParticipationUtils', () => {
       })
     })
 
-    describe('when `request.body.outcome.detail` is an empty string when trimmed', () => {
-      it('returns `courseParticipationUpdate.outcome.detail` as undefined and reports no errors', () => {
-        request.body.outcome.detail = ' \n \n '
-        expectedCourseParticipationUpdate.outcome.detail = undefined
+    describe('when `request.body.detail` is an empty string when trimmed', () => {
+      it('returns `courseParticipationUpdate.detail` as undefined and reports no errors', () => {
+        request.body.detail = ' \n \n '
+        expectedCourseParticipationUpdate.detail = undefined
 
         expect(CourseParticipationUtils.processDetailsFormData(request)).toEqual({
           courseParticipationUpdate: expectedCourseParticipationUpdate,
@@ -278,8 +278,8 @@ describe('CourseParticipationUtils', () => {
       ...courseParticipationFactory.build({
         addedBy: 'Eric McNally',
         createdAt: '2023-04-20T16:20:00.000Z',
+        detail: 'Motivation level over 9000!',
         outcome: {
-          detail: 'Motivation level over 9000!',
           status: 'complete',
           yearCompleted: 2019,
           yearStarted: undefined,
@@ -453,27 +453,10 @@ describe('CourseParticipationUtils', () => {
       })
 
       describe('additional detail', () => {
-        describe('when there is no outcome', () => {
-          const withoutOutcome: CourseParticipationWithName = {
-            ...courseParticipationWithName,
-            outcome: {},
-          }
-
-          it('displays "Not known"', () => {
-            const { rows } = CourseParticipationUtils.summaryListOptions(withoutOutcome, referralId)
-            expect(getRowValueText(rows, 'Additional detail')).toEqual('Not known')
-          })
-        })
-
-        describe('when there is no additional detail set on the outcome', () => {
+        describe('when there is no additional detail set', () => {
           const withoutOutcomeAdditionalDetail: CourseParticipationWithName = {
             ...courseParticipationWithName,
-            outcome: {
-              detail: undefined,
-              status: 'complete',
-              yearCompleted: 2019,
-              yearStarted: undefined,
-            },
+            detail: undefined,
           }
 
           it('displays "Not known"', () => {

--- a/server/utils/courseParticipationUtils.ts
+++ b/server/utils/courseParticipationUtils.ts
@@ -18,8 +18,8 @@ import type {
 import type { GovukFrontendSummaryListRowKey } from '@govuk-frontend'
 
 interface DetailsBody {
+  detail: string
   outcome: {
-    detail: string
     yearCompleted: string
     yearStarted: string
     status?: CourseParticipationOutcome['status']
@@ -89,11 +89,11 @@ export default class CourseParticipationUtils {
       return validatedYear
     }
 
-    const { outcome, setting, source } = body
+    const { detail, outcome, setting, source } = body
 
     const courseParticipationUpdate: CourseParticipationUpdate = {
+      detail: detail?.trim() || undefined,
       outcome: {
-        detail: outcome.detail?.trim() || undefined,
         status: outcome.status,
         yearCompleted: outcome.status === 'complete' ? validateYear('yearCompleted', outcome.yearCompleted) : undefined,
         yearStarted: outcome.status === 'incomplete' ? validateYear('yearStarted', outcome.yearStarted) : undefined,
@@ -157,7 +157,7 @@ export default class CourseParticipationUtils {
       CourseParticipationUtils.summaryListRow('Programme name', [courseParticipationWithName.name]),
       CourseParticipationUtils.summaryListRowSetting(courseParticipationWithName.setting),
       CourseParticipationUtils.summaryListRowOutcome(courseParticipationWithName.outcome),
-      CourseParticipationUtils.summaryListRow('Additional detail', [courseParticipationWithName.outcome.detail]),
+      CourseParticipationUtils.summaryListRow('Additional detail', [courseParticipationWithName.detail]),
       CourseParticipationUtils.summaryListRow('Source of information', [courseParticipationWithName.source]),
       CourseParticipationUtils.summaryListRow('Added by', [
         courseParticipationWithName.addedBy,

--- a/server/views/referrals/courseParticipations/details/show.njk
+++ b/server/views/referrals/courseParticipations/details/show.njk
@@ -164,15 +164,12 @@
         }) }}
 
         {{ govukTextarea({
-          name: "outcome[detail]",
-          id: "outcomeDetail",
+          name: "detail",
+          id: "detail",
           label: {
             text: "Provide additional detail (if known)"
           },
-          hint: {
-            text: "Include information about the outcome"
-          },
-          value: formValues.outcome.detail
+          value: formValues.detail
         }) }}
 
         {{ govukTextarea({

--- a/wiremock/stubs/courseParticipations.json
+++ b/wiremock/stubs/courseParticipations.json
@@ -5,8 +5,8 @@
     "createdAt": "2023-09-14T10:14:32.047Z",
     "prisonNumber": "DEF1234",
     "courseId": "986d6256-5e2c-4792-b93a-568d923cf50c",
+    "detail": "Simply the best",
     "outcome": {
-      "detail": "Simply the best outcome",
       "status": "complete",
       "yearCompleted": 2022
     },


### PR DESCRIPTION
## Context

<!-- Is there a Trello ticket you can link to? -->
<!-- Do you need to add any environment variables? -->
<!-- Is an ADR required? An ADR should be added if this PR introduces a change to the architecture. -->

On the API, a `detail` field has been added to the course participation model. This will replace the one on the course participation outcome

## Changes in this PR

Moves to the new field, allowing the API to drop the old one

## Release checklist

[Release process documentation](../doc/how-to/perform-a-release.md)

As part of our continuous deployment strategy we must ensure that this work is
ready to be released once merged.

### Pre-merge

- [x] There are changes required to the Accredited Programmes API for this change to work...
  - [? definitely dev] ... and they have been released to production already

### Post-merge

<!-- The outer checkboxes can be completed pre-merge -->

- [ ] This adds, extends or meaningfully modifies a feature...
  - [ ] ... and I have written or updated an end-to-end test for the happy path in the [Accredited Programmes E2E repo](https://github.com/ministryofjustice/hmpps-accredited-programmes-e2e)
- [ ] This makes new expectations of the API...
  - [ ] ... and I have notified the API developer(s) of changes to the contract tests (Pact), or the API is already compliant
- [ ] [Manually approve](../doc/how-to/perform-a-release.md#releasing-to-the-preprod-environment) release to preprod
- [ ] [Manually approve](../doc/how-to/perform-a-release.md#releasing-to-the-production-environment) release to prod

<!-- Should a release fail at any step, you as the author should now lead the work to
fix it as soon as possible. You can monitor deployment failures in CircleCI
itself and application errors are found in
[Sentry](https://ministryofjustice.sentry.io/projects/hmpps-accredited-programmes-ui/?project=4505330122686464&referrer=sidebar&statsPeriod=24h). -->
