### PR TITLE
Add instructions for Postman to readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -118,3 +118,33 @@ run either of the following:
 ```bash
   npm run test:integration:refer-disabled:ui
 ```
+
+## Using Postman
+
+We have a Postman team for interacting with APIs - please ask to be added to it.
+
+You'll need to populate secret environment variables in the `Environments`
+section of Postman.
+
+**Ensure you put these in the "Current value" box, rather than "Initial value"
+or they will be shared!**
+
+### Local
+
+These secrets can be copied across from `.env.example` in this repo.
+
+### Dev & Dev (API credentials)
+
+You can use project-specific credentials for interacting with dev APIs. You'll
+need to fetch the secrets for this section from Kubernetes.
+
+See instructions in the [Manage Infrastructure
+docs](./doc/how-to/manage-infrastructure.md#viewing-an-individual-set-of-secrets)
+for accessing these secrets.
+
+### Preprod
+
+You'll need to have a personal client created for you by the HMPPS Auth, Audit
+and Registers team to view preprod data. This will require you to have Security
+Clearance and be on the MOJ VPN. Ask for this in the
+`#hmpps-auth-audit-registers` Slack channel.

--- a/doc/how-to/manage-infrastructure.md
+++ b/doc/how-to/manage-infrastructure.md
@@ -92,6 +92,26 @@ kubectl --namespace hmpps-accredited-programmes-<env> edit secret <secret set na
 
 Consider a [rolling restart](#rolling-restart) to apply this change.
 
+#### Viewing an individual set of secrets
+
+You can an individual set of secrets with the following command.
+
+```bash
+kubectl -n hmpps-accredited-programmes-<env> get secret <secret set> -o yaml
+```
+
+e.g.
+
+```bash
+kubectl -n hmpps-accredited-programmes-dev get secret hmpps-accredited-programmes-ui -o yaml
+```
+
+This will output the base64 encoded secrets in that set, which you can then decode and view with:
+
+```bash
+echo 'MY_BASE_64_ENCODED_STRING' | base64 -d
+```
+
 ### Rolling restart
 
 Restart an individual service without downtime. Each service will have multiple


### PR DESCRIPTION
## Context

<!-- Is there a Trello ticket you can link to? -->
<!-- Do you need to add any environment variables? -->
<!-- Is an ADR required? An ADR should be added if this PR introduces a change to the architecture. -->

We've got a shared Postman team which we use for interacting with APIs, that I've recently tidied up to use environments.

## Changes in this PR

Adds instructions for how to get secret values for interacting with APIs.

## Release checklist

[Release process documentation](../doc/how-to/perform-a-release.md)

As part of our continuous deployment strategy we must ensure that this work is
ready to be released once merged.

### Pre-merge

- [ ] There are changes required to the Accredited Programmes API for this change to work...
  - [ ] ... and they have been released to production already

### Post-merge

<!-- The outer checkboxes can be completed pre-merge -->

- [ ] This adds, extends or meaningfully modifies a feature...
  - [ ] ... and I have written or updated an end-to-end test for the happy path in the [Accredited Programmes E2E repo](https://github.com/ministryofjustice/hmpps-accredited-programmes-e2e)
- [ ] This makes new expectations of the API...
  - [ ] ... and I have notified the API developer(s) of changes to the contract tests (Pact), or the API is already compliant
- [ ] [Manually approve](../doc/how-to/perform-a-release.md#releasing-to-the-preprod-environment) release to preprod
- [ ] [Manually approve](../doc/how-to/perform-a-release.md#releasing-to-the-production-environment) release to prod

<!-- Should a release fail at any step, you as the author should now lead the work to
fix it as soon as possible. You can monitor deployment failures in CircleCI
itself and application errors are found in
[Sentry](https://ministryofjustice.sentry.io/projects/hmpps-accredited-programmes-ui/?project=4505330122686464&referrer=sidebar&statsPeriod=24h). -->
