### PR TITLE
(1041) Update year in `CourseParticipationOutcomeFactory`

### DIFF
--- a/server/testutils/factories/courseParticipationOutcome.ts
+++ b/server/testutils/factories/courseParticipationOutcome.ts
@@ -4,23 +4,23 @@ import { Factory } from 'fishery'
 import FactoryHelpers from './factoryHelpers'
 import type { CourseParticipationOutcome } from '@accredited-programmes/models'
 
-const randomNonFutureYearFrom = (minimumYear: number): number => {
+const randomValidYear = (): number => {
   const currentYear = new Date().getFullYear()
-  return faker.number.int({ max: currentYear, min: minimumYear })
+  return faker.number.int({ max: currentYear, min: 1990 })
 }
 
 const outcomeTypes = {
   complete(): CourseParticipationOutcome {
     return {
       status: 'complete',
-      yearCompleted: FactoryHelpers.optionalArrayElement(randomNonFutureYearFrom(1980)),
+      yearCompleted: FactoryHelpers.optionalArrayElement(randomValidYear()),
     }
   },
 
   incomplete(): CourseParticipationOutcome {
     return {
       status: 'incomplete',
-      yearStarted: FactoryHelpers.optionalArrayElement(randomNonFutureYearFrom(1980)),
+      yearStarted: FactoryHelpers.optionalArrayElement(randomValidYear()),
     }
   },
 


### PR DESCRIPTION

## Context

A helper method was included in this factory to generate a random non-future year. We've since added validations to the year fields, but not updated this method. We were passing in a minimum year of 1980, but the minimum valid year is now 1990

This was producing flaky results when asserting against success messages in integration tests, since the factory would occasionally produce invalid course participation outcomes that would block success conditions

## Changes in this PR

- Update the minimum year in the course participation outcome factory

## Release checklist

[Release process documentation](../doc/how-to/perform-a-release.md)

As part of our continuous deployment strategy we must ensure that this work is
ready to be released once merged.

### Pre-merge

- [ ] There are changes required to the Accredited Programmes API for this change to work...
  - [ ] ... and they have been released to production already

### Post-merge

<!-- The outer checkboxes can be completed pre-merge -->

- [ ] This adds, extends or meaningfully modifies a feature...
  - [ ] ... and I have written or updated an end-to-end test for the happy path in the [Accredited Programmes E2E repo](https://github.com/ministryofjustice/hmpps-accredited-programmes-e2e)
- [ ] This makes new expectations of the API...
  - [ ] ... and I have notified the API developer(s) of changes to the contract tests (Pact), or the API is already compliant
- [x] [Manually approve](../doc/how-to/perform-a-release.md#releasing-to-the-preprod-environment) release to preprod
- [x] [Manually approve](../doc/how-to/perform-a-release.md#releasing-to-the-production-environment) release to prod

<!-- Should a release fail at any step, you as the author should now lead the work to
fix it as soon as possible. You can monitor deployment failures in CircleCI
itself and application errors are found in
[Sentry](https://ministryofjustice.sentry.io/projects/hmpps-accredited-programmes-ui/?project=4505330122686464&referrer=sidebar&statsPeriod=24h). -->
