### PR TITLE
(815) Redirect submitted referral

### DIFF
--- a/integration_tests/e2e/refer/submit.cy.ts
+++ b/integration_tests/e2e/refer/submit.cy.ts
@@ -217,7 +217,7 @@ context('Submitting a referral', () => {
   })
 
   it('Shows the complete page for a completed referral', () => {
-    const submittedReferral = referralFactory.submitted().build({ status: 'referral_submitted' })
+    const submittedReferral = referralFactory.submitted().build()
     cy.task('stubReferral', submittedReferral)
 
     const path = referPaths.complete({ referralId: submittedReferral.id })

--- a/server/controllers/refer/courseParticipationDetailsController.ts
+++ b/server/controllers/refer/courseParticipationDetailsController.ts
@@ -2,7 +2,7 @@ import type { Request, Response, TypedRequestHandler } from 'express'
 
 import { referPaths } from '../../paths'
 import type { CourseService, PersonService, ReferralService } from '../../services'
-import { CourseParticipationUtils, FormUtils, TypeUtils } from '../../utils'
+import { CourseParticipationUtils, FormUtils, ReferralUtils, TypeUtils } from '../../utils'
 
 export default class CourseParticipationDetailsController {
   constructor(
@@ -16,12 +16,14 @@ export default class CourseParticipationDetailsController {
       TypeUtils.assertHasUser(req)
       const { courseParticipationId, referralId } = req.params
 
+      const referral = await this.referralService.getReferral(req.user.token, referralId)
+      ReferralUtils.redirectIfSubmitted(referral, res)
+
       const { detail, outcome, setting, source } = await this.courseService.getParticipation(
         req.user.token,
         courseParticipationId,
       )
 
-      const referral = await this.referralService.getReferral(req.user.token, referralId)
       const person = await this.personService.getPerson(
         req.user.username,
         referral.prisonNumber,
@@ -56,6 +58,9 @@ export default class CourseParticipationDetailsController {
       TypeUtils.assertHasUser(req)
 
       const { courseParticipationId, referralId } = req.params
+
+      const referral = await this.referralService.getReferral(req.user.token, referralId)
+      ReferralUtils.redirectIfSubmitted(referral, res)
 
       const courseParticipation = await this.courseService.getParticipation(req.user.token, courseParticipationId)
 

--- a/server/controllers/refer/courseParticipationsController.test.ts
+++ b/server/controllers/refer/courseParticipationsController.test.ts
@@ -14,12 +14,13 @@ import {
   userFactory,
 } from '../../testutils/factories'
 import Helpers from '../../testutils/helpers'
-import { CourseParticipationUtils, CourseUtils, FormUtils, StringUtils } from '../../utils'
+import { CourseParticipationUtils, CourseUtils, FormUtils, ReferralUtils, StringUtils } from '../../utils'
 import type { CourseParticipation } from '@accredited-programmes/models'
 import type { CourseParticipationPresenter } from '@accredited-programmes/ui'
 
-jest.mock('../../utils/formUtils')
 jest.mock('../../utils/courseParticipationUtils')
+jest.mock('../../utils/formUtils')
+jest.mock('../../utils/referralUtils')
 
 describe('CourseParticipationsController', () => {
   const token = 'SOME_TOKEN'
@@ -44,6 +45,9 @@ describe('CourseParticipationsController', () => {
         return summaryListOptions
       },
     )
+    ;(ReferralUtils.redirectIfSubmitted as jest.Mock).mockImplementation((_referral, _response) => {
+      // Do nothing
+    })
   })
 
   afterEach(() => {
@@ -75,6 +79,7 @@ describe('CourseParticipationsController', () => {
         await requestHandler(request, response, next)
 
         expect(referralService.getReferral).toHaveBeenCalledWith(token, request.params.referralId)
+        expect(ReferralUtils.redirectIfSubmitted).toHaveBeenCalledWith(referral, response)
         expect(CourseParticipationUtils.processCourseFormData).toHaveBeenCalledWith(
           request.body.courseName,
           request.body.otherCourseName,
@@ -108,6 +113,7 @@ describe('CourseParticipationsController', () => {
         await requestHandler(request, response, next)
 
         expect(referralService.getReferral).toHaveBeenCalledWith(token, request.params.referralId)
+        expect(ReferralUtils.redirectIfSubmitted).toHaveBeenCalledWith(referral, response)
         expect(CourseParticipationUtils.processCourseFormData).toHaveBeenCalledWith(
           request.body.courseName,
           request.body.otherCourseName,
@@ -137,6 +143,7 @@ describe('CourseParticipationsController', () => {
         await requestHandler(request, response, next)
 
         expect(referralService.getReferral).toHaveBeenCalledWith(token, request.params.referralId)
+        expect(ReferralUtils.redirectIfSubmitted).toHaveBeenCalledWith(referral, response)
         expect(CourseParticipationUtils.processCourseFormData).toHaveBeenCalledWith(
           request.body.courseName,
           request.body.otherCourseName,
@@ -179,6 +186,8 @@ describe('CourseParticipationsController', () => {
       const requestHandler = courseParticipationsController.delete()
       await requestHandler(request, response, next)
 
+      expect(referralService.getReferral).toHaveBeenCalledWith(token, request.params.referralId)
+      expect(ReferralUtils.redirectIfSubmitted).toHaveBeenCalledWith(referral, response)
       expect(CourseParticipationUtils.summaryListOptions).toHaveBeenCalledWith(
         courseParticipationPresenter,
         referral.id,
@@ -199,6 +208,9 @@ describe('CourseParticipationsController', () => {
 
   describe('destroy', () => {
     it('asks the service to delete the participation and redirects to the index action', async () => {
+      const referral = referralFactory.started().build()
+      referralService.getReferral.mockResolvedValue(referral)
+
       const courseParticipationId = 'aCourseParticipationId'
       const referralId = 'aReferralId'
 
@@ -208,6 +220,8 @@ describe('CourseParticipationsController', () => {
       const requestHandler = courseParticipationsController.destroy()
       await requestHandler(request, response, next)
 
+      expect(referralService.getReferral).toHaveBeenCalledWith(token, request.params.referralId)
+      expect(ReferralUtils.redirectIfSubmitted).toHaveBeenCalledWith(referral, response)
       expect(courseService.deleteParticipation).toHaveBeenCalledWith(token, courseParticipationId)
       expect(request.flash).toHaveBeenCalledWith('successMessage', 'You have successfully removed a programme.')
       expect(response.redirect).toHaveBeenCalledWith(referPaths.programmeHistory.index({ referralId }))
@@ -261,6 +275,8 @@ describe('CourseParticipationsController', () => {
             person,
             referralId: referral.id,
           })
+          expect(referralService.getReferral).toHaveBeenCalledWith(token, request.params.referralId)
+          expect(ReferralUtils.redirectIfSubmitted).toHaveBeenCalledWith(referral, response)
           expect(FormUtils.setFieldErrors).toHaveBeenCalledWith(request, response, ['courseName', 'otherCourseName'])
         })
       },
@@ -311,6 +327,7 @@ describe('CourseParticipationsController', () => {
       const requestHandler = courseParticipationsController.index()
       await requestHandler(request, response, next)
 
+      expect(ReferralUtils.redirectIfSubmitted).toHaveBeenCalledWith(referral, response)
       expect(CourseParticipationUtils.summaryListOptions).toHaveBeenNthCalledWith(
         1,
         earliestCourseParticipationPresenter,
@@ -378,6 +395,7 @@ describe('CourseParticipationsController', () => {
         person,
         referralId: referral.id,
       })
+      expect(ReferralUtils.redirectIfSubmitted).toHaveBeenCalledWith(referral, response)
       expect(FormUtils.setFieldErrors).toHaveBeenCalledWith(request, response, ['courseName', 'otherCourseName'])
     })
   })
@@ -425,6 +443,8 @@ describe('CourseParticipationsController', () => {
         const requestHandler = courseParticipationsController.updateCourse()
         await requestHandler(request, response, next)
 
+        expect(referralService.getReferral).toHaveBeenCalledWith(token, request.params.referralId)
+        expect(ReferralUtils.redirectIfSubmitted).toHaveBeenCalledWith(referral, response)
         expect(courseService.getParticipation).toHaveBeenCalledWith(token, request.params.courseParticipationId)
         expect(CourseParticipationUtils.processCourseFormData).toHaveBeenCalledWith(
           request.body.courseName,
@@ -462,6 +482,8 @@ describe('CourseParticipationsController', () => {
         const requestHandler = courseParticipationsController.updateCourse()
         await requestHandler(request, response, next)
 
+        expect(referralService.getReferral).toHaveBeenCalledWith(token, request.params.referralId)
+        expect(ReferralUtils.redirectIfSubmitted).toHaveBeenCalledWith(referral, response)
         expect(courseService.getParticipation).toHaveBeenCalledWith(token, request.params.courseParticipationId)
         expect(CourseParticipationUtils.processCourseFormData).toHaveBeenCalledWith(
           request.body.courseName,
@@ -491,6 +513,8 @@ describe('CourseParticipationsController', () => {
       const requestHandler = courseParticipationsController.updateHasReviewedProgrammeHistory()
       await requestHandler(request, response, next)
 
+      expect(referralService.getReferral).toHaveBeenCalledWith(token, request.params.referralId)
+      expect(ReferralUtils.redirectIfSubmitted).toHaveBeenCalledWith(referral, response)
       expect(referralService.updateReferral).toHaveBeenCalledWith(token, referral.id, {
         hasReviewedProgrammeHistory,
         oasysConfirmed: referral.oasysConfirmed,

--- a/server/controllers/refer/courseParticipationsController.test.ts
+++ b/server/controllers/refer/courseParticipationsController.test.ts
@@ -304,6 +304,7 @@ describe('CourseParticipationsController', () => {
         .mockResolvedValue(earliestCourseParticipationPresenter)
       courseService.getCourse.mockResolvedValue(course)
       ;(request.flash as jest.Mock).mockImplementation(() => [])
+      request.params.referralId = referral.id
     })
 
     it("renders the index template for a person's programme history", async () => {
@@ -358,6 +359,7 @@ describe('CourseParticipationsController', () => {
 
       const referral = referralFactory.started().build({ prisonNumber: person.prisonNumber })
       referralService.getReferral.mockResolvedValue(referral)
+      request.params.referralId = referral.id
 
       const emptyErrorsLocal = { list: [], messages: {} }
       ;(FormUtils.setFieldErrors as jest.Mock).mockImplementation((_request, _response, _fields) => {

--- a/server/controllers/refer/oasysConfirmationController.test.ts
+++ b/server/controllers/refer/oasysConfirmationController.test.ts
@@ -69,6 +69,7 @@ describe('OasysConfirmationController', () => {
     })
 
     it("asks the service to update the field and redirects to the ReferralController's show action", async () => {
+      request.params.referralId = referral.id
       request.body.oasysConfirmed = true
 
       const requestHandler = oasysConfirmationController.update()

--- a/server/controllers/refer/oasysConfirmationController.ts
+++ b/server/controllers/refer/oasysConfirmationController.ts
@@ -36,15 +36,16 @@ export default class OasysConfirmationController {
     return async (req: Request, res: Response) => {
       TypeUtils.assertHasUser(req)
 
+      const { referralId } = req.params
       const { oasysConfirmed } = req.body
 
       if (!oasysConfirmed) {
         req.flash('oasysConfirmedError', 'Confirm the OASys information is up to date')
 
-        return res.redirect(referPaths.confirmOasys.show({ referralId: req.params.referralId }))
+        return res.redirect(referPaths.confirmOasys.show({ referralId }))
       }
 
-      const referral = await this.referralService.getReferral(req.user.token, req.params.referralId)
+      const referral = await this.referralService.getReferral(req.user.token, referralId)
 
       const referralUpdate: ReferralUpdate = {
         hasReviewedProgrammeHistory: referral.hasReviewedProgrammeHistory,
@@ -52,9 +53,9 @@ export default class OasysConfirmationController {
         reason: referral.reason,
       }
 
-      await this.referralService.updateReferral(req.user.token, referral.id, referralUpdate)
+      await this.referralService.updateReferral(req.user.token, referralId, referralUpdate)
 
-      return res.redirect(referPaths.show({ referralId: referral.id }))
+      return res.redirect(referPaths.show({ referralId }))
     }
   }
 }

--- a/server/controllers/refer/oasysConfirmationController.ts
+++ b/server/controllers/refer/oasysConfirmationController.ts
@@ -2,7 +2,7 @@ import type { Request, Response, TypedRequestHandler } from 'express'
 
 import { referPaths } from '../../paths'
 import type { PersonService, ReferralService } from '../../services'
-import { FormUtils, TypeUtils } from '../../utils'
+import { FormUtils, ReferralUtils, TypeUtils } from '../../utils'
 import type { ReferralUpdate } from '@accredited-programmes/models'
 
 export default class OasysConfirmationController {
@@ -16,6 +16,8 @@ export default class OasysConfirmationController {
       TypeUtils.assertHasUser(req)
 
       const referral = await this.referralService.getReferral(req.user.token, req.params.referralId)
+      ReferralUtils.redirectIfSubmitted(referral, res)
+
       const person = await this.personService.getPerson(
         req.user.username,
         referral.prisonNumber,
@@ -46,6 +48,7 @@ export default class OasysConfirmationController {
       }
 
       const referral = await this.referralService.getReferral(req.user.token, referralId)
+      ReferralUtils.redirectIfSubmitted(referral, res)
 
       const referralUpdate: ReferralUpdate = {
         hasReviewedProgrammeHistory: referral.hasReviewedProgrammeHistory,

--- a/server/controllers/refer/reasonController.test.ts
+++ b/server/controllers/refer/reasonController.test.ts
@@ -7,9 +7,10 @@ import { referPaths } from '../../paths'
 import type { PersonService, ReferralService } from '../../services'
 import { courseOfferingFactory, personFactory, referralFactory } from '../../testutils/factories'
 import Helpers from '../../testutils/helpers'
-import { FormUtils } from '../../utils'
+import { FormUtils, ReferralUtils } from '../../utils'
 
 jest.mock('../../utils/formUtils')
+jest.mock('../../utils/referralUtils')
 
 describe('ReasonController', () => {
   const token = 'SOME_TOKEN'
@@ -29,6 +30,9 @@ describe('ReasonController', () => {
     request = createMock<Request>({ user: { token } })
     response = Helpers.createMockResponseWithCaseloads()
     reasonController = new ReasonController(personService, referralService)
+    ;(ReferralUtils.redirectIfSubmitted as jest.Mock).mockImplementation((_referral, _response) => {
+      // Do nothing
+    })
   })
 
   afterEach(() => {
@@ -58,7 +62,7 @@ describe('ReasonController', () => {
         person,
         referral,
       })
-
+      expect(ReferralUtils.redirectIfSubmitted).toHaveBeenCalledWith(referral, response)
       expect(FormUtils.setFieldErrors).toHaveBeenCalledWith(request, response, ['reason'])
     })
   })
@@ -77,6 +81,8 @@ describe('ReasonController', () => {
       const requestHandler = reasonController.update()
       await requestHandler(request, response, next)
 
+      expect(referralService.getReferral).toHaveBeenCalledWith(token, request.params.referralId)
+      expect(ReferralUtils.redirectIfSubmitted).toHaveBeenCalledWith(referral, response)
       expect(referralService.updateReferral).toHaveBeenCalledWith(token, referral.id, {
         hasReviewedProgrammeHistory: referral.hasReviewedProgrammeHistory,
         oasysConfirmed: referral.oasysConfirmed,
@@ -92,6 +98,8 @@ describe('ReasonController', () => {
         const requestHandler = reasonController.update()
         await requestHandler(request, response, next)
 
+        expect(referralService.getReferral).toHaveBeenCalledWith(token, request.params.referralId)
+        expect(ReferralUtils.redirectIfSubmitted).toHaveBeenCalledWith(referral, response)
         expect(response.redirect).toHaveBeenCalledWith(referPaths.reason.show({ referralId: referral.id }))
         expect(request.flash).toHaveBeenCalledWith('reasonError', 'Enter a reason for the referral')
       })
@@ -106,6 +114,8 @@ describe('ReasonController', () => {
         const requestHandler = reasonController.update()
         await requestHandler(request, response, next)
 
+        expect(referralService.getReferral).toHaveBeenCalledWith(token, request.params.referralId)
+        expect(ReferralUtils.redirectIfSubmitted).toHaveBeenCalledWith(referral, response)
         expect(response.redirect).toHaveBeenCalledWith(referPaths.reason.show({ referralId: referral.id }))
         expect(request.flash).toHaveBeenCalledWith('reasonError', 'Enter a reason for the referral')
       })

--- a/server/controllers/refer/reasonController.test.ts
+++ b/server/controllers/refer/reasonController.test.ts
@@ -71,6 +71,7 @@ describe('ReasonController', () => {
     })
 
     it('ask the service to update the referral and redirects to the referral show action', async () => {
+      request.params.referralId = referral.id
       request.body.reason = ' Some reason\nAnother paragraph\n '
 
       const requestHandler = reasonController.update()

--- a/server/controllers/refer/reasonController.ts
+++ b/server/controllers/refer/reasonController.ts
@@ -36,15 +36,16 @@ export default class ReasonController {
     return async (req: Request, res: Response) => {
       TypeUtils.assertHasUser(req)
 
+      const { referralId } = req.params
       const formattedReason = req.body.reason?.trim()
 
       if (!formattedReason) {
         req.flash('reasonError', 'Enter a reason for the referral')
 
-        return res.redirect(referPaths.reason.show({ referralId: req.params.referralId }))
+        return res.redirect(referPaths.reason.show({ referralId }))
       }
 
-      const referral = await this.referralService.getReferral(req.user.token, req.params.referralId)
+      const referral = await this.referralService.getReferral(req.user.token, referralId)
 
       const referralUpdate: ReferralUpdate = {
         hasReviewedProgrammeHistory: referral.hasReviewedProgrammeHistory,
@@ -52,9 +53,9 @@ export default class ReasonController {
         reason: formattedReason,
       }
 
-      await this.referralService.updateReferral(req.user.token, referral.id, referralUpdate)
+      await this.referralService.updateReferral(req.user.token, referralId, referralUpdate)
 
-      return res.redirect(referPaths.show({ referralId: referral.id }))
+      return res.redirect(referPaths.show({ referralId }))
     }
   }
 }

--- a/server/controllers/refer/reasonController.ts
+++ b/server/controllers/refer/reasonController.ts
@@ -2,7 +2,7 @@ import type { Request, Response, TypedRequestHandler } from 'express'
 
 import { referPaths } from '../../paths'
 import type { PersonService, ReferralService } from '../../services'
-import { FormUtils, TypeUtils } from '../../utils'
+import { FormUtils, ReferralUtils, TypeUtils } from '../../utils'
 import type { ReferralUpdate } from '@accredited-programmes/models'
 
 export default class ReasonController {
@@ -16,6 +16,8 @@ export default class ReasonController {
       TypeUtils.assertHasUser(req)
 
       const referral = await this.referralService.getReferral(req.user.token, req.params.referralId)
+      ReferralUtils.redirectIfSubmitted(referral, res)
+
       const person = await this.personService.getPerson(
         req.user.username,
         referral.prisonNumber,
@@ -37,6 +39,10 @@ export default class ReasonController {
       TypeUtils.assertHasUser(req)
 
       const { referralId } = req.params
+
+      const referral = await this.referralService.getReferral(req.user.token, referralId)
+      ReferralUtils.redirectIfSubmitted(referral, res)
+
       const formattedReason = req.body.reason?.trim()
 
       if (!formattedReason) {
@@ -44,8 +50,6 @@ export default class ReasonController {
 
         return res.redirect(referPaths.reason.show({ referralId }))
       }
-
-      const referral = await this.referralService.getReferral(req.user.token, referralId)
 
       const referralUpdate: ReferralUpdate = {
         hasReviewedProgrammeHistory: referral.hasReviewedProgrammeHistory,

--- a/server/controllers/refer/referralsController.test.ts
+++ b/server/controllers/refer/referralsController.test.ts
@@ -172,6 +172,7 @@ describe('ReferralsController', () => {
 
       const referral = referralFactory.started().build({ prisonNumber: person.prisonNumber })
       referralService.getReferral.mockResolvedValue(referral)
+      request.params.referralId = referral.id
 
       const requestHandler = referralsController.showPerson()
       await requestHandler(request, response, next)

--- a/server/controllers/refer/referralsController.test.ts
+++ b/server/controllers/refer/referralsController.test.ts
@@ -145,13 +145,18 @@ describe('ReferralsController', () => {
         .started()
         .build({ offeringId: courseOffering.id, prisonNumber: person.prisonNumber })
       referralService.getReferral.mockResolvedValue(referral)
-
-      const requestHandler = referralsController.show()
-      await requestHandler(request, response, next)
+      ;(ReferralUtils.redirectIfSubmitted as jest.Mock).mockImplementation((_referral, _response) => {
+        // Do nothing
+      })
 
       const coursePresenter = createMock<CoursePresenter>({ name: course.name })
       ;(CourseUtils.presentCourse as jest.Mock).mockReturnValue(coursePresenter)
 
+      const requestHandler = referralsController.show()
+      await requestHandler(request, response, next)
+
+      expect(referralService.getReferral).toHaveBeenCalledWith(token, request.params.referralId)
+      expect(ReferralUtils.redirectIfSubmitted).toHaveBeenCalledWith(referral, response)
       expect(response.render).toHaveBeenCalledWith('referrals/show', {
         course: coursePresenter,
         organisation,
@@ -173,10 +178,15 @@ describe('ReferralsController', () => {
       const referral = referralFactory.started().build({ prisonNumber: person.prisonNumber })
       referralService.getReferral.mockResolvedValue(referral)
       request.params.referralId = referral.id
+      ;(ReferralUtils.redirectIfSubmitted as jest.Mock).mockImplementation((_referral, _response) => {
+        // Do nothing
+      })
 
       const requestHandler = referralsController.showPerson()
       await requestHandler(request, response, next)
 
+      expect(referralService.getReferral).toHaveBeenCalledWith(token, request.params.referralId)
+      expect(ReferralUtils.redirectIfSubmitted).toHaveBeenCalledWith(referral, response)
       expect(response.render).toHaveBeenCalledWith('referrals/showPerson', {
         pageHeading: "Del Hatton's details",
         person,
@@ -197,6 +207,9 @@ describe('ReferralsController', () => {
       request.params.referralId = referral.id
       referralService.getReferral.mockResolvedValue(referral)
       ;(ReferralUtils.isReadyForSubmission as jest.Mock).mockReturnValue(true)
+      ;(ReferralUtils.redirectIfSubmitted as jest.Mock).mockImplementation((_referral, _response) => {
+        // Do nothing
+      })
 
       TypeUtils.assertHasUser(request)
       request.user.username = 'BOBBY_BROWN'
@@ -255,6 +268,8 @@ describe('ReferralsController', () => {
         response.locals.errors = emptyErrorsLocal
       })
 
+      expect(referralService.getReferral).toHaveBeenCalledWith(token, request.params.referralId)
+      expect(ReferralUtils.redirectIfSubmitted).toHaveBeenCalledWith(referral, response)
       expect(FormUtils.setFieldErrors).toHaveBeenCalledWith(request, response, ['confirmation'])
       expect(CourseParticipationUtils.summaryListOptions).toHaveBeenNthCalledWith(
         1,
@@ -298,6 +313,8 @@ describe('ReferralsController', () => {
         const requestHandler = referralsController.checkAnswers()
         await requestHandler(request, response, next)
 
+        expect(referralService.getReferral).toHaveBeenCalledWith(token, request.params.referralId)
+        expect(ReferralUtils.redirectIfSubmitted).toHaveBeenCalledWith(referral, response)
         expect(response.redirect).toHaveBeenCalledWith(referPaths.show({ referralId: referral.id }))
       })
     })
@@ -323,6 +340,8 @@ describe('ReferralsController', () => {
       await requestHandler(request, response, next)
 
       expect(response.redirect).toHaveBeenCalledWith(referPaths.complete({ referralId: referral.id }))
+      expect(referralService.getReferral).toHaveBeenCalledWith(token, request.params.referralId)
+      expect(ReferralUtils.redirectIfSubmitted).toHaveBeenCalledWith(referral, response)
       expect(referralService.updateReferralStatus).toHaveBeenCalledWith(token, referral.id, 'referral_submitted')
     })
 
@@ -333,6 +352,8 @@ describe('ReferralsController', () => {
         const requestHandler = referralsController.submit()
         await requestHandler(request, response, next)
 
+        expect(referralService.getReferral).toHaveBeenCalledWith(token, request.params.referralId)
+        expect(ReferralUtils.redirectIfSubmitted).toHaveBeenCalledWith(referral, response)
         expect(request.flash).toHaveBeenCalledWith(
           'confirmationError',
           'Confirm that the information you have provided is complete, accurate and up to date',
@@ -353,6 +374,8 @@ describe('ReferralsController', () => {
         const requestHandler = referralsController.submit()
         await requestHandler(request, response, next)
 
+        expect(referralService.getReferral).toHaveBeenCalledWith(token, request.params.referralId)
+        expect(ReferralUtils.redirectIfSubmitted).toHaveBeenCalledWith(referral, response)
         expect(response.redirect).toHaveBeenCalledWith(referPaths.show({ referralId: referral.id }))
       })
     })

--- a/server/controllers/refer/referralsController.ts
+++ b/server/controllers/refer/referralsController.ts
@@ -22,6 +22,7 @@ export default class ReferralsController {
       const { username } = req.user
 
       const referral = await this.referralService.getReferral(req.user.token, referralId)
+      ReferralUtils.redirectIfSubmitted(referral, res)
 
       if (!ReferralUtils.isReadyForSubmission(referral)) {
         return res.redirect(referPaths.show({ referralId }))
@@ -129,6 +130,8 @@ export default class ReferralsController {
       TypeUtils.assertHasUser(req)
 
       const referral = await this.referralService.getReferral(req.user.token, req.params.referralId)
+      ReferralUtils.redirectIfSubmitted(referral, res)
+
       const course = await this.courseService.getCourseByOffering(req.user.token, referral.offeringId)
       const courseOffering = await this.courseService.getOffering(req.user.token, referral.offeringId)
       const organisation = await this.organisationService.getOrganisation(req.user.token, courseOffering.organisationId)
@@ -156,6 +159,8 @@ export default class ReferralsController {
       const { referralId } = req.params
 
       const referral = await this.referralService.getReferral(req.user.token, referralId)
+      ReferralUtils.redirectIfSubmitted(referral, res)
+
       const person = await this.personService.getPerson(
         req.user.username,
         referral.prisonNumber,
@@ -195,6 +200,9 @@ export default class ReferralsController {
 
       const { referralId } = req.params
 
+      const referral = await this.referralService.getReferral(req.user.token, referralId)
+      ReferralUtils.redirectIfSubmitted(referral, res)
+
       if (req.body.confirmation !== 'true') {
         req.flash(
           'confirmationError',
@@ -203,8 +211,6 @@ export default class ReferralsController {
 
         return res.redirect(referPaths.checkAnswers({ referralId }))
       }
-
-      const referral = await this.referralService.getReferral(req.user.token, referralId)
 
       if (!ReferralUtils.isReadyForSubmission(referral)) {
         return res.redirect(referPaths.show({ referralId }))

--- a/server/controllers/refer/referralsController.ts
+++ b/server/controllers/refer/referralsController.ts
@@ -24,7 +24,7 @@ export default class ReferralsController {
       const referral = await this.referralService.getReferral(req.user.token, referralId)
 
       if (!ReferralUtils.isReadyForSubmission(referral)) {
-        return res.redirect(referPaths.show({ referralId: referral.id }))
+        return res.redirect(referPaths.show({ referralId }))
       }
 
       const person = await this.personService.getPerson(
@@ -46,7 +46,7 @@ export default class ReferralsController {
         ),
       )
       const participationSummaryListsOptions = courseParticipationsPresenter.map(participation =>
-        CourseParticipationUtils.summaryListOptions(participation, referral.id, { change: true, remove: false }),
+        CourseParticipationUtils.summaryListOptions(participation, referralId, { change: true, remove: false }),
       )
       const coursePresenter = CourseUtils.presentCourse(course)
 
@@ -153,7 +153,9 @@ export default class ReferralsController {
     return async (req: Request, res: Response) => {
       TypeUtils.assertHasUser(req)
 
-      const referral = await this.referralService.getReferral(req.user.token, req.params.referralId)
+      const { referralId } = req.params
+
+      const referral = await this.referralService.getReferral(req.user.token, referralId)
       const person = await this.personService.getPerson(
         req.user.username,
         referral.prisonNumber,
@@ -164,7 +166,7 @@ export default class ReferralsController {
         pageHeading: `${person.name}'s details`,
         person,
         personSummaryListRows: PersonUtils.summaryListRows(person),
-        referralId: referral.id,
+        referralId,
       })
     }
   }
@@ -191,24 +193,26 @@ export default class ReferralsController {
     return async (req: Request, res: Response) => {
       TypeUtils.assertHasUser(req)
 
+      const { referralId } = req.params
+
       if (req.body.confirmation !== 'true') {
         req.flash(
           'confirmationError',
           'Confirm that the information you have provided is complete, accurate and up to date',
         )
 
-        return res.redirect(referPaths.checkAnswers({ referralId: req.params.referralId }))
+        return res.redirect(referPaths.checkAnswers({ referralId }))
       }
 
-      const referral = await this.referralService.getReferral(req.user.token, req.params.referralId)
+      const referral = await this.referralService.getReferral(req.user.token, referralId)
 
       if (!ReferralUtils.isReadyForSubmission(referral)) {
-        return res.redirect(referPaths.show({ referralId: referral.id }))
+        return res.redirect(referPaths.show({ referralId }))
       }
 
-      await this.referralService.updateReferralStatus(req.user.token, req.params.referralId, 'referral_submitted')
+      await this.referralService.updateReferralStatus(req.user.token, referralId, 'referral_submitted')
 
-      return res.redirect(referPaths.complete({ referralId: req.params.referralId }))
+      return res.redirect(referPaths.complete({ referralId }))
     }
   }
 }

--- a/server/utils/referralUtils.test.ts
+++ b/server/utils/referralUtils.test.ts
@@ -1,5 +1,10 @@
+import type { DeepMocked } from '@golevelup/ts-jest'
+import { createMock } from '@golevelup/ts-jest'
+import type { Response } from 'express'
+
 import CourseUtils from './courseUtils'
 import ReferralUtils from './referralUtils'
+import { referPaths } from '../paths'
 import {
   courseFactory,
   courseOfferingFactory,
@@ -88,6 +93,30 @@ describe('ReferralUtils', () => {
       const submittableReferral = referralFactory.submittable().build()
 
       expect(ReferralUtils.isReadyForSubmission(submittableReferral)).toEqual(true)
+    })
+  })
+
+  describe('redirectIfSubmitted', () => {
+    let response: DeepMocked<Response>
+
+    beforeEach(() => {
+      response = createMock<Response>({})
+    })
+
+    describe('when the referral status is "referral_started"', () => {
+      it('does nothing', () => {
+        const referral = referralFactory.started().build()
+        ReferralUtils.redirectIfSubmitted(referral, response)
+        expect(response.redirect).not.toHaveBeenCalled()
+      })
+    })
+
+    describe('when the referral status is not "referral_started"', () => {
+      it('redirects to the referral complete action', () => {
+        const referral = referralFactory.submitted().build()
+        ReferralUtils.redirectIfSubmitted(referral, response)
+        expect(response.redirect).toHaveBeenCalledWith(referPaths.complete({ referralId: referral.id }))
+      })
     })
   })
 

--- a/server/utils/referralUtils.ts
+++ b/server/utils/referralUtils.ts
@@ -1,3 +1,5 @@
+import type { Response } from 'express'
+
 import { referPaths } from '../paths'
 import type { CourseOffering, Organisation, Person, Referral } from '@accredited-programmes/models'
 import type {
@@ -46,6 +48,12 @@ export default class ReferralUtils {
 
   static isReadyForSubmission(referral: Referral): boolean {
     return referral.hasReviewedProgrammeHistory && referral.oasysConfirmed && !!referral.reason
+  }
+
+  static redirectIfSubmitted(referral: Referral, response: Response) {
+    if (referral.status !== 'referral_started') {
+      response.redirect(referPaths.complete({ referralId: referral.id }))
+    }
   }
 
   static taskListSections(referral: Referral): Array<ReferralTaskListSection> {


### PR DESCRIPTION
**Edit:** needs a rethink because we need to return something in the controller to exit after the redirect. We might be able to add this as middleware passed into the specific routes that need it. We'll spike on that next week

## Context

<!-- Is there a Trello ticket you can link to? -->
<!-- Do you need to add any environment variables? -->
<!-- Is an ADR required? An ADR should be added if this PR introduces a change to the architecture. -->

You can currently still access pages/actions related to a referral even after it's been submitted, which could lead to unwanted changes being made

## Changes in this PR

- Redirect from pages related to a referral once submitted

## Release checklist

[Release process documentation](../doc/how-to/perform-a-release.md)

As part of our continuous deployment strategy we must ensure that this work is
ready to be released once merged.

### Pre-merge

- [ ] There are changes required to the Accredited Programmes API for this change to work...
  - [ ] ... and they have been released to production already

### Post-merge

<!-- The outer checkboxes can be completed pre-merge -->

- [ ] This adds, extends or meaningfully modifies a feature...
  - [ ] ... and I have written or updated an end-to-end test for the happy path in the [Accredited Programmes E2E repo](https://github.com/ministryofjustice/hmpps-accredited-programmes-e2e)
- [ ] This makes new expectations of the API...
  - [ ] ... and I have notified the API developer(s) of changes to the contract tests (Pact), or the API is already compliant
- [ ] [Manually approve](../doc/how-to/perform-a-release.md#releasing-to-the-preprod-environment) release to preprod
- [ ] [Manually approve](../doc/how-to/perform-a-release.md#releasing-to-the-production-environment) release to prod

<!-- Should a release fail at any step, you as the author should now lead the work to
fix it as soon as possible. You can monitor deployment failures in CircleCI
itself and application errors are found in
[Sentry](https://ministryofjustice.sentry.io/projects/hmpps-accredited-programmes-ui/?project=4505330122686464&referrer=sidebar&statsPeriod=24h). -->
