### PR TITLE
(969) Add programme history to check your answers

### DIFF
--- a/integration_tests/e2e/refer/programmeHistory.cy.ts
+++ b/integration_tests/e2e/refer/programmeHistory.cy.ts
@@ -575,7 +575,10 @@ context('Programme history', () => {
       deleteProgrammeHistoryPage.shouldHavePersonDetails(person)
       deleteProgrammeHistoryPage.shouldContainNavigation(path)
       deleteProgrammeHistoryPage.shouldContainBackLink(referPaths.programmeHistory.index({ referralId: referral.id }))
-      deleteProgrammeHistoryPage.shouldContainHistorySummaryCards([courseParticipationWithName], referral.id, false)
+      deleteProgrammeHistoryPage.shouldContainHistorySummaryCards([courseParticipationWithName], referral.id, {
+        change: false,
+        remove: false,
+      })
       deleteProgrammeHistoryPage.shouldContainWarningText(
         'You are removing this programme. Once a programme has been removed, it cannot be undone.',
       )

--- a/integration_tests/e2e/refer/submit.cy.ts
+++ b/integration_tests/e2e/refer/submit.cy.ts
@@ -42,7 +42,7 @@ context('Submitting a referral', () => {
 
     const referral = referralFactory
       .submittable()
-      .build({ oasysConfirmed: true, offeringId: courseOffering.id, prisonNumber: person.prisonNumber })
+      .build({ offeringId: courseOffering.id, prisonNumber: person.prisonNumber })
 
     cy.task('stubCourseByOffering', { course, courseOfferingId: courseOffering.id })
     cy.task('stubOffering', { courseId: course.id, courseOffering })

--- a/integration_tests/e2e/refer/submit.cy.ts
+++ b/integration_tests/e2e/refer/submit.cy.ts
@@ -3,6 +3,7 @@ import { referPaths } from '../../../server/paths'
 import {
   courseFactory,
   courseOfferingFactory,
+  courseParticipationFactory,
   personFactory,
   prisonFactory,
   prisonerFactory,
@@ -12,6 +13,7 @@ import { OrganisationUtils } from '../../../server/utils'
 import auth from '../../mockApis/auth'
 import Page from '../../pages/page'
 import { CheckAnswersPage, CompletePage, TaskListPage } from '../../pages/refer'
+import type { CourseParticipationWithName } from '@accredited-programmes/models'
 
 context('Submitting a referral', () => {
   beforeEach(() => {
@@ -57,12 +59,9 @@ context('Submitting a referral', () => {
     taskListPage.shouldBeReadyForSubmission()
   })
 
-  it('Shows the correct information on the Check answers and submit task page', () => {
-    cy.signIn()
-
+  describe('When checking answers', () => {
     const course = courseFactory.build()
     const courseOffering = courseOfferingFactory.build()
-
     const prisoner = prisonerFactory.build({
       dateOfBirth: '1980-01-01',
       firstName: 'Del',
@@ -78,47 +77,89 @@ context('Submitting a referral', () => {
       religionOrBelief: prisoner.religion,
       setting: 'Custody',
     })
-
     const prison = prisonFactory.build({ prisonId: courseOffering.organisationId })
     const organisation = OrganisationUtils.organisationFromPrison(prison)
-
     const referral = referralFactory
       .submittable()
       .build({ offeringId: courseOffering.id, prisonNumber: person.prisonNumber })
 
-    cy.task('stubCourseByOffering', { course, courseOfferingId: courseOffering.id })
-    cy.task('stubOffering', { courseId: course.id, courseOffering })
-    cy.task('stubPrison', prison)
-    cy.task('stubPrisoner', prisoner)
-    cy.task('stubReferral', referral)
-
     const path = referPaths.checkAnswers({ referralId: referral.id })
-    cy.visit(path)
 
-    const checkAnswersPage = Page.verifyOnPage(CheckAnswersPage, {
-      course,
-      courseOffering,
-      organisation,
-      person,
-      username: auth.mockedUsername(),
+    beforeEach(() => {
+      cy.task('stubCourse', course)
+      cy.task('stubCourseByOffering', { course, courseOfferingId: courseOffering.id })
+      cy.task('stubOffering', { courseId: course.id, courseOffering })
+      cy.task('stubPrison', prison)
+      cy.task('stubPrisoner', prisoner)
+      cy.task('stubReferral', referral)
+
+      cy.signIn()
     })
 
-    checkAnswersPage.shouldHavePersonDetails(person)
-    checkAnswersPage.shouldContainNavigation(path)
-    checkAnswersPage.shouldContainBackLink(referPaths.show({ referralId: referral.id }))
-    checkAnswersPage.shouldHaveApplicationSummary()
-    checkAnswersPage.shouldContainPersonSummaryList(person)
-    checkAnswersPage.shouldHaveOasysConfirmation()
-    checkAnswersPage.shouldHaveAdditionalInformation(referral)
-    checkAnswersPage.shouldHaveConfirmationCheckbox()
-    checkAnswersPage.shouldContainButton('Submit referral')
-    checkAnswersPage.shouldContainButtonLink('Return to tasklist', referPaths.show({ referralId: referral.id }))
+    it('Shows the information the user has submitted in the referral form', () => {
+      const courseParticipations = [
+        courseParticipationFactory.withCourseId().build({ courseId: course.id, createdAt: '2023-01-01T12:00:00.000Z' }),
+        courseParticipationFactory
+          .withOtherCourseName()
+          .build({ createdAt: '2022-01-01T12:00:00.000Z', otherCourseName: 'A great course name' }),
+      ]
+      const courseParticipationsWithNames: Array<CourseParticipationWithName> = [
+        { ...courseParticipations[0], name: course.name },
+        {
+          ...courseParticipations[1],
+          name: courseParticipations[1].otherCourseName as CourseParticipationWithName['name'],
+        },
+      ]
+
+      cy.task('stubParticipationsByPerson', { courseParticipations, prisonNumber: prisoner.prisonerNumber })
+
+      cy.visit(path)
+
+      const checkAnswersPage = Page.verifyOnPage(CheckAnswersPage, {
+        course,
+        courseOffering,
+        organisation,
+        participations: courseParticipationsWithNames,
+        person,
+        referral,
+        username: auth.mockedUsername(),
+      })
+      checkAnswersPage.shouldHavePersonDetails(person)
+      checkAnswersPage.shouldContainNavigation(path)
+      checkAnswersPage.shouldContainBackLink(referPaths.show({ referralId: referral.id }))
+      checkAnswersPage.shouldHaveApplicationSummary()
+      checkAnswersPage.shouldContainPersonSummaryList(person)
+      checkAnswersPage.shouldHaveProgrammeHistory()
+      checkAnswersPage.shouldHaveOasysConfirmation()
+      checkAnswersPage.shouldHaveAdditionalInformation(referral)
+      checkAnswersPage.shouldHaveConfirmationCheckbox()
+      checkAnswersPage.shouldContainButton('Submit referral')
+      checkAnswersPage.shouldContainButtonLink('Return to tasklist', referPaths.show({ referralId: referral.id }))
+    })
+
+    describe('for a person with no programme history', () => {
+      it('indicate that there is no programme history', () => {
+        cy.task('stubParticipationsByPerson', { courseParticipations: [], prisonNumber: prisoner.prisonerNumber })
+
+        cy.visit(path)
+
+        const checkAnswersPage = Page.verifyOnPage(CheckAnswersPage, {
+          course,
+          courseOffering,
+          organisation,
+          participations: [],
+          person,
+          referral,
+          username: auth.mockedUsername(),
+        })
+        checkAnswersPage.shouldNotHaveProgrammeHistory()
+      })
+    })
   })
 
   describe('When submitting a referral', () => {
     const course = courseFactory.build()
     const courseOffering = courseOfferingFactory.build()
-
     const prisoner = prisonerFactory.build({
       firstName: 'Del',
       lastName: 'Hatton',
@@ -128,15 +169,29 @@ context('Submitting a referral', () => {
       name: 'Del Hatton',
       prisonNumber: prisoner.prisonerNumber,
     })
-
     const prison = prisonFactory.build({ prisonId: courseOffering.organisationId })
     const organisation = OrganisationUtils.organisationFromPrison(prison)
+    const courseParticipations = [
+      courseParticipationFactory.withCourseId().build({ courseId: course.id, createdAt: '2023-01-01T12:00:00.000Z' }),
+      courseParticipationFactory
+        .withOtherCourseName()
+        .build({ createdAt: '2022-01-01T12:00:00.000Z', otherCourseName: 'A great course name' }),
+    ]
+    const courseParticipationsWithNames: Array<CourseParticipationWithName> = [
+      { ...courseParticipations[0], name: course.name },
+      {
+        ...courseParticipations[1],
+        name: courseParticipations[1].otherCourseName as CourseParticipationWithName['name'],
+      },
+    ]
 
     beforeEach(() => {
       cy.signIn()
 
+      cy.task('stubCourse', course)
       cy.task('stubCourseByOffering', { course, courseOfferingId: courseOffering.id })
       cy.task('stubOffering', { courseId: course.id, courseOffering })
+      cy.task('stubParticipationsByPerson', { courseParticipations, prisonNumber: prisoner.prisonerNumber })
       cy.task('stubPrison', prison)
       cy.task('stubPrisoner', prisoner)
     })
@@ -156,7 +211,9 @@ context('Submitting a referral', () => {
         course,
         courseOffering,
         organisation,
+        participations: courseParticipationsWithNames,
         person,
+        referral,
         username: auth.mockedUsername(),
       })
       checkAnswersPage.confirmDetailsAndSubmitReferral(referral)
@@ -179,7 +236,9 @@ context('Submitting a referral', () => {
         course,
         courseOffering,
         organisation,
+        participations: courseParticipationsWithNames,
         person,
+        referral,
         username: auth.mockedUsername(),
       })
       checkAnswersPage.shouldContainButton('Submit referral').click()
@@ -188,7 +247,9 @@ context('Submitting a referral', () => {
         course,
         courseOffering,
         organisation,
+        participations: courseParticipationsWithNames,
         person,
+        referral,
         username: auth.mockedUsername(),
       })
       checkAnswersPageWithErrors.shouldHaveErrors([

--- a/integration_tests/pages/page.ts
+++ b/integration_tests/pages/page.ts
@@ -89,7 +89,7 @@ export default abstract class Page {
   shouldContainHistorySummaryCards(
     participations: Array<CourseParticipationWithName>,
     referralId: Referral['id'],
-    withActions = true,
+    withActions = { change: true, remove: true },
   ) {
     participations
       .sort((participationA, participationB) => participationA.createdAt.localeCompare(participationB.createdAt))
@@ -99,26 +99,29 @@ export default abstract class Page {
         cy.get('.govuk-summary-card')
           .eq(participationsIndex)
           .then(summaryCardElement => {
-            const actions = withActions
-              ? [
-                  {
-                    href: referPaths.programmeHistory.editProgramme({
-                      courseParticipationId: participation.id,
-                      referralId,
-                    }),
-                    text: 'Change',
-                    visuallyHiddenText: ` participation for ${participation.name}`,
-                  },
-                  {
-                    href: referPaths.programmeHistory.delete({
-                      courseParticipationId: participation.id,
-                      referralId,
-                    }),
-                    text: 'Remove',
-                    visuallyHiddenText: ` participation for ${participation.name}`,
-                  },
-                ]
-              : []
+            const actions = []
+
+            if (withActions.change) {
+              actions.push({
+                href: referPaths.programmeHistory.editProgramme({
+                  courseParticipationId: participation.id,
+                  referralId,
+                }),
+                text: 'Change',
+                visuallyHiddenText: ` participation for ${participation.name}`,
+              })
+            }
+
+            if (withActions.remove) {
+              actions.push({
+                href: referPaths.programmeHistory.delete({
+                  courseParticipationId: participation.id,
+                  referralId,
+                }),
+                text: 'Remove',
+                visuallyHiddenText: ` participation for ${participation.name}`,
+              })
+            }
 
             this.shouldContainSummaryCard(participation.name, actions, rows, summaryCardElement)
           })

--- a/integration_tests/pages/refer/checkAnswers.ts
+++ b/integration_tests/pages/refer/checkAnswers.ts
@@ -1,6 +1,13 @@
 import { CourseUtils, ReferralUtils } from '../../../server/utils'
 import Page from '../page'
-import type { Course, CourseOffering, Organisation, Person, Referral } from '@accredited-programmes/models'
+import type {
+  Course,
+  CourseOffering,
+  CourseParticipationWithName,
+  Organisation,
+  Person,
+  Referral,
+} from '@accredited-programmes/models'
 import type { CoursePresenter } from '@accredited-programmes/ui'
 
 export default class CheckAnswersPage extends Page {
@@ -10,7 +17,11 @@ export default class CheckAnswersPage extends Page {
 
   organisation: Organisation
 
+  participations: Array<CourseParticipationWithName>
+
   person: Person
+
+  referral: Referral
 
   username: Express.User['username']
 
@@ -18,16 +29,20 @@ export default class CheckAnswersPage extends Page {
     course: Course
     courseOffering: CourseOffering
     organisation: Organisation
+    participations: Array<CourseParticipationWithName>
     person: Person
+    referral: Referral
     username: Express.User['username']
   }) {
     super('Check your answers')
 
-    const { course, courseOffering, organisation, person, username } = args
+    const { course, courseOffering, organisation, participations, person, referral, username } = args
     this.course = CourseUtils.presentCourse(course)
     this.courseOffering = courseOffering
     this.organisation = organisation
+    this.participations = participations
     this.person = person
+    this.referral = referral
     this.username = username
   }
 
@@ -66,5 +81,18 @@ export default class CheckAnswersPage extends Page {
 
   shouldHaveOasysConfirmation(): void {
     cy.get('[data-testid="oasys-confirmation"]').should('have.text', 'I confirm that the information is up to date.')
+  }
+
+  shouldHaveProgrammeHistory(): void {
+    cy.get('[data-testid="programme-history"]').within(() => {
+      this.shouldContainHistorySummaryCards(this.participations, this.referral.id, { change: true, remove: false })
+    })
+  }
+
+  shouldNotHaveProgrammeHistory(): void {
+    cy.get('[data-testid="programme-history"] .govuk-body').should(
+      'have.text',
+      `There is no record of Accredited Programmes for ${this.person.name}.`,
+    )
   }
 }

--- a/server/@types/ui/index.d.ts
+++ b/server/@types/ui/index.d.ts
@@ -2,6 +2,7 @@ import type { Course, CourseOffering, Organisation } from '@accredited-programme
 import type {
   GovukFrontendRadiosItem,
   GovukFrontendSummaryList,
+  GovukFrontendSummaryListCardActions,
   GovukFrontendSummaryListCardActionsItem,
   GovukFrontendSummaryListRow,
   GovukFrontendSummaryListRowValue,
@@ -11,6 +12,10 @@ import type {
 type GovukFrontendRadiosItemWithLabel = GovukFrontendRadiosItem & { label: string }
 
 type GovukFrontendSummaryListCardActionsItemWithText = GovukFrontendSummaryListCardActionsItem & { text: string }
+
+type GovukFrontendSummaryListCardActionsWithItems = GovukFrontendSummaryListCardActions & {
+  items: Array<GovukFrontendSummaryListCardActionsItem>
+}
 
 type GovukFrontendSummaryListRowWithValue = GovukFrontendSummaryListRow & { value: GovukFrontendSummaryListRowValue }
 
@@ -86,6 +91,7 @@ export type {
   CoursePresenter,
   GovukFrontendRadiosItemWithLabel,
   GovukFrontendSummaryListCardActionsItemWithText,
+  GovukFrontendSummaryListCardActionsWithItems,
   GovukFrontendSummaryListRowWithValue,
   GovukFrontendSummaryListWithRowsWithValues,
   GovukFrontendTagWithText,

--- a/server/controllers/refer/courseParticipationsController.test.ts
+++ b/server/controllers/refer/courseParticipationsController.test.ts
@@ -32,7 +32,7 @@ describe('CourseParticipationsController', () => {
     response = Helpers.createMockResponseWithCaseloads()
     courseParticipationsController = new CourseParticipationsController(courseService, personService, referralService)
     ;(CourseParticipationUtils.summaryListOptions as jest.Mock).mockImplementation(
-      (_courseParticipationWithName, _referralId, _withActions = true) => {
+      (_courseParticipationWithName, _referralId, _withActions = { change: true, remove: true }) => {
         return summaryListOptions
       },
     )
@@ -177,7 +177,7 @@ describe('CourseParticipationsController', () => {
       expect(CourseParticipationUtils.summaryListOptions).toHaveBeenCalledWith(
         courseParticipationWithName,
         referral.id,
-        false,
+        { change: false, remove: false },
       )
       expect(response.render).toHaveBeenCalledWith('referrals/courseParticipations/delete', {
         action: `${referPaths.programmeHistory.destroy({ courseParticipationId, referralId })}?_method=DELETE`,

--- a/server/controllers/refer/courseParticipationsController.ts
+++ b/server/controllers/refer/courseParticipationsController.ts
@@ -62,11 +62,10 @@ export default class CourseParticipationsController {
         await this.courseParticipationsWithNames([courseParticipation], req.user.token)
       )[0]
 
-      const summaryListOptions = CourseParticipationUtils.summaryListOptions(
-        courseParticipationWithName,
-        referralId,
-        false,
-      )
+      const summaryListOptions = CourseParticipationUtils.summaryListOptions(courseParticipationWithName, referralId, {
+        change: false,
+        remove: false,
+      })
 
       res.render('referrals/courseParticipations/delete', {
         action: `${referPaths.programmeHistory.destroy({ courseParticipationId, referralId })}?_method=DELETE`,

--- a/server/controllers/refer/courseParticipationsController.ts
+++ b/server/controllers/refer/courseParticipationsController.ts
@@ -144,14 +144,10 @@ export default class CourseParticipationsController {
         req.user.token,
         person.prisonNumber,
       )
-      const courseParticipationsWithNames = await this.courseParticipationsWithNames(
-        courseParticipations,
-        req.user.token,
-      )
-      const sortedCourseParticipationsWithNames = courseParticipationsWithNames.sort((participationA, participationB) =>
-        participationA.createdAt.localeCompare(participationB.createdAt),
-      )
-      const summaryListsOptions = sortedCourseParticipationsWithNames.map(participation =>
+      const courseParticipationsWithNames = (
+        await this.courseParticipationsWithNames(courseParticipations, req.user.token)
+      ).sort((participationA, participationB) => participationA.createdAt.localeCompare(participationB.createdAt))
+      const summaryListsOptions = courseParticipationsWithNames.map(participation =>
         CourseParticipationUtils.summaryListOptions(participation, referral.id),
       )
 

--- a/server/controllers/refer/referralsController.ts
+++ b/server/controllers/refer/referralsController.ts
@@ -3,8 +3,12 @@ import createError from 'http-errors'
 
 import { referPaths } from '../../paths'
 import type { CourseService, OrganisationService, PersonService, ReferralService } from '../../services'
-import { CourseUtils, FormUtils, PersonUtils, ReferralUtils, TypeUtils } from '../../utils'
-import type { CreatedReferralResponse } from '@accredited-programmes/models'
+import { CourseParticipationUtils, CourseUtils, FormUtils, PersonUtils, ReferralUtils, TypeUtils } from '../../utils'
+import type {
+  CourseParticipation,
+  CourseParticipationWithName,
+  CreatedReferralResponse,
+} from '@accredited-programmes/models'
 
 export default class ReferralsController {
   constructor(
@@ -32,10 +36,21 @@ export default class ReferralsController {
         referral.prisonNumber,
         res.locals.user.caseloads,
       )
-
       const courseOffering = await this.courseService.getOffering(req.user.token, referral.offeringId)
       const organisation = await this.organisationService.getOrganisation(req.user.token, courseOffering.organisationId)
       const course = await this.courseService.getCourseByOffering(req.user.token, referral.offeringId)
+      const courseParticipations = await this.courseService.getParticipationsByPerson(
+        req.user.token,
+        person.prisonNumber,
+      )
+
+      const courseParticipationsWithNames = (
+        await this.courseParticipationsWithNames(courseParticipations, req.user.token)
+      ).sort((participationA, participationB) => participationA.createdAt.localeCompare(participationB.createdAt))
+      const participationSummaryListsOptions = courseParticipationsWithNames.map(participation =>
+        CourseParticipationUtils.summaryListOptions(participation, referral.id, { change: true, remove: false }),
+      )
+
       const coursePresenter = CourseUtils.presentCourse(course)
 
       FormUtils.setFieldErrors(req, res, ['confirmation'])
@@ -50,6 +65,7 @@ export default class ReferralsController {
           username,
         ),
         pageHeading: 'Check your answers',
+        participationSummaryListsOptions,
         person,
         personSummaryListRows: PersonUtils.summaryListRows(person),
         referralId,
@@ -197,5 +213,25 @@ export default class ReferralsController {
 
       return res.redirect(referPaths.complete({ referralId: req.params.referralId }))
     }
+  }
+
+  private async courseParticipationsWithNames(
+    courseParticipations: Array<CourseParticipation>,
+    token: Express.User['token'],
+  ): Promise<Array<CourseParticipationWithName>> {
+    return Promise.all(
+      courseParticipations.map(async courseParticipation => {
+        let name = ''
+
+        if (courseParticipation.courseId) {
+          const course = await this.courseService.getCourse(token, courseParticipation.courseId)
+          name = course.name
+        } else {
+          name = courseParticipation.otherCourseName as CourseParticipationWithName['name']
+        }
+
+        return { ...courseParticipation, name }
+      }),
+    )
   }
 }

--- a/server/utils/courseParticipationUtils.test.ts
+++ b/server/utils/courseParticipationUtils.test.ts
@@ -376,14 +376,22 @@ describe('CourseParticipationUtils', () => {
       })
     })
 
-    describe('when `withActions` is `false`', () => {
-      it('omits the actions', () => {
+    describe.each([
+      [{ change: false, remove: true }, 'the change action', 'Remove'],
+      [{ change: true, remove: false }, 'the remove action', 'Change'],
+      [{ change: false, remove: false }, 'both actions', null],
+    ])('when `withActions` is %s', (withActions, omits, actionText) => {
+      it(`omits ${omits}`, () => {
         const summaryListOptions = CourseParticipationUtils.summaryListOptions(
           courseParticipationWithName,
           referralId,
-          false,
+          withActions,
         )
-        expect(summaryListOptions.card?.actions).toBeUndefined()
+
+        expect(summaryListOptions.card?.actions?.items?.length).toEqual(actionText ? 1 : 0)
+        if (actionText) {
+          expect(summaryListOptions.card?.actions?.items?.[0].text).toEqual(actionText)
+        }
       })
     })
 

--- a/server/utils/courseParticipationUtils.ts
+++ b/server/utils/courseParticipationUtils.ts
@@ -12,6 +12,7 @@ import type {
   Referral,
 } from '@accredited-programmes/models'
 import type {
+  GovukFrontendSummaryListCardActionsWithItems,
   GovukFrontendSummaryListRowWithValue,
   GovukFrontendSummaryListWithRowsWithValues,
 } from '@accredited-programmes/ui'
@@ -120,30 +121,31 @@ export default class CourseParticipationUtils {
   static summaryListOptions(
     courseParticipationWithName: CourseParticipationWithName,
     referralId: Referral['id'],
-    withActions = true,
+    withActions = { change: true, remove: true },
   ): GovukFrontendSummaryListWithRowsWithValues {
-    const actions = withActions
-      ? {
-          items: [
-            {
-              href: referPaths.programmeHistory.editProgramme({
-                courseParticipationId: courseParticipationWithName.id,
-                referralId,
-              }),
-              text: 'Change',
-              visuallyHiddenText: `participation for ${courseParticipationWithName.name}`,
-            },
-            {
-              href: referPaths.programmeHistory.delete({
-                courseParticipationId: courseParticipationWithName.id,
-                referralId,
-              }),
-              text: 'Remove',
-              visuallyHiddenText: `participation for ${courseParticipationWithName.name}`,
-            },
-          ],
-        }
-      : undefined
+    const actions: GovukFrontendSummaryListCardActionsWithItems = { items: [] }
+
+    if (withActions.change) {
+      actions.items.push({
+        href: referPaths.programmeHistory.editProgramme({
+          courseParticipationId: courseParticipationWithName.id,
+          referralId,
+        }),
+        text: 'Change',
+        visuallyHiddenText: `participation for ${courseParticipationWithName.name}`,
+      })
+    }
+
+    if (withActions.remove) {
+      actions.items.push({
+        href: referPaths.programmeHistory.delete({
+          courseParticipationId: courseParticipationWithName.id,
+          referralId,
+        }),
+        text: 'Remove',
+        visuallyHiddenText: `participation for ${courseParticipationWithName.name}`,
+      })
+    }
 
     return {
       card: {

--- a/server/utils/referralUtils.test.ts
+++ b/server/utils/referralUtils.test.ts
@@ -66,8 +66,25 @@ describe('ReferralUtils', () => {
       expect(ReferralUtils.isReadyForSubmission(newReferral)).toEqual(false)
     })
 
-    it('returns true when OASys is confirmed and a reason is provided', () => {
-      // to be updated as the referral model is built out
+    it('returns false when programme history not reviewed', () => {
+      const referral = referralFactory.submittable().build({ hasReviewedProgrammeHistory: false })
+
+      expect(ReferralUtils.isReadyForSubmission(referral)).toEqual(false)
+    })
+
+    it('returns false when OASys not confirmed', () => {
+      const referral = referralFactory.submittable().build({ oasysConfirmed: false })
+
+      expect(ReferralUtils.isReadyForSubmission(referral)).toEqual(false)
+    })
+
+    it('returns false when reason not provided', () => {
+      const referral = referralFactory.submittable().build({ reason: '' })
+
+      expect(ReferralUtils.isReadyForSubmission(referral)).toEqual(false)
+    })
+
+    it('returns true when: programme history reviewed, OASys confirmed, and reason provided', () => {
       const submittableReferral = referralFactory.submittable().build()
 
       expect(ReferralUtils.isReadyForSubmission(submittableReferral)).toEqual(true)

--- a/server/utils/referralUtils.ts
+++ b/server/utils/referralUtils.ts
@@ -45,7 +45,7 @@ export default class ReferralUtils {
   }
 
   static isReadyForSubmission(referral: Referral): boolean {
-    return !!referral.oasysConfirmed && !!referral.reason
+    return referral.hasReviewedProgrammeHistory && referral.oasysConfirmed && !!referral.reason
   }
 
   static taskListSections(referral: Referral): Array<ReferralTaskListSection> {

--- a/server/views/referrals/checkAnswers.njk
+++ b/server/views/referrals/checkAnswers.njk
@@ -63,6 +63,16 @@
         }
       }) }}
 
+      <h2 class="govuk-heading-m">Accredited Programme history</h2>
+
+      {% if participationSummaryListsOptions.length %}
+        {% for summaryListOptions in participationSummaryListsOptions %}
+          {{ govukSummaryList(summaryListOptions) }}
+        {% endfor %}
+      {% else %}
+        <p class="govuk-body">There is no record of Accredited Programmes for {{ person.name }}.</p>
+      {% endif %}
+
       <h2 class="govuk-heading-m">OASys information</h2>
 
       <div class="govuk-summary-card">

--- a/server/views/referrals/checkAnswers.njk
+++ b/server/views/referrals/checkAnswers.njk
@@ -63,15 +63,17 @@
         }
       }) }}
 
-      <h2 class="govuk-heading-m">Accredited Programme history</h2>
+      <section data-testid="programme-history">
+        <h2 class="govuk-heading-m">Accredited Programme history</h2>
 
-      {% if participationSummaryListsOptions.length %}
-        {% for summaryListOptions in participationSummaryListsOptions %}
-          {{ govukSummaryList(summaryListOptions) }}
-        {% endfor %}
-      {% else %}
-        <p class="govuk-body">There is no record of Accredited Programmes for {{ person.name }}.</p>
-      {% endif %}
+        {% if participationSummaryListsOptions.length %}
+          {% for summaryListOptions in participationSummaryListsOptions %}
+            {{ govukSummaryList(summaryListOptions) }}
+          {% endfor %}
+        {% else %}
+          <p class="govuk-body">There is no record of Accredited Programmes for {{ person.name }}.</p>
+        {% endif %}
+      </section>
 
       <h2 class="govuk-heading-m">OASys information</h2>
 


### PR DESCRIPTION
## Changes in this PR

- Add programme history to check your answers
- A few small fixes and tidy ups

## Screenshots of UI changes

### Before

<img width="843" alt="image" src="https://github.com/ministryofjustice/hmpps-accredited-programmes-ui/assets/40244233/fa62abcd-00f5-4911-a756-4b3013a47dde">

### After

<img width="882" alt="image" src="https://github.com/ministryofjustice/hmpps-accredited-programmes-ui/assets/40244233/28e90cbb-cc3f-4036-8e6e-6bad7d08eb29">

## Release checklist

[Release process documentation](../doc/how-to/perform-a-release.md)

As part of our continuous deployment strategy we must ensure that this work is
ready to be released once merged.

### Pre-merge

- [ ] There are changes required to the Accredited Programmes API for this change to work...
  - [ ] ... and they have been released to production already

### Post-merge

<!-- The outer checkboxes can be completed pre-merge -->

- [ ] This adds, extends or meaningfully modifies a feature...
  - [ ] ... and I have written or updated an end-to-end test for the happy path in the [Accredited Programmes E2E repo](https://github.com/ministryofjustice/hmpps-accredited-programmes-e2e)
- [ ] This makes new expectations of the API...
  - [ ] ... and I have notified the API developer(s) of changes to the contract tests (Pact), or the API is already compliant
- [ ] [Manually approve](../doc/how-to/perform-a-release.md#releasing-to-the-preprod-environment) release to preprod
- [ ] [Manually approve](../doc/how-to/perform-a-release.md#releasing-to-the-production-environment) release to prod

<!-- Should a release fail at any step, you as the author should now lead the work to
fix it as soon as possible. You can monitor deployment failures in CircleCI
itself and application errors are found in
[Sentry](https://ministryofjustice.sentry.io/projects/hmpps-accredited-programmes-ui/?project=4505330122686464&referrer=sidebar&statsPeriod=24h). -->
