### PR TITLE
(975) Additional year validation

### DIFF
--- a/integration_tests/e2e/refer/programmeHistory.cy.ts
+++ b/integration_tests/e2e/refer/programmeHistory.cy.ts
@@ -421,7 +421,7 @@ context('Programme history', () => {
         programmeHistoryPage.shouldContainSuccessMessage('You have successfully added a programme.')
       })
 
-      it('displays an error when inputting a non numeric value for `yearCompleted`', () => {
+      it('displays an error when `yearCompleted` is invalid', () => {
         cy.task('stubParticipation', newCourseParticipation)
 
         cy.visit(newCourseParticipationPath)
@@ -448,7 +448,7 @@ context('Programme history', () => {
         ])
       })
 
-      it('displays an error when inputting a non numeric value for `yearStarted`', () => {
+      it('displays an error when `yearStarted` is invalid', () => {
         cy.task('stubParticipation', newCourseParticipation)
 
         cy.visit(newCourseParticipationPath)

--- a/server/utils/courseParticipationUtils.test.ts
+++ b/server/utils/courseParticipationUtils.test.ts
@@ -133,7 +133,7 @@ describe('CourseParticipationUtils', () => {
         ;(expectedCourseParticipationUpdate.outcome as CourseParticipationOutcome).yearCompleted = undefined
       })
 
-      describe('and `request.body.outcome.yearCompleted` is a valid `string` value', () => {
+      describe('and `request.body.outcome.yearStarted` is a valid `string` value', () => {
         it('returns `courseParticipationUpdate.outcome.yearStarted` as `number` and reports no errors', () => {
           request.body.outcome.yearStarted = '2019'
           ;(expectedCourseParticipationUpdate.outcome as CourseParticipationOutcome).yearStarted = 2019

--- a/server/utils/courseParticipationUtils.test.ts
+++ b/server/utils/courseParticipationUtils.test.ts
@@ -30,6 +30,7 @@ describe('CourseParticipationUtils', () => {
     let request: DeepMocked<RequestWithCourseParticipationDetailsBody>
     let expectedCourseParticipationUpdate: CourseParticipationUpdate
     const courseName = 'A course name'
+    const currentYear = new Date().getFullYear()
 
     beforeEach(() => {
       request = createMock<RequestWithCourseParticipationDetailsBody>({})
@@ -99,9 +100,9 @@ describe('CourseParticipationUtils', () => {
     })
 
     describe('when `request.body.outcome.status` is `complete`', () => {
-      describe('and `request.body.outcome.yearCompleted` is an empty string', () => {
+      describe('and `request.body.outcome.yearCompleted` is an empty string when trimmed', () => {
         it('returns `courseParticipationUpdate.outcome.yearCompleted` as undefined and reports no errors', () => {
-          request.body.outcome.yearCompleted = ''
+          request.body.outcome.yearCompleted = '  '
           ;(expectedCourseParticipationUpdate.outcome as CourseParticipationOutcome).yearCompleted = undefined
 
           expect(CourseParticipationUtils.processDetailsFormData(request, courseName)).toEqual({
@@ -121,6 +122,57 @@ describe('CourseParticipationUtils', () => {
             hasFormErrors: true,
           })
           expect(request.flash).toHaveBeenCalledWith('yearCompletedError', 'Enter a year using numbers only')
+          expect(request.flash).toHaveBeenCalledWith('formValues', JSON.stringify(request.body))
+        })
+      })
+
+      describe('and `request.body.outcome.yearCompleted` is not four digits long', () => {
+        it('flashes an appropriate error message, reports an error and returns `courseParticipationUpdate.outcome.yearCompleted` as undefined', () => {
+          request.body.outcome.yearCompleted = '202'
+          ;(expectedCourseParticipationUpdate.outcome as CourseParticipationOutcome).yearCompleted = undefined
+
+          expect(CourseParticipationUtils.processDetailsFormData(request, courseName)).toEqual({
+            courseParticipationUpdate: expectedCourseParticipationUpdate,
+            hasFormErrors: true,
+          })
+          expect(request.flash).toHaveBeenCalledWith(
+            'yearCompletedError',
+            'Enter a year using 4 digits only. For example, 1994',
+          )
+          expect(request.flash).toHaveBeenCalledWith('formValues', JSON.stringify(request.body))
+        })
+      })
+
+      describe('and `request.body.outcome.yearCompleted` is less than 1990', () => {
+        it('flashes an appropriate error message, reports an error and returns `courseParticipationUpdate.outcome.yearCompleted` as undefined', () => {
+          request.body.outcome.yearCompleted = '1989'
+          ;(expectedCourseParticipationUpdate.outcome as CourseParticipationOutcome).yearCompleted = undefined
+
+          expect(CourseParticipationUtils.processDetailsFormData(request, courseName)).toEqual({
+            courseParticipationUpdate: expectedCourseParticipationUpdate,
+            hasFormErrors: true,
+          })
+          expect(request.flash).toHaveBeenCalledWith(
+            'yearCompletedError',
+            `Enter a year between 1990 and ${currentYear}`,
+          )
+          expect(request.flash).toHaveBeenCalledWith('formValues', JSON.stringify(request.body))
+        })
+      })
+
+      describe('and `request.body.outcome.yearCompleted` is in the future', () => {
+        it('flashes an appropriate error message, reports an error and returns `courseParticipationUpdate.outcome.yearCompleted` as undefined', () => {
+          request.body.outcome.yearCompleted = (currentYear + 1).toString()
+          ;(expectedCourseParticipationUpdate.outcome as CourseParticipationOutcome).yearCompleted = undefined
+
+          expect(CourseParticipationUtils.processDetailsFormData(request, courseName)).toEqual({
+            courseParticipationUpdate: expectedCourseParticipationUpdate,
+            hasFormErrors: true,
+          })
+          expect(request.flash).toHaveBeenCalledWith(
+            'yearCompletedError',
+            `Enter a year between 1990 and ${currentYear}`,
+          )
           expect(request.flash).toHaveBeenCalledWith('formValues', JSON.stringify(request.body))
         })
       })
@@ -145,9 +197,9 @@ describe('CourseParticipationUtils', () => {
         })
       })
 
-      describe('and `request.body.outcome.yearStarted` is an empty string', () => {
+      describe('and `request.body.outcome.yearStarted` is an empty string when trimmed', () => {
         it('returns `courseParticipationUpdate.outcome.yearStarted` as undefined and reports no errors', () => {
-          request.body.outcome.yearStarted = ''
+          request.body.outcome.yearStarted = '  '
           ;(expectedCourseParticipationUpdate.outcome as CourseParticipationOutcome).yearStarted = undefined
 
           expect(CourseParticipationUtils.processDetailsFormData(request, courseName)).toEqual({
@@ -167,6 +219,51 @@ describe('CourseParticipationUtils', () => {
             hasFormErrors: true,
           })
           expect(request.flash).toHaveBeenCalledWith('yearStartedError', 'Enter a year using numbers only')
+          expect(request.flash).toHaveBeenCalledWith('formValues', JSON.stringify(request.body))
+        })
+      })
+
+      describe('and `request.body.outcome.yearStarted` is not four digits long', () => {
+        it('flashes an appropriate error message, reports an error and returns `courseParticipationUpdate.outcome.yearStarted` as undefined', () => {
+          request.body.outcome.yearStarted = '202'
+          ;(expectedCourseParticipationUpdate.outcome as CourseParticipationOutcome).yearStarted = undefined
+
+          expect(CourseParticipationUtils.processDetailsFormData(request, courseName)).toEqual({
+            courseParticipationUpdate: expectedCourseParticipationUpdate,
+            hasFormErrors: true,
+          })
+          expect(request.flash).toHaveBeenCalledWith(
+            'yearStartedError',
+            'Enter a year using 4 digits only. For example, 1994',
+          )
+          expect(request.flash).toHaveBeenCalledWith('formValues', JSON.stringify(request.body))
+        })
+      })
+
+      describe('and `request.body.outcome.yearStarted` is less than 1990', () => {
+        it('flashes an appropriate error message, reports an error and returns `courseParticipationUpdate.outcome.yearStarted` as undefined', () => {
+          request.body.outcome.yearStarted = '1989'
+          ;(expectedCourseParticipationUpdate.outcome as CourseParticipationOutcome).yearStarted = undefined
+
+          expect(CourseParticipationUtils.processDetailsFormData(request, courseName)).toEqual({
+            courseParticipationUpdate: expectedCourseParticipationUpdate,
+            hasFormErrors: true,
+          })
+          expect(request.flash).toHaveBeenCalledWith('yearStartedError', `Enter a year between 1990 and ${currentYear}`)
+          expect(request.flash).toHaveBeenCalledWith('formValues', JSON.stringify(request.body))
+        })
+      })
+
+      describe('and `request.body.outcome.yearStarted` is in the future', () => {
+        it('flashes an appropriate error message, reports an error and returns `courseParticipationUpdate.outcome.yearStarted` as undefined', () => {
+          request.body.outcome.yearStarted = (currentYear + 1).toString()
+          ;(expectedCourseParticipationUpdate.outcome as CourseParticipationOutcome).yearStarted = undefined
+
+          expect(CourseParticipationUtils.processDetailsFormData(request, courseName)).toEqual({
+            courseParticipationUpdate: expectedCourseParticipationUpdate,
+            hasFormErrors: true,
+          })
+          expect(request.flash).toHaveBeenCalledWith('yearStartedError', `Enter a year between 1990 and ${currentYear}`)
           expect(request.flash).toHaveBeenCalledWith('formValues', JSON.stringify(request.body))
         })
       })


### PR DESCRIPTION
## Context

<!-- Is there a Trello ticket you can link to? -->
<!-- Do you need to add any environment variables? -->
<!-- Is an ADR required? An ADR should be added if this PR introduces a change to the architecture. -->

We already validate that course participation years are a number

## Changes in this PR

- Validate that course participations are four digits long, no earlier than 1990 and no later than the current year

## Release checklist

[Release process documentation](../doc/how-to/perform-a-release.md)

As part of our continuous deployment strategy we must ensure that this work is
ready to be released once merged.

### Pre-merge

- [ ] There are changes required to the Accredited Programmes API for this change to work...
  - [ ] ... and they have been released to production already

### Post-merge

<!-- The outer checkboxes can be completed pre-merge -->

- [ ] This adds, extends or meaningfully modifies a feature...
  - [ ] ... and I have written or updated an end-to-end test for the happy path in the [Accredited Programmes E2E repo](https://github.com/ministryofjustice/hmpps-accredited-programmes-e2e)
- [ ] This makes new expectations of the API...
  - [ ] ... and I have notified the API developer(s) of changes to the contract tests (Pact), or the API is already compliant
- [ ] [Manually approve](../doc/how-to/perform-a-release.md#releasing-to-the-preprod-environment) release to preprod
- [ ] [Manually approve](../doc/how-to/perform-a-release.md#releasing-to-the-production-environment) release to prod

<!-- Should a release fail at any step, you as the author should now lead the work to
fix it as soon as possible. You can monitor deployment failures in CircleCI
itself and application errors are found in
[Sentry](https://ministryofjustice.sentry.io/projects/hmpps-accredited-programmes-ui/?project=4505330122686464&referrer=sidebar&statsPeriod=24h). -->
