### PR TITLE
(993) Use new course names endpoint

### DIFF
--- a/integration_tests/e2e/refer/programmeHistory.cy.ts
+++ b/integration_tests/e2e/refer/programmeHistory.cy.ts
@@ -33,6 +33,7 @@ context('Programme history', () => {
     prisonNumber: prisoner.prisonerNumber,
   })
   const courses = courseFactory.buildList(4)
+  const courseNames = courses.map(course => course.name)
   const addedByUser1 = userFactory.build()
   const addedByUser2 = userFactory.build()
   const courseParticipationWithKnownCourseName = courseParticipationFactory.build({
@@ -195,7 +196,7 @@ context('Programme history', () => {
   describe('When adding to the programme history', () => {
     describe('and selecting a programme', () => {
       beforeEach(() => {
-        cy.task('stubCourses', courses)
+        cy.task('stubCourseNames', courseNames)
       })
 
       describe('for a new entry', () => {
@@ -522,7 +523,7 @@ context('Programme history', () => {
       const updatedSuccessMessage = 'You have successfully updated a programme.'
 
       beforeEach(() => {
-        cy.task('stubCourses', courses)
+        cy.task('stubCourseNames', courseNames)
         cy.task('stubParticipationsByPerson', {
           courseParticipations,
           prisonNumber: prisoner.prisonerNumber,

--- a/integration_tests/mockApis/courses.ts
+++ b/integration_tests/mockApis/courses.ts
@@ -31,6 +31,19 @@ export default {
       },
     }),
 
+  stubCourseNames: (courseNames: Array<Course['name']>): SuperAgentRequest =>
+    stubFor({
+      request: {
+        method: 'GET',
+        url: apiPaths.courses.names({}),
+      },
+      response: {
+        headers: { 'Content-Type': 'application/json;charset=UTF-8' },
+        jsonBody: courseNames,
+        status: 200,
+      },
+    }),
+
   stubCourses: (courses: Array<Course>): SuperAgentRequest =>
     stubFor({
       request: {

--- a/server/controllers/refer/courseParticipationsController.test.ts
+++ b/server/controllers/refer/courseParticipationsController.test.ts
@@ -216,6 +216,7 @@ describe('CourseParticipationsController', () => {
 
   describe('editCourse', () => {
     const courses = courseFactory.buildList(2)
+    const courseNames = courses.map(course => course.name)
     const person = personFactory.build()
     const courseParticipationWithKnownCoursename = courseParticipationFactory.build({
       courseName: courses[0].name,
@@ -238,7 +239,7 @@ describe('CourseParticipationsController', () => {
           courseService.getParticipation.mockResolvedValue(courseParticipation)
           referralService.getReferral.mockResolvedValue(referral)
           personService.getPerson.mockResolvedValue(person)
-          courseService.getCourses.mockResolvedValue(courses)
+          courseService.getCourseNames.mockResolvedValue(courseNames)
           ;(FormUtils.setFieldErrors as jest.Mock).mockImplementation((_request, _response, _fields) => {
             response.locals.errors = { list: [], messages: {} }
           })
@@ -254,7 +255,7 @@ describe('CourseParticipationsController', () => {
               courseParticipationId: courseParticipation.id,
               referralId: referral.id,
             })}?_method=PUT`,
-            courseRadioOptions: CourseUtils.courseRadioOptions(courses),
+            courseRadioOptions: CourseUtils.courseRadioOptions(courseNames),
             formValues: isKnownCourse ? { courseName } : { courseName: 'Other', otherCourseName: courseName },
             otherCourseNameChecked: !isKnownCourse,
             pageHeading: 'Add Accredited Programme history',
@@ -351,7 +352,8 @@ describe('CourseParticipationsController', () => {
   describe('new', () => {
     it('renders the new template for selecting a course', async () => {
       const courses = courseFactory.buildList(2)
-      courseService.getCourses.mockResolvedValue(courses)
+      const courseNames = courses.map(course => course.name)
+      courseService.getCourseNames.mockResolvedValue(courseNames)
 
       const person = personFactory.build()
       personService.getPerson.mockResolvedValue(person)
@@ -369,7 +371,7 @@ describe('CourseParticipationsController', () => {
 
       expect(response.render).toHaveBeenCalledWith('referrals/courseParticipations/course', {
         action: referPaths.programmeHistory.create({ referralId: referral.id }),
-        courseRadioOptions: CourseUtils.courseRadioOptions(courses),
+        courseRadioOptions: CourseUtils.courseRadioOptions(courseNames),
         formValues: {},
         otherCourseNameChecked: false,
         pageHeading: 'Add Accredited Programme history',

--- a/server/controllers/refer/courseParticipationsController.ts
+++ b/server/controllers/refer/courseParticipationsController.ts
@@ -109,18 +109,18 @@ export default class CourseParticipationsController {
         referral.prisonNumber,
         res.locals.user.caseloads,
       )
-      const courses = await this.courseService.getCourses(req.user.token)
+      const courseNames = await this.courseService.getCourseNames(req.user.token)
 
       FormUtils.setFieldErrors(req, res, ['courseName', 'otherCourseName'])
 
       const { courseName } = courseParticipation
-      const isKnownCourse = courses.find(course => course.name === courseName)
+      const isKnownCourse = courseNames.find(knownCourseName => knownCourseName === courseName)
       const formValues = isKnownCourse ? { courseName } : { courseName: 'Other', otherCourseName: courseName }
       const hasOtherCourseNameError = !!res.locals.errors.messages.otherCourseName
 
       res.render('referrals/courseParticipations/course', {
         action: `${referPaths.programmeHistory.updateProgramme({ courseParticipationId, referralId })}?_method=PUT`,
-        courseRadioOptions: CourseUtils.courseRadioOptions(courses),
+        courseRadioOptions: CourseUtils.courseRadioOptions(courseNames),
         formValues,
         otherCourseNameChecked: !isKnownCourse || hasOtherCourseNameError,
         pageHeading: 'Add Accredited Programme history',
@@ -170,7 +170,7 @@ export default class CourseParticipationsController {
     return async (req: Request, res: Response) => {
       TypeUtils.assertHasUser(req)
 
-      const courses = await this.courseService.getCourses(req.user.token)
+      const courseNames = await this.courseService.getCourseNames(req.user.token)
       const referral = await this.referralService.getReferral(req.user.token, req.params.referralId)
       const person = await this.personService.getPerson(
         req.user.username,
@@ -182,7 +182,7 @@ export default class CourseParticipationsController {
 
       res.render('referrals/courseParticipations/course', {
         action: referPaths.programmeHistory.create({ referralId: referral.id }),
-        courseRadioOptions: CourseUtils.courseRadioOptions(courses),
+        courseRadioOptions: CourseUtils.courseRadioOptions(courseNames),
         formValues: {},
         otherCourseNameChecked: !!res.locals.errors.messages.otherCourseName,
         pageHeading: 'Add Accredited Programme history',

--- a/server/data/courseClient.test.ts
+++ b/server/data/courseClient.test.ts
@@ -204,6 +204,34 @@ pactWith({ consumer: 'Accredited Programmes UI', provider: 'Accredited Programme
     })
   })
 
+  describe('findCourseNames', () => {
+    const courseNames = allCourses.map(course => course.name)
+
+    beforeEach(() => {
+      provider.addInteraction({
+        state: 'Course names exist on the API',
+        uponReceiving: 'A request for all course names',
+        willRespondWith: {
+          body: Matchers.like(courseNames),
+          status: 200,
+        },
+        withRequest: {
+          headers: {
+            authorization: `Bearer ${token}`,
+          },
+          method: 'GET',
+          path: apiPaths.courses.names({}),
+        },
+      })
+    })
+
+    it('fetches all course names', async () => {
+      const result = await courseClient.findCourseNames()
+
+      expect(result).toEqual(courseNames)
+    })
+  })
+
   describe('findOffering', () => {
     beforeEach(() => {
       provider.addInteraction({

--- a/server/data/courseClient.ts
+++ b/server/data/courseClient.ts
@@ -47,6 +47,12 @@ export default class CourseClient {
     })) as Course
   }
 
+  async findCourseNames(): Promise<Array<Course['name']>> {
+    return (await this.restClient.get({
+      path: apiPaths.courses.names({}),
+    })) as Array<Course['name']>
+  }
+
   async findOffering(courseOfferingId: CourseOffering['id']): Promise<CourseOffering> {
     return (await this.restClient.get({
       path: apiPaths.offerings.show({ courseOfferingId }),

--- a/server/paths/api.ts
+++ b/server/paths/api.ts
@@ -1,6 +1,7 @@
 import { path } from 'static-path'
 
 const coursesPath = path('/courses')
+const courseNamesPath = coursesPath.path('course-names')
 const coursePath = coursesPath.path(':courseId')
 const offeringsByCoursePath = coursePath.path('offerings')
 
@@ -18,6 +19,7 @@ const participationPath = participationsPath.path(':courseParticipationId')
 export default {
   courses: {
     index: coursesPath,
+    names: courseNamesPath,
     offerings: offeringsByCoursePath,
     show: coursePath,
   },

--- a/server/services/courseService.test.ts
+++ b/server/services/courseService.test.ts
@@ -61,6 +61,21 @@ describe('CourseService', () => {
     })
   })
 
+  describe('getCourseNames', () => {
+    it('returns a list of all course names', async () => {
+      const courses = courseFactory.buildList(3)
+      const courseNames = courses.map(course => course.name)
+      courseClient.findCourseNames.mockResolvedValue(courseNames)
+
+      const result = await service.getCourseNames(token)
+
+      expect(result).toEqual(courseNames)
+
+      expect(courseClientBuilder).toHaveBeenCalledWith(token)
+      expect(courseClient.findCourseNames).toHaveBeenCalled()
+    })
+  })
+
   describe('getCourses', () => {
     it('returns a list of all courses', async () => {
       const courses = courseFactory.buildList(3)

--- a/server/services/courseService.ts
+++ b/server/services/courseService.ts
@@ -46,6 +46,11 @@ export default class CourseService {
     return courseClient.findCourseByOffering(courseOfferingId)
   }
 
+  async getCourseNames(token: Express.User['token']): Promise<Array<Course['name']>> {
+    const courseClient = this.courseClientBuilder(token)
+    return courseClient.findCourseNames()
+  }
+
   async getCourses(token: Express.User['token']): Promise<Array<Course>> {
     const courseClient = this.courseClientBuilder(token)
     return courseClient.all()

--- a/server/utils/courseUtils.test.ts
+++ b/server/utils/courseUtils.test.ts
@@ -5,10 +5,11 @@ describe('CourseUtils', () => {
   describe('courseRadioOptions', () => {
     it('returns a formatted array of courses to use with UI radios', () => {
       const courses = courseFactory.buildList(2)
+      const courseNames = courses.map(course => course.name)
 
-      expect(CourseUtils.courseRadioOptions(courses)).toEqual([
-        { text: courses[0].name, value: courses[0].name },
-        { text: courses[1].name, value: courses[1].name },
+      expect(CourseUtils.courseRadioOptions(courseNames)).toEqual([
+        { text: courseNames[0], value: courseNames[0] },
+        { text: courseNames[1], value: courseNames[1] },
       ])
     })
   })

--- a/server/utils/courseUtils.ts
+++ b/server/utils/courseUtils.ts
@@ -8,11 +8,11 @@ import type {
 } from '@accredited-programmes/ui'
 
 export default class CourseUtils {
-  static courseRadioOptions(courses: Array<Course>): Array<GovukFrontendTagWithText> {
-    return courses.map(course => {
+  static courseRadioOptions(courseNames: Array<Course['name']>): Array<GovukFrontendTagWithText> {
+    return courseNames.map(courseName => {
       return {
-        text: course.name,
-        value: course.name,
+        text: courseName,
+        value: courseName,
       }
     })
   }


### PR DESCRIPTION
## Context

To provide a unique list of course names on the course selection form pages.

https://trello.com/c/iqCz1E2v/993-use-programme-history-course-names-endpoint-ui-s

## Changes in this PR

- Update course client and service to use new `/courses/course-names` endpoint.
- Update `new` and `editCourse` controller methods to use new endpoint and return correctly formatted values.

## Release checklist

[Release process documentation](../doc/how-to/perform-a-release.md)

As part of our continuous deployment strategy we must ensure that this work is
ready to be released once merged.

### Pre-merge

- [ ] There are changes required to the Accredited Programmes API for this change to work...
  - [ ] ... and they have been released to production already

### Post-merge

<!-- The outer checkboxes can be completed pre-merge -->

- [ ] This adds, extends or meaningfully modifies a feature...
  - [ ] ... and I have written or updated an end-to-end test for the happy path in the [Accredited Programmes E2E repo](https://github.com/ministryofjustice/hmpps-accredited-programmes-e2e)
- [ ] This makes new expectations of the API...
  - [ ] ... and I have notified the API developer(s) of changes to the contract tests (Pact), or the API is already compliant
- [ ] [Manually approve](../doc/how-to/perform-a-release.md#releasing-to-the-preprod-environment) release to preprod
- [ ] [Manually approve](../doc/how-to/perform-a-release.md#releasing-to-the-production-environment) release to prod

<!-- Should a release fail at any step, you as the author should now lead the work to
fix it as soon as possible. You can monitor deployment failures in CircleCI
itself and application errors are found in
[Sentry](https://ministryofjustice.sentry.io/projects/hmpps-accredited-programmes-ui/?project=4505330122686464&referrer=sidebar&statsPeriod=24h). -->
