### PR TITLE
Add specific offering ID for Pact test

### DIFF
--- a/server/data/referralClient.test.ts
+++ b/server/data/referralClient.test.ts
@@ -17,7 +17,9 @@ pactWith({ consumer: 'Accredited Programmes UI', provider: 'Accredited Programme
     config.apis.accreditedProgrammesApi.url = provider.mockService.baseUrl
   })
 
-  const referral = referralFactory.started().build({ id: '0c46ed09-170b-4c0f-aee8-a24eeaeeddaa' })
+  const referral = referralFactory
+    .started()
+    .build({ id: '0c46ed09-170b-4c0f-aee8-a24eeaeeddaa', offeringId: 'be1d407c-3cb5-4c7e-bfee-d104bc79213f' })
   const { offeringId, prisonNumber, referrerId } = referral
   const createdReferralResponse: CreatedReferralResponse = { referralId: referral.id }
 


### PR DESCRIPTION
## Context

The test for creating a Referral is currently failing on the provider side, as the Offering we assign to the Referral needs to exist in the test DB when creating the Referral, yet we're currently generating one randomly with the Referral factory. This means with each merge the provider is looking for a referral with the newly-generated ID.

## Changes in this PR

Adds fixed ID of offering that exists in the API test database.


## Release checklist

[Release process documentation](../doc/how-to/perform-a-release.md)

As part of our continuous deployment strategy we must ensure that this work is
ready to be released once merged.

### Pre-merge

- [ ] There are changes required to the Accredited Programmes API for this change to work...
  - [ ] ... and they have been released to production already

### Post-merge

<!-- The outer checkboxes can be completed pre-merge -->

- [ ] This adds, extends or meaningfully modifies a feature...
  - [ ] ... and I have written or updated an end-to-end test for the happy path in the [Accredited Programmes E2E repo](https://github.com/ministryofjustice/hmpps-accredited-programmes-e2e)
- [ ] This makes new expectations of the API...
  - [ ] ... and I have notified the API developer(s) of changes to the contract tests (Pact), or the API is already compliant
- [ ] [Manually approve](../doc/how-to/perform-a-release.md#releasing-to-the-preprod-environment) release to preprod
- [ ] [Manually approve](../doc/how-to/perform-a-release.md#releasing-to-the-production-environment) release to prod

<!-- Should a release fail at any step, you as the author should now lead the work to
fix it as soon as possible. You can monitor deployment failures in CircleCI
itself and application errors are found in
[Sentry](https://ministryofjustice.sentry.io/projects/hmpps-accredited-programmes-ui/?project=4505330122686464&referrer=sidebar&statsPeriod=24h). -->
