### PR TITLE
Regenerate GOV.UK types after bootstrap

### DIFF
--- a/script/update
+++ b/script/update
@@ -10,10 +10,10 @@ echo "==> Pulling latest backing service images..."
 
 docker compose pull
 
-echo "==> Updating govuk-frontend types..."
-
-npm run generate-govuk-frontend-types
-
 echo "==> Bootstrapping..."
 
 script/bootstrap
+
+echo "==> Updating govuk-frontend types..."
+
+npm run generate-govuk-frontend-types


### PR DESCRIPTION
## Changes in this PR

This fixes a minor inconvenience: if we've bumped our Node version, when running `script/update` the script will exit when trying to update the GOV.UK types because it hasn't yet run `script/bootstrap` to install the new Node version. This reorders things so that the GOV.UK types are updated after Node and npm updates

## Release checklist

[Release process documentation](../doc/how-to/perform-a-release.md)

As part of our continuous deployment strategy we must ensure that this work is
ready to be released once merged.

### Pre-merge

- [ ] There are changes required to the Accredited Programmes API for this change to work...
  - [ ] ... and they have been released to production already

### Post-merge

<!-- The outer checkboxes can be completed pre-merge -->

- [ ] This adds, extends or meaningfully modifies a feature...
  - [ ] ... and I have written or updated an end-to-end test for the happy path in the [Accredited Programmes E2E repo](https://github.com/ministryofjustice/hmpps-accredited-programmes-e2e)
- [ ] This makes new expectations of the API...
  - [ ] ... and I have notified the API developer(s) of changes to the contract tests (Pact), or the API is already compliant
- [ ] [Manually approve](../doc/how-to/perform-a-release.md#releasing-to-the-preprod-environment) release to preprod
- [ ] [Manually approve](../doc/how-to/perform-a-release.md#releasing-to-the-production-environment) release to prod

<!-- Should a release fail at any step, you as the author should now lead the work to
fix it as soon as possible. You can monitor deployment failures in CircleCI
itself and application errors are found in
[Sentry](https://ministryofjustice.sentry.io/projects/hmpps-accredited-programmes-ui/?project=4505330122686464&referrer=sidebar&statsPeriod=24h). -->
