### PR TITLE
(968b) Add `getUserFromUsername` to `UserService`

### DIFF
--- a/integration_tests/e2e/refer/submit.cy.ts
+++ b/integration_tests/e2e/refer/submit.cy.ts
@@ -95,7 +95,7 @@ context('Submitting a referral', () => {
         participations: courseParticipations,
         person,
         referral: submittableReferral,
-        username: auth.mockedUsername(),
+        username: auth.mockedUser.username,
       })
       checkAnswersPage.shouldHavePersonDetails(person)
       checkAnswersPage.shouldContainNavigation(path)
@@ -126,7 +126,7 @@ context('Submitting a referral', () => {
           participations: [],
           person,
           referral: submittableReferral,
-          username: auth.mockedUsername(),
+          username: auth.mockedUser.username,
         })
         checkAnswersPage.shouldNotHaveProgrammeHistory()
       })
@@ -153,7 +153,7 @@ context('Submitting a referral', () => {
         participations: courseParticipations,
         person,
         referral: submittableReferral,
-        username: auth.mockedUsername(),
+        username: auth.mockedUser.username,
       })
       checkAnswersPage.confirmDetailsAndSubmitReferral(submittableReferral)
 
@@ -174,7 +174,7 @@ context('Submitting a referral', () => {
         participations: courseParticipations,
         person,
         referral: submittableReferral,
-        username: auth.mockedUsername(),
+        username: auth.mockedUser.username,
       })
       checkAnswersPage.shouldContainButton('Submit referral').click()
 
@@ -185,7 +185,7 @@ context('Submitting a referral', () => {
         participations: courseParticipations,
         person,
         referral: submittableReferral,
-        username: auth.mockedUsername(),
+        username: auth.mockedUser.username,
       })
       checkAnswersPageWithErrors.shouldHaveErrors([
         {

--- a/integration_tests/mockApis/auth.ts
+++ b/integration_tests/mockApis/auth.ts
@@ -4,11 +4,10 @@ import type { Response } from 'superagent'
 import manageUserStubs from './manageUsers'
 import tokenVerification from './tokenVerification'
 import type { ApplicationRoles } from '../../server/middleware/roleBasedAccessMiddleware'
+import { userFactory } from '../../server/testutils/factories'
 import { getMatchingRequests, stubFor } from '../../wiremock'
 
-const mockedUsername = () => {
-  return 'USER1'
-}
+const mockedUser = userFactory.build({ name: 'john smith', username: 'USER1' })
 
 const createToken = ({ authorities = [] }: { authorities?: Array<ApplicationRoles> }) => {
   const payload = {
@@ -17,7 +16,7 @@ const createToken = ({ authorities = [] }: { authorities?: Array<ApplicationRole
     client_id: 'clientid',
     jti: '83b50a10-cca6-41db-985f-e87efb303ddb',
     scope: ['read'],
-    user_name: mockedUsername(),
+    user_name: mockedUser.username,
   }
 
   return jwt.sign(payload, 'secret', { expiresIn: '1h' })
@@ -118,7 +117,7 @@ const token = ({ authorities }: { authorities?: Array<ApplicationRoles> }) =>
         internalUser: true,
         scope: 'read',
         token_type: 'bearer',
-        user_name: mockedUsername(),
+        user_name: mockedUser.username,
       },
       status: 200,
     },
@@ -126,12 +125,12 @@ const token = ({ authorities }: { authorities?: Array<ApplicationRoles> }) =>
 
 export default {
   getSignInUrl,
-  mockedUsername,
+  mockedUser,
   stubAuthPing: ping,
   stubAuthUser: (name = 'john smith'): Promise<[Response, Response]> =>
     Promise.all([
-      manageUserStubs.stubCurrentUser(mockedUsername()),
-      manageUserStubs.stubUserDetails({ name, username: mockedUsername() }),
+      manageUserStubs.stubCurrentUser(mockedUser.username),
+      manageUserStubs.stubUserDetails(userFactory.build({ ...mockedUser, name })),
     ]),
   stubSignIn: (
     args = {

--- a/integration_tests/mockApis/manageUsers.ts
+++ b/integration_tests/mockApis/manageUsers.ts
@@ -21,23 +21,17 @@ export default {
       },
     }),
 
-  stubUserDetails: (args: { name: User['name']; username: User['username'] }): SuperAgentRequest =>
+  stubUserDetails: (user: User): SuperAgentRequest =>
     stubFor({
       request: {
         method: 'GET',
-        urlPattern: `/users/${args.username}`,
+        urlPattern: `/users/${user.username}`,
       },
       response: {
         headers: {
           'Content-Type': 'application/json;charset=UTF-8',
         },
-        jsonBody: {
-          active: true,
-          authSource: 'auth',
-          name: args.name,
-          userId: '1234',
-          username: args.username,
-        },
+        jsonBody: user,
         status: 200,
       },
     }),

--- a/server/data/hmppsManageUsersClient.ts
+++ b/server/data/hmppsManageUsersClient.ts
@@ -1,5 +1,4 @@
 import RestClient from './restClient'
-import logger from '../../logger'
 import config from '../config'
 import type { User } from '@manage-users-api'
 
@@ -11,12 +10,10 @@ export default class HmppsManageUsersClient {
   }
 
   getCurrentUsername(): Promise<Pick<User, 'username'>> {
-    logger.info(`Getting username: calling HMPPS Manage Users`)
     return this.restClient.get({ path: '/users/me' }) as Promise<Pick<User, 'username'>>
   }
 
   getUserFromUsername(username: User['username']): Promise<User> {
-    logger.info(`Getting user details: calling HMPPS Manage Users`)
     return this.restClient.get({ path: `/users/${username}` }) as Promise<User>
   }
 }

--- a/server/services/userService.test.ts
+++ b/server/services/userService.test.ts
@@ -1,7 +1,9 @@
+import createError from 'http-errors'
+
 import UserService from './userService'
 import logger from '../../logger'
 import { CaseloadClient, HmppsManageUsersClient } from '../data'
-import { caseloadFactory } from '../testutils/factories'
+import { caseloadFactory, userFactory } from '../testutils/factories'
 
 jest.mock('../data/hmppsManageUsersClient')
 jest.mock('../data/caseloadClient')
@@ -18,6 +20,9 @@ describe('UserService', () => {
 
   let userService: UserService
 
+  const username = 'JOHN_SMITH'
+  const user = userFactory.build({ name: 'john smith', username })
+
   beforeEach(() => {
     jest.resetAllMocks()
 
@@ -28,16 +33,9 @@ describe('UserService', () => {
   })
 
   describe('getCurrentUserWithDetails', () => {
-    const username = 'JOHN_SMITH'
     beforeEach(() => {
       hmppsManageUsersClient.getCurrentUsername.mockResolvedValue({ username })
-      hmppsManageUsersClient.getUserFromUsername.mockResolvedValue({
-        active: true,
-        authSource: 'nomis',
-        name: 'john smith',
-        userId: 'user-id',
-        username,
-      })
+      hmppsManageUsersClient.getUserFromUsername.mockResolvedValue(user)
     })
 
     it('retrieves user and formats name', async () => {
@@ -71,6 +69,46 @@ describe('UserService', () => {
         const result = await userService.getCurrentUserWithDetails(token)
         expect(logger.error).toHaveBeenCalledWith(caseloadError, "Failed to fetch user's caseloads")
         expect(result.caseloads).toEqual([])
+      })
+    })
+  })
+
+  describe('getUserFromUsername', () => {
+    beforeEach(() => {
+      hmppsManageUsersClient.getUserFromUsername.mockResolvedValue(user)
+    })
+
+    it('returns the requested user', async () => {
+      const result = await userService.getUserFromUsername(token, username)
+
+      expect(result).toEqual(user)
+      expect(hmppsManageUsersClientBuilder).toHaveBeenCalledWith(token)
+      expect(hmppsManageUsersClient.getUserFromUsername).toHaveBeenCalledWith(username)
+    })
+
+    describe('when the HMPPS Manage Users client throws a 404 error', () => {
+      it('re-throws the error', async () => {
+        const clientError = createError(404)
+        hmppsManageUsersClient.getUserFromUsername.mockRejectedValue(clientError)
+
+        const expectedError = createError(404, `User with username ${username} not found.`)
+        await expect(userService.getUserFromUsername(token, username)).rejects.toEqual(expectedError)
+
+        expect(hmppsManageUsersClientBuilder).toHaveBeenCalledWith(token)
+        expect(hmppsManageUsersClient.getUserFromUsername).toHaveBeenCalledWith(username)
+      })
+    })
+
+    describe('when the HMPPS Manage Users client throws any other error', () => {
+      it('re-throws the error', async () => {
+        const clientError = createError(500)
+        hmppsManageUsersClient.getUserFromUsername.mockRejectedValue(clientError)
+
+        const expectedError = createError(500, `Error fetching user ${username}.`)
+        await expect(userService.getUserFromUsername(token, username)).rejects.toEqual(expectedError)
+
+        expect(hmppsManageUsersClientBuilder).toHaveBeenCalledWith(token)
+        expect(hmppsManageUsersClient.getUserFromUsername).toHaveBeenCalledWith(username)
       })
     })
   })

--- a/server/services/userService.ts
+++ b/server/services/userService.ts
@@ -18,10 +18,7 @@ export default class UserService {
     const hmppsManageUsersClient = this.hmppsManageUsersClientBuilder(token)
     const { username } = await hmppsManageUsersClient.getCurrentUsername()
 
-    const [user, caseloads] = await Promise.all([
-      hmppsManageUsersClient.getUserFromUsername(username),
-      this.getCaseloads(token),
-    ])
+    const [user, caseloads] = await Promise.all([this.getUserFromUsername(token, username), this.getCaseloads(token)])
 
     return { ...user, caseloads, displayName: StringUtils.convertToTitleCase(user.name) }
   }

--- a/server/services/userService.ts
+++ b/server/services/userService.ts
@@ -1,7 +1,11 @@
+import createError from 'http-errors'
+import type { ResponseError } from 'superagent'
+
 import logger from '../../logger'
 import type { CaseloadClient, HmppsManageUsersClient, RestClientBuilder } from '../data'
 import { StringUtils } from '../utils'
 import type { UserDetails } from '@accredited-programmes/users'
+import type { User } from '@manage-users-api'
 import type { Caseload } from '@prison-api'
 
 export default class UserService {
@@ -20,6 +24,25 @@ export default class UserService {
     ])
 
     return { ...user, caseloads, displayName: StringUtils.convertToTitleCase(user.name) }
+  }
+
+  async getUserFromUsername(token: Express.User['token'], username: User['username']): Promise<User> {
+    const hmppsManageUsersClient = this.hmppsManageUsersClientBuilder(token)
+
+    try {
+      return await hmppsManageUsersClient.getUserFromUsername(username)
+    } catch (error) {
+      const knownError = error as ResponseError
+
+      if (knownError.status === 404) {
+        throw createError(knownError.status, `User with username ${username} not found.`)
+      }
+
+      const errorMessage =
+        knownError.message === 'Internal Server Error' ? `Error fetching user ${username}.` : knownError.message
+
+      throw createError(knownError.status || 500, errorMessage)
+    }
   }
 
   private async getCaseloads(token: Express.User['token']): Promise<Array<Caseload>> {

--- a/server/testutils/factories/index.ts
+++ b/server/testutils/factories/index.ts
@@ -11,6 +11,7 @@ import prisonFactory from './prison'
 import prisonAddressFactory from './prisonAddress'
 import prisonerFactory from './prisoner'
 import referralFactory from './referral'
+import userFactory from './user'
 
 export {
   caseloadFactory,
@@ -26,4 +27,5 @@ export {
   prisonFactory,
   prisonerFactory,
   referralFactory,
+  userFactory,
 }

--- a/server/testutils/factories/user.ts
+++ b/server/testutils/factories/user.ts
@@ -1,0 +1,21 @@
+import { faker } from '@faker-js/faker/locale/en_GB'
+import { Factory } from 'fishery'
+
+import type { User } from '@manage-users-api'
+
+export default Factory.define<User>(() => {
+  const userId = faker.string.uuid()
+  const firstName = faker.person.firstName()
+  const lastName = faker.person.lastName()
+
+  return {
+    active: true,
+    activeCaseLoadId: faker.string.alpha({ casing: 'upper', length: 3 }),
+    authSource: 'nomis',
+    name: `${firstName} ${lastName}`,
+    staffId: faker.number.int(),
+    userId,
+    username: faker.internet.userName({ firstName, lastName }),
+    uuid: userId,
+  }
+})


### PR DESCRIPTION
## Context

Will be used in the first instance to display the name of the user who added a programme history/course participation record.

## Changes in this PR

- Added `UserService.getUserFromUsername` with error handling.
- Also added `userFactory` to help with testing
- Updated auth and user stubs for integration tests to use `userFactory`


## Release checklist

[Release process documentation](../doc/how-to/perform-a-release.md)

As part of our continuous deployment strategy we must ensure that this work is
ready to be released once merged.

### Pre-merge

- [ ] There are changes required to the Accredited Programmes API for this change to work...
  - [ ] ... and they have been released to production already

### Post-merge

<!-- The outer checkboxes can be completed pre-merge -->

- [ ] This adds, extends or meaningfully modifies a feature...
  - [ ] ... and I have written or updated an end-to-end test for the happy path in the [Accredited Programmes E2E repo](https://github.com/ministryofjustice/hmpps-accredited-programmes-e2e)
- [ ] This makes new expectations of the API...
  - [ ] ... and I have notified the API developer(s) of changes to the contract tests (Pact), or the API is already compliant
- [ ] [Manually approve](../doc/how-to/perform-a-release.md#releasing-to-the-preprod-environment) release to preprod
- [ ] [Manually approve](../doc/how-to/perform-a-release.md#releasing-to-the-production-environment) release to prod

<!-- Should a release fail at any step, you as the author should now lead the work to
fix it as soon as possible. You can monitor deployment failures in CircleCI
itself and application errors are found in
[Sentry](https://ministryofjustice.sentry.io/projects/hmpps-accredited-programmes-ui/?project=4505330122686464&referrer=sidebar&statsPeriod=24h). -->
