### PR TITLE
(1034) Use submit referral endpoint

### DIFF
--- a/integration_tests/e2e/refer/submit.cy.ts
+++ b/integration_tests/e2e/refer/submit.cy.ts
@@ -161,7 +161,7 @@ context('Submitting a referral', () => {
 
     it('redirects to the referral complete page when the user confirms the details', () => {
       cy.task('stubReferral', submittableReferral)
-      cy.task('stubUpdateReferralStatus', submittableReferral.id)
+      cy.task('stubSubmitReferral', submittableReferral.id)
 
       const path = referPaths.checkAnswers({ referralId: submittableReferral.id })
       cy.visit(path)
@@ -175,7 +175,7 @@ context('Submitting a referral', () => {
         referral: submittableReferral,
         username: auth.mockedUser.username,
       })
-      checkAnswersPage.confirmDetailsAndSubmitReferral(submittableReferral)
+      checkAnswersPage.confirmDetailsAndSubmitReferral()
 
       const completePage = Page.verifyOnPage(CompletePage)
       completePage.shouldContainPanel('Referral complete')

--- a/integration_tests/mockApis/referrals.ts
+++ b/integration_tests/mockApis/referrals.ts
@@ -4,6 +4,13 @@ import { apiPaths } from '../../server/paths'
 import { stubFor } from '../../wiremock'
 import type { Referral } from '@accredited-programmes/models'
 
+interface ReferralAndScenarioOptions {
+  referral: Referral
+  requiredScenarioState: string
+  scenarioName: string
+  newScenarioState?: string
+}
+
 export default {
   stubCreateReferral: (referral: Referral): SuperAgentRequest =>
     stubFor({
@@ -28,6 +35,39 @@ export default {
         headers: { 'Content-Type': 'application/json;charset=UTF-8' },
         jsonBody: referral,
         status: 200,
+      },
+    }),
+
+  stubReferralWithScenario: ({
+    newScenarioState,
+    referral,
+    requiredScenarioState,
+    scenarioName,
+  }: ReferralAndScenarioOptions): SuperAgentRequest =>
+    stubFor({
+      newScenarioState,
+      request: {
+        method: 'GET',
+        url: apiPaths.referrals.show({ referralId: referral.id }),
+      },
+      requiredScenarioState,
+      response: {
+        headers: { 'Content-Type': 'application/json;charset=UTF-8' },
+        jsonBody: referral,
+        status: 200,
+      },
+      scenarioName,
+    }),
+
+  stubSubmitReferral: (referralId: Referral['id']): SuperAgentRequest =>
+    stubFor({
+      request: {
+        method: 'POST',
+        url: apiPaths.referrals.submit({ referralId }),
+      },
+      response: {
+        headers: { 'Content-Type': 'application/json;charset=UTF-8' },
+        status: 204,
       },
     }),
 

--- a/integration_tests/pages/refer/checkAnswers.ts
+++ b/integration_tests/pages/refer/checkAnswers.ts
@@ -40,9 +40,23 @@ export default class CheckAnswersPage extends Page {
     this.username = username
   }
 
-  confirmDetailsAndSubmitReferral(referral: Referral) {
+  confirmDetailsAndSubmitReferral() {
+    // Need to stub the call to get the referral twice because
+    // the first stub is for the submit method and
+    // the second stub is for the complete page
+    cy.task('stubReferralWithScenario', {
+      newScenarioState: 'Submitted',
+      referral: this.referral,
+      requiredScenarioState: 'Started',
+      scenarioName: 'Submitting a referral',
+    })
+    cy.task('stubReferralWithScenario', {
+      referral: { ...this.referral, status: 'referral_submitted' },
+      requiredScenarioState: 'Submitted',
+      scenarioName: 'Submitting a referral',
+    })
+
     cy.get('[name="confirmation"]').check()
-    cy.task('stubReferral', { ...referral, status: 'referral_submitted' })
     this.shouldContainButton('Submit referral').click()
   }
 

--- a/server/@types/models/Referral.ts
+++ b/server/@types/models/Referral.ts
@@ -10,6 +10,7 @@ type Referral = {
   prisonNumber: Person['prisonNumber']
   referrerId: Express.User['userId']
   status: ReferralStatus
+  submittedAt?: string
 }
 
 type CreatedReferralResponse = {

--- a/server/controllers/refer/referralsController.test.ts
+++ b/server/controllers/refer/referralsController.test.ts
@@ -352,8 +352,6 @@ describe('ReferralsController', () => {
       referralService.getReferral.mockResolvedValue(submittableReferral)
       request.body.confirmation = 'true'
 
-      referralService.getReferral.mockResolvedValue(submittableReferral)
-
       request.params.referralId = referralId
       ;(ReferralUtils.isReadyForSubmission as jest.Mock).mockReturnValue(true)
 
@@ -362,7 +360,7 @@ describe('ReferralsController', () => {
 
       expect(referralService.getReferral).toHaveBeenCalledWith(token, referralId)
       expect(response.redirect).toHaveBeenCalledWith(referPaths.complete({ referralId }))
-      expect(referralService.updateReferralStatus).toHaveBeenCalledWith(token, referralId, 'referral_submitted')
+      expect(referralService.submitReferral).toHaveBeenCalledWith(token, referralId)
     })
 
     describe('when the body is invalid', () => {

--- a/server/controllers/refer/referralsController.ts
+++ b/server/controllers/refer/referralsController.ts
@@ -230,7 +230,7 @@ export default class ReferralsController {
         return res.redirect(referPaths.show({ referralId }))
       }
 
-      await this.referralService.updateReferralStatus(req.user.token, referralId, 'referral_submitted')
+      await this.referralService.submitReferral(req.user.token, referralId)
 
       return res.redirect(referPaths.complete({ referralId }))
     }

--- a/server/data/referralClient.test.ts
+++ b/server/data/referralClient.test.ts
@@ -80,6 +80,29 @@ pactWith({ consumer: 'Accredited Programmes UI', provider: 'Accredited Programme
     })
   })
 
+  describe('submit', () => {
+    beforeEach(() => {
+      provider.addInteraction({
+        state: 'Referral can be submitted',
+        uponReceiving: 'A request to submit a referral',
+        willRespondWith: {
+          status: 204,
+        },
+        withRequest: {
+          headers: {
+            authorization: `Bearer ${token}`,
+          },
+          method: 'POST',
+          path: apiPaths.referrals.submit({ referralId: referral.id }),
+        },
+      })
+    })
+
+    it('submits a referral', async () => {
+      await referralClient.submit(referral.id)
+    })
+  })
+
   describe('update', () => {
     const referralUpdate: ReferralUpdate = {
       additionalInformation: 'Some fascinating information',

--- a/server/data/referralClient.ts
+++ b/server/data/referralClient.ts
@@ -28,6 +28,12 @@ export default class ReferralClient {
     })) as Referral
   }
 
+  async submit(referralId: Referral['id']): Promise<void> {
+    await this.restClient.post({
+      path: apiPaths.referrals.submit({ referralId }),
+    })
+  }
+
   async update(referralId: Referral['id'], referralUpdate: ReferralUpdate): Promise<void> {
     await this.restClient.put({
       data: referralUpdate,

--- a/server/paths/api.ts
+++ b/server/paths/api.ts
@@ -11,6 +11,7 @@ const courseByOfferingPath = offeringPath.path('course')
 const referralsPath = path('/referrals')
 const referralPath = referralsPath.path(':referralId')
 const updateStatusPath = referralPath.path('status')
+const submitPath = referralPath.path('submit')
 
 const participationsByPersonPath = path('/people/:prisonNumber/course-participations')
 const participationsPath = path('/course-participations')
@@ -39,6 +40,7 @@ export default {
   referrals: {
     create: referralsPath,
     show: referralPath,
+    submit: submitPath,
     update: referralPath,
     updateStatus: updateStatusPath,
   },

--- a/server/services/referralService.test.ts
+++ b/server/services/referralService.test.ts
@@ -61,6 +61,17 @@ describe('ReferralService', () => {
     })
   })
 
+  describe('submitReferral', () => {
+    it('asks the client to submit a referral', async () => {
+      const referral = referralFactory.submitted().build()
+
+      await service.submitReferral(token, referral.id)
+
+      expect(referralClientBuilder).toHaveBeenCalledWith(token)
+      expect(referralClient.submit).toHaveBeenCalledWith(referral.id)
+    })
+  })
+
   describe('updateReferral', () => {
     it('asks the client to update a referral', async () => {
       const referralId = 'an-ID'

--- a/server/services/referralService.ts
+++ b/server/services/referralService.ts
@@ -19,6 +19,11 @@ export default class ReferralService {
     return referralClient.find(referralId)
   }
 
+  async submitReferral(token: Express.User['token'], referralId: Referral['id']): Promise<void> {
+    const referralClient = this.referralClientBuilder(token)
+    return referralClient.submit(referralId)
+  }
+
   async updateReferral(
     token: Express.User['token'],
     referralId: Referral['id'],

--- a/server/testutils/factories/referral.ts
+++ b/server/testutils/factories/referral.ts
@@ -10,6 +10,7 @@ class ReferralFactory extends Factory<Referral> {
       hasReviewedProgrammeHistory: false,
       oasysConfirmed: false,
       status: 'referral_started',
+      submittedAt: undefined,
     })
   }
 
@@ -19,6 +20,7 @@ class ReferralFactory extends Factory<Referral> {
       hasReviewedProgrammeHistory: true,
       oasysConfirmed: true,
       status: 'referral_started',
+      submittedAt: undefined,
     })
   }
 
@@ -28,11 +30,19 @@ class ReferralFactory extends Factory<Referral> {
       hasReviewedProgrammeHistory: true,
       oasysConfirmed: true,
       status: 'referral_submitted',
+      submittedAt: faker.date.past().toISOString(),
     })
   }
 }
 
-export default ReferralFactory.define(() => ({
+const status = faker.helpers.arrayElement([
+  'awaiting_assesment',
+  'assessment_started',
+  'referral_started',
+  'referral_submitted',
+]) as ReferralStatus
+
+export default ReferralFactory.define(({ params }) => ({
   id: faker.string.uuid(), // eslint-disable-next-line sort-keys
   additionalInformation: faker.lorem.paragraph({ max: 5, min: 0 }),
   hasReviewedProgrammeHistory: faker.datatype.boolean(),
@@ -40,10 +50,6 @@ export default ReferralFactory.define(() => ({
   offeringId: faker.string.uuid(),
   prisonNumber: faker.string.alphanumeric({ length: 7 }),
   referrerId: faker.string.numeric({ length: 6 }),
-  status: faker.helpers.arrayElement([
-    'awaiting_assesment',
-    'assessment_started',
-    'referral_started',
-    'referral_submitted',
-  ]) as ReferralStatus,
+  status,
+  submittedAt: (params.status || status) !== 'referral_started' ? faker.date.past().toISOString() : undefined,
 }))


### PR DESCRIPTION
## Context

When submitting check your answers page, instead of using the PUT endpoint for changing the referral’s status, hit `referrals/:id/submit`, allowing the API to set this submitted on date and update the status for us.

https://trello.com/c/msWXJ5HB/1034-update-ui-to-use-new-referrals-id-submit-endpoint-on-referral-submission-ui-s



## Changes in this PR

- Update referral client and service to utilise new endpoint.
- Update integration tests, including updating how we stub the calls to GET a referral.  One of the integration tests was giving a false positive because the referral was already being stubbed with a status of `referral_submitted`, before it was actually submitted.



## Release checklist

[Release process documentation](../doc/how-to/perform-a-release.md)

As part of our continuous deployment strategy we must ensure that this work is
ready to be released once merged.

### Pre-merge

- [ ] There are changes required to the Accredited Programmes API for this change to work...
  - [ ] ... and they have been released to production already

### Post-merge

<!-- The outer checkboxes can be completed pre-merge -->

- [ ] This adds, extends or meaningfully modifies a feature...
  - [ ] ... and I have written or updated an end-to-end test for the happy path in the [Accredited Programmes E2E repo](https://github.com/ministryofjustice/hmpps-accredited-programmes-e2e)
- [ ] This makes new expectations of the API...
  - [ ] ... and I have notified the API developer(s) of changes to the contract tests (Pact), or the API is already compliant
- [ ] [Manually approve](../doc/how-to/perform-a-release.md#releasing-to-the-preprod-environment) release to preprod
- [ ] [Manually approve](../doc/how-to/perform-a-release.md#releasing-to-the-production-environment) release to prod

<!-- Should a release fail at any step, you as the author should now lead the work to
fix it as soon as possible. You can monitor deployment failures in CircleCI
itself and application errors are found in
[Sentry](https://ministryofjustice.sentry.io/projects/hmpps-accredited-programmes-ui/?project=4505330122686464&referrer=sidebar&statsPeriod=24h). -->
