### PR TITLE
(815) Redirect submitted referral redux

### DIFF
--- a/integration_tests/e2e/refer/submit.cy.ts
+++ b/integration_tests/e2e/refer/submit.cy.ts
@@ -134,7 +134,7 @@ context('Submitting a referral', () => {
     })
 
     describe('for a person with no programme history', () => {
-      it('indicate that there is no programme history', () => {
+      it('indicates that there is no programme history', () => {
         cy.task('stubParticipationsByPerson', { courseParticipations: [], prisonNumber: prisoner.prisonerNumber })
 
         cy.visit(path)

--- a/integration_tests/e2e/refer/submit.cy.ts
+++ b/integration_tests/e2e/refer/submit.cy.ts
@@ -217,7 +217,7 @@ context('Submitting a referral', () => {
   })
 
   it('Shows the complete page for a completed referral', () => {
-    const submittedReferral = referralFactory.submitted().build({ status: 'referral_submitted' })
+    const submittedReferral = referralFactory.submitted().build()
     cy.task('stubReferral', submittedReferral)
 
     const path = referPaths.complete({ referralId: submittedReferral.id })

--- a/server/controllers/refer/courseParticipationDetailsController.test.ts
+++ b/server/controllers/refer/courseParticipationDetailsController.test.ts
@@ -29,11 +29,10 @@ describe('CourseParticipationDetailsController', () => {
   const referralService = createMock<ReferralService>({})
 
   const courseParticipationId = faker.string.uuid()
-  const referralId = faker.string.uuid()
-
-  const referral = referralFactory.build({ id: referralId })
   const courseParticipation = courseParticipationFactory.new().build()
 
+  const referralId = faker.string.uuid()
+  const draftReferral = referralFactory.started().build({ id: referralId })
   let courseParticipationDetailsController: CourseParticipationDetailsController
 
   beforeEach(() => {
@@ -52,7 +51,6 @@ describe('CourseParticipationDetailsController', () => {
       referralService,
     )
 
-    referralService.getReferral.mockResolvedValue(referral)
     courseService.getParticipation.mockResolvedValue(courseParticipation)
   })
 
@@ -62,6 +60,8 @@ describe('CourseParticipationDetailsController', () => {
 
   describe('show', () => {
     it('renders the details show page and calls `FormUtils.setFieldErrors` and `FormUtils.setFormValues` with the correct param values', async () => {
+      referralService.getReferral.mockResolvedValue(draftReferral)
+
       const person = personFactory.build()
       personService.getPerson.mockResolvedValue(person)
 
@@ -100,6 +100,8 @@ describe('CourseParticipationDetailsController', () => {
     describe('when the course participation has existing data', () => {
       describe('and has a `setting.type` of `community` and a `setting.location`', () => {
         it('calls `FormUtils.setFormValues` with the correct `defaultValues` param values', async () => {
+          referralService.getReferral.mockResolvedValue(draftReferral)
+
           const courseParticipationWithCommunitySetting = courseParticipationFactory.build({
             setting: { location: 'Somewhere', type: 'community' },
           }) as CourseParticipation & { setting: CourseParticipationSetting }
@@ -124,6 +126,8 @@ describe('CourseParticipationDetailsController', () => {
 
       describe('and has a `setting.type` of `custody` and a `setting.location`', () => {
         it('calls `FormUtils.setFormValues` with the correct `defaultValues` param values', async () => {
+          referralService.getReferral.mockResolvedValue(draftReferral)
+
           const courseParticipationWithCustodySetting = courseParticipationFactory.build({
             setting: { location: 'Somewhere', type: 'custody' },
           }) as CourseParticipation & { setting: CourseParticipationSetting }

--- a/server/controllers/refer/courseParticipationDetailsController.test.ts
+++ b/server/controllers/refer/courseParticipationDetailsController.test.ts
@@ -33,6 +33,8 @@ describe('CourseParticipationDetailsController', () => {
 
   const referralId = faker.string.uuid()
   const draftReferral = referralFactory.started().build({ id: referralId })
+  const submittedReferral = referralFactory.submitted().build({ id: referralId })
+
   let courseParticipationDetailsController: CourseParticipationDetailsController
 
   beforeEach(() => {
@@ -150,10 +152,24 @@ describe('CourseParticipationDetailsController', () => {
         })
       })
     })
+
+    describe('when the referral has been submitted', () => {
+      it('redirects to the referral confirmation action', async () => {
+        referralService.getReferral.mockResolvedValue(submittedReferral)
+
+        const requestHandler = courseParticipationDetailsController.show()
+        await requestHandler(request, response, next)
+
+        expect(referralService.getReferral).toHaveBeenCalledWith(token, referralId)
+        expect(response.redirect).toHaveBeenCalledWith(referPaths.complete({ referralId }))
+      })
+    })
   })
 
   describe('update', () => {
     it('asks the service to update the given course participation details and redirects to the `CourseParticipationsController` `index` action', async () => {
+      referralService.getReferral.mockResolvedValue(draftReferral)
+
       const courseParticipationUpdate: CourseParticipationUpdate = {
         courseName: courseParticipation.courseName,
         detail: 'Some additional detail',
@@ -178,6 +194,7 @@ describe('CourseParticipationDetailsController', () => {
       const requestHandler = courseParticipationDetailsController.update()
       await requestHandler(request, response, next)
 
+      expect(referralService.getReferral).toHaveBeenCalledWith(token, referralId)
       expect(courseService.getParticipation).toHaveBeenCalledWith(token, courseParticipationId)
       expect(CourseParticipationUtils.processDetailsFormData).toHaveBeenCalledWith(
         request,
@@ -192,8 +209,21 @@ describe('CourseParticipationDetailsController', () => {
       expect(response.redirect).toHaveBeenCalledWith(referPaths.programmeHistory.index({ referralId }))
     })
 
+    describe('when the referral has been submitted', () => {
+      it('redirects to the referral confirmation action', async () => {
+        referralService.getReferral.mockResolvedValue(submittedReferral)
+
+        const requestHandler = courseParticipationDetailsController.update()
+        await requestHandler(request, response, next)
+
+        expect(referralService.getReferral).toHaveBeenCalledWith(token, referralId)
+        expect(response.redirect).toHaveBeenCalledWith(referPaths.complete({ referralId }))
+      })
+    })
+
     describe('when the form has errors', () => {
       it('redirects back to the `show` action', async () => {
+        referralService.getReferral.mockResolvedValue(draftReferral)
         ;(CourseParticipationUtils.processDetailsFormData as jest.Mock).mockImplementation(_request => {
           return { hasFormErrors: true }
         })
@@ -201,6 +231,7 @@ describe('CourseParticipationDetailsController', () => {
         const requestHandler = courseParticipationDetailsController.update()
         await requestHandler(request, response, next)
 
+        expect(referralService.getReferral).toHaveBeenCalledWith(token, referralId)
         expect(courseService.getParticipation).toHaveBeenCalledWith(token, courseParticipationId)
         expect(CourseParticipationUtils.processDetailsFormData).toHaveBeenCalledWith(
           request,

--- a/server/controllers/refer/courseParticipationDetailsController.ts
+++ b/server/controllers/refer/courseParticipationDetailsController.ts
@@ -16,12 +16,17 @@ export default class CourseParticipationDetailsController {
       TypeUtils.assertHasUser(req)
       const { courseParticipationId, referralId } = req.params
 
+      const referral = await this.referralService.getReferral(req.user.token, referralId)
+
+      if (referral.status !== 'referral_started') {
+        return res.redirect(referPaths.complete({ referralId }))
+      }
+
       const { detail, outcome, setting, source } = await this.courseService.getParticipation(
         req.user.token,
         courseParticipationId,
       )
 
-      const referral = await this.referralService.getReferral(req.user.token, referralId)
       const person = await this.personService.getPerson(
         req.user.username,
         referral.prisonNumber,
@@ -40,7 +45,7 @@ export default class CourseParticipationDetailsController {
         source,
       })
 
-      res.render('referrals/courseParticipations/details/show', {
+      return res.render('referrals/courseParticipations/details/show', {
         action: `${referPaths.programmeHistory.details.update({ courseParticipationId, referralId })}?_method=PUT`,
         backLinkHref: referPaths.programmeHistory.editProgramme({ courseParticipationId, referralId }),
         courseParticipationId,
@@ -56,6 +61,12 @@ export default class CourseParticipationDetailsController {
       TypeUtils.assertHasUser(req)
 
       const { courseParticipationId, referralId } = req.params
+
+      const referral = await this.referralService.getReferral(req.user.token, referralId)
+
+      if (referral.status !== 'referral_started') {
+        return res.redirect(referPaths.complete({ referralId }))
+      }
 
       const courseParticipation = await this.courseService.getParticipation(req.user.token, courseParticipationId)
 

--- a/server/controllers/refer/courseParticipationsController.test.ts
+++ b/server/controllers/refer/courseParticipationsController.test.ts
@@ -305,6 +305,7 @@ describe('CourseParticipationsController', () => {
         .mockResolvedValue(earliestCourseParticipationPresenter)
       courseService.getCourse.mockResolvedValue(course)
       ;(request.flash as jest.Mock).mockImplementation(() => [])
+      request.params.referralId = referral.id
     })
 
     it("renders the index template for a person's programme history", async () => {
@@ -360,6 +361,7 @@ describe('CourseParticipationsController', () => {
 
       const referral = referralFactory.started().build({ prisonNumber: person.prisonNumber })
       referralService.getReferral.mockResolvedValue(referral)
+      request.params.referralId = referral.id
 
       const emptyErrorsLocal = { list: [], messages: {} }
       ;(FormUtils.setFieldErrors as jest.Mock).mockImplementation((_request, _response, _fields) => {

--- a/server/controllers/refer/courseParticipationsController.test.ts
+++ b/server/controllers/refer/courseParticipationsController.test.ts
@@ -37,6 +37,7 @@ describe('CourseParticipationsController', () => {
   const person = personFactory.build()
   const referralId = 'a-referral-id'
   const draftReferral = referralFactory.started().build({ id: referralId, prisonNumber: person.prisonNumber })
+  const submittedReferral = referralFactory.submitted().build({ id: referralId, prisonNumber: person.prisonNumber })
 
   beforeEach(() => {
     request = createMock<Request>({ params: { referralId }, user: { token } })
@@ -128,6 +129,18 @@ describe('CourseParticipationsController', () => {
       })
     })
 
+    describe('when the referral has been submitted', () => {
+      it('redirects to the referral confirmation action', async () => {
+        referralService.getReferral.mockResolvedValue(submittedReferral)
+
+        const requestHandler = courseParticipationsController.create()
+        await requestHandler(request, response, next)
+
+        expect(referralService.getReferral).toHaveBeenCalledWith(token, referralId)
+        expect(response.redirect).toHaveBeenCalledWith(referPaths.complete({ referralId }))
+      })
+    })
+
     describe('when there are form errors', () => {
       it('redirects back to the `new` action', async () => {
         referralService.getReferral.mockResolvedValue(draftReferral)
@@ -195,20 +208,46 @@ describe('CourseParticipationsController', () => {
         summaryListOptions,
       })
     })
+
+    describe('when the referral has been submitted', () => {
+      it('redirects to the referral confirmation action', async () => {
+        referralService.getReferral.mockResolvedValue(submittedReferral)
+
+        const requestHandler = courseParticipationsController.delete()
+        await requestHandler(request, response, next)
+
+        expect(referralService.getReferral).toHaveBeenCalledWith(token, request.params.referralId)
+        expect(response.redirect).toHaveBeenCalledWith(referPaths.complete({ referralId }))
+      })
+    })
   })
 
   describe('destroy', () => {
     it('asks the service to delete the participation and redirects to the index action', async () => {
-      const courseParticipationId = 'aCourseParticipationId'
+      referralService.getReferral.mockResolvedValue(draftReferral)
 
+      const courseParticipationId = 'aCourseParticipationId'
       request.params.courseParticipationId = courseParticipationId
 
       const requestHandler = courseParticipationsController.destroy()
       await requestHandler(request, response, next)
 
+      expect(referralService.getReferral).toHaveBeenCalledWith(token, referralId)
       expect(courseService.deleteParticipation).toHaveBeenCalledWith(token, courseParticipationId)
       expect(request.flash).toHaveBeenCalledWith('successMessage', 'You have successfully removed a programme.')
       expect(response.redirect).toHaveBeenCalledWith(referPaths.programmeHistory.index({ referralId }))
+    })
+
+    describe('when the referral has been submitted', () => {
+      it('redirects to the referral confirmation action', async () => {
+        referralService.getReferral.mockResolvedValue(submittedReferral)
+
+        const requestHandler = courseParticipationsController.destroy()
+        await requestHandler(request, response, next)
+
+        expect(referralService.getReferral).toHaveBeenCalledWith(token, referralId)
+        expect(response.redirect).toHaveBeenCalledWith(referPaths.complete({ referralId }))
+      })
     })
   })
 
@@ -263,6 +302,18 @@ describe('CourseParticipationsController', () => {
         })
       },
     )
+
+    describe('when the referral has been submitted', () => {
+      it('redirects to the referral confirmation action', async () => {
+        referralService.getReferral.mockResolvedValue(submittedReferral)
+
+        const requestHandler = courseParticipationsController.editCourse()
+        await requestHandler(request, response, next)
+
+        expect(referralService.getReferral).toHaveBeenCalledWith(token, referralId)
+        expect(response.redirect).toHaveBeenCalledWith(referPaths.complete({ referralId }))
+      })
+    })
   })
 
   describe('index', () => {
@@ -346,6 +397,18 @@ describe('CourseParticipationsController', () => {
         )
       })
     })
+
+    describe('when the referral has been submitted', () => {
+      it('redirects to the referral confirmation action', async () => {
+        referralService.getReferral.mockResolvedValue(submittedReferral)
+
+        const requestHandler = courseParticipationsController.index()
+        await requestHandler(request, response, next)
+
+        expect(referralService.getReferral).toHaveBeenCalledWith(token, referralId)
+        expect(response.redirect).toHaveBeenCalledWith(referPaths.complete({ referralId }))
+      })
+    })
   })
 
   describe('new', () => {
@@ -378,6 +441,18 @@ describe('CourseParticipationsController', () => {
       })
       expect(FormUtils.setFieldErrors).toHaveBeenCalledWith(request, response, ['courseName', 'otherCourseName'])
     })
+
+    describe('when the referral has been submitted', () => {
+      it('redirects to the referral confirmation action', async () => {
+        referralService.getReferral.mockResolvedValue(submittedReferral)
+
+        const requestHandler = courseParticipationsController.new()
+        await requestHandler(request, response, next)
+
+        expect(referralService.getReferral).toHaveBeenCalledWith(token, referralId)
+        expect(response.redirect).toHaveBeenCalledWith(referPaths.complete({ referralId }))
+      })
+    })
   })
 
   describe('updateCourse', () => {
@@ -386,6 +461,8 @@ describe('CourseParticipationsController', () => {
       ['when the `courseName` is "Other" and `otherCourseName` is a non-empty string when trimmed', true],
     ])('%s', (_description: string, isOtherCourse: boolean) => {
       it('asks the service to update the course data and redirects to the details action', async () => {
+        referralService.getReferral.mockResolvedValue(draftReferral)
+
         const courseParticipation = courseParticipationFactory.build()
         request.params.courseParticipationId = courseParticipation.id
         courseService.getParticipation.mockResolvedValue(courseParticipation)
@@ -416,6 +493,7 @@ describe('CourseParticipationsController', () => {
         const requestHandler = courseParticipationsController.updateCourse()
         await requestHandler(request, response, next)
 
+        expect(referralService.getReferral).toHaveBeenCalledWith(token, referralId)
         expect(courseService.getParticipation).toHaveBeenCalledWith(token, request.params.courseParticipationId)
         expect(CourseParticipationUtils.processCourseFormData).toHaveBeenCalledWith(
           request.body.courseName,
@@ -437,8 +515,22 @@ describe('CourseParticipationsController', () => {
       })
     })
 
+    describe('when the referral has been submitted', () => {
+      it('redirects to the referral confirmation action', async () => {
+        referralService.getReferral.mockResolvedValue(submittedReferral)
+
+        const requestHandler = courseParticipationsController.updateCourse()
+        await requestHandler(request, response, next)
+
+        expect(referralService.getReferral).toHaveBeenCalledWith(token, referralId)
+        expect(response.redirect).toHaveBeenCalledWith(referPaths.complete({ referralId }))
+      })
+    })
+
     describe('when there are form errors', () => {
       it('redirects back to the `editCourse` action', async () => {
+        referralService.getReferral.mockResolvedValue(draftReferral)
+
         const courseParticipation = courseParticipationFactory.build()
         request.params.courseParticipationId = courseParticipation.id
         courseService.getParticipation.mockResolvedValue(courseParticipation)
@@ -453,6 +545,7 @@ describe('CourseParticipationsController', () => {
         const requestHandler = courseParticipationsController.updateCourse()
         await requestHandler(request, response, next)
 
+        expect(referralService.getReferral).toHaveBeenCalledWith(token, referralId)
         expect(courseService.getParticipation).toHaveBeenCalledWith(token, request.params.courseParticipationId)
         expect(CourseParticipationUtils.processCourseFormData).toHaveBeenCalledWith(
           request.body.courseName,
@@ -486,6 +579,18 @@ describe('CourseParticipationsController', () => {
         reason: draftReferral.reason,
       })
       expect(response.redirect).toHaveBeenCalledWith(referPaths.show({ referralId }))
+    })
+
+    describe('when the referral has been submitted', () => {
+      it('redirects to the referral confirmation action', async () => {
+        referralService.getReferral.mockResolvedValue(submittedReferral)
+
+        const requestHandler = courseParticipationsController.updateHasReviewedProgrammeHistory()
+        await requestHandler(request, response, next)
+
+        expect(referralService.getReferral).toHaveBeenCalledWith(token, referralId)
+        expect(response.redirect).toHaveBeenCalledWith(referPaths.complete({ referralId }))
+      })
     })
   })
 })

--- a/server/controllers/refer/courseParticipationsController.ts
+++ b/server/controllers/refer/courseParticipationsController.ts
@@ -16,7 +16,9 @@ export default class CourseParticipationsController {
     return async (req: Request, res: Response) => {
       TypeUtils.assertHasUser(req)
 
-      const referral = await this.referralService.getReferral(req.user.token, req.params.referralId)
+      const { referralId } = req.params
+
+      const referral = await this.referralService.getReferral(req.user.token, referralId)
 
       const { courseName, hasFormErrors } = CourseParticipationUtils.processCourseFormData(
         req.body.courseName,
@@ -25,7 +27,7 @@ export default class CourseParticipationsController {
       )
 
       if (hasFormErrors) {
-        return res.redirect(referPaths.programmeHistory.new({ referralId: req.params.referralId }))
+        return res.redirect(referPaths.programmeHistory.new({ referralId }))
       }
 
       const courseParticipation = await this.courseService.createParticipation(
@@ -72,7 +74,7 @@ export default class CourseParticipationsController {
         action: `${referPaths.programmeHistory.destroy({ courseParticipationId, referralId })}?_method=DELETE`,
         pageHeading: 'Remove programme',
         person,
-        referralId: referral.id,
+        referralId,
         summaryListOptions,
       })
     }
@@ -135,7 +137,8 @@ export default class CourseParticipationsController {
       TypeUtils.assertHasUser(req)
 
       const successMessage = req.flash('successMessage')[0]
-      const referral = await this.referralService.getReferral(req.user.token, req.params.referralId)
+      const { referralId } = req.params
+      const referral = await this.referralService.getReferral(req.user.token, referralId)
       const person = await this.personService.getPerson(
         req.user.username,
         referral.prisonNumber,
@@ -152,14 +155,14 @@ export default class CourseParticipationsController {
       )
 
       const summaryListsOptions = courseParticipationsPresenter.map(participation =>
-        CourseParticipationUtils.summaryListOptions(participation, referral.id),
+        CourseParticipationUtils.summaryListOptions(participation, referralId),
       )
 
       res.render('referrals/courseParticipations/index', {
         action: `${referPaths.programmeHistory.updateReviewedStatus({ referralId: referral.id })}?_method=PUT`,
         pageHeading: 'Accredited Programme history',
         person,
-        referralId: referral.id,
+        referralId,
         successMessage,
         summaryListsOptions,
       })
@@ -169,9 +172,10 @@ export default class CourseParticipationsController {
   new(): TypedRequestHandler<Request, Response> {
     return async (req: Request, res: Response) => {
       TypeUtils.assertHasUser(req)
+      const { referralId } = req.params
 
+      const referral = await this.referralService.getReferral(req.user.token, referralId)
       const courseNames = await this.courseService.getCourseNames(req.user.token)
-      const referral = await this.referralService.getReferral(req.user.token, req.params.referralId)
       const person = await this.personService.getPerson(
         req.user.username,
         referral.prisonNumber,
@@ -181,7 +185,7 @@ export default class CourseParticipationsController {
       FormUtils.setFieldErrors(req, res, ['courseName', 'otherCourseName'])
 
       res.render('referrals/courseParticipations/course', {
-        action: referPaths.programmeHistory.create({ referralId: referral.id }),
+        action: referPaths.programmeHistory.create({ referralId }),
         courseRadioOptions: CourseUtils.courseRadioOptions(courseNames),
         formValues: {},
         otherCourseNameChecked: !!res.locals.errors.messages.otherCourseName,
@@ -196,9 +200,11 @@ export default class CourseParticipationsController {
     return async (req: Request, res: Response) => {
       TypeUtils.assertHasUser(req)
 
+      const { courseParticipationId, referralId } = req.params
+
       const currentCourseParticipation = await this.courseService.getParticipation(
         req.user.token,
-        req.params.courseParticipationId,
+        courseParticipationId,
       )
 
       const { courseName, hasFormErrors } = CourseParticipationUtils.processCourseFormData(
@@ -210,15 +216,15 @@ export default class CourseParticipationsController {
       if (hasFormErrors) {
         return res.redirect(
           referPaths.programmeHistory.editProgramme({
-            courseParticipationId: currentCourseParticipation.id,
-            referralId: req.params.referralId,
+            courseParticipationId,
+            referralId,
           }),
         )
       }
 
       const { detail, outcome, setting, source } = currentCourseParticipation
 
-      await this.courseService.updateParticipation(req.user.token, currentCourseParticipation.id, {
+      await this.courseService.updateParticipation(req.user.token, courseParticipationId, {
         courseName: courseName as CourseParticipation['courseName'],
         detail,
         outcome,
@@ -230,8 +236,8 @@ export default class CourseParticipationsController {
 
       return res.redirect(
         referPaths.programmeHistory.details.show({
-          courseParticipationId: req.params.courseParticipationId,
-          referralId: req.params.referralId,
+          courseParticipationId,
+          referralId,
         }),
       )
     }

--- a/server/controllers/refer/oasysConfirmationController.test.ts
+++ b/server/controllers/refer/oasysConfirmationController.test.ts
@@ -21,11 +21,16 @@ describe('OasysConfirmationController', () => {
   const referralService = createMock<ReferralService>({})
 
   const courseOffering = courseOfferingFactory.build()
+  const person = personFactory.build()
+  const referralId = 'A-REFERRAL-ID'
+  const draftReferral = referralFactory
+    .started()
+    .build({ id: referralId, oasysConfirmed: false, offeringId: courseOffering.id, prisonNumber: person.prisonNumber })
 
   let oasysConfirmationController: OasysConfirmationController
 
   beforeEach(() => {
-    request = createMock<Request>({ user: { token } })
+    request = createMock<Request>({ params: { referralId }, user: { token } })
     response = Helpers.createMockResponseWithCaseloads()
     oasysConfirmationController = new OasysConfirmationController(personService, referralService)
   })
@@ -36,13 +41,8 @@ describe('OasysConfirmationController', () => {
 
   describe('show', () => {
     it('renders the show template for confirming OASys information is up to date', async () => {
-      const person = personFactory.build()
+      referralService.getReferral.mockResolvedValue(draftReferral)
       personService.getPerson.mockResolvedValue(person)
-
-      const referral = referralFactory
-        .started()
-        .build({ offeringId: courseOffering.id, prisonNumber: person.prisonNumber })
-      referralService.getReferral.mockResolvedValue(referral)
 
       const emptyErrorsLocal = { list: [], messages: {} }
       ;(FormUtils.setFieldErrors as jest.Mock).mockImplementation((_request, _response, _fields) => {
@@ -52,45 +52,40 @@ describe('OasysConfirmationController', () => {
       const requestHandler = oasysConfirmationController.show()
       await requestHandler(request, response, next)
 
+      expect(referralService.getReferral).toHaveBeenCalledWith(token, referralId)
       expect(response.render).toHaveBeenCalledWith('referrals/oasysConfirmation/show', {
         pageHeading: 'Confirm the OASys information',
         person,
-        referral,
+        referral: draftReferral,
       })
       expect(FormUtils.setFieldErrors).toHaveBeenCalledWith(request, response, ['oasysConfirmed'])
     })
   })
 
   describe('update', () => {
-    const referral = referralFactory.build({ oasysConfirmed: false, status: 'referral_started' })
-
-    beforeEach(() => {
-      referralService.getReferral.mockResolvedValue(referral)
-    })
-
     it("asks the service to update the field and redirects to the ReferralController's show action", async () => {
-      request.params.referralId = referral.id
+      referralService.getReferral.mockResolvedValue(draftReferral)
+
       request.body.oasysConfirmed = true
 
       const requestHandler = oasysConfirmationController.update()
       await requestHandler(request, response, next)
 
-      expect(response.redirect).toHaveBeenCalledWith(referPaths.show({ referralId: referral.id }))
-      expect(referralService.updateReferral).toHaveBeenCalledWith(token, referral.id, {
-        hasReviewedProgrammeHistory: referral.hasReviewedProgrammeHistory,
+      expect(referralService.getReferral).toHaveBeenCalledWith(token, referralId)
+      expect(response.redirect).toHaveBeenCalledWith(referPaths.show({ referralId }))
+      expect(referralService.updateReferral).toHaveBeenCalledWith(token, referralId, {
+        hasReviewedProgrammeHistory: draftReferral.hasReviewedProgrammeHistory,
         oasysConfirmed: true,
-        reason: referral.reason,
+        reason: draftReferral.reason,
       })
     })
 
     describe('when the `oasysConfirmed` field is not set', () => {
       it('redirects back to the confirm oasys page with an error', async () => {
-        request.params.referralId = referral.id
-
         const requestHandler = oasysConfirmationController.update()
         await requestHandler(request, response, next)
 
-        expect(response.redirect).toHaveBeenCalledWith(referPaths.confirmOasys.show({ referralId: referral.id }))
+        expect(response.redirect).toHaveBeenCalledWith(referPaths.confirmOasys.show({ referralId }))
         expect(request.flash).toHaveBeenCalledWith('oasysConfirmedError', 'Confirm the OASys information is up to date')
       })
     })

--- a/server/controllers/refer/oasysConfirmationController.test.ts
+++ b/server/controllers/refer/oasysConfirmationController.test.ts
@@ -69,6 +69,7 @@ describe('OasysConfirmationController', () => {
     })
 
     it("asks the service to update the field and redirects to the ReferralController's show action", async () => {
+      request.params.referralId = referral.id
       request.body.oasysConfirmed = true
 
       const requestHandler = oasysConfirmationController.update()

--- a/server/controllers/refer/oasysConfirmationController.ts
+++ b/server/controllers/refer/oasysConfirmationController.ts
@@ -36,15 +36,16 @@ export default class OasysConfirmationController {
     return async (req: Request, res: Response) => {
       TypeUtils.assertHasUser(req)
 
+      const { referralId } = req.params
       const { oasysConfirmed } = req.body
 
       if (!oasysConfirmed) {
         req.flash('oasysConfirmedError', 'Confirm the OASys information is up to date')
 
-        return res.redirect(referPaths.confirmOasys.show({ referralId: req.params.referralId }))
+        return res.redirect(referPaths.confirmOasys.show({ referralId }))
       }
 
-      const referral = await this.referralService.getReferral(req.user.token, req.params.referralId)
+      const referral = await this.referralService.getReferral(req.user.token, referralId)
 
       const referralUpdate: ReferralUpdate = {
         hasReviewedProgrammeHistory: referral.hasReviewedProgrammeHistory,
@@ -52,9 +53,9 @@ export default class OasysConfirmationController {
         reason: referral.reason,
       }
 
-      await this.referralService.updateReferral(req.user.token, referral.id, referralUpdate)
+      await this.referralService.updateReferral(req.user.token, referralId, referralUpdate)
 
-      return res.redirect(referPaths.show({ referralId: referral.id }))
+      return res.redirect(referPaths.show({ referralId }))
     }
   }
 }

--- a/server/controllers/refer/reasonController.test.ts
+++ b/server/controllers/refer/reasonController.test.ts
@@ -22,11 +22,19 @@ describe('ReasonController', () => {
   const referralService = createMock<ReferralService>({})
 
   const courseOffering = courseOfferingFactory.build()
+  const person = personFactory.build()
+  const referralId = 'A-REFERRAL-ID'
+  const draftReferral = referralFactory.started().build({
+    id: referralId,
+    offeringId: courseOffering.id,
+    prisonNumber: person.prisonNumber,
+    reason: undefined,
+  })
 
   let reasonController: ReasonController
 
   beforeEach(() => {
-    request = createMock<Request>({ user: { token } })
+    request = createMock<Request>({ params: { referralId }, user: { token } })
     response = Helpers.createMockResponseWithCaseloads()
     reasonController = new ReasonController(personService, referralService)
   })
@@ -37,13 +45,8 @@ describe('ReasonController', () => {
 
   describe('show', () => {
     it('renders the reason for referral page', async () => {
-      const person = personFactory.build()
       personService.getPerson.mockResolvedValue(person)
-
-      const referral = referralFactory
-        .started()
-        .build({ offeringId: courseOffering.id, prisonNumber: person.prisonNumber })
-      referralService.getReferral.mockResolvedValue(referral)
+      referralService.getReferral.mockResolvedValue(draftReferral)
 
       const emptyErrorsLocal = { list: [], messages: {} }
       ;(FormUtils.setFieldErrors as jest.Mock).mockImplementation((_request, _response, _fields) => {
@@ -53,60 +56,51 @@ describe('ReasonController', () => {
       const requestHandler = reasonController.show()
       await requestHandler(request, response, next)
 
+      expect(referralService.getReferral).toHaveBeenCalledWith(token, referralId)
       expect(response.render).toHaveBeenCalledWith('referrals/reason/show', {
         pageHeading: 'Add reason for referral and any additional information',
         person,
-        referral,
+        referral: draftReferral,
       })
-
       expect(FormUtils.setFieldErrors).toHaveBeenCalledWith(request, response, ['reason'])
     })
   })
 
   describe('update', () => {
-    const referral = referralFactory.build({ reason: undefined, status: 'referral_started' })
-
-    beforeEach(() => {
-      referralService.getReferral.mockResolvedValue(referral)
-    })
-
     it('ask the service to update the referral and redirects to the referral show action', async () => {
-      request.params.referralId = referral.id
+      referralService.getReferral.mockResolvedValue(draftReferral)
       request.body.reason = ' Some reason\nAnother paragraph\n '
 
       const requestHandler = reasonController.update()
       await requestHandler(request, response, next)
 
-      expect(referralService.updateReferral).toHaveBeenCalledWith(token, referral.id, {
-        hasReviewedProgrammeHistory: referral.hasReviewedProgrammeHistory,
-        oasysConfirmed: referral.oasysConfirmed,
+      expect(referralService.getReferral).toHaveBeenCalledWith(token, referralId)
+      expect(referralService.updateReferral).toHaveBeenCalledWith(token, referralId, {
+        hasReviewedProgrammeHistory: draftReferral.hasReviewedProgrammeHistory,
+        oasysConfirmed: draftReferral.oasysConfirmed,
         reason: 'Some reason\nAnother paragraph',
       })
-      expect(response.redirect).toHaveBeenCalledWith(referPaths.show({ referralId: referral.id }))
+      expect(response.redirect).toHaveBeenCalledWith(referPaths.show({ referralId }))
     })
 
     describe('when the reason is not provided', () => {
       it('redirects to the reason show action with an error', async () => {
-        request.params.referralId = referral.id
-
         const requestHandler = reasonController.update()
         await requestHandler(request, response, next)
 
-        expect(response.redirect).toHaveBeenCalledWith(referPaths.reason.show({ referralId: referral.id }))
+        expect(response.redirect).toHaveBeenCalledWith(referPaths.reason.show({ referralId }))
         expect(request.flash).toHaveBeenCalledWith('reasonError', 'Enter a reason for the referral')
       })
     })
 
     describe('when the provided reason is just spaces and new lines', () => {
       it('redirects to the reason show action with an error', async () => {
-        request.params.referralId = referral.id
-
         request.body.reason = ' \n \n '
 
         const requestHandler = reasonController.update()
         await requestHandler(request, response, next)
 
-        expect(response.redirect).toHaveBeenCalledWith(referPaths.reason.show({ referralId: referral.id }))
+        expect(response.redirect).toHaveBeenCalledWith(referPaths.reason.show({ referralId }))
         expect(request.flash).toHaveBeenCalledWith('reasonError', 'Enter a reason for the referral')
       })
     })

--- a/server/controllers/refer/reasonController.test.ts
+++ b/server/controllers/refer/reasonController.test.ts
@@ -71,6 +71,7 @@ describe('ReasonController', () => {
     })
 
     it('ask the service to update the referral and redirects to the referral show action', async () => {
+      request.params.referralId = referral.id
       request.body.reason = ' Some reason\nAnother paragraph\n '
 
       const requestHandler = reasonController.update()

--- a/server/controllers/refer/reasonController.ts
+++ b/server/controllers/refer/reasonController.ts
@@ -36,15 +36,16 @@ export default class ReasonController {
     return async (req: Request, res: Response) => {
       TypeUtils.assertHasUser(req)
 
+      const { referralId } = req.params
       const formattedReason = req.body.reason?.trim()
 
       if (!formattedReason) {
         req.flash('reasonError', 'Enter a reason for the referral')
 
-        return res.redirect(referPaths.reason.show({ referralId: req.params.referralId }))
+        return res.redirect(referPaths.reason.show({ referralId }))
       }
 
-      const referral = await this.referralService.getReferral(req.user.token, req.params.referralId)
+      const referral = await this.referralService.getReferral(req.user.token, referralId)
 
       const referralUpdate: ReferralUpdate = {
         hasReviewedProgrammeHistory: referral.hasReviewedProgrammeHistory,
@@ -52,9 +53,9 @@ export default class ReasonController {
         reason: formattedReason,
       }
 
-      await this.referralService.updateReferral(req.user.token, referral.id, referralUpdate)
+      await this.referralService.updateReferral(req.user.token, referralId, referralUpdate)
 
-      return res.redirect(referPaths.show({ referralId: referral.id }))
+      return res.redirect(referPaths.show({ referralId }))
     }
   }
 }

--- a/server/controllers/refer/referralsController.test.ts
+++ b/server/controllers/refer/referralsController.test.ts
@@ -172,6 +172,7 @@ describe('ReferralsController', () => {
 
       const referral = referralFactory.started().build({ prisonNumber: person.prisonNumber })
       referralService.getReferral.mockResolvedValue(referral)
+      request.params.referralId = referral.id
 
       const requestHandler = referralsController.showPerson()
       await requestHandler(request, response, next)

--- a/server/controllers/refer/referralsController.test.ts
+++ b/server/controllers/refer/referralsController.test.ts
@@ -168,6 +168,19 @@ describe('ReferralsController', () => {
         taskListSections: ReferralUtils.taskListSections(draftReferral),
       })
     })
+
+    describe('when the referral has been submitted', () => {
+      it('redirects to the referral confirmation action', async () => {
+        request.params.referralId = referralId
+        referralService.getReferral.mockResolvedValue(submittedReferral)
+
+        const requestHandler = referralsController.show()
+        await requestHandler(request, response, next)
+
+        expect(referralService.getReferral).toHaveBeenCalledWith(token, referralId)
+        expect(response.redirect).toHaveBeenCalledWith(referPaths.complete({ referralId }))
+      })
+    })
   })
 
   describe('showPerson', () => {
@@ -186,6 +199,19 @@ describe('ReferralsController', () => {
         person,
         personSummaryListRows: PersonUtils.summaryListRows(person),
         referralId,
+      })
+    })
+
+    describe('when the referral has been submitted', () => {
+      it('redirects to the referral confirmation action', async () => {
+        request.params.referralId = referralId
+        referralService.getReferral.mockResolvedValue(submittedReferral)
+
+        const requestHandler = referralsController.showPerson()
+        await requestHandler(request, response, next)
+
+        expect(referralService.getReferral).toHaveBeenCalledWith(token, referralId)
+        expect(response.redirect).toHaveBeenCalledWith(referPaths.complete({ referralId }))
       })
     })
   })
@@ -286,6 +312,19 @@ describe('ReferralsController', () => {
       })
     })
 
+    describe('when the referral has been submitted', () => {
+      it('redirects to the referral confirmation action', async () => {
+        request.params.referralId = referralId
+        referralService.getReferral.mockResolvedValue(submittedReferral)
+
+        const requestHandler = referralsController.checkAnswers()
+        await requestHandler(request, response, next)
+
+        expect(referralService.getReferral).toHaveBeenCalledWith(token, referralId)
+        expect(response.redirect).toHaveBeenCalledWith(referPaths.complete({ referralId }))
+      })
+    })
+
     describe('when the referral is not ready for submission', () => {
       it('redirects to the show referral action', async () => {
         request.params.referralId = draftReferral.id
@@ -338,6 +377,20 @@ describe('ReferralsController', () => {
           'Confirm that the information you have provided is complete, accurate and up to date',
         )
         expect(response.redirect).toHaveBeenCalledWith(referPaths.checkAnswers({ referralId }))
+      })
+    })
+
+    describe('when the referral has been submitted', () => {
+      it('redirects to the referral confirmation action', async () => {
+        request.body.confirmation = 'true'
+        request.params.referralId = referralId
+        referralService.getReferral.mockResolvedValue(submittedReferral)
+
+        const requestHandler = referralsController.submit()
+        await requestHandler(request, response, next)
+
+        expect(referralService.getReferral).toHaveBeenCalledWith(token, referralId)
+        expect(response.redirect).toHaveBeenCalledWith(referPaths.complete({ referralId }))
       })
     })
 

--- a/server/controllers/refer/referralsController.test.ts
+++ b/server/controllers/refer/referralsController.test.ts
@@ -47,6 +47,19 @@ describe('ReferralsController', () => {
 
   const course = courseFactory.build()
   const courseOffering = courseOfferingFactory.build()
+  const person = personFactory.build({
+    name: 'Del Hatton',
+  })
+  const referralId = 'A-REFERRAL-ID'
+  const draftReferral = referralFactory
+    .started()
+    .build({ id: referralId, offeringId: courseOffering.id, prisonNumber: person.prisonNumber })
+  const submittableReferral = referralFactory
+    .submittable()
+    .build({ id: referralId, offeringId: courseOffering.id, prisonNumber: person.prisonNumber })
+  const submittedReferral = referralFactory
+    .submitted()
+    .build({ id: referralId, offeringId: courseOffering.id, prisonNumber: person.prisonNumber })
 
   let referralsController: ReferralsController
 
@@ -110,25 +123,23 @@ describe('ReferralsController', () => {
 
   describe('create', () => {
     it('asks the service to create a referral and redirects to the show action', async () => {
-      const referral = referralFactory.started().build()
-
-      request.body.courseOfferingId = referral.offeringId
-      request.body.prisonNumber = referral.prisonNumber
+      request.body.courseOfferingId = draftReferral.offeringId
+      request.body.prisonNumber = draftReferral.prisonNumber
 
       TypeUtils.assertHasUser(request)
-      request.user.userId = referral.referrerId
+      request.user.userId = draftReferral.referrerId
 
-      referralService.createReferral.mockResolvedValue({ referralId: referral.id })
+      referralService.createReferral.mockResolvedValue({ referralId })
 
       const requestHandler = referralsController.create()
       await requestHandler(request, response, next)
 
-      expect(response.redirect).toHaveBeenCalledWith(referPaths.show({ referralId: referral.id }))
+      expect(response.redirect).toHaveBeenCalledWith(referPaths.show({ referralId }))
       expect(referralService.createReferral).toHaveBeenCalledWith(
         token,
-        referral.offeringId,
-        referral.prisonNumber,
-        referral.referrerId,
+        draftReferral.offeringId,
+        draftReferral.prisonNumber,
+        draftReferral.referrerId,
       )
     })
   })
@@ -138,13 +149,9 @@ describe('ReferralsController', () => {
       const organisation = organisationFactory.build({ id: courseOffering.organisationId })
       organisationService.getOrganisation.mockResolvedValue(organisation)
 
-      const person = personFactory.build()
       personService.getPerson.mockResolvedValue(person)
-
-      const referral = referralFactory
-        .started()
-        .build({ offeringId: courseOffering.id, prisonNumber: person.prisonNumber })
-      referralService.getReferral.mockResolvedValue(referral)
+      referralService.getReferral.mockResolvedValue(draftReferral)
+      request.params.referralId = referralId
 
       const requestHandler = referralsController.show()
       await requestHandler(request, response, next)
@@ -152,50 +159,43 @@ describe('ReferralsController', () => {
       const coursePresenter = createMock<CoursePresenter>({ name: course.name })
       ;(CourseUtils.presentCourse as jest.Mock).mockReturnValue(coursePresenter)
 
+      expect(referralService.getReferral).toHaveBeenCalledWith(token, referralId)
       expect(response.render).toHaveBeenCalledWith('referrals/show', {
         course: coursePresenter,
         organisation,
         pageHeading: 'Make a referral',
         person,
-        taskListSections: ReferralUtils.taskListSections(referral),
+        taskListSections: ReferralUtils.taskListSections(draftReferral),
       })
     })
   })
 
   describe('showPerson', () => {
-    const person = personFactory.build({
-      name: 'Del Hatton',
-    })
-
     it("renders the page for viewing a person's details", async () => {
       personService.getPerson.mockResolvedValue(person)
 
-      const referral = referralFactory.started().build({ prisonNumber: person.prisonNumber })
-      referralService.getReferral.mockResolvedValue(referral)
-      request.params.referralId = referral.id
+      referralService.getReferral.mockResolvedValue(draftReferral)
+      request.params.referralId = referralId
 
       const requestHandler = referralsController.showPerson()
       await requestHandler(request, response, next)
 
+      expect(referralService.getReferral).toHaveBeenCalledWith(token, referralId)
       expect(response.render).toHaveBeenCalledWith('referrals/showPerson', {
         pageHeading: "Del Hatton's details",
         person,
         personSummaryListRows: PersonUtils.summaryListRows(person),
-        referralId: referral.id,
+        referralId,
       })
     })
   })
 
   describe('checkAnswers', () => {
     it('renders the referral check answers page', async () => {
-      const person = personFactory.build()
       personService.getPerson.mockResolvedValue(person)
 
-      const referral = referralFactory
-        .submittable()
-        .build({ offeringId: courseOffering.id, prisonNumber: person.prisonNumber })
-      request.params.referralId = referral.id
-      referralService.getReferral.mockResolvedValue(referral)
+      request.params.referralId = referralId
+      referralService.getReferral.mockResolvedValue(submittableReferral)
       ;(ReferralUtils.isReadyForSubmission as jest.Mock).mockReturnValue(true)
 
       TypeUtils.assertHasUser(request)
@@ -255,21 +255,22 @@ describe('ReferralsController', () => {
         response.locals.errors = emptyErrorsLocal
       })
 
+      expect(referralService.getReferral).toHaveBeenCalledWith(token, referralId)
       expect(FormUtils.setFieldErrors).toHaveBeenCalledWith(request, response, ['confirmation'])
       expect(CourseParticipationUtils.summaryListOptions).toHaveBeenNthCalledWith(
         1,
         earliestCourseParticipationPresenter,
-        referral.id,
+        referralId,
         { change: true, remove: false },
       )
       expect(CourseParticipationUtils.summaryListOptions).toHaveBeenNthCalledWith(
         2,
         latestCourseParticipationPresenter,
-        referral.id,
+        referralId,
         { change: true, remove: false },
       )
       expect(response.render).toHaveBeenCalledWith('referrals/checkAnswers', {
-        additionalInformation: referral.reason,
+        additionalInformation: submittableReferral.reason,
         applicationSummaryListRows: ReferralUtils.applicationSummaryListRows(
           courseOffering,
           coursePresenter,
@@ -281,15 +282,14 @@ describe('ReferralsController', () => {
         participationSummaryListsOptions: [summaryListOptions, summaryListOptions],
         person,
         personSummaryListRows: PersonUtils.summaryListRows(person),
-        referralId: referral.id,
+        referralId,
       })
     })
 
     describe('when the referral is not ready for submission', () => {
       it('redirects to the show referral action', async () => {
-        const referral = referralFactory.started().build()
-        request.params.referralId = referral.id
-        referralService.getReferral.mockResolvedValue(referral)
+        request.params.referralId = draftReferral.id
+        referralService.getReferral.mockResolvedValue(draftReferral)
         ;(ReferralUtils.isReadyForSubmission as jest.Mock).mockReturnValue(false)
 
         TypeUtils.assertHasUser(request)
@@ -298,32 +298,32 @@ describe('ReferralsController', () => {
         const requestHandler = referralsController.checkAnswers()
         await requestHandler(request, response, next)
 
-        expect(response.redirect).toHaveBeenCalledWith(referPaths.show({ referralId: referral.id }))
+        expect(referralService.getReferral).toHaveBeenCalledWith(token, referralId)
+        expect(response.redirect).toHaveBeenCalledWith(referPaths.show({ referralId }))
       })
     })
   })
 
   describe('submit', () => {
-    const referral = referralFactory.submittable().build()
-
     beforeEach(() => {
-      referralService.getReferral.mockResolvedValue(referral)
-      request.params.referralId = referral.id
+      request.params.referralId = referralId
     })
 
     it('asks the service to update the referral status to submitted and redirects to the complete action', async () => {
+      referralService.getReferral.mockResolvedValue(submittableReferral)
       request.body.confirmation = 'true'
 
-      referralService.getReferral.mockResolvedValue(referral)
+      referralService.getReferral.mockResolvedValue(submittableReferral)
 
-      request.params.referralId = referral.id
+      request.params.referralId = referralId
       ;(ReferralUtils.isReadyForSubmission as jest.Mock).mockReturnValue(true)
 
       const requestHandler = referralsController.submit()
       await requestHandler(request, response, next)
 
-      expect(response.redirect).toHaveBeenCalledWith(referPaths.complete({ referralId: referral.id }))
-      expect(referralService.updateReferralStatus).toHaveBeenCalledWith(token, referral.id, 'referral_submitted')
+      expect(referralService.getReferral).toHaveBeenCalledWith(token, referralId)
+      expect(response.redirect).toHaveBeenCalledWith(referPaths.complete({ referralId }))
+      expect(referralService.updateReferralStatus).toHaveBeenCalledWith(token, referralId, 'referral_submitted')
     })
 
     describe('when the body is invalid', () => {
@@ -337,7 +337,7 @@ describe('ReferralsController', () => {
           'confirmationError',
           'Confirm that the information you have provided is complete, accurate and up to date',
         )
-        expect(response.redirect).toHaveBeenCalledWith(referPaths.checkAnswers({ referralId: referral.id }))
+        expect(response.redirect).toHaveBeenCalledWith(referPaths.checkAnswers({ referralId }))
       })
     })
 
@@ -345,15 +345,15 @@ describe('ReferralsController', () => {
       it('redirects to the show referral action', async () => {
         request.body.confirmation = 'true'
 
-        referralService.getReferral.mockResolvedValue(referral)
-
-        request.params.referralId = referral.id
+        referralService.getReferral.mockResolvedValue(draftReferral)
+        request.params.referralId = referralId
         ;(ReferralUtils.isReadyForSubmission as jest.Mock).mockReturnValue(false)
 
         const requestHandler = referralsController.submit()
         await requestHandler(request, response, next)
 
-        expect(response.redirect).toHaveBeenCalledWith(referPaths.show({ referralId: referral.id }))
+        expect(referralService.getReferral).toHaveBeenCalledWith(token, referralId)
+        expect(response.redirect).toHaveBeenCalledWith(referPaths.show({ referralId }))
       })
     })
   })
@@ -361,29 +361,29 @@ describe('ReferralsController', () => {
   describe('complete', () => {
     describe('when the referral status is `referral_submitted`', () => {
       it('renders the referral complete page', async () => {
-        const referral = referralFactory.submitted().build()
-        referralService.getReferral.mockResolvedValue(referral)
+        referralService.getReferral.mockResolvedValue(submittedReferral)
 
-        request.params.referralId = referral.id
+        request.params.referralId = referralId
 
         const requestHandler = referralsController.complete()
         await requestHandler(request, response, next)
 
+        expect(referralService.getReferral).toHaveBeenCalledWith(token, referralId)
         expect(response.render).toHaveBeenCalledWith('referrals/complete', { pageHeading: 'Referral complete' })
       })
     })
 
     describe('when the referral status is `referral_started`', () => {
       it('responds with a 400', async () => {
-        const referral = referralFactory.build({ status: 'referral_started' })
-        referralService.getReferral.mockResolvedValue(referral)
+        referralService.getReferral.mockResolvedValue(draftReferral)
 
-        request.params.referralId = referral.id
+        request.params.referralId = referralId
 
         const requestHandler = referralsController.complete()
         const expectedError = createError(400)
 
         expect(() => requestHandler(request, response, next)).rejects.toThrowError(expectedError)
+        expect(referralService.getReferral).toHaveBeenCalledWith(token, referralId)
       })
     })
   })

--- a/server/controllers/refer/referralsController.ts
+++ b/server/controllers/refer/referralsController.ts
@@ -23,6 +23,10 @@ export default class ReferralsController {
 
       const referral = await this.referralService.getReferral(req.user.token, referralId)
 
+      if (referral.status !== 'referral_started') {
+        return res.redirect(referPaths.complete({ referralId }))
+      }
+
       if (!ReferralUtils.isReadyForSubmission(referral)) {
         return res.redirect(referPaths.show({ referralId }))
       }
@@ -128,7 +132,14 @@ export default class ReferralsController {
     return async (req: Request, res: Response) => {
       TypeUtils.assertHasUser(req)
 
-      const referral = await this.referralService.getReferral(req.user.token, req.params.referralId)
+      const { referralId } = req.params
+
+      const referral = await this.referralService.getReferral(req.user.token, referralId)
+
+      if (referral.status !== 'referral_started') {
+        return res.redirect(referPaths.complete({ referralId }))
+      }
+
       const course = await this.courseService.getCourseByOffering(req.user.token, referral.offeringId)
       const courseOffering = await this.courseService.getOffering(req.user.token, referral.offeringId)
       const organisation = await this.organisationService.getOrganisation(req.user.token, courseOffering.organisationId)
@@ -139,7 +150,7 @@ export default class ReferralsController {
       )
       const coursePresenter = CourseUtils.presentCourse(course)
 
-      res.render('referrals/show', {
+      return res.render('referrals/show', {
         course: coursePresenter,
         organisation,
         pageHeading: 'Make a referral',
@@ -156,13 +167,18 @@ export default class ReferralsController {
       const { referralId } = req.params
 
       const referral = await this.referralService.getReferral(req.user.token, referralId)
+
+      if (referral.status !== 'referral_started') {
+        return res.redirect(referPaths.complete({ referralId }))
+      }
+
       const person = await this.personService.getPerson(
         req.user.username,
         referral.prisonNumber,
         res.locals.user.caseloads,
       )
 
-      res.render('referrals/showPerson', {
+      return res.render('referrals/showPerson', {
         pageHeading: `${person.name}'s details`,
         person,
         personSummaryListRows: PersonUtils.summaryListRows(person),
@@ -205,6 +221,10 @@ export default class ReferralsController {
       }
 
       const referral = await this.referralService.getReferral(req.user.token, referralId)
+
+      if (referral.status !== 'referral_started') {
+        return res.redirect(referPaths.complete({ referralId }))
+      }
 
       if (!ReferralUtils.isReadyForSubmission(referral)) {
         return res.redirect(referPaths.show({ referralId }))

--- a/server/controllers/refer/referralsController.ts
+++ b/server/controllers/refer/referralsController.ts
@@ -24,7 +24,7 @@ export default class ReferralsController {
       const referral = await this.referralService.getReferral(req.user.token, referralId)
 
       if (!ReferralUtils.isReadyForSubmission(referral)) {
-        return res.redirect(referPaths.show({ referralId: referral.id }))
+        return res.redirect(referPaths.show({ referralId }))
       }
 
       const person = await this.personService.getPerson(
@@ -46,7 +46,7 @@ export default class ReferralsController {
         ),
       )
       const participationSummaryListsOptions = courseParticipationsPresenter.map(participation =>
-        CourseParticipationUtils.summaryListOptions(participation, referral.id, { change: true, remove: false }),
+        CourseParticipationUtils.summaryListOptions(participation, referralId, { change: true, remove: false }),
       )
       const coursePresenter = CourseUtils.presentCourse(course)
 
@@ -153,7 +153,9 @@ export default class ReferralsController {
     return async (req: Request, res: Response) => {
       TypeUtils.assertHasUser(req)
 
-      const referral = await this.referralService.getReferral(req.user.token, req.params.referralId)
+      const { referralId } = req.params
+
+      const referral = await this.referralService.getReferral(req.user.token, referralId)
       const person = await this.personService.getPerson(
         req.user.username,
         referral.prisonNumber,
@@ -164,7 +166,7 @@ export default class ReferralsController {
         pageHeading: `${person.name}'s details`,
         person,
         personSummaryListRows: PersonUtils.summaryListRows(person),
-        referralId: referral.id,
+        referralId,
       })
     }
   }
@@ -191,24 +193,26 @@ export default class ReferralsController {
     return async (req: Request, res: Response) => {
       TypeUtils.assertHasUser(req)
 
+      const { referralId } = req.params
+
       if (req.body.confirmation !== 'true') {
         req.flash(
           'confirmationError',
           'Confirm that the information you have provided is complete, accurate and up to date',
         )
 
-        return res.redirect(referPaths.checkAnswers({ referralId: req.params.referralId }))
+        return res.redirect(referPaths.checkAnswers({ referralId }))
       }
 
-      const referral = await this.referralService.getReferral(req.user.token, req.params.referralId)
+      const referral = await this.referralService.getReferral(req.user.token, referralId)
 
       if (!ReferralUtils.isReadyForSubmission(referral)) {
-        return res.redirect(referPaths.show({ referralId: referral.id }))
+        return res.redirect(referPaths.show({ referralId }))
       }
 
-      await this.referralService.updateReferralStatus(req.user.token, req.params.referralId, 'referral_submitted')
+      await this.referralService.updateReferralStatus(req.user.token, referralId, 'referral_submitted')
 
-      return res.redirect(referPaths.complete({ referralId: req.params.referralId }))
+      return res.redirect(referPaths.complete({ referralId }))
     }
   }
 }


### PR DESCRIPTION
## Context

<!-- Is there a Trello ticket you can link to? -->
<!-- Do you need to add any environment variables? -->
<!-- Is an ADR required? An ADR should be added if this PR introduces a change to the architecture. -->

You can currently still access pages/actions related to a referral even after it's been submitted, which could lead to unwanted changes being made

Closes #290 (replacement)

## Changes in this PR

- Redirect from pages related to a referral once submitted

## Release checklist

[Release process documentation](../doc/how-to/perform-a-release.md)

As part of our continuous deployment strategy we must ensure that this work is
ready to be released once merged.

### Pre-merge

- [ ] There are changes required to the Accredited Programmes API for this change to work...
  - [ ] ... and they have been released to production already

### Post-merge

<!-- The outer checkboxes can be completed pre-merge -->

- [ ] This adds, extends or meaningfully modifies a feature...
  - [ ] ... and I have written or updated an end-to-end test for the happy path in the [Accredited Programmes E2E repo](https://github.com/ministryofjustice/hmpps-accredited-programmes-e2e)
- [ ] This makes new expectations of the API...
  - [ ] ... and I have notified the API developer(s) of changes to the contract tests (Pact), or the API is already compliant
- [ ] [Manually approve](../doc/how-to/perform-a-release.md#releasing-to-the-preprod-environment) release to preprod
- [ ] [Manually approve](../doc/how-to/perform-a-release.md#releasing-to-the-production-environment) release to prod

<!-- Should a release fail at any step, you as the author should now lead the work to
fix it as soon as possible. You can monitor deployment failures in CircleCI
itself and application errors are found in
[Sentry](https://ministryofjustice.sentry.io/projects/hmpps-accredited-programmes-ui/?project=4505330122686464&referrer=sidebar&statsPeriod=24h). -->
