### PR TITLE
(968b) Show users name instead of username on programme history entries

### DIFF
--- a/integration_tests/e2e/refer/submit.cy.ts
+++ b/integration_tests/e2e/refer/submit.cy.ts
@@ -100,7 +100,7 @@ context('Submitting a referral', () => {
         participations: courseParticipationsWithNames,
         person,
         referral: submittableReferral,
-        username: auth.mockedUsername(),
+        username: auth.mockedUser.username,
       })
       checkAnswersPage.shouldHavePersonDetails(person)
       checkAnswersPage.shouldContainNavigation(path)
@@ -131,7 +131,7 @@ context('Submitting a referral', () => {
           participations: [],
           person,
           referral: submittableReferral,
-          username: auth.mockedUsername(),
+          username: auth.mockedUser.username,
         })
         checkAnswersPage.shouldNotHaveProgrammeHistory()
       })
@@ -158,7 +158,7 @@ context('Submitting a referral', () => {
         participations: courseParticipationsWithNames,
         person,
         referral: submittableReferral,
-        username: auth.mockedUsername(),
+        username: auth.mockedUser.username,
       })
       checkAnswersPage.confirmDetailsAndSubmitReferral(submittableReferral)
 
@@ -179,7 +179,7 @@ context('Submitting a referral', () => {
         participations: courseParticipationsWithNames,
         person,
         referral: submittableReferral,
-        username: auth.mockedUsername(),
+        username: auth.mockedUser.username,
       })
       checkAnswersPage.shouldContainButton('Submit referral').click()
 
@@ -190,7 +190,7 @@ context('Submitting a referral', () => {
         participations: courseParticipationsWithNames,
         person,
         referral: submittableReferral,
-        username: auth.mockedUsername(),
+        username: auth.mockedUser.username,
       })
       checkAnswersPageWithErrors.shouldHaveErrors([
         {

--- a/integration_tests/mockApis/auth.ts
+++ b/integration_tests/mockApis/auth.ts
@@ -4,11 +4,10 @@ import type { Response } from 'superagent'
 import manageUserStubs from './manageUsers'
 import tokenVerification from './tokenVerification'
 import type { ApplicationRoles } from '../../server/middleware/roleBasedAccessMiddleware'
+import { userFactory } from '../../server/testutils/factories'
 import { getMatchingRequests, stubFor } from '../../wiremock'
 
-const mockedUsername = () => {
-  return 'USER1'
-}
+const mockedUser = userFactory.build({ name: 'john smith', username: 'USER1' })
 
 const createToken = ({ authorities = [] }: { authorities?: Array<ApplicationRoles> }) => {
   const payload = {
@@ -17,7 +16,7 @@ const createToken = ({ authorities = [] }: { authorities?: Array<ApplicationRole
     client_id: 'clientid',
     jti: '83b50a10-cca6-41db-985f-e87efb303ddb',
     scope: ['read'],
-    user_name: mockedUsername(),
+    user_name: mockedUser.username,
   }
 
   return jwt.sign(payload, 'secret', { expiresIn: '1h' })
@@ -118,7 +117,7 @@ const token = ({ authorities }: { authorities?: Array<ApplicationRoles> }) =>
         internalUser: true,
         scope: 'read',
         token_type: 'bearer',
-        user_name: mockedUsername(),
+        user_name: mockedUser.username,
       },
       status: 200,
     },
@@ -126,12 +125,12 @@ const token = ({ authorities }: { authorities?: Array<ApplicationRoles> }) =>
 
 export default {
   getSignInUrl,
-  mockedUsername,
+  mockedUser,
   stubAuthPing: ping,
   stubAuthUser: (name = 'john smith'): Promise<[Response, Response]> =>
     Promise.all([
-      manageUserStubs.stubCurrentUser(mockedUsername()),
-      manageUserStubs.stubUserDetails({ name, username: mockedUsername() }),
+      manageUserStubs.stubCurrentUser(mockedUser.username),
+      manageUserStubs.stubUserDetails({ user: userFactory.build({ ...mockedUser, name }) }),
     ]),
   stubSignIn: (
     args = {

--- a/integration_tests/mockApis/manageUsers.ts
+++ b/integration_tests/mockApis/manageUsers.ts
@@ -21,23 +21,17 @@ export default {
       },
     }),
 
-  stubUserDetails: (args: { name: User['name']; username: User['username'] }): SuperAgentRequest =>
+  stubUserDetails: (args: { user: User }): SuperAgentRequest =>
     stubFor({
       request: {
         method: 'GET',
-        urlPattern: `/users/${args.username}`,
+        urlPattern: `/users/${args.user.username}`,
       },
       response: {
         headers: {
           'Content-Type': 'application/json;charset=UTF-8',
         },
-        jsonBody: {
-          active: true,
-          authSource: 'auth',
-          name: args.name,
-          userId: '1234',
-          username: args.username,
-        },
+        jsonBody: args.user,
         status: 200,
       },
     }),

--- a/integration_tests/pages/page.ts
+++ b/integration_tests/pages/page.ts
@@ -3,8 +3,9 @@ import type { AxeRules } from '@accredited-programmes/integration-tests'
 import { referPaths } from '../../server/paths'
 import { CourseParticipationUtils, PersonUtils } from '../../server/utils'
 import Helpers from '../support/helpers'
-import type { CourseParticipationWithName, Organisation, Person, Referral } from '@accredited-programmes/models'
+import type { Organisation, Person, Referral } from '@accredited-programmes/models'
 import type {
+  CourseParticipationPresenter,
   CoursePresenter,
   GovukFrontendRadiosItemWithLabel,
   GovukFrontendSummaryListCardActionsItemWithText,
@@ -87,7 +88,7 @@ export default abstract class Page {
   }
 
   shouldContainHistorySummaryCards(
-    participations: Array<CourseParticipationWithName>,
+    participations: Array<CourseParticipationPresenter>,
     referralId: Referral['id'],
     withActions = { change: true, remove: true },
   ) {
@@ -200,7 +201,7 @@ export default abstract class Page {
   }
 
   shouldContainSummaryCard(
-    courseName: CourseParticipationWithName['name'],
+    courseName: CourseParticipationPresenter['name'],
     actions: Array<GovukFrontendSummaryListCardActionsItemWithText>,
     rows: Array<GovukFrontendSummaryListRowWithValue>,
     summaryCardElement: JQuery<HTMLElement>,

--- a/integration_tests/pages/refer/checkAnswers.ts
+++ b/integration_tests/pages/refer/checkAnswers.ts
@@ -1,14 +1,7 @@
 import { CourseUtils, ReferralUtils } from '../../../server/utils'
 import Page from '../page'
-import type {
-  Course,
-  CourseOffering,
-  CourseParticipationWithName,
-  Organisation,
-  Person,
-  Referral,
-} from '@accredited-programmes/models'
-import type { CoursePresenter } from '@accredited-programmes/ui'
+import type { Course, CourseOffering, Organisation, Person, Referral } from '@accredited-programmes/models'
+import type { CourseParticipationPresenter, CoursePresenter } from '@accredited-programmes/ui'
 
 export default class CheckAnswersPage extends Page {
   course: CoursePresenter
@@ -17,7 +10,7 @@ export default class CheckAnswersPage extends Page {
 
   organisation: Organisation
 
-  participations: Array<CourseParticipationWithName>
+  participations: Array<CourseParticipationPresenter>
 
   person: Person
 
@@ -29,7 +22,7 @@ export default class CheckAnswersPage extends Page {
     course: Course
     courseOffering: CourseOffering
     organisation: Organisation
-    participations: Array<CourseParticipationWithName>
+    participations: Array<CourseParticipationPresenter>
     person: Person
     referral: Referral
     username: Express.User['username']

--- a/integration_tests/pages/refer/deleteProgrammeHistory.ts
+++ b/integration_tests/pages/refer/deleteProgrammeHistory.ts
@@ -1,18 +1,19 @@
 import Page from '../page'
-import type { CourseParticipationWithName, Person, Referral } from '@accredited-programmes/models'
+import type { Person, Referral } from '@accredited-programmes/models'
+import type { CourseParticipationPresenter } from '@accredited-programmes/ui'
 
 export default class DeleteProgrammeHistoryPage extends Page {
-  participation: CourseParticipationWithName
+  participation: CourseParticipationPresenter
 
   person: Person
 
   referral: Referral
 
-  constructor(args: { participationWithName: CourseParticipationWithName; person: Person; referral: Referral }) {
+  constructor(args: { participation: CourseParticipationPresenter; person: Person; referral: Referral }) {
     super('Remove programme')
 
-    const { participationWithName, person, referral } = args
-    this.participation = participationWithName
+    const { participation, person, referral } = args
+    this.participation = participation
     this.person = person
     this.referral = referral
   }

--- a/integration_tests/pages/refer/programmeHistory.ts
+++ b/integration_tests/pages/refer/programmeHistory.ts
@@ -1,22 +1,19 @@
 import Page from '../page'
-import type { CourseParticipationWithName, Person, Referral } from '@accredited-programmes/models'
+import type { Person, Referral } from '@accredited-programmes/models'
+import type { CourseParticipationPresenter } from '@accredited-programmes/ui'
 
 export default class ProgrammeHistoryPage extends Page {
-  participations: Array<CourseParticipationWithName>
+  participations: Array<CourseParticipationPresenter>
 
   person: Person
 
   referral: Referral
 
-  constructor(args: {
-    participationsWithNames: Array<CourseParticipationWithName>
-    person: Person
-    referral: Referral
-  }) {
+  constructor(args: { participations: Array<CourseParticipationPresenter>; person: Person; referral: Referral }) {
     super('Accredited Programme history')
 
-    const { participationsWithNames, person, referral } = args
-    this.participations = participationsWithNames
+    const { participations, person, referral } = args
+    this.participations = participations
     this.person = person
     this.referral = referral
   }

--- a/server/@types/models/CourseParticipation.ts
+++ b/server/@types/models/CourseParticipation.ts
@@ -34,14 +34,4 @@ type CourseParticipationUpdate = {
   source?: CourseParticipation['source']
 }
 
-type CourseParticipationWithName = CourseParticipation & {
-  name: string
-}
-
-export type {
-  CourseParticipation,
-  CourseParticipationOutcome,
-  CourseParticipationSetting,
-  CourseParticipationUpdate,
-  CourseParticipationWithName,
-}
+export type { CourseParticipation, CourseParticipationOutcome, CourseParticipationSetting, CourseParticipationUpdate }

--- a/server/@types/models/index.d.ts
+++ b/server/@types/models/index.d.ts
@@ -6,7 +6,6 @@ import type {
   CourseParticipationOutcome,
   CourseParticipationSetting,
   CourseParticipationUpdate,
-  CourseParticipationWithName,
 } from './CourseParticipation'
 import type { CoursePrerequisite } from './CoursePrerequisite'
 import type { Organisation } from './Organisation'
@@ -22,7 +21,6 @@ export type {
   CourseParticipationOutcome,
   CourseParticipationSetting,
   CourseParticipationUpdate,
-  CourseParticipationWithName,
   CoursePrerequisite,
   CreatedReferralResponse,
   Organisation,

--- a/server/@types/ui/index.d.ts
+++ b/server/@types/ui/index.d.ts
@@ -1,4 +1,5 @@
-import type { Course, CourseOffering, Organisation } from '@accredited-programmes/models'
+import type { Course, CourseOffering, CourseParticipationWithName, Organisation } from '@accredited-programmes/models'
+import type { User } from '@accredited-programmes/users'
 import type {
   GovukFrontendRadiosItem,
   GovukFrontendSummaryList,
@@ -34,6 +35,10 @@ type HasHtmlString = {
 }
 
 type TagColour = 'blue' | 'green' | 'grey' | 'orange' | 'pink' | 'purple' | 'red' | 'turquoise' | 'yellow'
+
+type CourseParticipationPresenter = CourseParticipationWithName & {
+  addedByName: User['name']
+}
 
 type CoursePresenter = Course & {
   audienceTags: Array<GovukFrontendTagWithText>
@@ -88,6 +93,7 @@ type ReferralTaskListSection = {
 }
 
 export type {
+  CourseParticipationPresenter,
   CoursePresenter,
   GovukFrontendRadiosItemWithLabel,
   GovukFrontendSummaryListCardActionsItemWithText,

--- a/server/@types/ui/index.d.ts
+++ b/server/@types/ui/index.d.ts
@@ -1,4 +1,4 @@
-import type { Course, CourseOffering, CourseParticipationWithName, Organisation } from '@accredited-programmes/models'
+import type { Course, CourseOffering, CourseParticipation, Organisation } from '@accredited-programmes/models'
 import type { User } from '@accredited-programmes/users'
 import type {
   GovukFrontendRadiosItem,
@@ -36,8 +36,9 @@ type HasHtmlString = {
 
 type TagColour = 'blue' | 'green' | 'grey' | 'orange' | 'pink' | 'purple' | 'red' | 'turquoise' | 'yellow'
 
-type CourseParticipationPresenter = CourseParticipationWithName & {
+type CourseParticipationPresenter = CourseParticipation & {
   addedByName: User['name']
+  name: Course['name']
 }
 
 type CoursePresenter = Course & {

--- a/server/controllers/refer/index.ts
+++ b/server/controllers/refer/index.ts
@@ -14,6 +14,7 @@ const controllers = (services: Services) => {
     services.organisationService,
     services.personService,
     services.referralService,
+    services.userService,
   )
   const peopleController = new PeopleController(services.personService)
   const reasonController = new ReasonController(services.personService, services.referralService)
@@ -22,6 +23,7 @@ const controllers = (services: Services) => {
     services.courseService,
     services.personService,
     services.referralService,
+    services.userService,
   )
   const courseParticipationDetailsController = new CourseParticipationDetailsController(
     services.courseService,

--- a/server/data/hmppsManageUsersClient.ts
+++ b/server/data/hmppsManageUsersClient.ts
@@ -1,5 +1,4 @@
 import RestClient from './restClient'
-import logger from '../../logger'
 import config from '../config'
 import type { User } from '@accredited-programmes/users'
 
@@ -11,12 +10,10 @@ export default class HmppsManageUsersClient {
   }
 
   getCurrentUsername(): Promise<Pick<User, 'username'>> {
-    logger.info(`Getting username: calling HMPPS Manage Users`)
     return this.restClient.get({ path: '/users/me' }) as Promise<Pick<User, 'username'>>
   }
 
   getUserFromUsername(username: User['username']): Promise<User> {
-    logger.info(`Getting user details: calling HMPPS Manage Users`)
     return this.restClient.get({ path: `/users/${username}` }) as Promise<User>
   }
 }

--- a/server/services/userService.ts
+++ b/server/services/userService.ts
@@ -1,7 +1,10 @@
+import createError from 'http-errors'
+import type { ResponseError } from 'superagent'
+
 import logger from '../../logger'
 import type { CaseloadClient, HmppsManageUsersClient, RestClientBuilder } from '../data'
 import { StringUtils } from '../utils'
-import type { UserDetails } from '@accredited-programmes/users'
+import type { User, UserDetails } from '@accredited-programmes/users'
 import type { Caseload } from '@prison-api'
 
 export default class UserService {
@@ -20,6 +23,25 @@ export default class UserService {
     ])
 
     return { ...user, caseloads, displayName: StringUtils.convertToTitleCase(user.name) }
+  }
+
+  async getUserFromUsername(token: Express.User['token'], username: User['username']): Promise<User> {
+    const hmppsManageUsersClient = this.hmppsManageUsersClientBuilder(token)
+
+    try {
+      return await hmppsManageUsersClient.getUserFromUsername(username)
+    } catch (error) {
+      const knownError = error as ResponseError
+
+      if (knownError.status === 404) {
+        throw createError(knownError.status, `User with username ${username} not found.`)
+      }
+
+      const errorMessage =
+        knownError.message === 'Internal Server Error' ? `Error fetching user ${username}.` : knownError.message
+
+      throw createError(knownError.status || 500, errorMessage)
+    }
   }
 
   private async getCaseloads(token: Express.User['token']): Promise<Array<Caseload>> {

--- a/server/testutils/factories/index.ts
+++ b/server/testutils/factories/index.ts
@@ -11,6 +11,7 @@ import prisonFactory from './prison'
 import prisonAddressFactory from './prisonAddress'
 import prisonerFactory from './prisoner'
 import referralFactory from './referral'
+import userFactory from './user'
 
 export {
   caseloadFactory,
@@ -26,4 +27,5 @@ export {
   prisonFactory,
   prisonerFactory,
   referralFactory,
+  userFactory,
 }

--- a/server/testutils/factories/user.ts
+++ b/server/testutils/factories/user.ts
@@ -1,0 +1,21 @@
+import { faker } from '@faker-js/faker/locale/en_GB'
+import { Factory } from 'fishery'
+
+import type { User } from '@accredited-programmes/users'
+
+export default Factory.define<User>(() => {
+  const userId = faker.string.uuid()
+  const firstName = faker.person.firstName()
+  const lastName = faker.person.lastName()
+
+  return {
+    active: true,
+    activeCaseLoadId: faker.string.alpha({ casing: 'upper', length: 3 }),
+    authSource: 'nomis',
+    name: `${firstName} ${lastName}`,
+    staffId: faker.number.int(),
+    userId,
+    username: faker.internet.userName({ firstName, lastName }),
+    uuid: userId,
+  }
+})

--- a/server/utils/courseParticipationUtils.test.ts
+++ b/server/utils/courseParticipationUtils.test.ts
@@ -10,8 +10,8 @@ import type {
   CourseParticipationOutcome,
   CourseParticipationSetting,
   CourseParticipationUpdate,
-  CourseParticipationWithName,
 } from '@accredited-programmes/models'
+import type { CourseParticipationPresenter } from '@accredited-programmes/ui'
 import type {
   GovukFrontendSummaryListRow,
   GovukFrontendSummaryListRowKey,
@@ -305,7 +305,7 @@ describe('CourseParticipationUtils', () => {
 
   describe('summaryListOptions', () => {
     const referralId = faker.string.uuid()
-    const courseParticipationWithName = {
+    const presentedCourseParticipation = {
       ...courseParticipationFactory.build({
         addedBy: 'Eric McNally',
         createdAt: '2023-04-20T16:20:00.000Z',
@@ -321,24 +321,25 @@ describe('CourseParticipationUtils', () => {
         },
         source: 'Word of mouth',
       }),
+      addedByName: 'Eric McNally',
       name: 'A mediocre course name (aMCN)',
     }
 
-    describe('when all fields are present on the CourseParticipationWithName', () => {
+    describe('when all fields are present on the CourseParticipationPresenter', () => {
       it('generates an object to pass into a Nunjucks macro for a GOV.UK summary list with card', () => {
-        expect(CourseParticipationUtils.summaryListOptions(courseParticipationWithName, referralId)).toEqual({
+        expect(CourseParticipationUtils.summaryListOptions(presentedCourseParticipation, referralId)).toEqual({
           card: {
             actions: {
               items: [
                 {
-                  href: `/referrals/${referralId}/programme-history/${courseParticipationWithName.id}/programme`,
+                  href: `/referrals/${referralId}/programme-history/${presentedCourseParticipation.id}/programme`,
                   text: 'Change',
-                  visuallyHiddenText: `participation for ${courseParticipationWithName.name}`,
+                  visuallyHiddenText: `participation for ${presentedCourseParticipation.name}`,
                 },
                 {
-                  href: `/referrals/${referralId}/programme-history/${courseParticipationWithName.id}/delete`,
+                  href: `/referrals/${referralId}/programme-history/${presentedCourseParticipation.id}/delete`,
                   text: 'Remove',
-                  visuallyHiddenText: `participation for ${courseParticipationWithName.name}`,
+                  visuallyHiddenText: `participation for ${presentedCourseParticipation.name}`,
                 },
               ],
             },
@@ -383,7 +384,7 @@ describe('CourseParticipationUtils', () => {
     ])('when `withActions` is %s', (withActions, omits, actionText) => {
       it(`omits ${omits}`, () => {
         const summaryListOptions = CourseParticipationUtils.summaryListOptions(
-          courseParticipationWithName,
+          presentedCourseParticipation,
           referralId,
           withActions,
         )
@@ -398,8 +399,8 @@ describe('CourseParticipationUtils', () => {
     describe('rows with optional values', () => {
       describe('setting', () => {
         describe('when the setting has no location', () => {
-          const withoutSettingLocation: CourseParticipationWithName = {
-            ...courseParticipationWithName,
+          const withoutSettingLocation: CourseParticipationPresenter = {
+            ...presentedCourseParticipation,
             setting: {
               location: undefined,
               type: 'community',
@@ -413,8 +414,8 @@ describe('CourseParticipationUtils', () => {
         })
 
         describe('when there is no setting', () => {
-          const withoutSetting: CourseParticipationWithName = {
-            ...courseParticipationWithName,
+          const withoutSetting: CourseParticipationPresenter = {
+            ...presentedCourseParticipation,
             setting: undefined,
           }
 
@@ -428,8 +429,8 @@ describe('CourseParticipationUtils', () => {
       describe('outcome', () => {
         describe('when the outcome is incomplete', () => {
           describe('and there is a yearStarted value', () => {
-            const withOutcomeYearStarted: CourseParticipationWithName = {
-              ...courseParticipationWithName,
+            const withOutcomeYearStarted: CourseParticipationPresenter = {
+              ...presentedCourseParticipation,
               outcome: { status: 'incomplete', yearStarted: 2019 },
             }
 
@@ -440,8 +441,8 @@ describe('CourseParticipationUtils', () => {
           })
 
           describe('and there is no yearStarted value', () => {
-            const withoutOutcomeYearStarted: CourseParticipationWithName = {
-              ...courseParticipationWithName,
+            const withoutOutcomeYearStarted: CourseParticipationPresenter = {
+              ...presentedCourseParticipation,
               outcome: { status: 'incomplete', yearStarted: undefined },
             }
 
@@ -454,8 +455,8 @@ describe('CourseParticipationUtils', () => {
 
         describe('when the outcome is complete', () => {
           describe('and there is a yearCompleted value', () => {
-            const withOutcomeYearCompleted: CourseParticipationWithName = {
-              ...courseParticipationWithName,
+            const withOutcomeYearCompleted: CourseParticipationPresenter = {
+              ...presentedCourseParticipation,
               outcome: { status: 'complete', yearCompleted: 2019 },
             }
 
@@ -466,8 +467,8 @@ describe('CourseParticipationUtils', () => {
           })
 
           describe('and there is no yearCompleted value', () => {
-            const withoutOutcomeYearCompleted: CourseParticipationWithName = {
-              ...courseParticipationWithName,
+            const withoutOutcomeYearCompleted: CourseParticipationPresenter = {
+              ...presentedCourseParticipation,
               outcome: { status: 'complete', yearCompleted: undefined },
             }
 
@@ -479,8 +480,8 @@ describe('CourseParticipationUtils', () => {
         })
 
         describe('when there is no outcome', () => {
-          const withoutOutcome: CourseParticipationWithName = {
-            ...courseParticipationWithName,
+          const withoutOutcome: CourseParticipationPresenter = {
+            ...presentedCourseParticipation,
             outcome: undefined,
           }
 
@@ -493,8 +494,8 @@ describe('CourseParticipationUtils', () => {
 
       describe('additional detail', () => {
         describe('when there is no additional detail set', () => {
-          const withoutOutcomeAdditionalDetail: CourseParticipationWithName = {
-            ...courseParticipationWithName,
+          const withoutOutcomeAdditionalDetail: CourseParticipationPresenter = {
+            ...presentedCourseParticipation,
             detail: undefined,
           }
 
@@ -507,8 +508,8 @@ describe('CourseParticipationUtils', () => {
 
       describe('source of information', () => {
         describe('when there is no source of information set', () => {
-          const withoutSource: CourseParticipationWithName = {
-            ...courseParticipationWithName,
+          const withoutSource: CourseParticipationPresenter = {
+            ...presentedCourseParticipation,
             source: undefined,
           }
 

--- a/server/utils/courseParticipationUtils.ts
+++ b/server/utils/courseParticipationUtils.ts
@@ -8,10 +8,10 @@ import type {
   CourseParticipationOutcome,
   CourseParticipationSetting,
   CourseParticipationUpdate,
-  CourseParticipationWithName,
   Referral,
 } from '@accredited-programmes/models'
 import type {
+  CourseParticipationPresenter,
   GovukFrontendSummaryListCardActionsWithItems,
   GovukFrontendSummaryListRowWithValue,
   GovukFrontendSummaryListWithRowsWithValues,
@@ -119,7 +119,7 @@ export default class CourseParticipationUtils {
   }
 
   static summaryListOptions(
-    courseParticipationWithName: CourseParticipationWithName,
+    courseParticipation: CourseParticipationPresenter,
     referralId: Referral['id'],
     withActions = { change: true, remove: true },
   ): GovukFrontendSummaryListWithRowsWithValues {
@@ -128,22 +128,22 @@ export default class CourseParticipationUtils {
     if (withActions.change) {
       actions.items.push({
         href: referPaths.programmeHistory.editProgramme({
-          courseParticipationId: courseParticipationWithName.id,
+          courseParticipationId: courseParticipation.id,
           referralId,
         }),
         text: 'Change',
-        visuallyHiddenText: `participation for ${courseParticipationWithName.name}`,
+        visuallyHiddenText: `participation for ${courseParticipation.name}`,
       })
     }
 
     if (withActions.remove) {
       actions.items.push({
         href: referPaths.programmeHistory.delete({
-          courseParticipationId: courseParticipationWithName.id,
+          courseParticipationId: courseParticipation.id,
           referralId,
         }),
         text: 'Remove',
-        visuallyHiddenText: `participation for ${courseParticipationWithName.name}`,
+        visuallyHiddenText: `participation for ${courseParticipation.name}`,
       })
     }
 
@@ -151,25 +151,25 @@ export default class CourseParticipationUtils {
       card: {
         actions,
         title: {
-          text: courseParticipationWithName.name,
+          text: courseParticipation.name,
         },
       },
-      rows: CourseParticipationUtils.summaryListRows(courseParticipationWithName),
+      rows: CourseParticipationUtils.summaryListRows(courseParticipation),
     }
   }
 
   private static summaryListRows(
-    courseParticipationWithName: CourseParticipationWithName,
+    courseParticipation: CourseParticipationPresenter,
   ): Array<GovukFrontendSummaryListRowWithValue> {
     return [
-      CourseParticipationUtils.summaryListRow('Programme name', [courseParticipationWithName.name]),
-      CourseParticipationUtils.summaryListRowSetting(courseParticipationWithName.setting),
-      CourseParticipationUtils.summaryListRowOutcome(courseParticipationWithName.outcome),
-      CourseParticipationUtils.summaryListRow('Additional detail', [courseParticipationWithName.detail]),
-      CourseParticipationUtils.summaryListRow('Source of information', [courseParticipationWithName.source]),
+      CourseParticipationUtils.summaryListRow('Programme name', [courseParticipation.name]),
+      CourseParticipationUtils.summaryListRowSetting(courseParticipation.setting),
+      CourseParticipationUtils.summaryListRowOutcome(courseParticipation.outcome),
+      CourseParticipationUtils.summaryListRow('Additional detail', [courseParticipation.detail]),
+      CourseParticipationUtils.summaryListRow('Source of information', [courseParticipation.source]),
       CourseParticipationUtils.summaryListRow('Added by', [
-        courseParticipationWithName.addedBy,
-        DateUtils.govukFormattedFullDateString(courseParticipationWithName.createdAt),
+        courseParticipation.addedByName,
+        DateUtils.govukFormattedFullDateString(courseParticipation.createdAt),
       ]),
     ]
   }


### PR DESCRIPTION
## Context

We want to display the name of the user who has added a programme history record.

## Changes in this PR
Added `getUserFromUsername` to `UserService` with error handling. This is then called in the referral and course participation controller to get the user details of each user.

Added a `userFactory` to help with testing.

Added `CourseParticipationPresenter` UI type which replaces `CourseParticipationWithName`.


## Screenshots of UI changes

### Before
![image](https://github.com/ministryofjustice/hmpps-accredited-programmes-ui/assets/1067537/e3633a7b-a333-485e-aa8d-781c6d1c859f)


### After
![image](https://github.com/ministryofjustice/hmpps-accredited-programmes-ui/assets/1067537/f1b4c409-157f-4e4e-88e6-69d796584b20)



## Release checklist

[Release process documentation](../doc/how-to/perform-a-release.md)

As part of our continuous deployment strategy we must ensure that this work is
ready to be released once merged.

### Pre-merge

- [ ] There are changes required to the Accredited Programmes API for this change to work...
  - [ ] ... and they have been released to production already

### Post-merge

<!-- The outer checkboxes can be completed pre-merge -->

- [ ] This adds, extends or meaningfully modifies a feature...
  - [ ] ... and I have written or updated an end-to-end test for the happy path in the [Accredited Programmes E2E repo](https://github.com/ministryofjustice/hmpps-accredited-programmes-e2e)
- [ ] This makes new expectations of the API...
  - [ ] ... and I have notified the API developer(s) of changes to the contract tests (Pact), or the API is already compliant
- [ ] [Manually approve](../doc/how-to/perform-a-release.md#releasing-to-the-preprod-environment) release to preprod
- [ ] [Manually approve](../doc/how-to/perform-a-release.md#releasing-to-the-production-environment) release to prod

<!-- Should a release fail at any step, you as the author should now lead the work to
fix it as soon as possible. You can monitor deployment failures in CircleCI
itself and application errors are found in
[Sentry](https://ministryofjustice.sentry.io/projects/hmpps-accredited-programmes-ui/?project=4505330122686464&referrer=sidebar&statsPeriod=24h). -->
