### PR TITLE
Tidy up types

### DIFF
--- a/integration_tests/e2e/refer/programmeHistory.cy.ts
+++ b/integration_tests/e2e/refer/programmeHistory.cy.ts
@@ -7,7 +7,7 @@ import {
   prisonerFactory,
   referralFactory,
 } from '../../../server/testutils/factories'
-import type { DetailsBody } from '../../../server/utils/courseParticipationUtils'
+import type { CourseParticipationDetailsBody } from '../../../server/utils'
 import Page from '../../pages/page'
 import {
   DeleteProgrammeHistoryPage,
@@ -343,7 +343,7 @@ context('Programme history', () => {
       })
 
       it('updates the entry and redirects to the programme history page', () => {
-        const formValues: DetailsBody = {
+        const formValues: CourseParticipationDetailsBody = {
           detail: 'Some outcome details',
           outcome: {
             status: 'complete',

--- a/integration_tests/tsconfig.json
+++ b/integration_tests/tsconfig.json
@@ -10,7 +10,6 @@
     "paths": {
       "@accredited-programmes/integration-tests": ["./@types/index.d.ts"],
       "@accredited-programmes/models": ["../server/@types/models/index.d.ts"],
-      "@accredited-programmes/server": ["../server/@types/server/index.d.ts"],
       "@accredited-programmes/ui": ["../server/@types/ui/index.d.ts"],
       "@accredited-programmes/users": ["../server/@types/users/index.d.ts"],
       "@govuk-frontend": ["../server/@types/govukFrontend/index.d.ts"],

--- a/integration_tests/tsconfig.json
+++ b/integration_tests/tsconfig.json
@@ -12,7 +12,7 @@
       "@accredited-programmes/models": ["../server/@types/models/index.d.ts"],
       "@accredited-programmes/server": ["../server/@types/server/index.d.ts"],
       "@accredited-programmes/ui": ["../server/@types/ui/index.d.ts"],
-      "@accredited-programmes/users": ["./server/@types/users/index.d.ts"],
+      "@accredited-programmes/users": ["../server/@types/users/index.d.ts"],
       "@govuk-frontend": ["../server/@types/govukFrontend/index.d.ts"],
       "@prison-api": ["../server/@types/prisonApi/index.d.ts"],
       "@prison-register-api": ["../server/@types/prisonRegisterApi/index.d.ts"],

--- a/server/@types/express/index.d.ts
+++ b/server/@types/express/index.d.ts
@@ -2,7 +2,7 @@
 // @ts-expect-error to fix later: https://github.com/microsoft/TypeScript/issues/16472
 import type { Request as ConnectFlashRequest } from '@types/connect-flash'
 
-import type { UserDetails } from '../users'
+import type { UserDetails } from '@accredited-programmes/users'
 
 declare module 'express-session' {
   // Declare that the session will potentially contain these additional fields

--- a/server/@types/server/index.d.ts
+++ b/server/@types/server/index.d.ts
@@ -1,5 +1,0 @@
-import type { ApplicationRoles } from '../../middleware/roleBasedAccessMiddleware'
-
-export type MiddlewareOptions = {
-  allowedRoles?: Array<ApplicationRoles>
-}

--- a/server/@types/ui/index.d.ts
+++ b/server/@types/ui/index.d.ts
@@ -1,3 +1,4 @@
+import type { Course, CourseOffering, Organisation } from '@accredited-programmes/models'
 import type {
   GovukFrontendRadiosItem,
   GovukFrontendSummaryList,
@@ -5,8 +6,7 @@ import type {
   GovukFrontendSummaryListRow,
   GovukFrontendSummaryListRowValue,
   GovukFrontendTag,
-} from '../govukFrontend'
-import type { Course, CourseOffering, Organisation } from '@accredited-programmes/models'
+} from '@govuk-frontend'
 
 type GovukFrontendRadiosItemWithLabel = GovukFrontendRadiosItem & { label: string }
 

--- a/server/@types/users/index.d.ts
+++ b/server/@types/users/index.d.ts
@@ -1,8 +1,15 @@
+import type { ApplicationRoles } from '../../middleware/roleBasedAccessMiddleware'
 import type { Caseload } from '@prison-api'
 
-export type UserDetails = {
+type MiddlewareOptions = {
+  allowedRoles?: Array<ApplicationRoles>
+}
+
+type UserDetails = {
   caseloads: Array<Caseload>
   displayName: string
   name: string
   userId: string
 }
+
+export type { MiddlewareOptions, UserDetails }

--- a/server/middleware/roleBasedAccessMiddleware.ts
+++ b/server/middleware/roleBasedAccessMiddleware.ts
@@ -1,7 +1,7 @@
 import type { NextFunction, Request, RequestHandler, Response } from 'express'
 
 import logger from '../../logger'
-import type { MiddlewareOptions } from '@accredited-programmes/server'
+import type { MiddlewareOptions } from '@accredited-programmes/users'
 
 export enum ApplicationRoles {
   ACP_REFERRER = 'ROLE_ACP_REFERRER',

--- a/server/utils/courseParticipationUtils.test.ts
+++ b/server/utils/courseParticipationUtils.test.ts
@@ -3,7 +3,8 @@ import type { DeepMocked } from '@golevelup/ts-jest'
 import { createMock } from '@golevelup/ts-jest'
 import type { Request } from 'express'
 
-import CourseParticipationUtils, { type RequestWithDetailsBody } from './courseParticipationUtils'
+import type { RequestWithCourseParticipationDetailsBody } from './courseParticipationUtils'
+import CourseParticipationUtils from './courseParticipationUtils'
 import { courseParticipationFactory } from '../testutils/factories'
 import type {
   CourseParticipationOutcome,
@@ -26,11 +27,11 @@ const getRowValueText = (
 
 describe('CourseParticipationUtils', () => {
   describe('processDetailsFormData', () => {
-    let request: DeepMocked<RequestWithDetailsBody>
+    let request: DeepMocked<RequestWithCourseParticipationDetailsBody>
     let expectedCourseParticipationUpdate: CourseParticipationUpdate
 
     beforeEach(() => {
-      request = createMock<RequestWithDetailsBody>({})
+      request = createMock<RequestWithCourseParticipationDetailsBody>({})
 
       request.body = {
         detail: 'Some additional detail',

--- a/server/utils/courseParticipationUtils.ts
+++ b/server/utils/courseParticipationUtils.ts
@@ -17,7 +17,7 @@ import type {
 } from '@accredited-programmes/ui'
 import type { GovukFrontendSummaryListRowKey } from '@govuk-frontend'
 
-interface DetailsBody {
+interface CourseParticipationDetailsBody {
   detail: string
   outcome: {
     yearCompleted: string
@@ -31,8 +31,9 @@ interface DetailsBody {
   }
   source: string
 }
-interface RequestWithDetailsBody extends Request {
-  body: DetailsBody
+
+interface RequestWithCourseParticipationDetailsBody extends Request {
+  body: CourseParticipationDetailsBody
 }
 
 export default class CourseParticipationUtils {
@@ -67,7 +68,7 @@ export default class CourseParticipationUtils {
     }
   }
 
-  static processDetailsFormData(request: RequestWithDetailsBody): {
+  static processDetailsFormData(request: RequestWithCourseParticipationDetailsBody): {
     courseParticipationUpdate: CourseParticipationUpdate
     hasFormErrors: boolean
   } {
@@ -217,4 +218,4 @@ export default class CourseParticipationUtils {
   }
 }
 
-export type { DetailsBody, RequestWithDetailsBody }
+export type { CourseParticipationDetailsBody, RequestWithCourseParticipationDetailsBody }

--- a/server/utils/index.ts
+++ b/server/utils/index.ts
@@ -1,3 +1,7 @@
+import type {
+  CourseParticipationDetailsBody,
+  RequestWithCourseParticipationDetailsBody,
+} from './courseParticipationUtils'
 import CourseParticipationUtils from './courseParticipationUtils'
 import CourseUtils from './courseUtils'
 import DateUtils from './dateUtils'
@@ -25,3 +29,5 @@ export {
   UserUtils,
   nunjucksSetup,
 }
+
+export type { CourseParticipationDetailsBody, RequestWithCourseParticipationDetailsBody }

--- a/server/utils/routeUtils.ts
+++ b/server/utils/routeUtils.ts
@@ -4,7 +4,7 @@ import type { RequestHandler, Router } from 'express'
 
 import asyncMiddleware from '../middleware/asyncMiddleware'
 import roleBasedAccessMiddleware from '../middleware/roleBasedAccessMiddleware'
-import type { MiddlewareOptions } from '@accredited-programmes/server'
+import type { MiddlewareOptions } from '@accredited-programmes/users'
 
 export default class RouteUtils {
   static actions(router: Router, defaultMiddlewareOptions?: MiddlewareOptions) {

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -18,7 +18,6 @@
     "typeRoots": ["./server/@types", "./node_modules/@types"],
     "paths": {
       "@accredited-programmes/models": ["./server/@types/models/index.d.ts"],
-      "@accredited-programmes/server": ["./server/@types/server/index.d.ts"],
       "@accredited-programmes/ui": ["./server/@types/ui/index.d.ts"],
       "@accredited-programmes/users": ["./server/@types/users/index.d.ts"],
       "@govuk-frontend": ["./server/@types/govukFrontend/index.d.ts"],


### PR DESCRIPTION
## Changes in this PR

A couple of type-related tidy ups

I wonder if we could clarify what the `server/index.d.ts` and `users/index.d.ts` should be used for/why we need them alongside `ui/index.td.ts` and the `models` folder? Perhaps one for the upcoming ADRs

## Release checklist

[Release process documentation](../doc/how-to/perform-a-release.md)

As part of our continuous deployment strategy we must ensure that this work is
ready to be released once merged.

### Pre-merge

- [ ] There are changes required to the Accredited Programmes API for this change to work...
  - [ ] ... and they have been released to production already

### Post-merge

<!-- The outer checkboxes can be completed pre-merge -->

- [ ] This adds, extends or meaningfully modifies a feature...
  - [ ] ... and I have written or updated an end-to-end test for the happy path in the [Accredited Programmes E2E repo](https://github.com/ministryofjustice/hmpps-accredited-programmes-e2e)
- [ ] This makes new expectations of the API...
  - [ ] ... and I have notified the API developer(s) of changes to the contract tests (Pact), or the API is already compliant
- [ ] [Manually approve](../doc/how-to/perform-a-release.md#releasing-to-the-preprod-environment) release to preprod
- [ ] [Manually approve](../doc/how-to/perform-a-release.md#releasing-to-the-production-environment) release to prod

<!-- Should a release fail at any step, you as the author should now lead the work to
fix it as soon as possible. You can monitor deployment failures in CircleCI
itself and application errors are found in
[Sentry](https://ministryofjustice.sentry.io/projects/hmpps-accredited-programmes-ui/?project=4505330122686464&referrer=sidebar&statsPeriod=24h). -->
