### PR TITLE
(998) Simplify integration tests

### DIFF
--- a/integration_tests/e2e/app.cy.ts
+++ b/integration_tests/e2e/app.cy.ts
@@ -8,12 +8,12 @@ context('App', () => {
     cy.task('stubSignIn')
     cy.task('stubAuthUser')
     cy.task('stubDefaultCaseloads')
+    cy.signIn()
+
+    cy.visit('/')
   })
 
   it('Shows the phase banner with a link to the feedback form', () => {
-    cy.signIn()
-    cy.visit('/')
-
     cy.get('.govuk-phase-banner__content__tag').then(phaseBannerTagElement => {
       const { actual, expected } = Helpers.parseHtml(phaseBannerTagElement, 'Beta')
       expect(actual).to.equal(expected)
@@ -37,9 +37,6 @@ context('App', () => {
   })
 
   it("Doesn't show navigation on the index page", () => {
-    cy.signIn()
-    cy.visit('/')
-
     const indexPage = Page.verifyOnPage(IndexPage)
     indexPage.shouldNotContainNavigation()
   })

--- a/integration_tests/e2e/authentication.cy.ts
+++ b/integration_tests/e2e/authentication.cy.ts
@@ -13,45 +13,54 @@ context('Authentication', () => {
 
   it('Unauthenticated user directed to auth', () => {
     cy.visit('/')
+
     Page.verifyOnPage(AuthSignInPage)
   })
 
   it('Unauthenticated user navigating to sign in page directed to auth', () => {
     cy.visit('/sign-in')
+
     Page.verifyOnPage(AuthSignInPage)
   })
 
   it('User name visible in header', () => {
     cy.signIn()
+
     const indexPage = Page.verifyOnPage(IndexPage)
     indexPage.headerUserName().should('contain.text', 'J. Smith')
   })
 
   it('Redirects signed in users to a landing page', () => {
     cy.signIn()
+
     const indexPage = Page.verifyOnPage(IndexPage)
     indexPage.findLink().should('contain.text', 'Find an accredited programme')
   })
 
   it('User can log out', () => {
     cy.signIn()
+
     const indexPage = Page.verifyOnPage(IndexPage)
     indexPage.signOut().click()
+
     Page.verifyOnPage(AuthSignInPage)
   })
 
   it('User can manage their details', () => {
     cy.signIn()
-    const indexPage = Page.verifyOnPage(IndexPage)
 
+    const indexPage = Page.verifyOnPage(IndexPage)
     indexPage.manageDetails().get('a').invoke('removeAttr', 'target')
     indexPage.manageDetails().click()
+
     Page.verifyOnPage(AuthManageDetailsPage)
   })
 
   it('Token verification failure takes user to sign in page', () => {
     cy.signIn()
+
     Page.verifyOnPage(IndexPage)
+
     cy.task('stubVerifyToken', false)
 
     // can't do a visit here as cypress requires only one domain
@@ -60,7 +69,9 @@ context('Authentication', () => {
 
   it('Token verification failure clears user session', () => {
     cy.signIn()
+
     const indexPage = Page.verifyOnPage(IndexPage)
+
     cy.task('stubVerifyToken', false)
 
     // can't do a visit here as cypress requires only one domain
@@ -68,6 +79,7 @@ context('Authentication', () => {
 
     cy.task('stubVerifyToken', true)
     cy.task('stubAuthUser', 'bobby brown')
+
     cy.signIn()
 
     indexPage.headerUserName().contains('B. Brown')

--- a/integration_tests/e2e/health.cy.ts
+++ b/integration_tests/e2e/health.cy.ts
@@ -1,8 +1,11 @@
 context('Health', () => {
+  beforeEach(() => {
+    cy.task('reset')
+    cy.task('stubAuthPing')
+  })
+
   context('All healthy', () => {
     beforeEach(() => {
-      cy.task('reset')
-      cy.task('stubAuthPing')
       cy.task('stubTokenVerificationPing')
     })
 
@@ -17,8 +20,6 @@ context('Health', () => {
 
   context('Some unhealthy', () => {
     it('Reports correctly when token verification down', () => {
-      cy.task('reset')
-      cy.task('stubAuthPing')
       cy.task('stubTokenVerificationPing', 500)
 
       cy.request({ failOnStatusCode: false, method: 'GET', url: '/health' }).then(response => {

--- a/integration_tests/e2e/refer.cy.ts
+++ b/integration_tests/e2e/refer.cy.ts
@@ -1,33 +1,22 @@
-import { ApplicationRoles } from '../../server/middleware/roleBasedAccessMiddleware'
 import { referPaths } from '../../server/paths'
 import { courseFactory, courseOfferingFactory, prisonFactory } from '../../server/testutils/factories'
 import AuthErrorPage from '../pages/authError'
 import Page from '../pages/page'
 
 context('General Refer functionality', () => {
-  beforeEach(() => {
-    cy.task('reset')
-    cy.task('stubSignIn', { authorities: [ApplicationRoles.ACP_REFERRER] })
-    cy.task('stubAuthUser')
-    cy.task('stubDefaultCaseloads')
-  })
-
   describe('When the user does not have the `ROLE_ACP_REFERRER` role', () => {
-    beforeEach(() => {
+    it('shows the authentication error page', () => {
       cy.task('reset')
       cy.task('stubSignIn', { authorities: [] })
       cy.task('stubAuthUser')
       cy.task('stubDefaultCaseloads')
-    })
-
-    it('shows the authentication error page', () => {
       cy.signIn()
 
       const course = courseFactory.build()
       const courseOffering = courseOfferingFactory.build()
-      const prison = prisonFactory.build({ prisonId: courseOffering.organisationId })
-
       cy.task('stubCourseByOffering', { course, courseOfferingId: courseOffering.id })
+
+      const prison = prisonFactory.build({ prisonId: courseOffering.organisationId })
       cy.task('stubPrison', prison)
 
       const path = referPaths.start({ courseOfferingId: courseOffering.id })

--- a/integration_tests/e2e/refer/confirmOasys.cy.ts
+++ b/integration_tests/e2e/refer/confirmOasys.cy.ts
@@ -13,31 +13,30 @@ import Page from '../../pages/page'
 import { ConfirmOasysPage, TaskListPage } from '../../pages/refer'
 
 context('OASys confirmation', () => {
+  const courseOffering = courseOfferingFactory.build()
+  const prisoner = prisonerFactory.build({
+    firstName: 'Del',
+    lastName: 'Hatton',
+  })
+  const person = personFactory.build({
+    currentPrison: prisoner.prisonName,
+    name: 'Del Hatton',
+    prisonNumber: prisoner.prisonerNumber,
+  })
+  const referral = referralFactory.started().build({ offeringId: courseOffering.id, prisonNumber: person.prisonNumber })
+
   beforeEach(() => {
     cy.task('reset')
     cy.task('stubSignIn', { authorities: [ApplicationRoles.ACP_REFERRER] })
     cy.task('stubAuthUser')
     cy.task('stubDefaultCaseloads')
-  })
-
-  it('Shows the confirm OASys form page', () => {
     cy.signIn()
-
-    const prisoner = prisonerFactory.build({
-      firstName: 'Del',
-      lastName: 'Hatton',
-    })
-    const person = personFactory.build({
-      currentPrison: prisoner.prisonName,
-      name: 'Del Hatton',
-      prisonNumber: prisoner.prisonerNumber,
-    })
-
-    const referral = referralFactory.started().build({ prisonNumber: person.prisonNumber })
 
     cy.task('stubPrisoner', prisoner)
     cy.task('stubReferral', referral)
+  })
 
+  it('Shows the confirm OASys form page', () => {
     const path = referPaths.confirmOasys.show({ referralId: referral.id })
     cy.visit(path)
 
@@ -53,34 +52,15 @@ context('OASys confirmation', () => {
 
   describe('When confirming OASys information', () => {
     it('updates the referral and redirects to the task list', () => {
-      cy.signIn()
+      cy.task('stubUpdateReferral', referral.id)
 
       const course = courseFactory.build()
-      const courseOffering = courseOfferingFactory.build()
-
-      const prisoner = prisonerFactory.build({
-        firstName: 'Del',
-        lastName: 'Hatton',
-      })
-      const person = personFactory.build({
-        currentPrison: prisoner.prisonName,
-        name: 'Del Hatton',
-        prisonNumber: prisoner.prisonerNumber,
-      })
+      cy.task('stubCourseByOffering', { course, courseOfferingId: courseOffering.id })
+      cy.task('stubOffering', { courseId: course.id, courseOffering })
 
       const prison = prisonFactory.build({ prisonId: courseOffering.organisationId })
       const organisation = OrganisationUtils.organisationFromPrison(prison)
-
-      const referral = referralFactory
-        .started()
-        .build({ offeringId: courseOffering.id, prisonNumber: person.prisonNumber })
-
-      cy.task('stubCourseByOffering', { course, courseOfferingId: courseOffering.id })
-      cy.task('stubOffering', { courseId: course.id, courseOffering })
       cy.task('stubPrison', prison)
-      cy.task('stubPrisoner', prisoner)
-      cy.task('stubReferral', referral)
-      cy.task('stubUpdateReferral', referral.id)
 
       const path = referPaths.confirmOasys.show({ referralId: referral.id })
       cy.visit(path)
@@ -93,23 +73,6 @@ context('OASys confirmation', () => {
     })
 
     it('displays an error when the checkbox is not checked', () => {
-      cy.signIn()
-
-      const prisoner = prisonerFactory.build({
-        firstName: 'Del',
-        lastName: 'Hatton',
-      })
-      const person = personFactory.build({
-        currentPrison: prisoner.prisonName,
-        name: 'Del Hatton',
-        prisonNumber: prisoner.prisonerNumber,
-      })
-
-      const referral = referralFactory.started().build({ prisonNumber: person.prisonNumber })
-
-      cy.task('stubPrisoner', prisoner)
-      cy.task('stubReferral', referral)
-
       const path = referPaths.confirmOasys.show({ referralId: referral.id })
       cy.visit(path)
 

--- a/integration_tests/e2e/refer/reason.cy.ts
+++ b/integration_tests/e2e/refer/reason.cy.ts
@@ -13,31 +13,30 @@ import Page from '../../pages/page'
 import { ReasonPage, TaskListPage } from '../../pages/refer'
 
 context('Reason', () => {
+  const courseOffering = courseOfferingFactory.build()
+  const prisoner = prisonerFactory.build({
+    firstName: 'Del',
+    lastName: 'Hatton',
+  })
+  const person = personFactory.build({
+    currentPrison: prisoner.prisonName,
+    name: 'Del Hatton',
+    prisonNumber: prisoner.prisonerNumber,
+  })
+  const referral = referralFactory.started().build({ offeringId: courseOffering.id, prisonNumber: person.prisonNumber })
+
   beforeEach(() => {
     cy.task('reset')
     cy.task('stubSignIn', { authorities: [ApplicationRoles.ACP_REFERRER] })
     cy.task('stubAuthUser')
     cy.task('stubDefaultCaseloads')
-  })
-
-  it('Shows the reason form page', () => {
     cy.signIn()
-
-    const prisoner = prisonerFactory.build({
-      firstName: 'Del',
-      lastName: 'Hatton',
-    })
-    const person = personFactory.build({
-      currentPrison: prisoner.prisonName,
-      name: 'Del Hatton',
-      prisonNumber: prisoner.prisonerNumber,
-    })
-
-    const referral = referralFactory.started().build({ prisonNumber: person.prisonNumber })
 
     cy.task('stubPrisoner', prisoner)
     cy.task('stubReferral', referral)
+  })
 
+  it('Shows the reason form page', () => {
     const path = referPaths.reason.show({ referralId: referral.id })
     cy.visit(path)
 
@@ -52,34 +51,15 @@ context('Reason', () => {
 
   describe('When updating the reason', () => {
     it('updates the referral and redirects to the task list', () => {
-      cy.signIn()
+      cy.task('stubUpdateReferral', referral.id)
 
       const course = courseFactory.build()
-      const courseOffering = courseOfferingFactory.build()
-
-      const prisoner = prisonerFactory.build({
-        firstName: 'Del',
-        lastName: 'Hatton',
-      })
-      const person = personFactory.build({
-        currentPrison: prisoner.prisonName,
-        name: 'Del Hatton',
-        prisonNumber: prisoner.prisonerNumber,
-      })
+      cy.task('stubCourseByOffering', { course, courseOfferingId: courseOffering.id })
+      cy.task('stubOffering', { courseId: course.id, courseOffering })
 
       const prison = prisonFactory.build({ prisonId: courseOffering.organisationId })
       const organisation = OrganisationUtils.organisationFromPrison(prison)
-
-      const referral = referralFactory
-        .started()
-        .build({ offeringId: courseOffering.id, prisonNumber: person.prisonNumber })
-
-      cy.task('stubCourseByOffering', { course, courseOfferingId: courseOffering.id })
-      cy.task('stubOffering', { courseId: course.id, courseOffering })
       cy.task('stubPrison', prison)
-      cy.task('stubPrisoner', prisoner)
-      cy.task('stubReferral', referral)
-      cy.task('stubUpdateReferral', referral.id)
 
       const path = referPaths.reason.show({ referralId: referral.id })
       cy.visit(path)
@@ -92,23 +72,6 @@ context('Reason', () => {
     })
 
     it('displays an error when the reason is not provided', () => {
-      cy.signIn()
-
-      const prisoner = prisonerFactory.build({
-        firstName: 'Del',
-        lastName: 'Hatton',
-      })
-      const person = personFactory.build({
-        currentPrison: prisoner.prisonName,
-        name: 'Del Hatton',
-        prisonNumber: prisoner.prisonerNumber,
-      })
-
-      const referral = referralFactory.started().build({ prisonNumber: person.prisonNumber })
-
-      cy.task('stubPrisoner', prisoner)
-      cy.task('stubReferral', referral)
-
       const path = referPaths.reason.show({ referralId: referral.id })
       cy.visit(path)
 

--- a/integration_tests/e2e/refer/show.cy.ts
+++ b/integration_tests/e2e/refer/show.cy.ts
@@ -13,41 +13,44 @@ import Page from '../../pages/page'
 import { ShowPersonPage, TaskListPage } from '../../pages/refer'
 
 context('Showing the referral task list and person page', () => {
+  const courseOffering = courseOfferingFactory.build()
+  const prisoner = prisonerFactory.build({
+    dateOfBirth: '1980-01-01',
+    firstName: 'Del',
+    lastName: 'Hatton',
+  })
+  const person = personFactory.build({
+    currentPrison: prisoner.prisonName,
+    dateOfBirth: '1 January 1980',
+    ethnicity: prisoner.ethnicity,
+    gender: prisoner.gender,
+    name: 'Del Hatton',
+    prisonNumber: prisoner.prisonerNumber,
+    religionOrBelief: prisoner.religion,
+    setting: 'Custody',
+  })
+  const referral = referralFactory.started().build({ offeringId: courseOffering.id, prisonNumber: person.prisonNumber })
+
   beforeEach(() => {
     cy.task('reset')
     cy.task('stubSignIn', { authorities: [ApplicationRoles.ACP_REFERRER] })
     cy.task('stubAuthUser')
     cy.task('stubDefaultCaseloads')
+    cy.signIn()
+
+    cy.task('stubPrisoner', prisoner)
+    cy.task('stubReferral', referral)
   })
 
   it('Shows the in-progress referral task list', () => {
-    cy.signIn()
+    cy.task('stubOffering', { courseOffering })
 
     const course = courseFactory.build()
-    const courseOffering = courseOfferingFactory.build()
-
-    const prisoner = prisonerFactory.build({
-      firstName: 'Del',
-      lastName: 'Hatton',
-    })
-    const person = personFactory.build({
-      currentPrison: prisoner.prisonName,
-      name: 'Del Hatton',
-      prisonNumber: prisoner.prisonerNumber,
-    })
+    cy.task('stubCourseByOffering', { course, courseOfferingId: courseOffering.id })
 
     const prison = prisonFactory.build({ prisonId: courseOffering.organisationId })
     const organisation = OrganisationUtils.organisationFromPrison(prison)
-
-    const referral = referralFactory
-      .started()
-      .build({ offeringId: courseOffering.id, prisonNumber: person.prisonNumber })
-
-    cy.task('stubCourseByOffering', { course, courseOfferingId: courseOffering.id })
-    cy.task('stubOffering', { courseOffering })
     cy.task('stubPrison', prison)
-    cy.task('stubPrisoner', prisoner)
-    cy.task('stubReferral', referral)
 
     const path = referPaths.show({ referralId: referral.id })
     cy.visit(path)
@@ -63,29 +66,6 @@ context('Showing the referral task list and person page', () => {
   })
 
   it('Shows the person page for a referral', () => {
-    cy.signIn()
-
-    const prisoner = prisonerFactory.build({
-      dateOfBirth: '1980-01-01',
-      firstName: 'Del',
-      lastName: 'Hatton',
-    })
-    const person = personFactory.build({
-      currentPrison: prisoner.prisonName,
-      dateOfBirth: '1 January 1980',
-      ethnicity: prisoner.ethnicity,
-      gender: prisoner.gender,
-      name: 'Del Hatton',
-      prisonNumber: prisoner.prisonerNumber,
-      religionOrBelief: prisoner.religion,
-      setting: 'Custody',
-    })
-
-    const referral = referralFactory.started().build({ prisonNumber: prisoner.prisonerNumber })
-
-    cy.task('stubPrisoner', prisoner)
-    cy.task('stubReferral', referral)
-
     const path = referPaths.showPerson({ referralId: referral.id })
     cy.visit(path)
 

--- a/integration_tests/e2e/refer/submit.cy.ts
+++ b/integration_tests/e2e/refer/submit.cy.ts
@@ -16,101 +16,79 @@ import { CheckAnswersPage, CompletePage, TaskListPage } from '../../pages/refer'
 import type { CourseParticipationWithName } from '@accredited-programmes/models'
 
 context('Submitting a referral', () => {
+  const course = courseFactory.build()
+  const courseOffering = courseOfferingFactory.build()
+  const prisoner = prisonerFactory.build({
+    dateOfBirth: '1980-01-01',
+    firstName: 'Del',
+    lastName: 'Hatton',
+  })
+  const person = personFactory.build({
+    currentPrison: prisoner.prisonName,
+    dateOfBirth: '1 January 1980',
+    ethnicity: prisoner.ethnicity,
+    gender: prisoner.gender,
+    name: 'Del Hatton',
+    prisonNumber: prisoner.prisonerNumber,
+    religionOrBelief: prisoner.religion,
+    setting: 'Custody',
+  })
+  const prison = prisonFactory.build({ prisonId: courseOffering.organisationId })
+  const organisation = OrganisationUtils.organisationFromPrison(prison)
+  const courseParticipations = [
+    courseParticipationFactory.withCourseId().build({ courseId: course.id, createdAt: '2023-01-01T12:00:00.000Z' }),
+    courseParticipationFactory
+      .withOtherCourseName()
+      .build({ createdAt: '2022-01-01T12:00:00.000Z', otherCourseName: 'A great course name' }),
+  ]
+  const courseParticipationsWithNames: Array<CourseParticipationWithName> = [
+    { ...courseParticipations[0], name: course.name },
+    {
+      ...courseParticipations[1],
+      name: courseParticipations[1].otherCourseName as CourseParticipationWithName['name'],
+    },
+  ]
+  const submittableReferral = referralFactory
+    .submittable()
+    .build({ offeringId: courseOffering.id, prisonNumber: person.prisonNumber })
+
   beforeEach(() => {
     cy.task('reset')
     cy.task('stubSignIn', { authorities: [ApplicationRoles.ACP_REFERRER] })
     cy.task('stubAuthUser')
     cy.task('stubDefaultCaseloads')
-  })
-
-  it('Links to the check answers page when the referral is ready for submission', () => {
     cy.signIn()
-
-    const course = courseFactory.build()
-    const courseOffering = courseOfferingFactory.build()
-
-    const prisoner = prisonerFactory.build({
-      firstName: 'Del',
-      lastName: 'Hatton',
-    })
-    const person = personFactory.build({
-      currentPrison: prisoner.prisonName,
-      name: 'Del Hatton',
-      prisonNumber: prisoner.prisonerNumber,
-    })
-
-    const prison = prisonFactory.build({ prisonId: courseOffering.organisationId })
-    const organisation = OrganisationUtils.organisationFromPrison(prison)
-
-    const referral = referralFactory
-      .submittable()
-      .build({ offeringId: courseOffering.id, prisonNumber: person.prisonNumber })
 
     cy.task('stubCourseByOffering', { course, courseOfferingId: courseOffering.id })
     cy.task('stubOffering', { courseId: course.id, courseOffering })
     cy.task('stubPrison', prison)
     cy.task('stubPrisoner', prisoner)
-    cy.task('stubReferral', referral)
+  })
 
-    const path = referPaths.show({ referralId: referral.id })
+  it('Links to the check answers page when the referral is ready for submission', () => {
+    cy.task('stubReferral', submittableReferral)
+
+    const path = referPaths.show({ referralId: submittableReferral.id })
     cy.visit(path)
 
-    const taskListPage = Page.verifyOnPage(TaskListPage, { course, courseOffering, organisation, referral })
+    const taskListPage = Page.verifyOnPage(TaskListPage, {
+      course,
+      courseOffering,
+      organisation,
+      referral: submittableReferral,
+    })
     taskListPage.shouldBeReadyForSubmission()
   })
 
   describe('When checking answers', () => {
-    const course = courseFactory.build()
-    const courseOffering = courseOfferingFactory.build()
-    const prisoner = prisonerFactory.build({
-      dateOfBirth: '1980-01-01',
-      firstName: 'Del',
-      lastName: 'Hatton',
-    })
-    const person = personFactory.build({
-      currentPrison: prisoner.prisonName,
-      dateOfBirth: '1 January 1980',
-      ethnicity: prisoner.ethnicity,
-      gender: prisoner.gender,
-      name: 'Del Hatton',
-      prisonNumber: prisoner.prisonerNumber,
-      religionOrBelief: prisoner.religion,
-      setting: 'Custody',
-    })
-    const prison = prisonFactory.build({ prisonId: courseOffering.organisationId })
-    const organisation = OrganisationUtils.organisationFromPrison(prison)
-    const referral = referralFactory
-      .submittable()
-      .build({ offeringId: courseOffering.id, prisonNumber: person.prisonNumber })
-
-    const path = referPaths.checkAnswers({ referralId: referral.id })
+    const path = referPaths.checkAnswers({ referralId: submittableReferral.id })
 
     beforeEach(() => {
       cy.task('stubCourse', course)
-      cy.task('stubCourseByOffering', { course, courseOfferingId: courseOffering.id })
-      cy.task('stubOffering', { courseId: course.id, courseOffering })
-      cy.task('stubPrison', prison)
-      cy.task('stubPrisoner', prisoner)
-      cy.task('stubReferral', referral)
-
-      cy.signIn()
+      cy.task('stubReferral', submittableReferral)
     })
 
     it('Shows the information the user has submitted in the referral form', () => {
-      const courseParticipations = [
-        courseParticipationFactory.withCourseId().build({ courseId: course.id, createdAt: '2023-01-01T12:00:00.000Z' }),
-        courseParticipationFactory
-          .withOtherCourseName()
-          .build({ createdAt: '2022-01-01T12:00:00.000Z', otherCourseName: 'A great course name' }),
-      ]
-      const courseParticipationsWithNames: Array<CourseParticipationWithName> = [
-        { ...courseParticipations[0], name: course.name },
-        {
-          ...courseParticipations[1],
-          name: courseParticipations[1].otherCourseName as CourseParticipationWithName['name'],
-        },
-      ]
-
       cy.task('stubParticipationsByPerson', { courseParticipations, prisonNumber: prisoner.prisonerNumber })
 
       cy.visit(path)
@@ -121,20 +99,23 @@ context('Submitting a referral', () => {
         organisation,
         participations: courseParticipationsWithNames,
         person,
-        referral,
+        referral: submittableReferral,
         username: auth.mockedUsername(),
       })
       checkAnswersPage.shouldHavePersonDetails(person)
       checkAnswersPage.shouldContainNavigation(path)
-      checkAnswersPage.shouldContainBackLink(referPaths.show({ referralId: referral.id }))
+      checkAnswersPage.shouldContainBackLink(referPaths.show({ referralId: submittableReferral.id }))
       checkAnswersPage.shouldHaveApplicationSummary()
       checkAnswersPage.shouldContainPersonSummaryList(person)
       checkAnswersPage.shouldHaveProgrammeHistory()
       checkAnswersPage.shouldHaveOasysConfirmation()
-      checkAnswersPage.shouldHaveAdditionalInformation(referral)
+      checkAnswersPage.shouldHaveAdditionalInformation(submittableReferral)
       checkAnswersPage.shouldHaveConfirmationCheckbox()
       checkAnswersPage.shouldContainButton('Submit referral')
-      checkAnswersPage.shouldContainButtonLink('Return to tasklist', referPaths.show({ referralId: referral.id }))
+      checkAnswersPage.shouldContainButtonLink(
+        'Return to tasklist',
+        referPaths.show({ referralId: submittableReferral.id }),
+      )
     })
 
     describe('for a person with no programme history', () => {
@@ -149,7 +130,7 @@ context('Submitting a referral', () => {
           organisation,
           participations: [],
           person,
-          referral,
+          referral: submittableReferral,
           username: auth.mockedUsername(),
         })
         checkAnswersPage.shouldNotHaveProgrammeHistory()
@@ -158,53 +139,16 @@ context('Submitting a referral', () => {
   })
 
   describe('When submitting a referral', () => {
-    const course = courseFactory.build()
-    const courseOffering = courseOfferingFactory.build()
-    const prisoner = prisonerFactory.build({
-      firstName: 'Del',
-      lastName: 'Hatton',
-    })
-    const person = personFactory.build({
-      currentPrison: prisoner.prisonName,
-      name: 'Del Hatton',
-      prisonNumber: prisoner.prisonerNumber,
-    })
-    const prison = prisonFactory.build({ prisonId: courseOffering.organisationId })
-    const organisation = OrganisationUtils.organisationFromPrison(prison)
-    const courseParticipations = [
-      courseParticipationFactory.withCourseId().build({ courseId: course.id, createdAt: '2023-01-01T12:00:00.000Z' }),
-      courseParticipationFactory
-        .withOtherCourseName()
-        .build({ createdAt: '2022-01-01T12:00:00.000Z', otherCourseName: 'A great course name' }),
-    ]
-    const courseParticipationsWithNames: Array<CourseParticipationWithName> = [
-      { ...courseParticipations[0], name: course.name },
-      {
-        ...courseParticipations[1],
-        name: courseParticipations[1].otherCourseName as CourseParticipationWithName['name'],
-      },
-    ]
-
     beforeEach(() => {
-      cy.signIn()
-
       cy.task('stubCourse', course)
-      cy.task('stubCourseByOffering', { course, courseOfferingId: courseOffering.id })
-      cy.task('stubOffering', { courseId: course.id, courseOffering })
       cy.task('stubParticipationsByPerson', { courseParticipations, prisonNumber: prisoner.prisonerNumber })
-      cy.task('stubPrison', prison)
-      cy.task('stubPrisoner', prisoner)
     })
 
     it('redirects to the referral complete page when the user confirms the details', () => {
-      const referral = referralFactory
-        .submittable()
-        .build({ offeringId: courseOffering.id, prisonNumber: person.prisonNumber })
+      cy.task('stubReferral', submittableReferral)
+      cy.task('stubUpdateReferralStatus', submittableReferral.id)
 
-      cy.task('stubReferral', referral)
-      cy.task('stubUpdateReferralStatus', referral.id)
-
-      const path = referPaths.checkAnswers({ referralId: referral.id })
+      const path = referPaths.checkAnswers({ referralId: submittableReferral.id })
       cy.visit(path)
 
       const checkAnswersPage = Page.verifyOnPage(CheckAnswersPage, {
@@ -213,23 +157,19 @@ context('Submitting a referral', () => {
         organisation,
         participations: courseParticipationsWithNames,
         person,
-        referral,
+        referral: submittableReferral,
         username: auth.mockedUsername(),
       })
-      checkAnswersPage.confirmDetailsAndSubmitReferral(referral)
+      checkAnswersPage.confirmDetailsAndSubmitReferral(submittableReferral)
 
       const completePage = Page.verifyOnPage(CompletePage)
       completePage.shouldContainPanel('Referral complete')
     })
 
     it('shows an error when the user tries to submit a referral without confirming the details', () => {
-      const referral = referralFactory
-        .submittable()
-        .build({ offeringId: courseOffering.id, prisonNumber: person.prisonNumber })
+      cy.task('stubReferral', submittableReferral)
 
-      cy.task('stubReferral', referral)
-
-      const path = referPaths.checkAnswers({ referralId: referral.id })
+      const path = referPaths.checkAnswers({ referralId: submittableReferral.id })
       cy.visit(path)
 
       const checkAnswersPage = Page.verifyOnPage(CheckAnswersPage, {
@@ -238,7 +178,7 @@ context('Submitting a referral', () => {
         organisation,
         participations: courseParticipationsWithNames,
         person,
-        referral,
+        referral: submittableReferral,
         username: auth.mockedUsername(),
       })
       checkAnswersPage.shouldContainButton('Submit referral').click()
@@ -249,7 +189,7 @@ context('Submitting a referral', () => {
         organisation,
         participations: courseParticipationsWithNames,
         person,
-        referral,
+        referral: submittableReferral,
         username: auth.mockedUsername(),
       })
       checkAnswersPageWithErrors.shouldHaveErrors([
@@ -262,13 +202,10 @@ context('Submitting a referral', () => {
   })
 
   it('Shows the complete page for a completed referral', () => {
-    cy.signIn()
+    const submittedReferral = referralFactory.submitted().build({ status: 'referral_submitted' })
+    cy.task('stubReferral', submittedReferral)
 
-    const referral = referralFactory.submitted().build({ status: 'referral_submitted' })
-
-    cy.task('stubReferral', referral)
-
-    const path = referPaths.complete({ referralId: referral.id })
+    const path = referPaths.complete({ referralId: submittedReferral.id })
     cy.visit(path)
 
     const completePage = Page.verifyOnPage(CompletePage)

--- a/integration_tests/e2eReferDisabled/find.cy.ts
+++ b/integration_tests/e2eReferDisabled/find.cy.ts
@@ -5,24 +5,21 @@ import { CourseOfferingPage } from '../pages/find'
 import Page from '../pages/page'
 
 context('Find', () => {
-  beforeEach(() => {
+  it("Doesn't show the 'Make a referral' button on an offering", () => {
     cy.task('reset')
     cy.task('stubSignIn')
     cy.task('stubAuthUser')
-  })
-
-  it("Doesn't show the 'Make a referral' button on an offering", () => {
     cy.signIn()
 
     const course = courseFactory.build()
     const courseOffering = courseOfferingFactory.build({
       secondaryContactEmail: null,
     })
+    cy.task('stubOffering', { courseOffering })
+    cy.task('stubCourseByOffering', { course, courseOfferingId: courseOffering.id })
+
     const prison = prisonFactory.build({ prisonId: courseOffering.organisationId })
     const organisation = OrganisationUtils.organisationFromPrison(prison)
-
-    cy.task('stubCourseByOffering', { course, courseOfferingId: courseOffering.id })
-    cy.task('stubOffering', { courseOffering })
     cy.task('stubPrison', prison)
 
     const path = findPaths.offerings.show({ courseOfferingId: courseOffering.id })


### PR DESCRIPTION
## Context

<!-- Is there a Trello ticket you can link to? -->
<!-- Do you need to add any environment variables? -->
<!-- Is an ADR required? An ADR should be added if this PR introduces a change to the architecture. -->

We have a lot of unDRY code in our integration tests, which is making navigation within specs and comparison across contexts and specs a little painful. When adding new specs and contexts there's a not insignificant careful copy/paste overhead, which also rears its head in review

## Changes in this PR

- Simplify assignment and stubbing
- DRY up sign in

## Release checklist

[Release process documentation](../doc/how-to/perform-a-release.md)

As part of our continuous deployment strategy we must ensure that this work is
ready to be released once merged.

### Pre-merge

- [ ] There are changes required to the Accredited Programmes API for this change to work...
  - [ ] ... and they have been released to production already

### Post-merge

<!-- The outer checkboxes can be completed pre-merge -->

- [ ] This adds, extends or meaningfully modifies a feature...
  - [ ] ... and I have written or updated an end-to-end test for the happy path in the [Accredited Programmes E2E repo](https://github.com/ministryofjustice/hmpps-accredited-programmes-e2e)
- [ ] This makes new expectations of the API...
  - [ ] ... and I have notified the API developer(s) of changes to the contract tests (Pact), or the API is already compliant
- [ ] [Manually approve](../doc/how-to/perform-a-release.md#releasing-to-the-preprod-environment) release to preprod
- [ ] [Manually approve](../doc/how-to/perform-a-release.md#releasing-to-the-production-environment) release to prod

<!-- Should a release fail at any step, you as the author should now lead the work to
fix it as soon as possible. You can monitor deployment failures in CircleCI
itself and application errors are found in
[Sentry](https://ministryofjustice.sentry.io/projects/hmpps-accredited-programmes-ui/?project=4505330122686464&referrer=sidebar&statsPeriod=24h). -->
