### PR TITLE
(889a) Add sentence information client

### DIFF
--- a/integration_tests/mockApis/caseloads.ts
+++ b/integration_tests/mockApis/caseloads.ts
@@ -10,7 +10,7 @@ export default {
     stubFor({
       request: {
         method: 'GET',
-        url: prisonApiPaths.users.current.caseloads({}),
+        url: prisonApiPaths.caseloads.currentUser({}),
       },
       response: {
         headers: { 'Content-Type': 'application/json;charset=UTF-8' },
@@ -23,7 +23,7 @@ export default {
     stubFor({
       request: {
         method: 'GET',
-        url: prisonApiPaths.users.current.caseloads({}),
+        url: prisonApiPaths.caseloads.currentUser({}),
       },
       response: {
         headers: { 'Content-Type': 'application/json;charset=UTF-8' },

--- a/server/@types/models/Person.ts
+++ b/server/@types/models/Person.ts
@@ -1,4 +1,5 @@
 export type Person = {
+  bookingId: string
   currentPrison: string
   dateOfBirth: string
   ethnicity: string

--- a/server/@types/prisonApi/index.d.ts
+++ b/server/@types/prisonApi/index.d.ts
@@ -1,7 +1,14 @@
-export type Caseload = {
+type Caseload = {
   caseLoadId: string // eslint-disable-next-line @typescript-eslint/member-ordering
   caseloadFunction: string
   currentlyActive: boolean
   description: string
   type: string
 }
+
+type SentenceAndOffenceDetails = {
+  sentenceDate: string
+  sentenceTypeDescription: string
+}
+
+export type { Caseload, SentenceAndOffenceDetails }

--- a/server/@types/prisonerOffenderSearch/index.d.ts
+++ b/server/@types/prisonerOffenderSearch/index.d.ts
@@ -1,4 +1,5 @@
 export type Prisoner = {
+  bookingId: string
   dateOfBirth: string
   firstName: string
   gender: string

--- a/server/data/caseloadClient.test.ts
+++ b/server/data/caseloadClient.test.ts
@@ -31,7 +31,7 @@ describe('caseloadClient', () => {
 
     it('fetches all Caseloads for the logged in user', async () => {
       fakePrisonApi
-        .get(prisonApiPaths.users.current.caseloads({}))
+        .get(prisonApiPaths.caseloads.currentUser({}))
         .matchHeader('authorization', `Bearer ${token}`)
         .reply(200, caseloads)
 

--- a/server/data/caseloadClient.ts
+++ b/server/data/caseloadClient.ts
@@ -13,7 +13,7 @@ export default class CaseloadClient {
 
   async allByCurrentUser(): Promise<Array<Caseload>> {
     return (await this.restClient.get({
-      path: prisonApiPaths.users.current.caseloads({}),
+      path: prisonApiPaths.caseloads.currentUser({}),
     })) as Array<Caseload>
   }
 }

--- a/server/data/index.ts
+++ b/server/data/index.ts
@@ -22,6 +22,7 @@ import PrisonerClient from './prisonerClient'
 import type { RedisClient } from './redisClient'
 import { createRedisClient } from './redisClient'
 import ReferralClient from './referralClient'
+import SentenceInformationClient from './sentenceInformationClient'
 import TokenStore from './tokenStore'
 import type { TokenVerifier } from './tokenVerification'
 import verifyToken from './tokenVerification'
@@ -41,6 +42,8 @@ const prisonerClientBuilder: RestClientBuilder<PrisonerClient> = (token: Express
   new PrisonerClient(token)
 const referralClientBuilder: RestClientBuilder<ReferralClient> = (token: Express.User['token']) =>
   new ReferralClient(token)
+const sentenceInformationClientBuilder: RestClientBuilder<SentenceInformationClient> = (token: Express.User['token']) =>
+  new SentenceInformationClient(token)
 
 export {
   CaseloadClient,
@@ -50,6 +53,7 @@ export {
   PrisonClient,
   PrisonerClient,
   ReferralClient,
+  SentenceInformationClient,
   TokenStore,
   caseloadClientBuilder,
   courseClientBuilder,
@@ -59,6 +63,7 @@ export {
   prisonClientBuilder,
   prisonerClientBuilder,
   referralClientBuilder,
+  sentenceInformationClientBuilder,
   serviceCheckFactory,
   verifyToken,
 }

--- a/server/data/sentenceInformationClient.test.ts
+++ b/server/data/sentenceInformationClient.test.ts
@@ -1,0 +1,43 @@
+import nock from 'nock'
+
+import SentenceInformationClient from './sentenceInformationClient'
+import config from '../config'
+import { prisonApiPaths } from '../paths'
+import { prisonerFactory, sentenceAndOffenceDetailsFactory } from '../testutils/factories'
+import type { Prisoner } from '@prisoner-offender-search'
+
+describe('SentenceInformationClient', () => {
+  let fakePrisonApi: nock.Scope
+  let sentenceInformationClient: SentenceInformationClient
+
+  const token = 'token-1'
+
+  beforeEach(() => {
+    fakePrisonApi = nock(config.apis.prisonApi.url)
+    sentenceInformationClient = new SentenceInformationClient(token)
+  })
+
+  afterEach(() => {
+    if (!nock.isDone()) {
+      nock.cleanAll()
+      throw new Error('Not all nock interceptors were used!')
+    }
+    nock.abortPendingRequests()
+    nock.cleanAll()
+  })
+
+  describe('findSentenceAndOffenceDetails', () => {
+    const prisoner: Prisoner = prisonerFactory.build()
+    const sentenceAndOffenceDetails = sentenceAndOffenceDetailsFactory.build()
+
+    it("searches for a prisoner's sentence and offence details by booking ID", async () => {
+      fakePrisonApi
+        .get(prisonApiPaths.sentenceAndOffenceDetails({ bookingId: prisoner.bookingId }))
+        .matchHeader('authorization', `Bearer ${token}`)
+        .reply(200, sentenceAndOffenceDetails)
+
+      const output = await sentenceInformationClient.findSentenceAndOffenceDetails(prisoner.bookingId)
+      expect(output).toEqual(sentenceAndOffenceDetails)
+    })
+  })
+})

--- a/server/data/sentenceInformationClient.ts
+++ b/server/data/sentenceInformationClient.ts
@@ -1,0 +1,20 @@
+import RestClient from './restClient'
+import type { ApiConfig } from '../config'
+import config from '../config'
+import { prisonApiPaths } from '../paths'
+import type { SentenceAndOffenceDetails } from '@prison-api'
+import type { Prisoner } from '@prisoner-offender-search'
+
+export default class SentenceInformationClient {
+  restClient: RestClient
+
+  constructor(token: Express.User['token']) {
+    this.restClient = new RestClient('prisonerClient', config.apis.prisonApi as ApiConfig, token)
+  }
+
+  async findSentenceAndOffenceDetails(bookingId: Prisoner['bookingId']): Promise<SentenceAndOffenceDetails> {
+    return (await this.restClient.get({
+      path: prisonApiPaths.sentenceAndOffenceDetails({ bookingId }),
+    })) as SentenceAndOffenceDetails
+  }
+}

--- a/server/paths/prisonApi.ts
+++ b/server/paths/prisonApi.ts
@@ -3,9 +3,7 @@ import { path } from 'static-path'
 const caseloadsPath = path('/api/users/me/caseLoads')
 
 export default {
-  users: {
-    current: {
-      caseloads: caseloadsPath,
-    },
+  caseloads: {
+    currentUser: caseloadsPath,
   },
 }

--- a/server/paths/prisonApi.ts
+++ b/server/paths/prisonApi.ts
@@ -1,9 +1,14 @@
 import { path } from 'static-path'
 
-const caseloadsPath = path('/api/users/me/caseLoads')
+const apiBasePath = path('/api')
+const caseloadsPath = apiBasePath.path('users/me/caseLoads')
+const sentenceAndOffenceDetailsPath = apiBasePath.path('offender-sentences/booking/:bookingId/sentences-and-offences')
+const sentenceDatesPath = apiBasePath.path('bookings/:bookingId/sentenceDetail')
 
 export default {
   caseloads: {
     currentUser: caseloadsPath,
   },
+  sentenceAndOffenceDetails: sentenceAndOffenceDetailsPath,
+  sentenceDates: sentenceDatesPath,
 }

--- a/server/testutils/factories/index.ts
+++ b/server/testutils/factories/index.ts
@@ -11,6 +11,7 @@ import prisonFactory from './prison'
 import prisonAddressFactory from './prisonAddress'
 import prisonerFactory from './prisoner'
 import referralFactory from './referral'
+import sentenceAndOffenceDetailsFactory from './sentenceAndOffenceDetails'
 import userFactory from './user'
 
 export {
@@ -27,5 +28,6 @@ export {
   prisonFactory,
   prisonerFactory,
   referralFactory,
+  sentenceAndOffenceDetailsFactory,
   userFactory,
 }

--- a/server/testutils/factories/person.ts
+++ b/server/testutils/factories/person.ts
@@ -8,6 +8,7 @@ export default Factory.define<Person>(({ params }) => {
   const currentPrison = params.currentPrison || `${county} (HMP)`
 
   return {
+    bookingId: faker.string.numeric({ length: 10 }),
     currentPrison,
     dateOfBirth: faker.date.birthdate().toDateString(),
     ethnicity: faker.lorem.word(),

--- a/server/testutils/factories/prisoner.ts
+++ b/server/testutils/factories/prisoner.ts
@@ -13,6 +13,7 @@ export default Factory.define<Prisoner>(({ params }) => {
   const day = dateOfBirth.getDate()
 
   return {
+    bookingId: faker.string.numeric({ length: 10 }),
     dateOfBirth: [year, month, day].join('-'),
     ethnicity: faker.lorem.word(),
     firstName: faker.person.firstName(),

--- a/server/testutils/factories/sentenceAndOffenceDetails.ts
+++ b/server/testutils/factories/sentenceAndOffenceDetails.ts
@@ -1,0 +1,9 @@
+import { faker } from '@faker-js/faker/locale/en_GB'
+import { Factory } from 'fishery'
+
+import type { SentenceAndOffenceDetails } from '@prison-api'
+
+export default Factory.define<SentenceAndOffenceDetails>(() => ({
+  sentenceDate: `${faker.date.past({ years: 20 })}`.substring(0, 10),
+  sentenceTypeDescription: faker.word.words({ count: { max: 5, min: 1 } }),
+}))

--- a/server/utils/personUtils.test.ts
+++ b/server/utils/personUtils.test.ts
@@ -6,6 +6,7 @@ describe('PersonUtils', () => {
     describe('when all fields are present on a Prison Offender Search "Prisoner"', () => {
       it('returns a "Person" with those fields', () => {
         const prisoner = prisonerFactory.build({
+          bookingId: '1234567890',
           dateOfBirth: '1971-07-05',
           ethnicity: 'White',
           firstName: 'Del',
@@ -17,6 +18,7 @@ describe('PersonUtils', () => {
         })
 
         expect(PersonUtils.personFromPrisoner(prisoner)).toEqual({
+          bookingId: '1234567890',
           currentPrison: 'HMP Hewell',
           dateOfBirth: '5 July 1971',
           ethnicity: 'White',
@@ -40,6 +42,7 @@ describe('PersonUtils', () => {
     describe('when fields are missing on a Prison Offender Search "Prisoner"', () => {
       it('returns a "Person" with those "Not entered" for those fields', () => {
         const prisoner = prisonerFactory.build({
+          bookingId: '1234567890',
           dateOfBirth: '1971-07-05',
           ethnicity: undefined,
           firstName: 'Del',
@@ -51,6 +54,7 @@ describe('PersonUtils', () => {
         })
 
         expect(PersonUtils.personFromPrisoner(prisoner)).toEqual({
+          bookingId: '1234567890',
           currentPrison: 'HMP Hewell',
           dateOfBirth: '5 July 1971',
           ethnicity: 'Not entered',

--- a/server/utils/personUtils.ts
+++ b/server/utils/personUtils.ts
@@ -9,6 +9,7 @@ export default class PersonUtils {
     const unavailable = 'Not entered'
 
     return {
+      bookingId: prisoner.bookingId,
       currentPrison: prisoner.prisonName,
       dateOfBirth: DateUtils.govukFormattedFullDateString(prisoner.dateOfBirth),
       ethnicity: prisoner.ethnicity || unavailable,

--- a/wiremock/scripts/stubCaseloads.ts
+++ b/wiremock/scripts/stubCaseloads.ts
@@ -7,7 +7,7 @@ import { caseloads } from '../stubs'
 stubFor({
   request: {
     method: 'GET',
-    url: prisonApiPaths.users.current.caseloads({}),
+    url: prisonApiPaths.caseloads.currentUser({}),
   },
   response: {
     headers: {


### PR DESCRIPTION
## Context

<!-- Is there a Trello ticket you can link to? -->
<!-- Do you need to add any environment variables? -->
<!-- Is an ADR required? An ADR should be added if this PR introduces a change to the architecture. -->

We need to access sentence information including type and various dates

## Changes in this PR

- Update `Person`/`Prisoner` types to include `bookingId` to enable sentence information requests
- Add new type
- Update paths
- Add sentence information client and sentence `findSentenceAndOffenceDetails` method

## Release checklist

[Release process documentation](../doc/how-to/perform-a-release.md)

As part of our continuous deployment strategy we must ensure that this work is
ready to be released once merged.

### Pre-merge

- [ ] There are changes required to the Accredited Programmes API for this change to work...
  - [ ] ... and they have been released to production already

### Post-merge

<!-- The outer checkboxes can be completed pre-merge -->

- [ ] This adds, extends or meaningfully modifies a feature...
  - [ ] ... and I have written or updated an end-to-end test for the happy path in the [Accredited Programmes E2E repo](https://github.com/ministryofjustice/hmpps-accredited-programmes-e2e)
- [ ] This makes new expectations of the API...
  - [ ] ... and I have notified the API developer(s) of changes to the contract tests (Pact), or the API is already compliant
- [ ] [Manually approve](../doc/how-to/perform-a-release.md#releasing-to-the-preprod-environment) release to preprod
- [ ] [Manually approve](../doc/how-to/perform-a-release.md#releasing-to-the-production-environment) release to prod

<!-- Should a release fail at any step, you as the author should now lead the work to
fix it as soon as possible. You can monitor deployment failures in CircleCI
itself and application errors are found in
[Sentry](https://ministryofjustice.sentry.io/projects/hmpps-accredited-programmes-ui/?project=4505330122686464&referrer=sidebar&statsPeriod=24h). -->
