### PR TITLE
(982) Sort programme history

### DIFF
--- a/integration_tests/e2e/refer/programmeHistory.cy.ts
+++ b/integration_tests/e2e/refer/programmeHistory.cy.ts
@@ -41,8 +41,10 @@ context('Programme history', () => {
     const course = courseFactory.build()
 
     const courseParticipations = [
-      courseParticipationFactory.withCourseId().build({ courseId: course.id }),
-      courseParticipationFactory.withOtherCourseName().build({ otherCourseName: 'A great course name' }),
+      courseParticipationFactory.withCourseId().build({ courseId: course.id, createdAt: '2023-01-01T12:00:00.000Z' }),
+      courseParticipationFactory
+        .withOtherCourseName()
+        .build({ createdAt: '2022-01-01T12:00:00.000Z', otherCourseName: 'A great course name' }),
     ]
     const courseParticipationsWithNames: Array<CourseParticipationWithName> = [
       { ...courseParticipations[0], name: course.name },

--- a/integration_tests/pages/page.ts
+++ b/integration_tests/pages/page.ts
@@ -91,36 +91,38 @@ export default abstract class Page {
     referralId: Referral['id'],
     withActions = true,
   ) {
-    participations.forEach((participation, participationsIndex) => {
-      const { rows } = CourseParticipationUtils.summaryListOptions(participation, referralId)
+    participations
+      .sort((participationA, participationB) => participationA.createdAt.localeCompare(participationB.createdAt))
+      .forEach((participation, participationsIndex) => {
+        const { rows } = CourseParticipationUtils.summaryListOptions(participation, referralId)
 
-      cy.get('.govuk-summary-card')
-        .eq(participationsIndex)
-        .then(summaryCardElement => {
-          const actions = withActions
-            ? [
-                {
-                  href: referPaths.programmeHistory.editProgramme({
-                    courseParticipationId: participation.id,
-                    referralId,
-                  }),
-                  text: 'Change',
-                  visuallyHiddenText: ` participation for ${participation.name}`,
-                },
-                {
-                  href: referPaths.programmeHistory.delete({
-                    courseParticipationId: participation.id,
-                    referralId,
-                  }),
-                  text: 'Remove',
-                  visuallyHiddenText: ` participation for ${participation.name}`,
-                },
-              ]
-            : []
+        cy.get('.govuk-summary-card')
+          .eq(participationsIndex)
+          .then(summaryCardElement => {
+            const actions = withActions
+              ? [
+                  {
+                    href: referPaths.programmeHistory.editProgramme({
+                      courseParticipationId: participation.id,
+                      referralId,
+                    }),
+                    text: 'Change',
+                    visuallyHiddenText: ` participation for ${participation.name}`,
+                  },
+                  {
+                    href: referPaths.programmeHistory.delete({
+                      courseParticipationId: participation.id,
+                      referralId,
+                    }),
+                    text: 'Remove',
+                    visuallyHiddenText: ` participation for ${participation.name}`,
+                  },
+                ]
+              : []
 
-          this.shouldContainSummaryCard(participation.name, actions, rows, summaryCardElement)
-        })
-    })
+            this.shouldContainSummaryCard(participation.name, actions, rows, summaryCardElement)
+          })
+      })
   }
 
   shouldContainLink(text: string, href: string): void {

--- a/server/controllers/refer/courseParticipationsController.test.ts
+++ b/server/controllers/refer/courseParticipationsController.test.ts
@@ -25,10 +25,17 @@ describe('CourseParticipationsController', () => {
 
   let courseParticipationsController: CourseParticipationsController
 
+  const summaryListOptions = 'summary list options'
+
   beforeEach(() => {
     request = createMock<Request>({ user: { token } })
     response = Helpers.createMockResponseWithCaseloads()
     courseParticipationsController = new CourseParticipationsController(courseService, personService, referralService)
+    ;(CourseParticipationUtils.summaryListOptions as jest.Mock).mockImplementation(
+      (_courseParticipationWithName, _referralId, _withActions = true) => {
+        return summaryListOptions
+      },
+    )
   })
 
   afterEach(() => {
@@ -163,15 +170,15 @@ describe('CourseParticipationsController', () => {
       courseService.getParticipation.mockResolvedValue(courseParticipation)
 
       const courseParticipationWithName = { ...courseParticipation, name: course.name }
-      const summaryListOptions = CourseParticipationUtils.summaryListOptions(
-        courseParticipationWithName,
-        referral.id,
-        false,
-      )
 
       const requestHandler = courseParticipationsController.delete()
       await requestHandler(request, response, next)
 
+      expect(CourseParticipationUtils.summaryListOptions).toHaveBeenCalledWith(
+        courseParticipationWithName,
+        referral.id,
+        false,
+      )
       expect(response.render).toHaveBeenCalledWith('referrals/courseParticipations/delete', {
         action: `${referPaths.programmeHistory.destroy({ courseParticipationId, referralId })}?_method=DELETE`,
         pageHeading: 'Remove programme',
@@ -270,9 +277,6 @@ describe('CourseParticipationsController', () => {
       { ...courseParticipations[0], name: course.name },
       { ...courseParticipations[1], name: 'Another course' },
     ]
-    const summaryListsOptions = courseParticipationsWithNames.map(courseParticipation =>
-      CourseParticipationUtils.summaryListOptions(courseParticipation, referral.id),
-    )
 
     beforeEach(() => {
       referralService.getReferral.mockResolvedValue(referral)
@@ -291,7 +295,7 @@ describe('CourseParticipationsController', () => {
         person,
         referralId: referral.id,
         successMessage: undefined,
-        summaryListsOptions,
+        summaryListsOptions: [summaryListOptions, summaryListOptions],
       })
     })
 

--- a/server/controllers/refer/courseParticipationsController.test.ts
+++ b/server/controllers/refer/courseParticipationsController.test.ts
@@ -269,8 +269,12 @@ describe('CourseParticipationsController', () => {
     const referral = referralFactory.build()
     const person = personFactory.build()
     const courseParticipations = [
-      courseParticipationFactory.build({ courseId: 'an-ID' }),
-      courseParticipationFactory.build({ courseId: undefined, otherCourseName: 'Another course' }),
+      courseParticipationFactory.build({ courseId: 'an-ID', createdAt: '2023-01-01T12:00:00.000Z' }),
+      courseParticipationFactory.build({
+        courseId: undefined,
+        createdAt: '2022-01-01T12:00:00.000Z',
+        otherCourseName: 'Another course',
+      }),
     ]
     const course = courseFactory.build()
     const courseParticipationsWithNames = [
@@ -290,6 +294,16 @@ describe('CourseParticipationsController', () => {
       const requestHandler = courseParticipationsController.index()
       await requestHandler(request, response, next)
 
+      expect(CourseParticipationUtils.summaryListOptions).toHaveBeenNthCalledWith(
+        1,
+        courseParticipationsWithNames[1],
+        referral.id,
+      )
+      expect(CourseParticipationUtils.summaryListOptions).toHaveBeenNthCalledWith(
+        2,
+        courseParticipationsWithNames[0],
+        referral.id,
+      )
       expect(response.render).toHaveBeenCalledWith('referrals/courseParticipations/index', {
         pageHeading: 'Accredited Programme history',
         person,

--- a/server/controllers/refer/courseParticipationsController.ts
+++ b/server/controllers/refer/courseParticipationsController.ts
@@ -149,8 +149,11 @@ export default class CourseParticipationsController {
         courseParticipations,
         req.user.token,
       )
-      const summaryListsOptions = courseParticipationsWithNames.map(courseParticipationWithName =>
-        CourseParticipationUtils.summaryListOptions(courseParticipationWithName, referral.id),
+      const sortedCourseParticipationsWithNames = courseParticipationsWithNames.sort((participationA, participationB) =>
+        participationA.createdAt.localeCompare(participationB.createdAt),
+      )
+      const summaryListsOptions = sortedCourseParticipationsWithNames.map(participation =>
+        CourseParticipationUtils.summaryListOptions(participation, referral.id),
       )
 
       res.render('referrals/courseParticipations/index', {


### PR DESCRIPTION
## Context

<!-- Is there a Trello ticket you can link to? -->
<!-- Do you need to add any environment variables? -->
<!-- Is an ADR required? An ADR should be added if this PR introduces a change to the architecture. -->

When adding E2E tests for the programme history journey, we discovered that the order of course participations on the page was less predictable than expected

## Changes in this PR

- Fix the order of course participations on the programme history page
- Fully mock a semi-mocked method

## Screenshots of UI changes

### Before

[Unclear sorting logic: mostly sorted by created at, but currently not entirely on dev]

### After

1 = first added, 2 = second added

<img width="789" alt="image" src="https://github.com/ministryofjustice/hmpps-accredited-programmes-ui/assets/40244233/75a7c3b8-191a-4dd6-bef7-5063ac592214">

## Release checklist

[Release process documentation](../doc/how-to/perform-a-release.md)

As part of our continuous deployment strategy we must ensure that this work is
ready to be released once merged.

### Pre-merge

- [ ] There are changes required to the Accredited Programmes API for this change to work...
  - [ ] ... and they have been released to production already

### Post-merge

<!-- The outer checkboxes can be completed pre-merge -->

- [ ] This adds, extends or meaningfully modifies a feature...
  - [ ] ... and I have written or updated an end-to-end test for the happy path in the [Accredited Programmes E2E repo](https://github.com/ministryofjustice/hmpps-accredited-programmes-e2e)
- [ ] This makes new expectations of the API...
  - [ ] ... and I have notified the API developer(s) of changes to the contract tests (Pact), or the API is already compliant
- [ ] [Manually approve](../doc/how-to/perform-a-release.md#releasing-to-the-preprod-environment) release to preprod
- [ ] [Manually approve](../doc/how-to/perform-a-release.md#releasing-to-the-production-environment) release to prod

<!-- Should a release fail at any step, you as the author should now lead the work to
fix it as soon as possible. You can monitor deployment failures in CircleCI
itself and application errors are found in
[Sentry](https://ministryofjustice.sentry.io/projects/hmpps-accredited-programmes-ui/?project=4505330122686464&referrer=sidebar&statsPeriod=24h). -->
