### PR TITLE
(967) Set `hasReviewedProgrammeHistory` on a referral

### DIFF
--- a/integration_tests/pages/refer/programmeHistory.ts
+++ b/integration_tests/pages/refer/programmeHistory.ts
@@ -21,6 +21,13 @@ export default class ProgrammeHistoryPage extends Page {
     this.referral = referral
   }
 
+  reviewProgrammeHistory() {
+    this.referral = { ...this.referral, hasReviewedProgrammeHistory: true }
+    // We're stubbing the referral here to make sure the updated referral is available on the task list page
+    cy.task('stubReferral', this.referral)
+    this.shouldContainButton('Continue').click()
+  }
+
   shouldContainNoHistoryHeading() {
     cy.get('[data-testid="no-history-heading"]').should(
       'have.text',

--- a/integration_tests/pages/refer/taskList.ts
+++ b/integration_tests/pages/refer/taskList.ts
@@ -77,6 +77,12 @@ export default class TaskListPage extends Page {
     })
   }
 
+  shouldHaveReviewedProgrammeHistory() {
+    cy.get('[data-testid="programme-history-tag"]').then(tagElement => {
+      this.shouldContainTag({ classes: 'govuk-tag moj-task-list__task-completed', text: 'completed' }, tagElement)
+    })
+  }
+
   shouldNotBeReadyForSubmission() {
     cy.get('[data-testid="check-answers-list-item"]').within(() => {
       cy.get('a').should('not.exist')

--- a/server/@types/models/Referral.ts
+++ b/server/@types/models/Referral.ts
@@ -3,6 +3,7 @@ import type { Person } from './Person'
 
 type Referral = {
   id: string // eslint-disable-next-line @typescript-eslint/member-ordering
+  hasReviewedProgrammeHistory: boolean
   oasysConfirmed: boolean
   offeringId: CourseOffering['id']
   prisonNumber: Person['prisonNumber']
@@ -16,6 +17,7 @@ type CreatedReferralResponse = {
 }
 
 type ReferralUpdate = {
+  hasReviewedProgrammeHistory: Referral['hasReviewedProgrammeHistory']
   oasysConfirmed: Referral['oasysConfirmed']
   reason?: Referral['reason']
 }

--- a/server/controllers/refer/courseParticipationsController.test.ts
+++ b/server/controllers/refer/courseParticipationsController.test.ts
@@ -305,6 +305,7 @@ describe('CourseParticipationsController', () => {
         referral.id,
       )
       expect(response.render).toHaveBeenCalledWith('referrals/courseParticipations/index', {
+        action: `${referPaths.programmeHistory.updateReviewedStatus({ referralId: referral.id })}?_method=PUT`,
         pageHeading: 'Accredited Programme history',
         person,
         referralId: referral.id,

--- a/server/controllers/refer/courseParticipationsController.test.ts
+++ b/server/controllers/refer/courseParticipationsController.test.ts
@@ -450,4 +450,26 @@ describe('CourseParticipationsController', () => {
       })
     })
   })
+
+  describe('updateHasReviewedProgrammeHistory', () => {
+    it('asks the service to update the referral and redirects to the index action', async () => {
+      const referral = referralFactory.started().build()
+
+      referralService.getReferral.mockResolvedValue(referral)
+      request.params.referralId = referral.id
+
+      const hasReviewedProgrammeHistory = true
+      request.body = { hasReviewedProgrammeHistory: hasReviewedProgrammeHistory.toString() }
+
+      const requestHandler = courseParticipationsController.updateHasReviewedProgrammeHistory()
+      await requestHandler(request, response, next)
+
+      expect(referralService.updateReferral).toHaveBeenCalledWith(token, referral.id, {
+        hasReviewedProgrammeHistory,
+        oasysConfirmed: referral.oasysConfirmed,
+        reason: referral.reason,
+      })
+      expect(response.redirect).toHaveBeenCalledWith(referPaths.show({ referralId: referral.id }))
+    })
+  })
 })

--- a/server/controllers/refer/courseParticipationsController.ts
+++ b/server/controllers/refer/courseParticipationsController.ts
@@ -157,6 +157,7 @@ export default class CourseParticipationsController {
       )
 
       res.render('referrals/courseParticipations/index', {
+        action: `${referPaths.programmeHistory.updateReviewedStatus({ referralId: referral.id })}?_method=PUT`,
         pageHeading: 'Accredited Programme history',
         person,
         referralId: referral.id,

--- a/server/controllers/refer/courseParticipationsController.ts
+++ b/server/controllers/refer/courseParticipationsController.ts
@@ -3,7 +3,7 @@ import type { Request, Response, TypedRequestHandler } from 'express'
 import { referPaths } from '../../paths'
 import type { CourseService, PersonService, ReferralService } from '../../services'
 import { CourseParticipationUtils, CourseUtils, FormUtils, TypeUtils } from '../../utils'
-import type { CourseParticipation, CourseParticipationWithName } from '@accredited-programmes/models'
+import type { CourseParticipation, CourseParticipationWithName, ReferralUpdate } from '@accredited-programmes/models'
 
 export default class CourseParticipationsController {
   constructor(
@@ -228,6 +228,28 @@ export default class CourseParticipationsController {
           referralId: req.params.referralId,
         }),
       )
+    }
+  }
+
+  updateHasReviewedProgrammeHistory(): TypedRequestHandler<Request, Response> {
+    return async (req: Request, res: Response) => {
+      TypeUtils.assertHasUser(req)
+
+      const { referralId } = req.params
+
+      const hasReviewedProgrammeHistory = req.body.hasReviewedProgrammeHistory === 'true'
+
+      const { oasysConfirmed, reason } = await this.referralService.getReferral(req.user.token, referralId)
+
+      const referralUpdate: ReferralUpdate = {
+        hasReviewedProgrammeHistory,
+        oasysConfirmed,
+        reason,
+      }
+
+      await this.referralService.updateReferral(req.user.token, referralId, referralUpdate)
+
+      return res.redirect(referPaths.show({ referralId }))
     }
   }
 

--- a/server/controllers/refer/oasysConfirmationController.test.ts
+++ b/server/controllers/refer/oasysConfirmationController.test.ts
@@ -76,6 +76,7 @@ describe('OasysConfirmationController', () => {
 
       expect(response.redirect).toHaveBeenCalledWith(referPaths.show({ referralId: referral.id }))
       expect(referralService.updateReferral).toHaveBeenCalledWith(token, referral.id, {
+        hasReviewedProgrammeHistory: referral.hasReviewedProgrammeHistory,
         oasysConfirmed: true,
         reason: referral.reason,
       })

--- a/server/controllers/refer/oasysConfirmationController.ts
+++ b/server/controllers/refer/oasysConfirmationController.ts
@@ -47,6 +47,7 @@ export default class OasysConfirmationController {
       const referral = await this.referralService.getReferral(req.user.token, req.params.referralId)
 
       const referralUpdate: ReferralUpdate = {
+        hasReviewedProgrammeHistory: referral.hasReviewedProgrammeHistory,
         oasysConfirmed,
         reason: referral.reason,
       }

--- a/server/controllers/refer/reasonController.test.ts
+++ b/server/controllers/refer/reasonController.test.ts
@@ -77,6 +77,7 @@ describe('ReasonController', () => {
       await requestHandler(request, response, next)
 
       expect(referralService.updateReferral).toHaveBeenCalledWith(token, referral.id, {
+        hasReviewedProgrammeHistory: referral.hasReviewedProgrammeHistory,
         oasysConfirmed: referral.oasysConfirmed,
         reason: 'Some reason\nAnother paragraph',
       })

--- a/server/controllers/refer/reasonController.ts
+++ b/server/controllers/refer/reasonController.ts
@@ -47,6 +47,7 @@ export default class ReasonController {
       const referral = await this.referralService.getReferral(req.user.token, req.params.referralId)
 
       const referralUpdate: ReferralUpdate = {
+        hasReviewedProgrammeHistory: referral.hasReviewedProgrammeHistory,
         oasysConfirmed: referral.oasysConfirmed,
         reason: formattedReason,
       }

--- a/server/data/referralClient.test.ts
+++ b/server/data/referralClient.test.ts
@@ -79,7 +79,11 @@ pactWith({ consumer: 'Accredited Programmes UI', provider: 'Accredited Programme
   })
 
   describe('update', () => {
-    const referralUpdate: ReferralUpdate = { oasysConfirmed: true, reason: 'A brilliant reason' }
+    const referralUpdate: ReferralUpdate = {
+      hasReviewedProgrammeHistory: true,
+      oasysConfirmed: true,
+      reason: 'A brilliant reason',
+    }
 
     beforeEach(() => {
       provider.addInteraction({

--- a/server/paths/refer.ts
+++ b/server/paths/refer.ts
@@ -50,6 +50,7 @@ export default {
     index: programmeHistoryPath,
     new: newProgrammeHistoryPath,
     updateProgramme: programmeHistoryProgrammePath,
+    updateReviewedStatus: programmeHistoryPath,
   },
   reason: {
     show: reasonForReferralPath,

--- a/server/routes/refer.ts
+++ b/server/routes/refer.ts
@@ -38,6 +38,10 @@ export default function routes(controllers: Controllers, router: Router): Router
   put(referPaths.reason.update.pattern, reasonController.update())
 
   get(referPaths.programmeHistory.index.pattern, courseParticipationsController.index())
+  put(
+    referPaths.programmeHistory.updateReviewedStatus.pattern,
+    courseParticipationsController.updateHasReviewedProgrammeHistory(),
+  )
   get(referPaths.programmeHistory.new.pattern, courseParticipationsController.new())
   post(referPaths.programmeHistory.create.pattern, courseParticipationsController.create())
   get(referPaths.programmeHistory.editProgramme.pattern, courseParticipationsController.editCourse())

--- a/server/services/referralService.test.ts
+++ b/server/services/referralService.test.ts
@@ -64,7 +64,10 @@ describe('ReferralService', () => {
   describe('updateReferral', () => {
     it('asks the client to update a referral', async () => {
       const referralId = 'an-ID'
-      const referralUpdate: ReferralUpdate = { oasysConfirmed: true }
+      const referralUpdate: ReferralUpdate = {
+        hasReviewedProgrammeHistory: false,
+        oasysConfirmed: true,
+      }
 
       await service.updateReferral(token, referralId, referralUpdate)
 

--- a/server/testutils/factories/referral.ts
+++ b/server/testutils/factories/referral.ts
@@ -6,6 +6,7 @@ import type { Referral, ReferralStatus } from '@accredited-programmes/models'
 class ReferralFactory extends Factory<Referral> {
   started() {
     return this.params({
+      hasReviewedProgrammeHistory: false,
       oasysConfirmed: false,
       reason: undefined,
       status: 'referral_started',
@@ -14,6 +15,7 @@ class ReferralFactory extends Factory<Referral> {
 
   submittable() {
     return this.params({
+      hasReviewedProgrammeHistory: true,
       oasysConfirmed: true,
       reason: faker.lorem.paragraph({ max: 5, min: 1 }),
       status: 'referral_started',
@@ -22,6 +24,7 @@ class ReferralFactory extends Factory<Referral> {
 
   submitted() {
     return this.params({
+      hasReviewedProgrammeHistory: true,
       oasysConfirmed: true,
       reason: faker.lorem.paragraph({ max: 5, min: 1 }),
       status: 'referral_submitted',
@@ -31,6 +34,7 @@ class ReferralFactory extends Factory<Referral> {
 
 export default ReferralFactory.define(() => ({
   id: faker.string.uuid(), // eslint-disable-next-line sort-keys
+  hasReviewedProgrammeHistory: faker.datatype.boolean(),
   oasysConfirmed: faker.datatype.boolean(),
   offeringId: faker.string.uuid(),
   prisonNumber: faker.string.alphanumeric({ length: 7 }),

--- a/server/utils/referralUtils.test.ts
+++ b/server/utils/referralUtils.test.ts
@@ -93,7 +93,11 @@ describe('ReferralUtils', () => {
           heading: 'Referral information',
           items: [
             {
-              statusTag: { classes: 'govuk-tag--grey moj-task-list__task-completed', text: 'not started' },
+              statusTag: {
+                attributes: { 'data-testid': 'programme-history-tag' },
+                classes: 'govuk-tag--grey moj-task-list__task-completed',
+                text: 'not started',
+              },
               text: 'Review Accredited Programme history',
               url: `/referrals/${referral.id}/programme-history`,
             },
@@ -138,12 +142,21 @@ describe('ReferralUtils', () => {
       const referralWithCompletedInformation = referralFactory.submittable().build()
       const taskListSections = ReferralUtils.taskListSections(referralWithCompletedInformation)
       const referralInformationSection = getTaskListSection('Referral information', taskListSections)
+      const accreditedProgrammeHistoryStatusTag = getTaskListItem(
+        'Review Accredited Programme history',
+        referralInformationSection,
+      ).statusTag
       const reasonStatusTag = getTaskListItem('Add additional information', referralInformationSection).statusTag
       const confirmOasysStatusTag = getTaskListItem(
         'Confirm the OASys information',
         referralInformationSection,
       ).statusTag
 
+      expect(accreditedProgrammeHistoryStatusTag).toEqual({
+        attributes: { 'data-testid': 'programme-history-tag' },
+        classes: 'moj-task-list__task-completed',
+        text: 'completed',
+      })
       expect(reasonStatusTag).toEqual({
         attributes: { 'data-testid': 'reason-tag' },
         classes: 'moj-task-list__task-completed',

--- a/server/utils/referralUtils.ts
+++ b/server/utils/referralUtils.ts
@@ -68,7 +68,10 @@ export default class ReferralUtils {
         heading: 'Referral information',
         items: [
           {
-            statusTag: ReferralUtils.taskListStatusTag('not started'),
+            statusTag: ReferralUtils.taskListStatusTag(
+              referral.hasReviewedProgrammeHistory ? 'completed' : 'not started',
+              'programme-history-tag',
+            ),
             text: 'Review Accredited Programme history',
             url: referPaths.programmeHistory.index({ referralId: referral.id }),
           },

--- a/server/views/referrals/courseParticipations/index.njk
+++ b/server/views/referrals/courseParticipations/index.njk
@@ -5,6 +5,28 @@
 
 {% extends "../../partials/layout.njk" %}
 
+{% macro actionForm(secondaryActionText) %}
+  <form action="{{ action }}" method="post">
+    <input type="hidden" name="_csrf" value="{{ csrfToken }}"/>
+    <input type="hidden" name="hasReviewedProgrammeHistory" value="true"/>
+
+    <div class="govuk-button-group">
+      {{ govukButton({
+        text: "Continue"
+      }) }}
+
+      {{ govukButton({
+        text: secondaryActionText,
+        classes: "govuk-button--secondary",
+        href: referPaths.programmeHistory.new({ referralId: referralId }),
+        attributes: {
+          "data-testid": "add-history-button"
+        }
+      }) }}
+    </div>
+  </form>
+{% endmacro %}
+
 {% block personBanner %}
   {% include "../_personBanner.njk" %}
 {% endblock personBanner %}
@@ -39,39 +61,13 @@
           {{ govukSummaryList(summaryListOptions) }}
         {% endfor %}
 
-        <div class="govuk-button-group">
-          {{ govukButton({
-            text: "Continue"
-          }) }}
-
-          {{ govukButton({
-            text: "Add another",
-            classes: "govuk-button--secondary",
-            href: referPaths.programmeHistory.new({ referralId: referralId }),
-            attributes: {
-              "data-testid": "add-history-button"
-            }
-          }) }}
-        </div>
+        {{ actionForm(secondaryActionText="Add another") }}
       {% else %}
         <h2 class="govuk-heading-m" data-testid="no-history-heading">There is no record of Accredited Programmes for {{ person.name }}.</h2>
 
         <p class="govuk-body" data-testid="no-history-paragraph">The programme team may use information about a person's Accredited Programme history to assess whether they are suitable. You can add a programme to this history or continue with the referral if the {{ person.name }}'s history is unknown.</p>
 
-        <div class="govuk-button-group">
-          {{ govukButton({
-            text: "Continue"
-          }) }}
-
-          {{ govukButton({
-            text: "Add a programme",
-            classes: "govuk-button--secondary",
-            href: referPaths.programmeHistory.new({ referralId: referralId }),
-            attributes: {
-              "data-testid": "add-history-button"
-            }
-          }) }}
-        </div>
+        {{ actionForm(secondaryActionText="Add a programme") }}
       {% endif %}
     </div>
   </div>


### PR DESCRIPTION
## Context

https://trello.com/c/Fl2C9Vve/967-set-and-fetch-hasreviewedprogrammehistory-ui

## Changes in this PR

Add `updateHasReviewedProgrammeHistory` method which updates the `hasReviewedProgrammeHistory` value on a referral when used by the form on the programme history index.  

When clicking Continue on the Programme history index, `updateHasReviewedProgrammeHistory` is set to true and the user is redirected back to the task list where the status of the **Review Accredited Programme history** task is set to `Completed`.


## Screenshots of UI changes

![localhost_3000_referrals_c11fab18-dc8d-420c-9c82-d0edd373732d](https://github.com/ministryofjustice/hmpps-accredited-programmes-ui/assets/1067537/e76291c0-a6f7-4f2a-b7d3-6b259d73c388)



## Release checklist

[Release process documentation](../doc/how-to/perform-a-release.md)

As part of our continuous deployment strategy we must ensure that this work is
ready to be released once merged.

### Pre-merge

- [ ] There are changes required to the Accredited Programmes API for this change to work...
  - [ ] ... and they have been released to production already

### Post-merge

<!-- The outer checkboxes can be completed pre-merge -->

- [ ] This adds, extends or meaningfully modifies a feature...
  - [ ] ... and I have written or updated an end-to-end test for the happy path in the [Accredited Programmes E2E repo](https://github.com/ministryofjustice/hmpps-accredited-programmes-e2e)
- [ ] This makes new expectations of the API...
  - [ ] ... and I have notified the API developer(s) of changes to the contract tests (Pact), or the API is already compliant
- [ ] [Manually approve](../doc/how-to/perform-a-release.md#releasing-to-the-preprod-environment) release to preprod
- [ ] [Manually approve](../doc/how-to/perform-a-release.md#releasing-to-the-production-environment) release to prod

<!-- Should a release fail at any step, you as the author should now lead the work to
fix it as soon as possible. You can monitor deployment failures in CircleCI
itself and application errors are found in
[Sentry](https://ministryofjustice.sentry.io/projects/hmpps-accredited-programmes-ui/?project=4505330122686464&referrer=sidebar&statsPeriod=24h). -->
