### PR TITLE
(956) Fix programme history success messages

### DIFF
--- a/integration_tests/e2e/refer/programmeHistory.cy.ts
+++ b/integration_tests/e2e/refer/programmeHistory.cy.ts
@@ -42,6 +42,7 @@ context('Programme history', () => {
   const courseOffering = courseOfferingFactory.build()
   const referral = referralFactory.started().build({ offeringId: courseOffering.id, prisonNumber: person.prisonNumber })
   const programmeHistoryPath = referPaths.programmeHistory.index({ referralId: referral.id })
+  const newParticipationPath = referPaths.programmeHistory.new({ referralId: referral.id })
 
   beforeEach(() => {
     cy.task('reset')
@@ -84,10 +85,7 @@ context('Programme history', () => {
         programmeHistoryPage.shouldContainPreHistoryParagraph()
         programmeHistoryPage.shouldContainHistorySummaryCards(courseParticipations, referral.id)
         programmeHistoryPage.shouldContainButton('Continue')
-        programmeHistoryPage.shouldContainButtonLink(
-          'Add another',
-          referPaths.programmeHistory.new({ referralId: referral.id }),
-        )
+        programmeHistoryPage.shouldContainButtonLink('Add another', newParticipationPath)
       })
 
       describe('and the programme history has been reviewed', () => {
@@ -142,10 +140,7 @@ context('Programme history', () => {
         programmeHistoryPage.shouldContainNoHistoryHeading()
         programmeHistoryPage.shouldContainNoHistoryParagraph()
         programmeHistoryPage.shouldContainButton('Continue')
-        programmeHistoryPage.shouldContainButtonLink(
-          'Add a programme',
-          referPaths.programmeHistory.new({ referralId: referral.id }),
-        )
+        programmeHistoryPage.shouldContainButtonLink('Add a programme', newParticipationPath)
       })
 
       describe('and the programme history has been reviewed', () => {
@@ -183,16 +178,14 @@ context('Programme history', () => {
       })
 
       describe('for a new entry', () => {
-        const path = referPaths.programmeHistory.new({ referralId: referral.id })
-
         beforeEach(() => {
-          cy.visit(path)
+          cy.visit(newParticipationPath)
         })
 
         it('shows the select programme page', () => {
           const selectProgrammePage = Page.verifyOnPage(SelectProgrammePage, { courses })
           selectProgrammePage.shouldHavePersonDetails(person)
-          selectProgrammePage.shouldContainNavigation(path)
+          selectProgrammePage.shouldContainNavigation(newParticipationPath)
           selectProgrammePage.shouldContainBackLink(referPaths.programmeHistory.index({ referralId: referral.id }))
           selectProgrammePage.shouldContainCourseOptions()
           selectProgrammePage.shouldNotDisplayOtherCourseInput()
@@ -498,7 +491,6 @@ context('Programme history', () => {
 
     describe('success messages', () => {
       const courseParticipations = [courseParticipationWithKnownCourseName]
-      const newParticipationPath = referPaths.programmeHistory.new({ referralId: referral.id })
       const addedSuccessMessage = 'You have successfully added a programme.'
       const updatedSuccessMessage = 'You have successfully updated a programme.'
 

--- a/integration_tests/e2e/refer/programmeHistory.cy.ts
+++ b/integration_tests/e2e/refer/programmeHistory.cy.ts
@@ -296,7 +296,7 @@ context('Programme history', () => {
           selectProgrammePage.submitSelection(courseParticipationWithKnownCourseName, newCourseName)
 
           Page.verifyOnPage(ProgrammeHistoryDetailsPage, {
-            course: courses[0],
+            course: courses[2],
             courseParticipation: updatedParticipation,
             person,
           })

--- a/integration_tests/e2e/refer/programmeHistory.cy.ts
+++ b/integration_tests/e2e/refer/programmeHistory.cy.ts
@@ -41,6 +41,7 @@ context('Programme history', () => {
   })
   const courseOffering = courseOfferingFactory.build()
   const referral = referralFactory.started().build({ offeringId: courseOffering.id, prisonNumber: person.prisonNumber })
+  const programmeHistoryPath = referPaths.programmeHistory.index({ referralId: referral.id })
 
   beforeEach(() => {
     cy.task('reset')
@@ -59,8 +60,6 @@ context('Programme history', () => {
 
     const courseParticipations = [courseParticipationWithKnownCourseName, courseParticipationWithUnknownCourseName]
 
-    const path = referPaths.programmeHistory.index({ referralId: referral.id })
-
     beforeEach(() => {
       cy.task('stubCourse', courses[0])
     })
@@ -69,7 +68,7 @@ context('Programme history', () => {
       beforeEach(() => {
         cy.task('stubParticipationsByPerson', { courseParticipations, prisonNumber: prisoner.prisonerNumber })
 
-        cy.visit(path)
+        cy.visit(programmeHistoryPath)
       })
 
       it('shows the page with an existing programme history', () => {
@@ -79,7 +78,7 @@ context('Programme history', () => {
           referral,
         })
         programmeHistoryPage.shouldHavePersonDetails(person)
-        programmeHistoryPage.shouldContainNavigation(path)
+        programmeHistoryPage.shouldContainNavigation(programmeHistoryPath)
         programmeHistoryPage.shouldContainBackLink(referPaths.show({ referralId: referral.id }))
         programmeHistoryPage.shouldNotContainSuccessMessage()
         programmeHistoryPage.shouldContainPreHistoryParagraph()
@@ -127,7 +126,7 @@ context('Programme history', () => {
           prisonNumber: prisoner.prisonerNumber,
         })
 
-        cy.visit(path)
+        cy.visit(programmeHistoryPath)
       })
 
       it('shows the page without an existing programme history', () => {
@@ -137,7 +136,7 @@ context('Programme history', () => {
           referral,
         })
         programmeHistoryPage.shouldHavePersonDetails(person)
-        programmeHistoryPage.shouldContainNavigation(path)
+        programmeHistoryPage.shouldContainNavigation(programmeHistoryPath)
         programmeHistoryPage.shouldContainBackLink(referPaths.show({ referralId: referral.id }))
         programmeHistoryPage.shouldNotContainSuccessMessage()
         programmeHistoryPage.shouldContainNoHistoryHeading()

--- a/integration_tests/e2e/refer/programmeHistory.cy.ts
+++ b/integration_tests/e2e/refer/programmeHistory.cy.ts
@@ -328,7 +328,7 @@ context('Programme history', () => {
         courseName: courses[0].name,
         prisonNumber: person.prisonNumber,
       })
-      const newCourseParticipationPath = referPaths.programmeHistory.details.show({
+      const newCourseParticipationDetailsPath = referPaths.programmeHistory.details.show({
         courseParticipationId: newCourseParticipation.id,
         referralId: referral.id,
       })
@@ -336,14 +336,14 @@ context('Programme history', () => {
       it('shows the details page', () => {
         cy.task('stubParticipation', newCourseParticipation)
 
-        cy.visit(newCourseParticipationPath)
+        cy.visit(newCourseParticipationDetailsPath)
 
         const programmeHistoryDetailsPage = Page.verifyOnPage(ProgrammeHistoryDetailsPage, {
           course: courses[0],
           courseParticipation: newCourseParticipation,
           person,
         })
-        programmeHistoryDetailsPage.shouldContainNavigation(newCourseParticipationPath)
+        programmeHistoryDetailsPage.shouldContainNavigation(newCourseParticipationDetailsPath)
         programmeHistoryDetailsPage.shouldHavePersonDetails(person)
         programmeHistoryDetailsPage.shouldContainBackLink(
           referPaths.programmeHistory.editProgramme({
@@ -370,7 +370,7 @@ context('Programme history', () => {
       it('updates the entry and redirects to the programme history page', () => {
         cy.task('stubParticipation', newCourseParticipation)
 
-        cy.visit(newCourseParticipationPath)
+        cy.visit(newCourseParticipationDetailsPath)
 
         const formValues: CourseParticipationDetailsBody = {
           detail: 'Some outcome details',
@@ -424,7 +424,7 @@ context('Programme history', () => {
       it('displays an error when `yearCompleted` is invalid', () => {
         cy.task('stubParticipation', newCourseParticipation)
 
-        cy.visit(newCourseParticipationPath)
+        cy.visit(newCourseParticipationDetailsPath)
 
         const programmeHistoryDetailsPage = Page.verifyOnPage(ProgrammeHistoryDetailsPage, {
           course: courses[0],
@@ -451,7 +451,7 @@ context('Programme history', () => {
       it('displays an error when `yearStarted` is invalid', () => {
         cy.task('stubParticipation', newCourseParticipation)
 
-        cy.visit(newCourseParticipationPath)
+        cy.visit(newCourseParticipationDetailsPath)
 
         const programmeHistoryDetailsPage = Page.verifyOnPage(ProgrammeHistoryDetailsPage, {
           course: courses[0],

--- a/server/controllers/refer/courseParticipationDetailsController.test.ts
+++ b/server/controllers/refer/courseParticipationDetailsController.test.ts
@@ -184,7 +184,7 @@ describe('CourseParticipationDetailsController', () => {
         courseParticipationId,
         courseParticipationUpdate,
       )
-      expect(request.flash).toHaveBeenCalledWith('successMessage', 'You have successfully added a programme.')
+      expect(request.flash).toHaveBeenCalledWith('successMessage', 'You have successfully updated a programme.')
       expect(response.redirect).toHaveBeenCalledWith(referPaths.programmeHistory.index({ referralId }))
     })
 

--- a/server/controllers/refer/courseParticipationDetailsController.ts
+++ b/server/controllers/refer/courseParticipationDetailsController.ts
@@ -71,7 +71,7 @@ export default class CourseParticipationDetailsController {
         processedFormData.courseParticipationUpdate,
       )
 
-      req.flash('successMessage', 'You have successfully added a programme.')
+      req.flash('successMessage', 'You have successfully updated a programme.')
 
       return res.redirect(referPaths.programmeHistory.index({ referralId }))
     }

--- a/server/controllers/refer/courseParticipationsController.test.ts
+++ b/server/controllers/refer/courseParticipationsController.test.ts
@@ -394,6 +394,7 @@ describe('CourseParticipationsController', () => {
           courseParticipation.id,
           courseParticipationUpdate,
         )
+        expect(request.flash).toHaveBeenCalledWith('successMessage', 'You have successfully updated a programme.')
         expect(response.redirect).toHaveBeenCalledWith(
           referPaths.programmeHistory.details.show({
             courseParticipationId: courseParticipation.id,

--- a/server/controllers/refer/courseParticipationsController.test.ts
+++ b/server/controllers/refer/courseParticipationsController.test.ts
@@ -73,6 +73,7 @@ describe('CourseParticipationsController', () => {
           request,
         )
         expect(courseService.createParticipation).toHaveBeenCalledWith(token, referral.prisonNumber, courseName)
+        expect(request.flash).toHaveBeenCalledWith('successMessage', 'You have successfully added a programme.')
         expect(response.redirect).toHaveBeenCalledWith(
           referPaths.programmeHistory.details.show({
             courseParticipationId: courseParticipation.id,
@@ -105,6 +106,7 @@ describe('CourseParticipationsController', () => {
           request,
         )
         expect(courseService.createParticipation).toHaveBeenCalledWith(token, referral.prisonNumber, otherCourseName)
+        expect(request.flash).toHaveBeenCalledWith('successMessage', 'You have successfully added a programme.')
         expect(response.redirect).toHaveBeenCalledWith(
           referPaths.programmeHistory.details.show({
             courseParticipationId: courseParticipation.id,

--- a/server/controllers/refer/courseParticipationsController.ts
+++ b/server/controllers/refer/courseParticipationsController.ts
@@ -34,6 +34,8 @@ export default class CourseParticipationsController {
         courseName as CourseParticipation['courseName'],
       )
 
+      req.flash('successMessage', 'You have successfully added a programme.')
+
       return res.redirect(
         referPaths.programmeHistory.details.show({
           courseParticipationId: courseParticipation.id,

--- a/server/controllers/refer/courseParticipationsController.ts
+++ b/server/controllers/refer/courseParticipationsController.ts
@@ -215,6 +215,8 @@ export default class CourseParticipationsController {
         source,
       })
 
+      req.flash('successMessage', 'You have successfully updated a programme.')
+
       return res.redirect(
         referPaths.programmeHistory.details.show({
           courseParticipationId: req.params.courseParticipationId,


### PR DESCRIPTION
## Context

<!-- Is there a Trello ticket you can link to? -->
<!-- Do you need to add any environment variables? -->
<!-- Is an ADR required? An ADR should be added if this PR introduces a change to the architecture. -->

Currently the only success message that gets shown when adding/updating programme history entries is "You have successfully added a programme"

## Changes in this PR

- Show "added" or "updated" as appropriate in programme history success messages (outside of deletion)
- A few very small tidy ups in the integration tests

## Screenshots of UI changes

Where appropriate:

<img width="797" alt="image" src="https://github.com/ministryofjustice/hmpps-accredited-programmes-ui/assets/40244233/b2470f8f-1e6a-4be1-8762-c9f03445d612">

## Release checklist

[Release process documentation](../doc/how-to/perform-a-release.md)

As part of our continuous deployment strategy we must ensure that this work is
ready to be released once merged.

### Pre-merge

- [ ] There are changes required to the Accredited Programmes API for this change to work...
  - [ ] ... and they have been released to production already

### Post-merge

<!-- The outer checkboxes can be completed pre-merge -->

- [ ] This adds, extends or meaningfully modifies a feature...
  - [ ] ... and I have written or updated an end-to-end test for the happy path in the [Accredited Programmes E2E repo](https://github.com/ministryofjustice/hmpps-accredited-programmes-e2e)
- [ ] This makes new expectations of the API...
  - [ ] ... and I have notified the API developer(s) of changes to the contract tests (Pact), or the API is already compliant
- [ ] [Manually approve](../doc/how-to/perform-a-release.md#releasing-to-the-preprod-environment) release to preprod
- [ ] [Manually approve](../doc/how-to/perform-a-release.md#releasing-to-the-production-environment) release to prod

<!-- Should a release fail at any step, you as the author should now lead the work to
fix it as soon as possible. You can monitor deployment failures in CircleCI
itself and application errors are found in
[Sentry](https://ministryofjustice.sentry.io/projects/hmpps-accredited-programmes-ui/?project=4505330122686464&referrer=sidebar&statsPeriod=24h). -->
