### PR TITLE
Use new prison number for Pact test

### DIFF
--- a/server/data/courseClient.test.ts
+++ b/server/data/courseClient.test.ts
@@ -295,10 +295,11 @@ pactWith({ consumer: 'Accredited Programmes UI', provider: 'Accredited Programme
   })
 
   describe('findParticipationsByPerson', () => {
+    const prisonNumber = 'B1234BB'
     beforeEach(() => {
       provider.addInteraction({
-        state: `Participations exist for a person with prison number ${person.prisonNumber}`,
-        uponReceiving: `A request for person "${person.prisonNumber}"'s participations`,
+        state: `Participations exist for a person with prison number ${prisonNumber}`,
+        uponReceiving: `A request for person "${prisonNumber}"'s participations`,
         willRespondWith: {
           body: Matchers.like(courseParticipations),
           status: 200,
@@ -308,13 +309,13 @@ pactWith({ consumer: 'Accredited Programmes UI', provider: 'Accredited Programme
             authorization: `Bearer ${token}`,
           },
           method: 'GET',
-          path: apiPaths.people.participations({ prisonNumber: person.prisonNumber }),
+          path: apiPaths.people.participations({ prisonNumber }),
         },
       })
     })
 
     it("fetches the given person's course participations", async () => {
-      const result = await courseClient.findParticipationsByPerson(person.prisonNumber)
+      const result = await courseClient.findParticipationsByPerson(prisonNumber)
 
       expect(result).toEqual(courseParticipations)
     })


### PR DESCRIPTION

## Context

<!-- Is there a Trello ticket you can link to? -->
<!-- Do you need to add any environment variables? -->
<!-- Is an ADR required? An ADR should be added if this PR introduces a change to the architecture. -->

Because of the way our tests are written on the provider side, we need to use a unique prison number for this test.

## Changes in this PR

Uses a unique prison number for one of our Course client tests.


## Release checklist

[Release process documentation](../doc/how-to/perform-a-release.md)

As part of our continuous deployment strategy we must ensure that this work is
ready to be released once merged.

### Pre-merge

- [ ] There are changes required to the Accredited Programmes API for this change to work...
  - [ ] ... and they have been released to production already

### Post-merge

<!-- The outer checkboxes can be completed pre-merge -->

- [ ] This adds, extends or meaningfully modifies a feature...
  - [ ] ... and I have written or updated an end-to-end test for the happy path in the [Accredited Programmes E2E repo](https://github.com/ministryofjustice/hmpps-accredited-programmes-e2e)
- [ ] This makes new expectations of the API...
  - [ ] ... and I have notified the API developer(s) of changes to the contract tests (Pact), or the API is already compliant
- [ ] [Manually approve](../doc/how-to/perform-a-release.md#releasing-to-the-preprod-environment) release to preprod
- [ ] [Manually approve](../doc/how-to/perform-a-release.md#releasing-to-the-production-environment) release to prod

<!-- Should a release fail at any step, you as the author should now lead the work to
fix it as soon as possible. You can monitor deployment failures in CircleCI
itself and application errors are found in
[Sentry](https://ministryofjustice.sentry.io/projects/hmpps-accredited-programmes-ui/?project=4505330122686464&referrer=sidebar&statsPeriod=24h). -->
