### PR TITLE
(968a) Add HMPPS Manage Users API

### DIFF
--- a/cypress.config.ts
+++ b/cypress.config.ts
@@ -6,6 +6,7 @@ import auth from './integration_tests/mockApis/auth'
 import caseloads from './integration_tests/mockApis/caseloads'
 import courses from './integration_tests/mockApis/courses'
 import courseParticipations from './integration_tests/mockApis/courseParticipations'
+import manageUsers from './integration_tests/mockApis/manageUsers'
 import prisons from './integration_tests/mockApis/prisons'
 import prisoners from './integration_tests/mockApis/prisoners'
 import referrals from './integration_tests/mockApis/referrals'
@@ -37,6 +38,7 @@ export const defaultConfig: Cypress.ConfigOptions = {
         ...caseloads,
         ...courses,
         ...courseParticipations,
+        ...manageUsers,
         ...prisons,
         ...prisoners,
         ...referrals,

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -41,9 +41,13 @@ services:
 
   hmpps-auth:
     container_name: hmpps-auth
+    depends_on:
+      - hmpps-auth-db
     environment:
-      - SPRING_PROFILES_ACTIVE=dev
+      - SPRING_PROFILES_ACTIVE=dev,local-postgres
+      - SPRING_H2_CONSOLE_SETTINGS_WEBALLOWOTHERS=true
       - APPLICATION_AUTHENTICATION_UI_ALLOWLIST=0.0.0.0/0
+      - SPRING_DATASOURCE_URL=jdbc:postgresql://hmpps-auth-db:5432/hmpps-auth-db
     healthcheck:
       test: ['CMD', 'curl', '-f', 'http://localhost:8080/auth/health']
     image: quay.io/hmpps/hmpps-auth:latest
@@ -51,6 +55,77 @@ services:
       - hmpps
     ports:
       - '9090:8080'
+
+  hmpps-auth-db:
+    container_name: hmpps-auth-db
+    environment:
+      - POSTGRES_PASSWORD=admin_password
+      - POSTGRES_USER=admin
+      - POSTGRES_DB=hmpps-auth-db
+    healthcheck:
+      test: ['CMD', 'pg_isready', '--username=admin', '--dbname=hmpps-auth-db']
+    image: postgres:15
+    networks:
+      - hmpps
+    ports:
+      - '5434:5432'
+    restart: always
+
+  hmpps-external-users-api:
+    container_name: hmpps-external-users-api
+    depends_on:
+      - hmpps-auth-db
+      - hmpps-auth
+    environment:
+      - SERVER_PORT=8080
+      - SPRING_PROFILES_ACTIVE=dev,local-postgres
+      - SPRING_R2DBC_URL=r2dbc:postgresql://hmpps-auth-db:5432/hmpps-auth-db?sslmode=prefer
+      - SPRING_FLYWAY_URL=jdbc:postgresql://hmpps-auth-db:5432/hmpps-auth-db?sslmode=prefer
+      - API_BASE_URL_OAUTH=http://hmpps-auth:8080/auth
+    healthcheck:
+      test: ['CMD', 'curl', '-f', 'http://localhost:8080/health/ping']
+    image: quay.io/hmpps/hmpps-external-users-api:latest
+    networks:
+      - hmpps
+    ports:
+      - '9097:8080'
+
+  hmpps-manage-users-api:
+    container_name: hmpps-manage-users-api
+    depends_on:
+      - hmpps-auth
+      - hmpps-external-users-api
+    environment:
+      - SERVER_PORT=8080
+      - HMPPS_AUTH_ENDPOINT_URL=http://hmpps-auth:8080/auth
+      - API_BASE_URL_OAUTH=http://hmpps-auth:8080/auth
+      - SPRING_PROFILES_ACTIVE=dev
+      - EXTERNAL_USERS_ENDPOINT_URL=http://hmpps-external-users-api:8080
+      - AUTHORIZATION_SERVER_TOKEN_ENDPOINT_URL=http://hmpps-auth:8080/auth/oauth/token
+      - NOMIS_ENDPOINT_URL=http://nomis-user-roles-api:8080
+    healthcheck:
+      test: ['CMD', 'curl', '-f', 'http://localhost:8080/health']
+    image: quay.io/hmpps/hmpps-manage-users-api:latest
+    networks:
+      - hmpps
+    ports:
+      - '9095:8080'
+
+  nomis-user-roles-api:
+    container_name: nomis-user-roles-api
+    depends_on:
+      - hmpps-auth
+    environment:
+      - SERVER_PORT=8080
+      - SPRING_PROFILES_ACTIVE=dev
+      - API_BASE_URL_OAUTH=http://hmpps-auth:8080/auth
+    healthcheck:
+      test: ['CMD', 'curl', '-f', 'http://localhost:8080/health']
+    image: quay.io/hmpps/nomis-user-roles-api:latest
+    networks:
+      - hmpps
+    ports:
+      - '9096:8080'
 
   prison-register-api:
     container_name: prison-register-api

--- a/helm_deploy/values-dev.yaml
+++ b/helm_deploy/values-dev.yaml
@@ -13,6 +13,7 @@ generic-service:
     ACCREDITED_PROGRAMMES_API_URL: 'https://accredited-programmes-api-dev.hmpps.service.justice.gov.uk'
     INGRESS_URL: 'https://accredited-programmes-dev.hmpps.service.justice.gov.uk'
     HMPPS_AUTH_URL: 'https://sign-in-dev.hmpps.service.justice.gov.uk/auth'
+    HMPPS_MANAGE_USERS_API_URL: 'https://manage-users-api-dev.hmpps.service.justice.gov.uk'
     TOKEN_VERIFICATION_API_URL: 'https://token-verification-api-dev.prison.service.justice.gov.uk'
     PRISON_API_URL: 'https://prison-api-dev.prison.service.justice.gov.uk'
     PRISON_REGISTER_API_URL: 'https://prison-register-dev.hmpps.service.justice.gov.uk'

--- a/helm_deploy/values-preprod.yaml
+++ b/helm_deploy/values-preprod.yaml
@@ -11,6 +11,7 @@ generic-service:
     ACCREDITED_PROGRAMMES_API_URL: 'https://accredited-programmes-api-preprod.hmpps.service.justice.gov.uk'
     INGRESS_URL: 'https://accredited-programmes-preprod.hmpps.service.justice.gov.uk'
     HMPPS_AUTH_URL: 'https://sign-in-preprod.hmpps.service.justice.gov.uk/auth'
+    HMPPS_MANAGE_USERS_API_URL: 'https://manage-users-api-preprod.hmpps.service.justice.gov.uk'
     TOKEN_VERIFICATION_API_URL: 'https://token-verification-api-preprod.prison.service.justice.gov.uk'
     PRISON_API_URL: 'https://api-preprod.prison.service.justice.gov.uk'
     PRISON_REGISTER_API_URL: 'https://prison-register-preprod.hmpps.service.justice.gov.uk'

--- a/helm_deploy/values-prod.yaml
+++ b/helm_deploy/values-prod.yaml
@@ -11,6 +11,7 @@ generic-service:
     ACCREDITED_PROGRAMMES_API_URL: 'https://accredited-programmes-api.hmpps.service.justice.gov.uk'
     INGRESS_URL: 'https://accredited-programmes.hmpps.service.justice.gov.uk'
     HMPPS_AUTH_URL: 'https://sign-in.hmpps.service.justice.gov.uk/auth'
+    HMPPS_MANAGE_USERS_API_URL: 'https://manage-users-api.hmpps.service.justice.gov.uk'
     TOKEN_VERIFICATION_API_URL: 'https://token-verification-api.prison.service.justice.gov.uk'
     PRISON_API_URL: 'https://api.prison.service.justice.gov.uk'
     PRISON_REGISTER_API_URL: 'https://prison-register.hmpps.service.justice.gov.uk'

--- a/integration.env
+++ b/integration.env
@@ -1,6 +1,7 @@
 PORT=3007
 REDIS_PORT=6380
 HMPPS_AUTH_URL=http://localhost:9199/auth
+HMPPS_MANAGE_USERS_API_URL=http://localhost:9199
 TOKEN_VERIFICATION_API_URL=http://localhost:9199/verification
 TOKEN_VERIFICATION_ENABLED=true
 NODE_ENV=development

--- a/integration_tests/mockApis/auth.ts
+++ b/integration_tests/mockApis/auth.ts
@@ -1,6 +1,7 @@
 import jwt from 'jsonwebtoken'
 import type { Response } from 'superagent'
 
+import manageUserStubs from './manageUsers'
 import tokenVerification from './tokenVerification'
 import type { ApplicationRoles } from '../../server/middleware/roleBasedAccessMiddleware'
 import { getMatchingRequests, stubFor } from '../../wiremock'
@@ -123,46 +124,15 @@ const token = ({ authorities }: { authorities?: Array<ApplicationRoles> }) =>
     },
   })
 
-const stubUser = (name: string) =>
-  stubFor({
-    request: {
-      method: 'GET',
-      urlPattern: '/auth/api/user/me',
-    },
-    response: {
-      headers: {
-        'Content-Type': 'application/json;charset=UTF-8',
-      },
-      jsonBody: {
-        active: true,
-        name,
-        staffId: 231232,
-        username: mockedUsername(),
-      },
-      status: 200,
-    },
-  })
-
-const stubUserRoles = () =>
-  stubFor({
-    request: {
-      method: 'GET',
-      urlPattern: '/auth/api/user/me/roles',
-    },
-    response: {
-      headers: {
-        'Content-Type': 'application/json;charset=UTF-8',
-      },
-      jsonBody: [{ roleCode: 'SOME_USER_ROLE' }],
-      status: 200,
-    },
-  })
-
 export default {
   getSignInUrl,
   mockedUsername,
   stubAuthPing: ping,
-  stubAuthUser: (name = 'john smith'): Promise<[Response, Response]> => Promise.all([stubUser(name), stubUserRoles()]),
+  stubAuthUser: (name = 'john smith'): Promise<[Response, Response]> =>
+    Promise.all([
+      manageUserStubs.stubCurrentUser(mockedUsername()),
+      manageUserStubs.stubUserDetails({ name, username: mockedUsername() }),
+    ]),
   stubSignIn: (
     args = {
       authorities: [],

--- a/integration_tests/mockApis/manageUsers.ts
+++ b/integration_tests/mockApis/manageUsers.ts
@@ -1,0 +1,44 @@
+import type { SuperAgentRequest } from 'superagent'
+
+import { stubFor } from '../../wiremock'
+import type { User } from '@accredited-programmes/users'
+
+export default {
+  stubCurrentUser: (username: User['username']): SuperAgentRequest =>
+    stubFor({
+      request: {
+        method: 'GET',
+        urlPattern: '/users/me',
+      },
+      response: {
+        headers: {
+          'Content-Type': 'application/json;charset=UTF-8',
+        },
+        jsonBody: {
+          username,
+        },
+        status: 200,
+      },
+    }),
+
+  stubUserDetails: (args: { name: User['name']; username: User['username'] }): SuperAgentRequest =>
+    stubFor({
+      request: {
+        method: 'GET',
+        urlPattern: `/users/${args.username}`,
+      },
+      response: {
+        headers: {
+          'Content-Type': 'application/json;charset=UTF-8',
+        },
+        jsonBody: {
+          active: true,
+          authSource: 'auth',
+          name: args.name,
+          userId: '1234',
+          username: args.username,
+        },
+        status: 200,
+      },
+    }),
+}

--- a/server/@types/users/index.d.ts
+++ b/server/@types/users/index.d.ts
@@ -5,11 +5,20 @@ type MiddlewareOptions = {
   allowedRoles?: Array<ApplicationRoles>
 }
 
-type UserDetails = {
-  caseloads: Array<Caseload>
-  displayName: string
+type User = {
+  active: boolean
+  authSource: string
   name: string
   userId: string
+  username: string
+  activeCaseLoadId?: string
+  staffId?: number
+  uuid?: string
 }
 
-export type { MiddlewareOptions, UserDetails }
+type UserDetails = User & {
+  caseloads: Array<Caseload>
+  displayName: string
+}
+
+export type { MiddlewareOptions, User, UserDetails }

--- a/server/config.ts
+++ b/server/config.ts
@@ -52,6 +52,14 @@ export default {
       },
       url: get('HMPPS_AUTH_URL', 'http://localhost:9090/auth', requiredInProduction),
     },
+    hmppsManageUsers: {
+      agent: new AgentConfig(Number(get('HMPPS_MANAGE_USERS_API_TIMEOUT_RESPONSE', 10000))),
+      timeout: {
+        deadline: Number(get('HMPPS_MANAGE_USERS_API_TIMEOUT_DEADLINE', 10000)),
+        response: Number(get('HMPPS_MANAGE_USERS_API_TIMEOUT_RESPONSE', 10000)),
+      },
+      url: get('HMPPS_MANAGE_USERS_API_URL', 'http://localhost:9095', requiredInProduction),
+    },
     prisonApi: {
       agent: new AgentConfig(Number(get('HMPPS_AUTH_TIMEOUT_RESPONSE', 10000))),
       timeout: {

--- a/server/data/hmppsAuthClient.test.ts
+++ b/server/data/hmppsAuthClient.test.ts
@@ -30,32 +30,6 @@ describe('hmppsAuthClient', () => {
     nock.cleanAll()
   })
 
-  describe('getUser', () => {
-    it('returns data from the API', async () => {
-      const response = { data: 'data' }
-
-      fakeHmppsAuthApi
-        .get('/api/user/me')
-        .matchHeader('authorization', `Bearer ${token.access_token}`)
-        .reply(200, response)
-
-      const output = await hmppsAuthClient.getUser(token.access_token)
-      expect(output).toEqual(response)
-    })
-  })
-
-  describe('getUserRoles', () => {
-    it('returns data from the API', async () => {
-      fakeHmppsAuthApi
-        .get('/api/user/me/roles')
-        .matchHeader('authorization', `Bearer ${token.access_token}`)
-        .reply(200, [{ roleCode: 'role1' }, { roleCode: 'role2' }])
-
-      const output = await hmppsAuthClient.getUserRoles(token.access_token)
-      expect(output).toEqual(['role1', 'role2'])
-    })
-  })
-
   describe('getSystemClientToken', () => {
     it('instantiates the Redis client', async () => {
       tokenStore.getToken.mockResolvedValue(token.access_token)

--- a/server/data/hmppsAuthClient.ts
+++ b/server/data/hmppsAuthClient.ts
@@ -1,7 +1,6 @@
 import superagent from 'superagent'
 import { URLSearchParams } from 'url'
 
-import RestClient from './restClient'
 import type TokenStore from './tokenStore'
 import logger from '../../logger'
 import { ClientCredentials } from '../authentication'
@@ -31,22 +30,7 @@ function getSystemClientTokenFromHmppsAuth(username?: string): Promise<superagen
     .timeout(timeoutSpec)
 }
 
-interface User {
-  activeCaseLoadId: string
-  name: string
-  userId: string
-  username: string
-}
-
-interface UserRole {
-  roleCode: string
-}
-
 export default class HmppsAuthClient {
-  private static restClient(token: Express.User['token']): RestClient {
-    return new RestClient('HMPPS Auth Client', config.apis.hmppsAuth, token)
-  }
-
   constructor(private readonly tokenStore: TokenStore) {}
 
   async getSystemClientToken(username?: string): Promise<string> {
@@ -64,17 +48,4 @@ export default class HmppsAuthClient {
 
     return newToken.body.access_token
   }
-
-  getUser(token: Express.User['token']): Promise<User> {
-    logger.info(`Getting user details: calling HMPPS Auth`)
-    return HmppsAuthClient.restClient(token).get({ path: '/api/user/me' }) as Promise<User>
-  }
-
-  getUserRoles(token: Express.User['token']): Promise<Array<string>> {
-    return HmppsAuthClient.restClient(token)
-      .get({ path: '/api/user/me/roles' })
-      .then(roles => (<Array<UserRole>>roles).map(role => role.roleCode))
-  }
 }
-
-export type { User, UserRole }

--- a/server/data/hmppsManageUsersClient.test.ts
+++ b/server/data/hmppsManageUsersClient.test.ts
@@ -1,0 +1,59 @@
+import nock from 'nock'
+
+import HmppsManageUsersClient from './hmppsManageUsersClient'
+import config from '../config'
+import type { User } from '@accredited-programmes/users'
+
+jest.mock('./tokenStore')
+
+const token = 'token-1'
+
+describe('HmppsManageUsersClient', () => {
+  let fakeManageUsersApiUrl: nock.Scope
+  let hmppsManageUsersClient: HmppsManageUsersClient
+
+  beforeEach(() => {
+    fakeManageUsersApiUrl = nock(config.apis.hmppsManageUsers.url)
+    hmppsManageUsersClient = new HmppsManageUsersClient(token)
+  })
+
+  afterEach(() => {
+    if (!nock.isDone()) {
+      nock.cleanAll()
+      throw new Error('Not all nock interceptors were used!')
+    }
+    nock.abortPendingRequests()
+    nock.cleanAll()
+  })
+
+  describe('getCurrentUsername', () => {
+    it("should return the logged-in user's username from the API", async () => {
+      const response: Pick<User, 'username'> = { username: 'DEL_HATTON' }
+
+      fakeManageUsersApiUrl.get('/users/me').matchHeader('authorization', `Bearer ${token}`).reply(200, response)
+
+      const output = await hmppsManageUsersClient.getCurrentUsername()
+      expect(output).toEqual(response)
+    })
+  })
+
+  describe('getUserFromUsername', () => {
+    it('should return the user from the API', async () => {
+      const response: User = {
+        active: true,
+        authSource: 'nomis',
+        name: 'John Smith',
+        userId: 'user-id',
+        username: 'JOHN_SMITH',
+      }
+
+      fakeManageUsersApiUrl
+        .get('/users/JOHN_SMITH')
+        .matchHeader('authorization', `Bearer ${token}`)
+        .reply(200, response)
+
+      const output = await hmppsManageUsersClient.getUserFromUsername('JOHN_SMITH')
+      expect(output).toEqual(response)
+    })
+  })
+})

--- a/server/data/hmppsManageUsersClient.ts
+++ b/server/data/hmppsManageUsersClient.ts
@@ -1,0 +1,22 @@
+import RestClient from './restClient'
+import logger from '../../logger'
+import config from '../config'
+import type { User } from '@accredited-programmes/users'
+
+export default class HmppsManageUsersClient {
+  restClient: RestClient
+
+  constructor(token: Express.User['token']) {
+    this.restClient = new RestClient('HMPPS Manage Users Client', config.apis.hmppsManageUsers, token)
+  }
+
+  getCurrentUsername(): Promise<Pick<User, 'username'>> {
+    logger.info(`Getting username: calling HMPPS Manage Users`)
+    return this.restClient.get({ path: '/users/me' }) as Promise<Pick<User, 'username'>>
+  }
+
+  getUserFromUsername(username: User['username']): Promise<User> {
+    logger.info(`Getting user details: calling HMPPS Manage Users`)
+    return this.restClient.get({ path: `/users/${username}` }) as Promise<User>
+  }
+}

--- a/server/data/index.ts
+++ b/server/data/index.ts
@@ -17,6 +17,7 @@ import CourseClient from './courseClient'
 import { serviceCheckFactory } from './healthCheck'
 import type { User } from './hmppsAuthClient'
 import HmppsAuthClient from './hmppsAuthClient'
+import HmppsManageUsersClient from './hmppsManageUsersClient'
 import PrisonClient from './prisonClient'
 import PrisonerClient from './prisonerClient'
 import type { RedisClient } from './redisClient'
@@ -31,6 +32,8 @@ type RestClientBuilderWithoutToken<T> = () => T
 
 const hmppsAuthClientBuilder: RestClientBuilderWithoutToken<HmppsAuthClient> = () =>
   new HmppsAuthClient(new TokenStore(createRedisClient()))
+const hmppsManageUsersClientBuilder: RestClientBuilder<HmppsManageUsersClient> = (token: Express.User['token']) =>
+  new HmppsManageUsersClient(token)
 const caseloadClientBuilder: RestClientBuilder<CaseloadClient> = (token: Express.User['token']) =>
   new CaseloadClient(token)
 const courseClientBuilder: RestClientBuilder<CourseClient> = (token: Express.User['token']) => new CourseClient(token)
@@ -44,6 +47,7 @@ export {
   CaseloadClient,
   CourseClient,
   HmppsAuthClient,
+  HmppsManageUsersClient,
   PrisonClient,
   PrisonerClient,
   ReferralClient,
@@ -52,6 +56,7 @@ export {
   courseClientBuilder,
   createRedisClient,
   hmppsAuthClientBuilder,
+  hmppsManageUsersClientBuilder,
   prisonClientBuilder,
   prisonerClientBuilder,
   referralClientBuilder,

--- a/server/data/index.ts
+++ b/server/data/index.ts
@@ -15,7 +15,6 @@ AppInsightsUtils.buildClient()
 import CaseloadClient from './caseloadClient'
 import CourseClient from './courseClient'
 import { serviceCheckFactory } from './healthCheck'
-import type { User } from './hmppsAuthClient'
 import HmppsAuthClient from './hmppsAuthClient'
 import HmppsManageUsersClient from './hmppsManageUsersClient'
 import PrisonClient from './prisonClient'
@@ -64,4 +63,4 @@ export {
   verifyToken,
 }
 
-export type { RedisClient, RestClientBuilder, RestClientBuilderWithoutToken, TokenVerifier, User }
+export type { RedisClient, RestClientBuilder, RestClientBuilderWithoutToken, TokenVerifier }

--- a/server/middleware/populateCurrentUser.ts
+++ b/server/middleware/populateCurrentUser.ts
@@ -10,7 +10,7 @@ export default function populateCurrentUser(userService: UserService): RequestHa
     try {
       if (res.locals.user) {
         const { token } = res.locals.user
-        req.session.user ||= await userService.getUser(token)
+        req.session.user ||= await userService.getCurrentUserWithDetails(token)
 
         if (req.session.user) {
           const roles = UserUtils.getUserRolesFromToken(token)

--- a/server/services/index.ts
+++ b/server/services/index.ts
@@ -10,6 +10,7 @@ import {
   caseloadClientBuilder,
   courseClientBuilder,
   hmppsAuthClientBuilder,
+  hmppsManageUsersClientBuilder,
   prisonClientBuilder,
   prisonerClientBuilder,
   referralClientBuilder,
@@ -20,7 +21,7 @@ const services = () => {
   const organisationService = new OrganisationService(prisonClientBuilder)
   const personService = new PersonService(hmppsAuthClientBuilder, prisonerClientBuilder)
   const referralService = new ReferralService(referralClientBuilder)
-  const userService = new UserService(hmppsAuthClientBuilder, caseloadClientBuilder)
+  const userService = new UserService(hmppsManageUsersClientBuilder, caseloadClientBuilder)
 
   return {
     courseService,

--- a/server/services/userService.test.ts
+++ b/server/services/userService.test.ts
@@ -1,22 +1,17 @@
-import { createMock } from '@golevelup/ts-jest'
-
 import UserService from './userService'
 import logger from '../../logger'
-import type { RedisClient, User } from '../data'
-import { CaseloadClient, HmppsAuthClient, TokenStore } from '../data'
+import { CaseloadClient, HmppsManageUsersClient } from '../data'
 import { caseloadFactory } from '../testutils/factories'
 
-jest.mock('../data/hmppsAuthClient')
+jest.mock('../data/hmppsManageUsersClient')
 jest.mock('../data/caseloadClient')
 jest.mock('../../logger')
 
-const redisClient = createMock<RedisClient>({})
-const tokenStore = new TokenStore(redisClient) as jest.Mocked<TokenStore>
 const token = 'some token'
 
 describe('UserService', () => {
-  const hmppsAuthClient = new HmppsAuthClient(tokenStore) as jest.Mocked<HmppsAuthClient>
-  const hmppsAuthClientBuilder = jest.fn()
+  const hmppsManageUsersClient = new HmppsManageUsersClient('token') as jest.Mocked<HmppsManageUsersClient>
+  const hmppsManageUsersClientBuilder = jest.fn()
 
   const caseloadClient = new CaseloadClient(token) as jest.Mocked<CaseloadClient>
   const caseloadClientBuilder = jest.fn()
@@ -26,19 +21,27 @@ describe('UserService', () => {
   beforeEach(() => {
     jest.resetAllMocks()
 
-    hmppsAuthClientBuilder.mockReturnValue(hmppsAuthClient)
+    hmppsManageUsersClientBuilder.mockReturnValue(hmppsManageUsersClient)
     caseloadClientBuilder.mockReturnValue(caseloadClient)
 
-    userService = new UserService(hmppsAuthClientBuilder, caseloadClientBuilder)
+    userService = new UserService(hmppsManageUsersClientBuilder, caseloadClientBuilder)
   })
 
-  describe('getUser', () => {
+  describe('getCurrentUserWithDetails', () => {
+    const username = 'JOHN_SMITH'
     beforeEach(() => {
-      hmppsAuthClient.getUser.mockResolvedValue({ name: 'john smith' } as User)
+      hmppsManageUsersClient.getCurrentUsername.mockResolvedValue({ username })
+      hmppsManageUsersClient.getUserFromUsername.mockResolvedValue({
+        active: true,
+        authSource: 'nomis',
+        name: 'john smith',
+        userId: 'user-id',
+        username,
+      })
     })
 
     it('retrieves user and formats name', async () => {
-      const result = await userService.getUser(token)
+      const result = await userService.getCurrentUserWithDetails(token)
 
       expect(result.displayName).toEqual('John Smith')
     })
@@ -47,16 +50,16 @@ describe('UserService', () => {
       const caseloads = [caseloadFactory.active().build(), caseloadFactory.inactive().build()]
       caseloadClient.allByCurrentUser.mockResolvedValue(caseloads)
 
-      const result = await userService.getUser(token)
+      const result = await userService.getCurrentUserWithDetails(token)
 
       expect(result.caseloads).toEqual(caseloads)
     })
 
-    describe('when the HMPPS Auth client throws an error', () => {
+    describe('when the HMPPS Manage Users client throws an error', () => {
       it('propagates the error', async () => {
-        hmppsAuthClient.getUser.mockRejectedValue(new Error('some error'))
+        hmppsManageUsersClient.getCurrentUsername.mockRejectedValue(new Error('some error'))
 
-        await expect(userService.getUser(token)).rejects.toEqual(new Error('some error'))
+        await expect(userService.getCurrentUserWithDetails(token)).rejects.toEqual(new Error('some error'))
       })
     })
 
@@ -65,7 +68,7 @@ describe('UserService', () => {
         const caseloadError = new Error('some caseload error')
         caseloadClient.allByCurrentUser.mockRejectedValue(caseloadError)
 
-        const result = await userService.getUser(token)
+        const result = await userService.getCurrentUserWithDetails(token)
         expect(logger.error).toHaveBeenCalledWith(caseloadError, "Failed to fetch user's caseloads")
         expect(result.caseloads).toEqual([])
       })

--- a/server/utils/appInsightsUtils.ts
+++ b/server/utils/appInsightsUtils.ts
@@ -5,12 +5,12 @@ import { Contracts, DistributedTracingModes, defaultClient, setup } from 'applic
 import type { EnvelopeTelemetry } from 'applicationinsights/out/Declarations/Contracts'
 
 import { buildNumber, packageData } from '../applicationVersion'
-import type { User } from '../data'
+import type { UserDetails } from '@accredited-programmes/users'
 
 type ContextObjectWithUser = {
   res?: {
     locals?: {
-      user: Partial<User>
+      user: Partial<UserDetails>
     }
   }
 }


### PR DESCRIPTION
## Context

We need to display the actual names of the user who makes a referral, not just their username.  To do this it means making use of https://github.com/ministryofjustice/hmpps-manage-users-api.

https://trello.com/c/K6mwNUHH/968-fetch-name-of-referrer-rather-than-username-for-programme-history-and-cya-page



## Changes in this PR
This PR is for integrating the HMPPS Manage Users API and in the first instance, replacing the existing `/user/me` endpoint from HMPPS Auth with the new `/users/me` and `/users/${username}` from HMPPS Manage Users API.

This also meant making some changes to some of the User types as the response schema in the new api is slightly different.


## Release checklist

[Release process documentation](../doc/how-to/perform-a-release.md)

As part of our continuous deployment strategy we must ensure that this work is
ready to be released once merged.

### Pre-merge

- [ ] There are changes required to the Accredited Programmes API for this change to work...
  - [ ] ... and they have been released to production already

### Post-merge

<!-- The outer checkboxes can be completed pre-merge -->

- [ ] This adds, extends or meaningfully modifies a feature...
  - [ ] ... and I have written or updated an end-to-end test for the happy path in the [Accredited Programmes E2E repo](https://github.com/ministryofjustice/hmpps-accredited-programmes-e2e)
- [ ] This makes new expectations of the API...
  - [ ] ... and I have notified the API developer(s) of changes to the contract tests (Pact), or the API is already compliant
- [ ] [Manually approve](../doc/how-to/perform-a-release.md#releasing-to-the-preprod-environment) release to preprod
- [ ] [Manually approve](../doc/how-to/perform-a-release.md#releasing-to-the-production-environment) release to prod

<!-- Should a release fail at any step, you as the author should now lead the work to
fix it as soon as possible. You can monitor deployment failures in CircleCI
itself and application errors are found in
[Sentry](https://ministryofjustice.sentry.io/projects/hmpps-accredited-programmes-ui/?project=4505330122686464&referrer=sidebar&statsPeriod=24h). -->
