### PR TITLE
(1036) Update refer and draft referral URL paths

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,7 +63,7 @@ There are three user accounts with different roles that can be used when running
 
 The local copy of the Accredited Programmes API has various seeds in place providing data to work with in local development. These include courses, course offerings, and associated data, as well as one referral. This referral is at the stage of having just been created, and can be used to jump to the task list part of the Refer journey.
 
-Seeded referral ID and local server link: [c11fab18-dc8d-420c-9c82-d0edd373732d](http://localhost:3000/referrals/c11fab18-dc8d-420c-9c82-d0edd373732d)
+Seeded referral ID and local server link: [c11fab18-dc8d-420c-9c82-d0edd373732d](http://localhost:3000/refer/new/referrals/c11fab18-dc8d-420c-9c82-d0edd373732d)
 
 ## Running the tests
 

--- a/integration_tests/pages/refer/checkAnswers.ts
+++ b/integration_tests/pages/refer/checkAnswers.ts
@@ -46,7 +46,7 @@ export default class CheckAnswersPage extends Page {
   }
 
   shouldHaveAdditionalInformation(referral: Referral): void {
-    this.shouldContainLink('Change additional information', `/referrals/${referral.id}/reason`)
+    this.shouldContainLink('Change additional information', `/refer/new/referrals/${referral.id}/reason`)
     cy.get('[data-testid="additional-information"]').should('have.text', referral.reason)
   }
 

--- a/integration_tests/pages/refer/taskList.ts
+++ b/integration_tests/pages/refer/taskList.ts
@@ -30,7 +30,7 @@ export default class TaskListPage extends Page {
 
   shouldBeReadyForSubmission() {
     cy.get('[data-testid="check-answers-list-item"]').within(() => {
-      cy.get('a').should('have.attr', 'href', `/referrals/${this.referral.id}/check-answers`)
+      cy.get('a').should('have.attr', 'href', `/refer/new/referrals/${this.referral.id}/check-answers`)
       cy.get('.govuk-tag').then(tagElement => {
         const { actual, expected } = Helpers.parseHtml(tagElement, 'not started')
         expect(actual).to.equal(expected)

--- a/server/paths/refer.ts
+++ b/server/paths/refer.ts
@@ -10,20 +10,22 @@ const peoplePathBase = offeringReferralPathBase.path('people')
 const findPersonPath = peoplePathBase.path('search')
 const personPath = peoplePathBase.path(':prisonNumber')
 
-const referralsPath = path('/referrals')
-const showReferralPath = referralsPath.path(':referralId')
-const referralPersonPath = showReferralPath.path('person')
-const programmeHistoryPath = showReferralPath.path('programme-history')
+const referBasePath = path('/refer')
+
+const draftReferralsPath = referBasePath.path('/new/referrals')
+const showDraftReferralPath = draftReferralsPath.path(':referralId')
+const referralPersonPath = showDraftReferralPath.path('person')
+const programmeHistoryPath = showDraftReferralPath.path('programme-history')
 const newProgrammeHistoryPath = programmeHistoryPath.path('new')
 const showProgrammeHistoryPath = programmeHistoryPath.path(':courseParticipationId')
 const programmeHistoryProgrammePath = showProgrammeHistoryPath.path('programme')
 const programmeHistoryDetailsPath = showProgrammeHistoryPath.path('details')
 const deleteProgrammeHistoryPath = showProgrammeHistoryPath.path('delete')
-const confirmOasysPath = showReferralPath.path('confirm-oasys')
-const reasonForReferralPath = showReferralPath.path('reason')
-const checkAnswersPath = showReferralPath.path('check-answers')
-const completeReferralPath = showReferralPath.path('complete')
-const submitReferralPath = showReferralPath.path('submit')
+const confirmOasysPath = showDraftReferralPath.path('confirm-oasys')
+const reasonForReferralPath = showDraftReferralPath.path('reason')
+const checkAnswersPath = showDraftReferralPath.path('check-answers')
+const completeReferralPath = showDraftReferralPath.path('complete')
+const submitReferralPath = showDraftReferralPath.path('submit')
 
 export default {
   checkAnswers: checkAnswersPath,
@@ -32,7 +34,7 @@ export default {
     show: confirmOasysPath,
     update: confirmOasysPath,
   },
-  create: referralsPath,
+  create: draftReferralsPath,
   new: newReferralPath,
   people: {
     find: findPersonPath,
@@ -56,9 +58,9 @@ export default {
     show: reasonForReferralPath,
     update: reasonForReferralPath,
   },
-  show: showReferralPath,
+  show: showDraftReferralPath,
   showPerson: referralPersonPath,
   start: startReferralPath,
   submit: submitReferralPath,
-  update: showReferralPath,
+  update: showDraftReferralPath,
 }

--- a/server/utils/courseParticipationUtils.test.ts
+++ b/server/utils/courseParticipationUtils.test.ts
@@ -431,12 +431,12 @@ describe('CourseParticipationUtils', () => {
             actions: {
               items: [
                 {
-                  href: `/referrals/${referralId}/programme-history/${courseParticipationPresenter.id}/programme`,
+                  href: `/refer/new/referrals/${referralId}/programme-history/${courseParticipationPresenter.id}/programme`,
                   text: 'Change',
                   visuallyHiddenText: `participation for ${courseParticipationPresenter.courseName}`,
                 },
                 {
-                  href: `/referrals/${referralId}/programme-history/${courseParticipationPresenter.id}/delete`,
+                  href: `/refer/new/referrals/${referralId}/programme-history/${courseParticipationPresenter.id}/delete`,
                   text: 'Remove',
                   visuallyHiddenText: `participation for ${courseParticipationPresenter.courseName}`,
                 },

--- a/server/utils/referralUtils.test.ts
+++ b/server/utils/referralUtils.test.ts
@@ -102,7 +102,7 @@ describe('ReferralUtils', () => {
             {
               statusTag: { classes: 'moj-task-list__task-completed', text: 'completed' },
               text: 'Confirm personal details',
-              url: `/referrals/${referral.id}/person`,
+              url: `/refer/new/referrals/${referral.id}/person`,
             },
           ],
         },
@@ -116,7 +116,7 @@ describe('ReferralUtils', () => {
                 text: 'not started',
               },
               text: 'Review Accredited Programme history',
-              url: `/referrals/${referral.id}/programme-history`,
+              url: `/refer/new/referrals/${referral.id}/programme-history`,
             },
             {
               statusTag: {
@@ -125,7 +125,7 @@ describe('ReferralUtils', () => {
                 text: 'not started',
               },
               text: 'Confirm the OASys information',
-              url: `/referrals/${referral.id}/confirm-oasys`,
+              url: `/refer/new/referrals/${referral.id}/confirm-oasys`,
             },
             {
               statusTag: {
@@ -134,7 +134,7 @@ describe('ReferralUtils', () => {
                 text: 'not started',
               },
               text: 'Add additional information',
-              url: `/referrals/${referral.id}/reason`,
+              url: `/refer/new/referrals/${referral.id}/reason`,
             },
           ],
         },
@@ -192,7 +192,7 @@ describe('ReferralUtils', () => {
       const checkAnswersSection = getTaskListSection('Check answers and submit', taskListSections)
       const checkAnswersTask = getTaskListItem('Check answers and submit', checkAnswersSection)
 
-      expect(checkAnswersTask.url).toEqual(`/referrals/${referralWithOasysConfirmed.id}/check-answers`)
+      expect(checkAnswersTask.url).toEqual(`/refer/new/referrals/${referralWithOasysConfirmed.id}/check-answers`)
       expect(checkAnswersTask.statusTag.text).toEqual('not started')
     })
   })


### PR DESCRIPTION
## Context

https://trello.com/c/6THL9PqW/1036-update-refer-paths-for-creating-and-viewing-a-referral

## Changes in this PR

- Prefix refer paths with `/refer`
- Prefix draft referral paths with `/new` (e.g. full draft referral would be `refer/new/referrals/:id`)

## Release checklist

[Release process documentation](../doc/how-to/perform-a-release.md)

As part of our continuous deployment strategy we must ensure that this work is
ready to be released once merged.

### Pre-merge

- [ ] There are changes required to the Accredited Programmes API for this change to work...
  - [ ] ... and they have been released to production already

### Post-merge

<!-- The outer checkboxes can be completed pre-merge -->

- [ ] This adds, extends or meaningfully modifies a feature...
  - [ ] ... and I have written or updated an end-to-end test for the happy path in the [Accredited Programmes E2E repo](https://github.com/ministryofjustice/hmpps-accredited-programmes-e2e)
- [ ] This makes new expectations of the API...
  - [ ] ... and I have notified the API developer(s) of changes to the contract tests (Pact), or the API is already compliant
- [ ] [Manually approve](../doc/how-to/perform-a-release.md#releasing-to-the-preprod-environment) release to preprod
- [ ] [Manually approve](../doc/how-to/perform-a-release.md#releasing-to-the-production-environment) release to prod

<!-- Should a release fail at any step, you as the author should now lead the work to
fix it as soon as possible. You can monitor deployment failures in CircleCI
itself and application errors are found in
[Sentry](https://ministryofjustice.sentry.io/projects/hmpps-accredited-programmes-ui/?project=4505330122686464&referrer=sidebar&statsPeriod=24h). -->
