### PR TITLE
Add `data-testid` for E2E tests

### DIFF
--- a/server/views/referrals/courseParticipations/index.njk
+++ b/server/views/referrals/courseParticipations/index.njk
@@ -47,7 +47,10 @@
           {{ govukButton({
             text: "Add another",
             classes: "govuk-button--secondary",
-            href: referPaths.programmeHistory.new({ referralId: referralId })
+            href: referPaths.programmeHistory.new({ referralId: referralId }),
+            attributes: {
+              "data-testid": "add-history-button"
+            }
           }) }}
         </div>
       {% else %}
@@ -63,7 +66,10 @@
           {{ govukButton({
             text: "Add a programme",
             classes: "govuk-button--secondary",
-            href: referPaths.programmeHistory.new({ referralId: referralId })
+            href: referPaths.programmeHistory.new({ referralId: referralId }),
+            attributes: {
+              "data-testid": "add-history-button"
+            }
           }) }}
         </div>
       {% endif %}


### PR DESCRIPTION
## Context

<!-- Is there a Trello ticket you can link to? -->
<!-- Do you need to add any environment variables? -->
<!-- Is an ADR required? An ADR should be added if this PR introduces a change to the architecture. -->

We should to update the E2E tests now that the programme history journey is mostly built. Two buttons serve the same purpose but have a different label dependent on whether there are existing course participations

## Changes in this PR

- Add a shared test ID attribute to allow us to add an E2E test that will work regardless of whether the dev test user has existing course participations

## Release checklist

[Release process documentation](../doc/how-to/perform-a-release.md)

As part of our continuous deployment strategy we must ensure that this work is
ready to be released once merged.

### Pre-merge

- [ ] There are changes required to the Accredited Programmes API for this change to work...
  - [ ] ... and they have been released to production already

### Post-merge

<!-- The outer checkboxes can be completed pre-merge -->

- [ ] This adds, extends or meaningfully modifies a feature...
  - [ ] ... and I have written or updated an end-to-end test for the happy path in the [Accredited Programmes E2E repo](https://github.com/ministryofjustice/hmpps-accredited-programmes-e2e)
- [ ] This makes new expectations of the API...
  - [ ] ... and I have notified the API developer(s) of changes to the contract tests (Pact), or the API is already compliant
- [ ] [Manually approve](../doc/how-to/perform-a-release.md#releasing-to-the-preprod-environment) release to preprod
- [ ] [Manually approve](../doc/how-to/perform-a-release.md#releasing-to-the-production-environment) release to prod

<!-- Should a release fail at any step, you as the author should now lead the work to
fix it as soon as possible. You can monitor deployment failures in CircleCI
itself and application errors are found in
[Sentry](https://ministryofjustice.sentry.io/projects/hmpps-accredited-programmes-ui/?project=4505330122686464&referrer=sidebar&statsPeriod=24h). -->
