### PR TITLE
(885a) Review Referral Personal details page

### DIFF
--- a/integration_tests/e2e/refer/submitted.cy.ts
+++ b/integration_tests/e2e/refer/submitted.cy.ts
@@ -1,0 +1,75 @@
+import { ApplicationRoles } from '../../../server/middleware/roleBasedAccessMiddleware'
+import { referPaths } from '../../../server/paths'
+import {
+  courseFactory,
+  courseOfferingFactory,
+  personFactory,
+  prisonFactory,
+  prisonerFactory,
+  referralFactory,
+} from '../../../server/testutils/factories'
+import { CourseUtils, OrganisationUtils } from '../../../server/utils'
+import Page from '../../pages/page'
+import { SubmittedPersonalDetailsPage } from '../../pages/refer'
+
+context('Viewing a submitted referral', () => {
+  const course = courseFactory.build()
+  const coursePresenter = CourseUtils.presentCourse(course)
+  const courseOffering = courseOfferingFactory.build()
+  const prison = prisonFactory.build({ prisonId: courseOffering.organisationId })
+  const prisoner = prisonerFactory.build({
+    dateOfBirth: '1980-01-01',
+    firstName: 'Del',
+    lastName: 'Hatton',
+  })
+  const person = personFactory.build({
+    currentPrison: prisoner.prisonName,
+    dateOfBirth: '1 January 1980',
+    ethnicity: prisoner.ethnicity,
+    gender: prisoner.gender,
+    name: 'Del Hatton',
+    prisonNumber: prisoner.prisonerNumber,
+    religionOrBelief: prisoner.religion,
+    setting: 'Custody',
+  })
+  const referral = referralFactory.submitted().build({
+    offeringId: courseOffering.id,
+    prisonNumber: person.prisonNumber,
+  })
+  const organisation = OrganisationUtils.organisationFromPrison(prison)
+
+  beforeEach(() => {
+    cy.task('reset')
+    cy.task('stubSignIn', { authorities: [ApplicationRoles.ACP_REFERRER] })
+    cy.task('stubAuthUser')
+    cy.task('stubDefaultCaseloads')
+    cy.signIn()
+
+    cy.task('stubCourseByOffering', { course, courseOfferingId: courseOffering.id })
+    cy.task('stubOffering', { courseId: course.id, courseOffering })
+    cy.task('stubPrison', prison)
+    cy.task('stubPrisoner', prisoner)
+    cy.task('stubReferral', referral)
+  })
+
+  describe('When reviewing personal details', () => {
+    it('shows the correct information', () => {
+      const path = referPaths.submitted.personalDetails({ referralId: referral.id })
+
+      cy.visit(path)
+
+      const submittedPersonalDetailsPage = Page.verifyOnPage(SubmittedPersonalDetailsPage, {
+        course,
+        organisation,
+        referral,
+      })
+      submittedPersonalDetailsPage.shouldHavePersonDetails(person)
+      submittedPersonalDetailsPage.shouldContainNavigation(path)
+      submittedPersonalDetailsPage.shouldContainBackLink('#')
+      submittedPersonalDetailsPage.shouldContainCourseOfferingSummaryList(coursePresenter, organisation.name)
+      submittedPersonalDetailsPage.shouldContainSideNavigation(path)
+      submittedPersonalDetailsPage.shouldContainImportedFromText()
+      submittedPersonalDetailsPage.shouldContainPersonSummaryList(person)
+    })
+  })
+})

--- a/integration_tests/e2eReferDisabled/refer.cy.ts
+++ b/integration_tests/e2eReferDisabled/refer.cy.ts
@@ -198,4 +198,22 @@ context('Refer', () => {
     const notFoundPage = Page.verifyOnPage(NotFoundPage)
     notFoundPage.shouldContain404H2()
   })
+
+  it("Doesn't show the view submitted personal details page for a referral", () => {
+    const referral = referralFactory.submitted().build({
+      offeringId: courseOffering.id,
+      prisonNumber: prisoner.prisonerNumber,
+    })
+    cy.task('stubCourseByOffering', { course, courseOfferingId: courseOffering.id })
+    cy.task('stubOffering', { courseId: course.id, courseOffering })
+    cy.task('stubPrison', prison)
+    cy.task('stubPrisoner', prisoner)
+    cy.task('stubReferral', referral)
+
+    const path = referPaths.submitted.personalDetails({ referralId: referral.id })
+    cy.visit(path, { failOnStatusCode: false })
+
+    const notFoundPage = Page.verifyOnPage(NotFoundPage)
+    notFoundPage.shouldContain404H2()
+  })
 })

--- a/integration_tests/pages/page.ts
+++ b/integration_tests/pages/page.ts
@@ -1,7 +1,7 @@
 import type { AxeRules } from '@accredited-programmes/integration-tests'
 
 import { referPaths } from '../../server/paths'
-import { CourseParticipationUtils, PersonUtils } from '../../server/utils'
+import { CourseParticipationUtils, PersonUtils, ReferralUtils } from '../../server/utils'
 import Helpers from '../support/helpers'
 import type { CourseParticipation, Organisation, Person, Referral } from '@accredited-programmes/models'
 import type {
@@ -74,6 +74,15 @@ export default abstract class Page {
   shouldContainCheckbox(name: string, label: string): void {
     cy.get(`.govuk-checkboxes__input[name="${name}"]`).should('exist')
     cy.get(`.govuk-checkboxes__label[for="${name}"]`).should('contain.text', label)
+  }
+
+  shouldContainCourseOfferingSummaryList(course: CoursePresenter, organisationName: Organisation['name']) {
+    cy.get('[data-testid="course-offering-summary-list"]').then(summaryListElement => {
+      this.shouldContainSummaryListRows(
+        ReferralUtils.courseOfferingSummaryListRows(course, organisationName),
+        summaryListElement,
+      )
+    })
   }
 
   shouldContainDetails(summaryText: string, detailsText: string, detailsElement: JQuery<HTMLElement>): void {

--- a/integration_tests/pages/refer/index.ts
+++ b/integration_tests/pages/refer/index.ts
@@ -10,6 +10,7 @@ import ProgrammeHistoryDetailsPage from './programmeHistoryDetails'
 import SelectProgrammePage from './selectProgramme'
 import ShowPersonPage from './showPerson'
 import StartReferralPage from './startReferral'
+import SubmittedPersonalDetailsPage from './submittedPersonalDetails'
 import TaskListPage from './taskList'
 
 export {
@@ -25,5 +26,6 @@ export {
   SelectProgrammePage,
   ShowPersonPage,
   StartReferralPage,
+  SubmittedPersonalDetailsPage,
   TaskListPage,
 }

--- a/integration_tests/pages/refer/submittedPersonalDetails.ts
+++ b/integration_tests/pages/refer/submittedPersonalDetails.ts
@@ -1,0 +1,52 @@
+import { CourseUtils, DateUtils, ReferralUtils } from '../../../server/utils'
+import Helpers from '../../support/helpers'
+import Page from '../page'
+import type { Course, Organisation, Referral } from '@accredited-programmes/models'
+import type { CoursePresenter } from '@accredited-programmes/ui'
+
+export default class SubmittedPersonalDetailsPage extends Page {
+  course: CoursePresenter
+
+  organisation: Organisation
+
+  referral: Referral
+
+  constructor(args: { course: Course; organisation: Organisation; referral: Referral }) {
+    const { course, organisation, referral } = args
+    const coursePresenter = CourseUtils.presentCourse(course)
+
+    super(`Referral to ${coursePresenter.nameAndAlternateName}`)
+
+    this.course = coursePresenter
+    this.organisation = organisation
+    this.referral = referral
+  }
+
+  shouldContainImportedFromText(): void {
+    cy.get('[data-testid="imported-from-text"]').should(
+      'contain.text',
+      `Imported from Nomis on ${DateUtils.govukFormattedFullDateString()}.`,
+    )
+  }
+
+  shouldContainSideNavigation(currentPath: string): void {
+    const navigationItems = ReferralUtils.viewReferralNavigationItems('/', this.referral.id)
+
+    cy.get('.moj-side-navigation__item').each((navigationItemElement, navigationItemElementIndex) => {
+      const { href, text } = navigationItems[navigationItemElementIndex]
+
+      const { actual, expected } = Helpers.parseHtml(navigationItemElement, text)
+      expect(actual).to.equal(expected)
+
+      cy.wrap(navigationItemElement).within(() => {
+        cy.get('a').should('have.attr', 'href', href)
+
+        if (currentPath === href) {
+          cy.get('a').should('have.attr', 'aria-current', 'location')
+        } else {
+          cy.get('a').should('not.have.attr', 'aria-current', 'location')
+        }
+      })
+    })
+  }
+}

--- a/server/@types/ui/index.d.ts
+++ b/server/@types/ui/index.d.ts
@@ -91,6 +91,12 @@ type ReferralTaskListSection = {
   items: Array<ReferralTaskListItem>
 }
 
+type MojFrontendSideNavigationItem = {
+  active: boolean
+  href: string
+  text: string
+}
+
 export type {
   CourseParticipationPresenter,
   CoursePresenter,
@@ -102,6 +108,7 @@ export type {
   GovukFrontendTagWithText,
   HasHtmlString,
   HasTextString,
+  MojFrontendSideNavigationItem,
   OrganisationWithOfferingEmailsPresenter,
   OrganisationWithOfferingId,
   ReferralTaskListItem,

--- a/server/controllers/index.ts
+++ b/server/controllers/index.ts
@@ -3,6 +3,7 @@
 import DashboardController from './dashboardController'
 import findControllers from './find'
 import referControllers from './refer'
+import sharedControllers from './shared'
 import type { Services } from '../services'
 
 export const controllers = (services: Services) => {
@@ -12,6 +13,7 @@ export const controllers = (services: Services) => {
     dashboardController,
     ...findControllers(services),
     ...referControllers(services),
+    ...sharedControllers(services),
   }
 }
 

--- a/server/controllers/shared/index.ts
+++ b/server/controllers/shared/index.ts
@@ -1,0 +1,19 @@
+/* istanbul ignore file */
+
+import SubmittedReferralsController from './submittedReferralsController'
+import type { Services } from '../../services'
+
+const controllers = (services: Services) => {
+  const submittedReferralsController = new SubmittedReferralsController(
+    services.courseService,
+    services.organisationService,
+    services.personService,
+    services.referralService,
+  )
+
+  return {
+    submittedReferralsController,
+  }
+}
+
+export default controllers

--- a/server/controllers/shared/submittedReferralsController.test.ts
+++ b/server/controllers/shared/submittedReferralsController.test.ts
@@ -1,0 +1,72 @@
+import type { DeepMocked } from '@golevelup/ts-jest'
+import { createMock } from '@golevelup/ts-jest'
+import type { NextFunction, Request, Response } from 'express'
+
+import SubmittedReferralsController from './submittedReferralsController'
+import { referPaths } from '../../paths'
+import type { CourseService, OrganisationService, PersonService, ReferralService } from '../../services'
+import { courseFactory, organisationFactory, personFactory, referralFactory } from '../../testutils/factories'
+import Helpers from '../../testutils/helpers'
+import { CourseUtils, DateUtils, PersonUtils, ReferralUtils } from '../../utils'
+
+describe('SubmittedReferralsController', () => {
+  const token = 'SOME_TOKEN'
+
+  let request: DeepMocked<Request>
+  let response: DeepMocked<Response>
+  const next: DeepMocked<NextFunction> = createMock<NextFunction>({})
+
+  const courseService = createMock<CourseService>({})
+  const organisationService = createMock<OrganisationService>({})
+  const personService = createMock<PersonService>({})
+  const referralService = createMock<ReferralService>({})
+
+  const course = courseFactory.build()
+  const organisation = organisationFactory.build()
+  const person = personFactory.build()
+  const referral = referralFactory.submitted().build({ prisonNumber: person.prisonNumber })
+
+  let submittedReferralsController: SubmittedReferralsController
+
+  beforeEach(() => {
+    request = createMock<Request>({ user: { token } })
+    response = Helpers.createMockResponseWithCaseloads()
+
+    courseService.getCourseByOffering.mockResolvedValue(course)
+    organisationService.getOrganisation.mockResolvedValue(organisation)
+    personService.getPerson.mockResolvedValue(person)
+    referralService.getReferral.mockResolvedValue(referral)
+
+    submittedReferralsController = new SubmittedReferralsController(
+      courseService,
+      organisationService,
+      personService,
+      referralService,
+    )
+  })
+
+  afterEach(() => {
+    jest.resetAllMocks()
+  })
+
+  describe('personalDetails', () => {
+    it('renders the personal details template with the correct response locals', async () => {
+      request.path = referPaths.submitted.personalDetails({ referralId: referral.id })
+
+      const requestHandler = submittedReferralsController.personalDetails()
+      await requestHandler(request, response, next)
+
+      const coursePresenter = CourseUtils.presentCourse(course)
+
+      expect(response.render).toHaveBeenCalledWith('referrals/submitted/personalDetails', {
+        courseOfferingSummaryListRows: ReferralUtils.courseOfferingSummaryListRows(coursePresenter, organisation.name),
+        importedFromText: `Imported from Nomis on ${DateUtils.govukFormattedFullDateString()}.`,
+        navigationItems: ReferralUtils.viewReferralNavigationItems(request.path, referral.id),
+        pageHeading: `Referral to ${coursePresenter.nameAndAlternateName}`,
+        person,
+        personSummaryListRows: PersonUtils.summaryListRows(person),
+        referral,
+      })
+    })
+  })
+})

--- a/server/controllers/shared/submittedReferralsController.ts
+++ b/server/controllers/shared/submittedReferralsController.ts
@@ -1,0 +1,64 @@
+import type { Request, Response, TypedRequestHandler } from 'express'
+
+import type { CourseService, OrganisationService, PersonService, ReferralService } from '../../services'
+import { CourseUtils, DateUtils, PersonUtils, ReferralUtils, TypeUtils } from '../../utils'
+import type { Person, Referral } from '@accredited-programmes/models'
+import type { GovukFrontendSummaryListRowWithValue, MojFrontendSideNavigationItem } from '@accredited-programmes/ui'
+
+export default class SubmittedReferralsController {
+  constructor(
+    private readonly courseService: CourseService,
+    private readonly organisationService: OrganisationService,
+    private readonly personService: PersonService,
+    private readonly referralService: ReferralService,
+  ) {}
+
+  personalDetails(): TypedRequestHandler<Request, Response> {
+    return async (req: Request, res: Response) => {
+      TypeUtils.assertHasUser(req)
+
+      const sharedPageData = await this.sharedPageData(req, res)
+
+      res.render('referrals/submitted/personalDetails', {
+        ...sharedPageData,
+        importedFromText: `Imported from Nomis on ${DateUtils.govukFormattedFullDateString()}.`,
+        personSummaryListRows: PersonUtils.summaryListRows(sharedPageData.person),
+      })
+    }
+  }
+
+  private async sharedPageData(
+    req: Request,
+    res: Response,
+  ): Promise<{
+    courseOfferingSummaryListRows: Array<GovukFrontendSummaryListRowWithValue>
+    navigationItems: Array<MojFrontendSideNavigationItem>
+    pageHeading: string
+    person: Person
+    referral: Referral
+  }> {
+    TypeUtils.assertHasUser(req)
+
+    const { referralId } = req.params
+    const { token, username } = req.user
+
+    const referral = await this.referralService.getReferral(token, referralId)
+    const [course, courseOffering, person] = await Promise.all([
+      this.courseService.getCourseByOffering(token, referral.offeringId),
+      this.courseService.getOffering(token, referral.offeringId),
+      this.personService.getPerson(username, referral.prisonNumber, res.locals.user.caseloads),
+    ])
+
+    const organisation = await this.organisationService.getOrganisation(token, courseOffering.organisationId)
+
+    const coursePresenter = CourseUtils.presentCourse(course)
+
+    return {
+      courseOfferingSummaryListRows: ReferralUtils.courseOfferingSummaryListRows(coursePresenter, organisation.name),
+      navigationItems: ReferralUtils.viewReferralNavigationItems(req.path, referral.id),
+      pageHeading: `Referral to ${coursePresenter.nameAndAlternateName}`,
+      person,
+      referral,
+    }
+  }
+}

--- a/server/paths/refer.ts
+++ b/server/paths/refer.ts
@@ -27,6 +27,13 @@ const checkAnswersPath = showDraftReferralPath.path('check-answers')
 const completeReferralPath = showDraftReferralPath.path('complete')
 const submitReferralPath = showDraftReferralPath.path('submit')
 
+const submittedReferralsPath = referBasePath.path('/referrals')
+const showSubmittedReferralPath = submittedReferralsPath.path(':referralId')
+const submittedReferralPersonalDetailsPath = showSubmittedReferralPath.path('personal-details')
+const submittedReferralProgrammeHistoryPath = showSubmittedReferralPath.path('programme-history')
+const submittedReferralSentenceInformationPath = showSubmittedReferralPath.path('sentence-information')
+const submittedReferralAdditionalInformationPath = showSubmittedReferralPath.path('additional-information')
+
 export default {
   additionalInformation: {
     show: additionalInformationPath,
@@ -62,5 +69,11 @@ export default {
   showPerson: referralPersonPath,
   start: startReferralPath,
   submit: submitReferralPath,
+  submitted: {
+    additionalInformation: submittedReferralAdditionalInformationPath,
+    personalDetails: submittedReferralPersonalDetailsPath,
+    programmeHistory: submittedReferralProgrammeHistoryPath,
+    sentenceInformation: submittedReferralSentenceInformationPath,
+  },
   update: showDraftReferralPath,
 }

--- a/server/routes/refer.ts
+++ b/server/routes/refer.ts
@@ -19,6 +19,7 @@ export default function routes(controllers: Controllers, router: Router): Router
     referralsController,
     peopleController,
     oasysConfirmationController,
+    submittedReferralsController,
   } = controllers
 
   get(referPaths.start.pattern, referralsController.start())
@@ -55,6 +56,8 @@ export default function routes(controllers: Controllers, router: Router): Router
   get(referPaths.checkAnswers.pattern, referralsController.checkAnswers())
   get(referPaths.complete.pattern, referralsController.complete())
   post(referPaths.submit.pattern, referralsController.submit())
+
+  get(referPaths.submitted.personalDetails.pattern, submittedReferralsController.personalDetails())
 
   return router
 }

--- a/server/utils/dateUtils.test.ts
+++ b/server/utils/dateUtils.test.ts
@@ -2,8 +2,19 @@ import DateUtils from './dateUtils'
 
 describe('DateUtils', () => {
   describe('govukFormattedFullDateString', () => {
-    it('returns a date string in the format specified by the GOV.UK style guide', () => {
-      expect(DateUtils.govukFormattedFullDateString('2001-06-03')).toEqual('3 June 2001')
+    it('returns todays date as a date string in the format specified by the GOV.UK style guide', () => {
+      const mockTodaysDate = new Date('2001-06-04')
+      jest.spyOn(global, 'Date').mockImplementation(() => mockTodaysDate)
+
+      expect(DateUtils.govukFormattedFullDateString()).toEqual('4 June 2001')
+
+      jest.spyOn(global, 'Date').mockRestore()
+    })
+
+    describe('when `datestring` is provided', () => {
+      it('returns the provided date as a date string in the format specified by the GOV.UK style guide', () => {
+        expect(DateUtils.govukFormattedFullDateString('2001-06-03')).toEqual('3 June 2001')
+      })
     })
   })
 })

--- a/server/utils/dateUtils.ts
+++ b/server/utils/dateUtils.ts
@@ -6,8 +6,10 @@ export default class DateUtils {
    * @param datestring A datetime string e.g. 2011-10-05T14:48:00.000Z or 2001-06-03
    * @returns A string
    * */
-  static govukFormattedFullDateString(datestring: string): string {
-    return new Date(datestring).toLocaleDateString('en-GB', {
+  static govukFormattedFullDateString(datestring?: string): string {
+    const date = datestring ? new Date(datestring) : new Date()
+
+    return new Date(date).toLocaleDateString('en-GB', {
       day: 'numeric',
       month: 'long',
       year: 'numeric',

--- a/server/utils/referralUtils.test.ts
+++ b/server/utils/referralUtils.test.ts
@@ -60,6 +60,38 @@ describe('ReferralUtils', () => {
     })
   })
 
+  describe('courseOfferingSummaryListRows', () => {
+    it('formats course offering information in the appropriate format for passing to a GOV.UK summary list Nunjucks macro', () => {
+      const course = courseFactory.build({
+        alternateName: 'TC+',
+        audiences: [
+          {
+            id: '1',
+            value: 'General offence',
+          },
+        ],
+        name: 'Test Course',
+      })
+      const coursePresenter = CourseUtils.presentCourse(course)
+      const organisation = organisationFactory.build({ name: 'HMP Hewell' })
+
+      expect(ReferralUtils.courseOfferingSummaryListRows(coursePresenter, organisation.name)).toEqual([
+        {
+          key: { text: 'Programme name' },
+          value: { text: 'Test Course (TC+)' },
+        },
+        {
+          key: { text: 'Programme strand' },
+          value: { text: 'General offence' },
+        },
+        {
+          key: { text: 'Programme location' },
+          value: { text: 'HMP Hewell' },
+        },
+      ])
+    })
+  })
+
   describe('isReadyForSubmission', () => {
     it('returns false for a new referral', () => {
       const newReferral = referralFactory.started().build()

--- a/server/utils/referralUtils.test.ts
+++ b/server/utils/referralUtils.test.ts
@@ -1,5 +1,6 @@
 import CourseUtils from './courseUtils'
 import ReferralUtils from './referralUtils'
+import { referPaths } from '../paths'
 import {
   courseFactory,
   courseOfferingFactory,
@@ -197,6 +198,36 @@ describe('ReferralUtils', () => {
 
       expect(checkAnswersTask.url).toEqual(`/refer/new/referrals/${referralWithOasysConfirmed.id}/check-answers`)
       expect(checkAnswersTask.statusTag.text).toEqual('not started')
+    })
+  })
+
+  describe('viewReferralNavigationItems', () => {
+    it('returns navigation items for the view referral pages and sets the requested page as active', () => {
+      const mockReferralId = 'mock-referral-id'
+      const currentRequestPath = referPaths.submitted.personalDetails({ referralId: mockReferralId })
+
+      expect(ReferralUtils.viewReferralNavigationItems(currentRequestPath, mockReferralId)).toEqual([
+        {
+          active: true,
+          href: referPaths.submitted.personalDetails({ referralId: mockReferralId }),
+          text: 'Personal details',
+        },
+        {
+          active: false,
+          href: referPaths.submitted.programmeHistory({ referralId: mockReferralId }),
+          text: 'Programme history',
+        },
+        {
+          active: false,
+          href: referPaths.submitted.sentenceInformation({ referralId: mockReferralId }),
+          text: 'Sentence information',
+        },
+        {
+          active: false,
+          href: referPaths.submitted.additionalInformation({ referralId: mockReferralId }),
+          text: 'Additional information',
+        },
+      ])
     })
   })
 })

--- a/server/utils/referralUtils.ts
+++ b/server/utils/referralUtils.ts
@@ -1,8 +1,11 @@
+import type { Request } from 'express'
+
 import { referPaths } from '../paths'
 import type { CourseOffering, Organisation, Person, Referral } from '@accredited-programmes/models'
 import type {
   CoursePresenter,
   GovukFrontendSummaryListRowWithValue,
+  MojFrontendSideNavigationItem,
   ReferralTaskListSection,
   ReferralTaskListStatusTag,
   ReferralTaskListStatusText,
@@ -105,6 +108,35 @@ export default class ReferralUtils {
         ],
       },
     ]
+  }
+
+  static viewReferralNavigationItems(
+    currentPath: Request['path'],
+    referralId: Referral['id'],
+  ): Array<MojFrontendSideNavigationItem> {
+    const navigationItems = [
+      {
+        href: referPaths.submitted.personalDetails({ referralId }),
+        text: 'Personal details',
+      },
+      {
+        href: referPaths.submitted.programmeHistory({ referralId }),
+        text: 'Programme history',
+      },
+      {
+        href: referPaths.submitted.sentenceInformation({ referralId }),
+        text: 'Sentence information',
+      },
+      {
+        href: referPaths.submitted.additionalInformation({ referralId }),
+        text: 'Additional information',
+      },
+    ]
+
+    return navigationItems.map(item => ({
+      ...item,
+      active: currentPath === item.href,
+    }))
   }
 
   private static taskListStatusTag(text: ReferralTaskListStatusText, dataTestId?: string): ReferralTaskListStatusTag {

--- a/server/utils/referralUtils.ts
+++ b/server/utils/referralUtils.ts
@@ -47,6 +47,26 @@ export default class ReferralUtils {
     ]
   }
 
+  static courseOfferingSummaryListRows(
+    coursePresenter: CoursePresenter,
+    organisationName: Organisation['name'],
+  ): Array<GovukFrontendSummaryListRowWithValue> {
+    return [
+      {
+        key: { text: 'Programme name' },
+        value: { text: coursePresenter.nameAndAlternateName },
+      },
+      {
+        key: { text: 'Programme strand' },
+        value: { text: coursePresenter.audiences.map(audience => audience.value).join(', ') },
+      },
+      {
+        key: { text: 'Programme location' },
+        value: { text: organisationName },
+      },
+    ]
+  }
+
   static isReadyForSubmission(referral: Referral): boolean {
     return referral.hasReviewedProgrammeHistory && referral.oasysConfirmed && !!referral.additionalInformation
   }

--- a/server/views/referrals/submitted/partials/layout.njk
+++ b/server/views/referrals/submitted/partials/layout.njk
@@ -1,0 +1,48 @@
+{% from "govuk/components/back-link/macro.njk" import govukBackLink %}
+{% from "moj/components/side-navigation/macro.njk" import mojSideNavigation %}
+
+{% extends "../../../partials/layout.njk" %}
+
+{% block personBanner %}
+  {% include "../../_personBanner.njk" %}
+{% endblock personBanner %}
+
+{% block backLink %}
+  {{ govukBackLink({
+    text: "Back to my referrals",
+    href: "#"
+  }) }}
+{% endblock backLink %}
+
+{% block content %}
+  <div class="govuk-grid-row">
+    <div class="govuk-grid-column-two-thirds">
+      <h1 class="govuk-heading-l">{{ pageHeading }}</h1>
+
+      <h2 class="govuk-heading-m">Referral details</h2>
+
+      {{ govukSummaryList({
+        classes: 'govuk-summary-list--no-border',
+        rows: courseOfferingSummaryListRows,
+        attributes: {
+          "data-testid": "course-offering-summary-list"
+        }
+      }) }}
+    </div>
+  </div>
+
+  <hr class="govuk-section-break govuk-section-break--l govuk-section-break--visible">
+
+  <div class="govuk-grid-row">
+    <div class="govuk-grid-column-one-third">
+      {{ mojSideNavigation({
+        label: 'Side navigation',
+        items: navigationItems
+      }) }}
+    </div>
+
+    <div class="govuk-grid-column-two-thirds govuk-!-margin-top-4">
+      {% block submittedReferralContent %}{% endblock submittedReferralContent %}
+    </div>
+  </div>
+{% endblock content %}

--- a/server/views/referrals/submitted/personalDetails.njk
+++ b/server/views/referrals/submitted/personalDetails.njk
@@ -1,0 +1,26 @@
+{% from "govuk/components/inset-text/macro.njk" import govukInsetText %}
+{% from "govuk/components/summary-list/macro.njk" import govukSummaryList %}
+
+{% extends "./partials/layout.njk" %}
+
+{% block submittedReferralContent %}
+  {{ govukInsetText({
+    classes: "govuk-!-margin-top-0",
+    text: importedFromText,
+    attributes: {
+      "data-testid": "imported-from-text"
+    }
+  }) }}
+
+  {{ govukSummaryList({
+    card: {
+      title: {
+        text: "Personal details"
+      }
+    },
+    rows: personSummaryListRows,
+    attributes: {
+      "data-testid": "person-summary-list"
+    }
+  }) }}
+{% endblock submittedReferralContent %}


### PR DESCRIPTION
## Context

https://trello.com/c/VU6o1f4K/885-add-basic-page-for-viewing-a-referral-personal-details-m

## Changes in this PR

- Add new partial for all of the view submitted referral details pages to use
- Add paths for submitted referral pages (including the yet to be created ones) and created the navigation
- Add new `SubmittedReferralsController` with `personalDetails` and also a shared `getPageDetails` method to be used by all view submitted pages.

## Screenshots of UI changes
![localhost_3000_referrals_c11fab18-dc8d-420c-9c82-d0edd373732d_review_personal-details (3)](https://github.com/ministryofjustice/hmpps-accredited-programmes-ui/assets/1067537/875518d8-47c3-44c2-9a0e-cff6c1f3d2dc)




## Release checklist

[Release process documentation](../doc/how-to/perform-a-release.md)

As part of our continuous deployment strategy we must ensure that this work is
ready to be released once merged.

### Pre-merge

- [ ] There are changes required to the Accredited Programmes API for this change to work...
  - [ ] ... and they have been released to production already

### Post-merge

<!-- The outer checkboxes can be completed pre-merge -->

- [ ] This adds, extends or meaningfully modifies a feature...
  - [ ] ... and I have written or updated an end-to-end test for the happy path in the [Accredited Programmes E2E repo](https://github.com/ministryofjustice/hmpps-accredited-programmes-e2e)
- [ ] This makes new expectations of the API...
  - [ ] ... and I have notified the API developer(s) of changes to the contract tests (Pact), or the API is already compliant
- [ ] [Manually approve](../doc/how-to/perform-a-release.md#releasing-to-the-preprod-environment) release to preprod
- [ ] [Manually approve](../doc/how-to/perform-a-release.md#releasing-to-the-production-environment) release to prod

<!-- Should a release fail at any step, you as the author should now lead the work to
fix it as soon as possible. You can monitor deployment failures in CircleCI
itself and application errors are found in
[Sentry](https://ministryofjustice.sentry.io/projects/hmpps-accredited-programmes-ui/?project=4505330122686464&referrer=sidebar&statsPeriod=24h). -->
