### PR TITLE
Fix `script/test` cleanup and improve feedback

### DIFF
--- a/script/test
+++ b/script/test
@@ -33,6 +33,22 @@ if [ "$UPDATE" = true ]; then
   script/update
 fi
 
+cleanup() {
+  docker-compose -p hmpps-accredited-programmes-ui_integration-test -f docker-compose-test.yml down
+
+  GREEN='\033[1;32m'
+  RED='\033[1;31m'
+  RESET_COLOUR='\033[0m'
+
+  if [ "$SUCCESS" = true ]; then
+    echo "\n\n${GREEN}( ͡° ͜ʖ ͡°) The full test suite ran successfully!${RESET_COLOUR}"
+  else
+    echo "\n\n${RED}( ͡° ʖ̯ ͡°) The test suite failed.${RESET_COLOUR}"
+  fi
+}
+
+trap cleanup EXIT
+
 echo "==> Linting the code..."
 
 npm run lint
@@ -60,19 +76,3 @@ echo "==> Running refer-disabled integration tests..."
 npm run test:integration:refer-disabled:cli
 
 SUCCESS=true
-
-cleanup() {
-  docker-compose -p hmpps-accredited-programmes-ui_integration-test -f docker-compose-test.yml down
-
-  GREEN='\033[1;32m'
-  GREEN='\033[1;31m'
-  RESET_COLOUR='\033[0m'
-
-  if [ "$SUCCESS" = true ]; then
-    echo "${GREEN}( ͡° ͜ʖ ͡°) The full test suite ran successfully!${RESET_COLOUR}\n\n"
-  else
-    echo "${RED}( ͡° ʖ̯ ͡°) The test suite failed.${RESET_COLOUR}\n\n"
-  fi
-}
-
-trap cleanup EXIT

--- a/script/test
+++ b/script/test
@@ -12,6 +12,7 @@ fi
 
 BUILD=true
 UPDATE=true
+SUCCESS=false
 
 for arg in "$@"
 do
@@ -58,8 +59,20 @@ echo "==> Running refer-disabled integration tests..."
 
 npm run test:integration:refer-disabled:cli
 
+SUCCESS=true
+
 cleanup() {
   docker-compose -p hmpps-accredited-programmes-ui_integration-test -f docker-compose-test.yml down
+
+  GREEN='\033[1;32m'
+  GREEN='\033[1;31m'
+  RESET_COLOUR='\033[0m'
+
+  if [ "$SUCCESS" = true ]; then
+    echo "${GREEN}( ͡° ͜ʖ ͡°) The full test suite ran successfully!${RESET_COLOUR}\n\n"
+  else
+    echo "${RED}( ͡° ʖ̯ ͡°) The test suite failed.${RESET_COLOUR}\n\n"
+  fi
 }
 
 trap cleanup EXIT

--- a/script/test-history
+++ b/script/test-history
@@ -9,9 +9,13 @@
 #
 #              Inspired by a Gary Bernhardt script: https://youtu.be/ZQnyApKysg4?t=183
 
+GREEN='\033[1;32m'
+RED='\033[1;31m'
+RESET_COLOUR='\033[0m'
+
 if [ $(git status --porcelain=v1 2>/dev/null | wc -l) = 1 ]
 then
-  echo "( ͡° ʖ̯ ͡°) Unable to execute script: commit or stash changes and try again"
+  echo "\n\n${RED}( ͡° ʖ̯ ͡°) Unable to execute script: commit or stash changes and try again${RESET_COLOUR}"
   exit 1
 fi
 
@@ -49,12 +53,12 @@ do
   
   if [ $? != 0 ]
   then
-    echo "( ͡° ʖ̯ ͡°) Identified bad commit: $revision. Exiting script..."
+    echo "\n\n${RED}( ͡° ʖ̯ ͡°) Identified bad commit: $revision.${RESET_COLOUR}"
     git checkout $BRANCH
     exit 1
   fi
 done <<< "$HISTORY"
 
-echo "( ͡° ͜ʖ ͡°) History clean. Exiting script..."
+echo "\n\n${GREEN}( ͡° ͜ʖ ͡°) History clean!${RESET_COLOUR}"
 
 git checkout $BRANCH


### PR DESCRIPTION
## Context

<!-- Is there a Trello ticket you can link to? -->
<!-- Do you need to add any environment variables? -->
<!-- Is an ADR required? An ADR should be added if this PR introduces a change to the architecture. -->

In `script/test`, it's currently only possible for `trap cleanup EXIT` to run on successful test runs, which is not very helpful

Another issue is that it can be hard to differentiate successful and unsuccessful `script/test` runs at a glance/with limited space

## Changes in this PR

- Fix use of `trap cleanup EXIT` so that `cleanup` is invoked on failed test runs
- Show a message on successful `script/test` runs

## Screenshots of UI changes

### Before

<img width="640" alt="image" src="https://github.com/ministryofjustice/hmpps-accredited-programmes-ui/assets/40244233/7784e84b-fec1-429f-81c1-d1028addee0d">

<img width="636" alt="image" src="https://github.com/ministryofjustice/hmpps-accredited-programmes-ui/assets/40244233/35107eb0-6a0b-4557-8c5d-1b04630e34f9">

### After

<img width="640" alt="image" src="https://github.com/ministryofjustice/hmpps-accredited-programmes-ui/assets/40244233/ddd65f16-673b-48d2-aed8-f2a8489692f1">

<img width="637" alt="image" src="https://github.com/ministryofjustice/hmpps-accredited-programmes-ui/assets/40244233/7d1b215b-7414-4251-8fa5-1810becf2652">

## Release checklist

[Release process documentation](../doc/how-to/perform-a-release.md)

As part of our continuous deployment strategy we must ensure that this work is
ready to be released once merged.

### Pre-merge

- [ ] There are changes required to the Accredited Programmes API for this change to work...
  - [ ] ... and they have been released to production already

### Post-merge

<!-- The outer checkboxes can be completed pre-merge -->

- [ ] This adds, extends or meaningfully modifies a feature...
  - [ ] ... and I have written or updated an end-to-end test for the happy path in the [Accredited Programmes E2E repo](https://github.com/ministryofjustice/hmpps-accredited-programmes-e2e)
- [ ] This makes new expectations of the API...
  - [ ] ... and I have notified the API developer(s) of changes to the contract tests (Pact), or the API is already compliant
- [ ] [Manually approve](../doc/how-to/perform-a-release.md#releasing-to-the-preprod-environment) release to preprod
- [ ] [Manually approve](../doc/how-to/perform-a-release.md#releasing-to-the-production-environment) release to prod

<!-- Should a release fail at any step, you as the author should now lead the work to
fix it as soon as possible. You can monitor deployment failures in CircleCI
itself and application errors are found in
[Sentry](https://ministryofjustice.sentry.io/projects/hmpps-accredited-programmes-ui/?project=4505330122686464&referrer=sidebar&statsPeriod=24h). -->
