### PR TITLE
(968c) Show users name instead of username on programme history entries

### DIFF
--- a/integration_tests/e2e/refer/submit.cy.ts
+++ b/integration_tests/e2e/refer/submit.cy.ts
@@ -8,11 +8,13 @@ import {
   prisonFactory,
   prisonerFactory,
   referralFactory,
+  userFactory,
 } from '../../../server/testutils/factories'
-import { OrganisationUtils } from '../../../server/utils'
+import { OrganisationUtils, StringUtils } from '../../../server/utils'
 import auth from '../../mockApis/auth'
 import Page from '../../pages/page'
 import { CheckAnswersPage, CompletePage, TaskListPage } from '../../pages/refer'
+import type { CourseParticipationPresenter } from '@accredited-programmes/ui'
 
 context('Submitting a referral', () => {
   const course = courseFactory.build()
@@ -34,15 +36,31 @@ context('Submitting a referral', () => {
   })
   const prison = prisonFactory.build({ prisonId: courseOffering.organisationId })
   const organisation = OrganisationUtils.organisationFromPrison(prison)
+  const addedByUser1 = userFactory.build()
+  const addedByUser2 = userFactory.build()
   const courseParticipationWithKnownCourseName = courseParticipationFactory.build({
+    addedBy: addedByUser1.username,
     courseName: course.name,
     prisonNumber: person.prisonNumber,
   })
+  const courseParticipationWithKnownCourseNamePresenter: CourseParticipationPresenter = {
+    ...courseParticipationWithKnownCourseName,
+    addedByDisplayName: StringUtils.convertToTitleCase(addedByUser1.name),
+  }
   const courseParticipationWithUnknownCourseName = courseParticipationFactory.build({
+    addedBy: addedByUser2.username,
     courseName: 'An course not in our system',
     prisonNumber: person.prisonNumber,
   })
+  const courseParticipationWithUnknownCourseNamePresenter: CourseParticipationPresenter = {
+    ...courseParticipationWithUnknownCourseName,
+    addedByDisplayName: StringUtils.convertToTitleCase(addedByUser2.name),
+  }
   const courseParticipations = [courseParticipationWithKnownCourseName, courseParticipationWithUnknownCourseName]
+  const courseParticipationsPresenter: Array<CourseParticipationPresenter> = [
+    courseParticipationWithKnownCourseNamePresenter,
+    courseParticipationWithUnknownCourseNamePresenter,
+  ]
   const submittableReferral = referralFactory
     .submittable()
     .build({ offeringId: courseOffering.id, prisonNumber: person.prisonNumber })
@@ -58,6 +76,8 @@ context('Submitting a referral', () => {
     cy.task('stubOffering', { courseId: course.id, courseOffering })
     cy.task('stubPrison', prison)
     cy.task('stubPrisoner', prisoner)
+    cy.task('stubUserDetails', addedByUser1)
+    cy.task('stubUserDetails', addedByUser2)
   })
 
   it('Links to the check answers page when the referral is ready for submission', () => {
@@ -92,7 +112,7 @@ context('Submitting a referral', () => {
         course,
         courseOffering,
         organisation,
-        participations: courseParticipations,
+        participations: courseParticipationsPresenter,
         person,
         referral: submittableReferral,
         username: auth.mockedUser.username,
@@ -150,7 +170,7 @@ context('Submitting a referral', () => {
         course,
         courseOffering,
         organisation,
-        participations: courseParticipations,
+        participations: courseParticipationsPresenter,
         person,
         referral: submittableReferral,
         username: auth.mockedUser.username,
@@ -171,7 +191,7 @@ context('Submitting a referral', () => {
         course,
         courseOffering,
         organisation,
-        participations: courseParticipations,
+        participations: courseParticipationsPresenter,
         person,
         referral: submittableReferral,
         username: auth.mockedUser.username,
@@ -182,7 +202,7 @@ context('Submitting a referral', () => {
         course,
         courseOffering,
         organisation,
-        participations: courseParticipations,
+        participations: courseParticipationsPresenter,
         person,
         referral: submittableReferral,
         username: auth.mockedUser.username,

--- a/integration_tests/pages/page.ts
+++ b/integration_tests/pages/page.ts
@@ -5,6 +5,7 @@ import { CourseParticipationUtils, PersonUtils } from '../../server/utils'
 import Helpers from '../support/helpers'
 import type { CourseParticipation, Organisation, Person, Referral } from '@accredited-programmes/models'
 import type {
+  CourseParticipationPresenter,
   CoursePresenter,
   GovukFrontendRadiosItemWithLabel,
   GovukFrontendSummaryListCardActionsItemWithText,
@@ -87,7 +88,7 @@ export default abstract class Page {
   }
 
   shouldContainHistorySummaryCards(
-    participations: Array<CourseParticipation>,
+    participations: Array<CourseParticipationPresenter>,
     referralId: Referral['id'],
     withActions = { change: true, remove: true },
   ) {

--- a/integration_tests/pages/refer/checkAnswers.ts
+++ b/integration_tests/pages/refer/checkAnswers.ts
@@ -1,14 +1,7 @@
 import { CourseUtils, ReferralUtils } from '../../../server/utils'
 import Page from '../page'
-import type {
-  Course,
-  CourseOffering,
-  CourseParticipation,
-  Organisation,
-  Person,
-  Referral,
-} from '@accredited-programmes/models'
-import type { CoursePresenter } from '@accredited-programmes/ui'
+import type { Course, CourseOffering, Organisation, Person, Referral } from '@accredited-programmes/models'
+import type { CourseParticipationPresenter, CoursePresenter } from '@accredited-programmes/ui'
 
 export default class CheckAnswersPage extends Page {
   course: CoursePresenter
@@ -17,7 +10,7 @@ export default class CheckAnswersPage extends Page {
 
   organisation: Organisation
 
-  participations: Array<CourseParticipation>
+  participations: Array<CourseParticipationPresenter>
 
   person: Person
 
@@ -29,7 +22,7 @@ export default class CheckAnswersPage extends Page {
     course: Course
     courseOffering: CourseOffering
     organisation: Organisation
-    participations: Array<CourseParticipation>
+    participations: Array<CourseParticipationPresenter>
     person: Person
     referral: Referral
     username: Express.User['username']

--- a/integration_tests/pages/refer/programmeHistory.ts
+++ b/integration_tests/pages/refer/programmeHistory.ts
@@ -1,14 +1,15 @@
 import Page from '../page'
-import type { CourseParticipation, Person, Referral } from '@accredited-programmes/models'
+import type { Person, Referral } from '@accredited-programmes/models'
+import type { CourseParticipationPresenter } from '@accredited-programmes/ui'
 
 export default class ProgrammeHistoryPage extends Page {
-  participations: Array<CourseParticipation>
+  participations: Array<CourseParticipationPresenter>
 
   person: Person
 
   referral: Referral
 
-  constructor(args: { participations: Array<CourseParticipation>; person: Person; referral: Referral }) {
+  constructor(args: { participations: Array<CourseParticipationPresenter>; person: Person; referral: Referral }) {
     super('Accredited Programme history')
 
     const { participations, person, referral } = args

--- a/server/@types/ui/index.d.ts
+++ b/server/@types/ui/index.d.ts
@@ -1,4 +1,4 @@
-import type { Course, CourseOffering, Organisation } from '@accredited-programmes/models'
+import type { Course, CourseOffering, CourseParticipation, Organisation } from '@accredited-programmes/models'
 import type {
   GovukFrontendRadiosItem,
   GovukFrontendSummaryList,
@@ -34,6 +34,10 @@ type HasHtmlString = {
 }
 
 type TagColour = 'blue' | 'green' | 'grey' | 'orange' | 'pink' | 'purple' | 'red' | 'turquoise' | 'yellow'
+
+type CourseParticipationPresenter = CourseParticipation & {
+  addedByDisplayName: string
+}
 
 type CoursePresenter = Course & {
   audienceTags: Array<GovukFrontendTagWithText>
@@ -88,6 +92,7 @@ type ReferralTaskListSection = {
 }
 
 export type {
+  CourseParticipationPresenter,
   CoursePresenter,
   GovukFrontendRadiosItemWithLabel,
   GovukFrontendSummaryListCardActionsItemWithText,

--- a/server/controllers/refer/referralsController.ts
+++ b/server/controllers/refer/referralsController.ts
@@ -35,10 +35,17 @@ export default class ReferralsController {
       const courseOffering = await this.courseService.getOffering(req.user.token, referral.offeringId)
       const organisation = await this.organisationService.getOrganisation(req.user.token, courseOffering.organisationId)
       const course = await this.courseService.getCourseByOffering(req.user.token, referral.offeringId)
+
       const sortedCourseParticipations = (
         await this.courseService.getParticipationsByPerson(req.user.token, person.prisonNumber)
       ).sort((participationA, participationB) => participationA.createdAt.localeCompare(participationB.createdAt))
-      const participationSummaryListsOptions = sortedCourseParticipations.map(participation =>
+
+      const courseParticipationsPresenter = await Promise.all(
+        sortedCourseParticipations.map(participation =>
+          this.courseService.presentCourseParticipation(req.user.token, participation),
+        ),
+      )
+      const participationSummaryListsOptions = courseParticipationsPresenter.map(participation =>
         CourseParticipationUtils.summaryListOptions(participation, referral.id, { change: true, remove: false }),
       )
       const coursePresenter = CourseUtils.presentCourse(course)

--- a/server/services/index.ts
+++ b/server/services/index.ts
@@ -17,11 +17,11 @@ import {
 } from '../data'
 
 const services = () => {
-  const courseService = new CourseService(courseClientBuilder)
   const organisationService = new OrganisationService(prisonClientBuilder)
   const personService = new PersonService(hmppsAuthClientBuilder, prisonerClientBuilder)
   const referralService = new ReferralService(referralClientBuilder)
   const userService = new UserService(hmppsManageUsersClientBuilder, caseloadClientBuilder)
+  const courseService = new CourseService(courseClientBuilder, userService)
 
   return {
     courseService,

--- a/server/testutils/factories/user.ts
+++ b/server/testutils/factories/user.ts
@@ -7,12 +7,13 @@ export default Factory.define<User>(() => {
   const userId = faker.string.uuid()
   const firstName = faker.person.firstName()
   const lastName = faker.person.lastName()
+  const name = `${firstName} ${lastName}`
 
   return {
     active: true,
     activeCaseLoadId: faker.string.alpha({ casing: 'upper', length: 3 }),
     authSource: 'nomis',
-    name: `${firstName} ${lastName}`,
+    name: faker.helpers.arrayElement([name, name.toLowerCase()]),
     staffId: faker.number.int(),
     userId,
     username: faker.internet.userName({ firstName, lastName }),

--- a/server/utils/courseParticipationUtils.test.ts
+++ b/server/utils/courseParticipationUtils.test.ts
@@ -7,11 +7,11 @@ import type { RequestWithCourseParticipationDetailsBody } from './courseParticip
 import CourseParticipationUtils from './courseParticipationUtils'
 import { courseParticipationFactory } from '../testutils/factories'
 import type {
-  CourseParticipation,
   CourseParticipationOutcome,
   CourseParticipationSetting,
   CourseParticipationUpdate,
 } from '@accredited-programmes/models'
+import type { CourseParticipationPresenter } from '@accredited-programmes/ui'
 import type {
   GovukFrontendSummaryListRow,
   GovukFrontendSummaryListRowKey,
@@ -404,9 +404,9 @@ describe('CourseParticipationUtils', () => {
 
   describe('summaryListOptions', () => {
     const referralId = faker.string.uuid()
-    const courseParticipation = {
+    const courseParticipationPresenter: CourseParticipationPresenter = {
       ...courseParticipationFactory.build({
-        addedBy: 'Eric McNally',
+        addedBy: 'ERIC_MCNALLY',
         courseName: 'A mediocre course name (aMCN)',
         createdAt: '2023-04-20T16:20:00.000Z',
         detail: 'Motivation level over 9000!',
@@ -421,23 +421,24 @@ describe('CourseParticipationUtils', () => {
         },
         source: 'Word of mouth',
       }),
+      addedByDisplayName: 'Eric McNally',
     }
 
     describe('when all fields are present on the CourseParticipation', () => {
       it('generates an object to pass into a Nunjucks macro for a GOV.UK summary list with card', () => {
-        expect(CourseParticipationUtils.summaryListOptions(courseParticipation, referralId)).toEqual({
+        expect(CourseParticipationUtils.summaryListOptions(courseParticipationPresenter, referralId)).toEqual({
           card: {
             actions: {
               items: [
                 {
-                  href: `/referrals/${referralId}/programme-history/${courseParticipation.id}/programme`,
+                  href: `/referrals/${referralId}/programme-history/${courseParticipationPresenter.id}/programme`,
                   text: 'Change',
-                  visuallyHiddenText: `participation for ${courseParticipation.courseName}`,
+                  visuallyHiddenText: `participation for ${courseParticipationPresenter.courseName}`,
                 },
                 {
-                  href: `/referrals/${referralId}/programme-history/${courseParticipation.id}/delete`,
+                  href: `/referrals/${referralId}/programme-history/${courseParticipationPresenter.id}/delete`,
                   text: 'Remove',
-                  visuallyHiddenText: `participation for ${courseParticipation.courseName}`,
+                  visuallyHiddenText: `participation for ${courseParticipationPresenter.courseName}`,
                 },
               ],
             },
@@ -482,7 +483,7 @@ describe('CourseParticipationUtils', () => {
     ])('when `withActions` is %s', (withActions, omits, actionText) => {
       it(`omits ${omits}`, () => {
         const summaryListOptions = CourseParticipationUtils.summaryListOptions(
-          courseParticipation,
+          courseParticipationPresenter,
           referralId,
           withActions,
         )
@@ -497,8 +498,8 @@ describe('CourseParticipationUtils', () => {
     describe('rows with optional values', () => {
       describe('setting', () => {
         describe('when the setting has no location', () => {
-          const withoutSettingLocation: CourseParticipation = {
-            ...courseParticipation,
+          const withoutSettingLocation: CourseParticipationPresenter = {
+            ...courseParticipationPresenter,
             setting: {
               location: undefined,
               type: 'community',
@@ -512,8 +513,8 @@ describe('CourseParticipationUtils', () => {
         })
 
         describe('when there is no setting', () => {
-          const withoutSetting: CourseParticipation = {
-            ...courseParticipation,
+          const withoutSetting: CourseParticipationPresenter = {
+            ...courseParticipationPresenter,
             setting: undefined,
           }
 
@@ -527,8 +528,8 @@ describe('CourseParticipationUtils', () => {
       describe('outcome', () => {
         describe('when the outcome is incomplete', () => {
           describe('and there is a yearStarted value', () => {
-            const withOutcomeYearStarted: CourseParticipation = {
-              ...courseParticipation,
+            const withOutcomeYearStarted: CourseParticipationPresenter = {
+              ...courseParticipationPresenter,
               outcome: { status: 'incomplete', yearStarted: 2019 },
             }
 
@@ -539,8 +540,8 @@ describe('CourseParticipationUtils', () => {
           })
 
           describe('and there is no yearStarted value', () => {
-            const withoutOutcomeYearStarted: CourseParticipation = {
-              ...courseParticipation,
+            const withoutOutcomeYearStarted: CourseParticipationPresenter = {
+              ...courseParticipationPresenter,
               outcome: { status: 'incomplete', yearStarted: undefined },
             }
 
@@ -553,8 +554,8 @@ describe('CourseParticipationUtils', () => {
 
         describe('when the outcome is complete', () => {
           describe('and there is a yearCompleted value', () => {
-            const withOutcomeYearCompleted: CourseParticipation = {
-              ...courseParticipation,
+            const withOutcomeYearCompleted: CourseParticipationPresenter = {
+              ...courseParticipationPresenter,
               outcome: { status: 'complete', yearCompleted: 2019 },
             }
 
@@ -565,8 +566,8 @@ describe('CourseParticipationUtils', () => {
           })
 
           describe('and there is no yearCompleted value', () => {
-            const withoutOutcomeYearCompleted: CourseParticipation = {
-              ...courseParticipation,
+            const withoutOutcomeYearCompleted: CourseParticipationPresenter = {
+              ...courseParticipationPresenter,
               outcome: { status: 'complete', yearCompleted: undefined },
             }
 
@@ -578,8 +579,8 @@ describe('CourseParticipationUtils', () => {
         })
 
         describe('when there is no outcome', () => {
-          const withoutOutcome: CourseParticipation = {
-            ...courseParticipation,
+          const withoutOutcome: CourseParticipationPresenter = {
+            ...courseParticipationPresenter,
             outcome: undefined,
           }
 
@@ -592,8 +593,8 @@ describe('CourseParticipationUtils', () => {
 
       describe('additional detail', () => {
         describe('when there is no additional detail set', () => {
-          const withoutOutcomeAdditionalDetail: CourseParticipation = {
-            ...courseParticipation,
+          const withoutOutcomeAdditionalDetail: CourseParticipationPresenter = {
+            ...courseParticipationPresenter,
             detail: undefined,
           }
 
@@ -606,8 +607,8 @@ describe('CourseParticipationUtils', () => {
 
       describe('source of information', () => {
         describe('when there is no source of information set', () => {
-          const withoutSource: CourseParticipation = {
-            ...courseParticipation,
+          const withoutSource: CourseParticipationPresenter = {
+            ...courseParticipationPresenter,
             source: undefined,
           }
 

--- a/server/utils/courseParticipationUtils.ts
+++ b/server/utils/courseParticipationUtils.ts
@@ -11,6 +11,7 @@ import type {
   Referral,
 } from '@accredited-programmes/models'
 import type {
+  CourseParticipationPresenter,
   GovukFrontendSummaryListCardActionsWithItems,
   GovukFrontendSummaryListRowWithValue,
   GovukFrontendSummaryListWithRowsWithValues,
@@ -109,7 +110,7 @@ export default class CourseParticipationUtils {
   }
 
   static summaryListOptions(
-    courseParticipation: CourseParticipation,
+    courseParticipation: CourseParticipationPresenter,
     referralId: Referral['id'],
     withActions = { change: true, remove: true },
   ): GovukFrontendSummaryListWithRowsWithValues {
@@ -149,7 +150,7 @@ export default class CourseParticipationUtils {
   }
 
   private static summaryListRows(
-    courseParticipation: CourseParticipation,
+    courseParticipation: CourseParticipationPresenter,
   ): Array<GovukFrontendSummaryListRowWithValue> {
     return [
       CourseParticipationUtils.summaryListRow('Programme name', [courseParticipation.courseName]),
@@ -158,7 +159,7 @@ export default class CourseParticipationUtils {
       CourseParticipationUtils.summaryListRow('Additional detail', [courseParticipation.detail]),
       CourseParticipationUtils.summaryListRow('Source of information', [courseParticipation.source]),
       CourseParticipationUtils.summaryListRow('Added by', [
-        courseParticipation.addedBy,
+        courseParticipation.addedByDisplayName,
         DateUtils.govukFormattedFullDateString(courseParticipation.createdAt),
       ]),
     ]


### PR DESCRIPTION
## Context

We want to display the name of the user who has added a programme history record.



## Changes in this PR
- Updated the User factory to return randomly formatted name to replicate what the manage-users-api might return.
- Add a new `presentCourseParticipation` method to `CourseService` which can be called from controllers where we need to return a formatted name for the `addedBy` user.


## Screenshots of UI changes

### Before
![image](https://github.com/ministryofjustice/hmpps-accredited-programmes-ui/assets/1067537/e3633a7b-a333-485e-aa8d-781c6d1c859f)


### After
![image](https://github.com/ministryofjustice/hmpps-accredited-programmes-ui/assets/1067537/d9a2cfa4-3e10-48cc-bd9a-222df20aa103)



## Release checklist

[Release process documentation](../doc/how-to/perform-a-release.md)

As part of our continuous deployment strategy we must ensure that this work is
ready to be released once merged.

### Pre-merge

- [ ] There are changes required to the Accredited Programmes API for this change to work...
  - [ ] ... and they have been released to production already

### Post-merge

<!-- The outer checkboxes can be completed pre-merge -->

- [ ] This adds, extends or meaningfully modifies a feature...
  - [ ] ... and I have written or updated an end-to-end test for the happy path in the [Accredited Programmes E2E repo](https://github.com/ministryofjustice/hmpps-accredited-programmes-e2e)
- [ ] This makes new expectations of the API...
  - [ ] ... and I have notified the API developer(s) of changes to the contract tests (Pact), or the API is already compliant
- [ ] [Manually approve](../doc/how-to/perform-a-release.md#releasing-to-the-preprod-environment) release to preprod
- [ ] [Manually approve](../doc/how-to/perform-a-release.md#releasing-to-the-production-environment) release to prod

<!-- Should a release fail at any step, you as the author should now lead the work to
fix it as soon as possible. You can monitor deployment failures in CircleCI
itself and application errors are found in
[Sentry](https://ministryofjustice.sentry.io/projects/hmpps-accredited-programmes-ui/?project=4505330122686464&referrer=sidebar&statsPeriod=24h). -->
