### PR TITLE
(893a) Refactor course participation presentation

### DIFF
--- a/server/controllers/refer/courseParticipationsController.test.ts
+++ b/server/controllers/refer/courseParticipationsController.test.ts
@@ -13,9 +13,9 @@ import {
   userFactory,
 } from '../../testutils/factories'
 import Helpers from '../../testutils/helpers'
-import { CourseParticipationUtils, CourseUtils, FormUtils, StringUtils } from '../../utils'
+import { CourseParticipationUtils, CourseUtils, FormUtils } from '../../utils'
 import type { CourseParticipation } from '@accredited-programmes/models'
-import type { CourseParticipationPresenter } from '@accredited-programmes/ui'
+import type { GovukFrontendSummaryListWithRowsWithValues } from '@accredited-programmes/ui'
 
 jest.mock('../../utils/formUtils')
 jest.mock('../../utils/courseParticipationUtils')
@@ -32,7 +32,7 @@ describe('CourseParticipationsController', () => {
 
   let courseParticipationsController: CourseParticipationsController
 
-  const summaryListOptions = 'summary list options'
+  const summaryListOptions = 'summary list options' as unknown as GovukFrontendSummaryListWithRowsWithValues
   const person = personFactory.build()
   const referralId = 'a-referral-id'
   const draftReferral = referralFactory.started().build({ id: referralId, prisonNumber: person.prisonNumber })
@@ -42,11 +42,8 @@ describe('CourseParticipationsController', () => {
     request = createMock<Request>({ params: { referralId }, user: { token } })
     response = Helpers.createMockResponseWithCaseloads()
     courseParticipationsController = new CourseParticipationsController(courseService, personService, referralService)
-    ;(CourseParticipationUtils.summaryListOptions as jest.Mock).mockImplementation(
-      (_courseParticipationWithName, _referralId, _withActions = { change: true, remove: true }) => {
-        return summaryListOptions
-      },
-    )
+    courseService.presentCourseParticipation.mockResolvedValue(summaryListOptions)
+    courseService.getAndPresentParticipationsByPerson.mockResolvedValue([summaryListOptions, summaryListOptions])
   })
 
   afterEach(() => {
@@ -173,10 +170,6 @@ describe('CourseParticipationsController', () => {
         courseName: course.name,
         prisonNumber: person.prisonNumber,
       })
-      const courseParticipationPresenter: CourseParticipationPresenter = {
-        ...courseParticipation,
-        addedByDisplayName: StringUtils.convertToTitleCase(addedByUser.name),
-      }
       const courseParticipationId = courseParticipation.id
 
       request.params.courseParticipationId = courseParticipationId
@@ -185,20 +178,15 @@ describe('CourseParticipationsController', () => {
       referralService.getReferral.mockResolvedValue(draftReferral)
       courseService.getCourse.mockResolvedValue(course)
       courseService.getParticipation.mockResolvedValue(courseParticipation)
-      courseService.presentCourseParticipation.mockResolvedValue(courseParticipationPresenter)
 
       const requestHandler = courseParticipationsController.delete()
       await requestHandler(request, response, next)
 
       expect(referralService.getReferral).toHaveBeenCalledWith(token, request.params.referralId)
-      expect(CourseParticipationUtils.summaryListOptions).toHaveBeenCalledWith(
-        courseParticipationPresenter,
-        referralId,
-        {
-          change: false,
-          remove: false,
-        },
-      )
+      expect(courseService.presentCourseParticipation).toHaveBeenCalledWith(token, courseParticipation, referralId, {
+        change: false,
+        remove: false,
+      })
       expect(response.render).toHaveBeenCalledWith('referrals/courseParticipations/delete', {
         action: `${referPaths.programmeHistory.destroy({ courseParticipationId, referralId })}?_method=DELETE`,
         pageHeading: 'Remove programme',
@@ -316,27 +304,10 @@ describe('CourseParticipationsController', () => {
   })
 
   describe('index', () => {
-    const addedByUser = userFactory.build()
-    const earliestCourseParticipationPresenter: CourseParticipationPresenter = {
-      ...courseParticipationFactory.build({
-        createdAt: '2022-01-01T12:00:00.000Z',
-      }),
-      addedByDisplayName: StringUtils.convertToTitleCase(addedByUser.name),
-    }
-    const latestCourseParticipationPresenter: CourseParticipationPresenter = {
-      ...courseParticipationFactory.build({
-        createdAt: '2023-01-01T12:00:00.000Z',
-      }),
-      addedByDisplayName: StringUtils.convertToTitleCase(addedByUser.name),
-    }
     const course = courseFactory.build()
 
     beforeEach(() => {
       personService.getPerson.mockResolvedValue(person)
-      courseService.getAndPresentParticipationsByPerson.mockResolvedValue([
-        earliestCourseParticipationPresenter,
-        latestCourseParticipationPresenter,
-      ])
       courseService.getCourse.mockResolvedValue(course)
       ;(request.flash as jest.Mock).mockImplementation(() => [])
     })
@@ -348,16 +319,12 @@ describe('CourseParticipationsController', () => {
       await requestHandler(request, response, next)
 
       expect(referralService.getReferral).toHaveBeenCalledWith(token, referralId)
-      expect(CourseParticipationUtils.summaryListOptions).toHaveBeenNthCalledWith(
-        1,
-        earliestCourseParticipationPresenter,
+      expect(courseService.getAndPresentParticipationsByPerson).toHaveBeenCalledWith(
+        token,
+        person.prisonNumber,
         referralId,
       )
-      expect(CourseParticipationUtils.summaryListOptions).toHaveBeenNthCalledWith(
-        2,
-        latestCourseParticipationPresenter,
-        referralId,
-      )
+
       expect(response.render).toHaveBeenCalledWith('referrals/courseParticipations/index', {
         action: `${referPaths.programmeHistory.updateReviewedStatus({ referralId })}?_method=PUT`,
         pageHeading: 'Accredited Programme history',

--- a/server/controllers/refer/courseParticipationsController.test.ts
+++ b/server/controllers/refer/courseParticipationsController.test.ts
@@ -1,7 +1,6 @@
 import type { DeepMocked } from '@golevelup/ts-jest'
 import { createMock } from '@golevelup/ts-jest'
 import type { NextFunction, Request, Response } from 'express'
-import { when } from 'jest-when'
 
 import CourseParticipationsController from './courseParticipationsController'
 import { referPaths } from '../../paths'
@@ -318,36 +317,26 @@ describe('CourseParticipationsController', () => {
 
   describe('index', () => {
     const addedByUser = userFactory.build()
-    const earliestCourseParticipation = courseParticipationFactory.build({
-      addedBy: addedByUser.username,
-      createdAt: '2022-01-01T12:00:00.000Z',
-    })
     const earliestCourseParticipationPresenter: CourseParticipationPresenter = {
-      ...earliestCourseParticipation,
+      ...courseParticipationFactory.build({
+        createdAt: '2022-01-01T12:00:00.000Z',
+      }),
       addedByDisplayName: StringUtils.convertToTitleCase(addedByUser.name),
     }
-    const latestCourseParticipation = courseParticipationFactory.build({
-      addedBy: addedByUser.username,
-      createdAt: '2023-01-01T12:00:00.000Z',
-    })
     const latestCourseParticipationPresenter: CourseParticipationPresenter = {
-      ...latestCourseParticipation,
+      ...courseParticipationFactory.build({
+        createdAt: '2023-01-01T12:00:00.000Z',
+      }),
       addedByDisplayName: StringUtils.convertToTitleCase(addedByUser.name),
     }
     const course = courseFactory.build()
 
     beforeEach(() => {
       personService.getPerson.mockResolvedValue(person)
-      courseService.getParticipationsByPerson.mockResolvedValue([
-        latestCourseParticipation,
-        earliestCourseParticipation,
+      courseService.getAndPresentParticipationsByPerson.mockResolvedValue([
+        earliestCourseParticipationPresenter,
+        latestCourseParticipationPresenter,
       ])
-      when(courseService.presentCourseParticipation)
-        .calledWith(token, latestCourseParticipation)
-        .mockResolvedValue(latestCourseParticipationPresenter)
-      when(courseService.presentCourseParticipation)
-        .calledWith(token, earliestCourseParticipation)
-        .mockResolvedValue(earliestCourseParticipationPresenter)
       courseService.getCourse.mockResolvedValue(course)
       ;(request.flash as jest.Mock).mockImplementation(() => [])
     })

--- a/server/controllers/refer/courseParticipationsController.ts
+++ b/server/controllers/refer/courseParticipationsController.ts
@@ -64,20 +64,17 @@ export default class CourseParticipationsController {
       }
 
       const courseParticipation = await this.courseService.getParticipation(req.user.token, courseParticipationId)
-      const courseParticipationPresenter = await this.courseService.presentCourseParticipation(
+      const summaryListOptions = await this.courseService.presentCourseParticipation(
         req.user.token,
         courseParticipation,
+        referralId,
+        { change: false, remove: false },
       )
       const person = await this.personService.getPerson(
         req.user.username,
         referral.prisonNumber,
         res.locals.user.caseloads,
       )
-
-      const summaryListOptions = CourseParticipationUtils.summaryListOptions(courseParticipationPresenter, referralId, {
-        change: false,
-        remove: false,
-      })
 
       return res.render('referrals/courseParticipations/delete', {
         action: `${referPaths.programmeHistory.destroy({ courseParticipationId, referralId })}?_method=DELETE`,
@@ -170,13 +167,10 @@ export default class CourseParticipationsController {
         res.locals.user.caseloads,
       )
 
-      const sortedCourseParticipations = await this.courseService.getAndPresentParticipationsByPerson(
+      const summaryListsOptions = await this.courseService.getAndPresentParticipationsByPerson(
         req.user.token,
         person.prisonNumber,
-      )
-
-      const summaryListsOptions = sortedCourseParticipations.map(participation =>
-        CourseParticipationUtils.summaryListOptions(participation, referralId),
+        referralId,
       )
 
       const successMessage = req.flash('successMessage')[0]

--- a/server/controllers/refer/courseParticipationsController.ts
+++ b/server/controllers/refer/courseParticipationsController.ts
@@ -169,17 +169,13 @@ export default class CourseParticipationsController {
         referral.prisonNumber,
         res.locals.user.caseloads,
       )
-      const sortedCourseParticipations = (
-        await this.courseService.getParticipationsByPerson(req.user.token, person.prisonNumber)
-      ).sort((participationA, participationB) => participationA.createdAt.localeCompare(participationB.createdAt))
 
-      const courseParticipationsPresenter = await Promise.all(
-        sortedCourseParticipations.map(participation =>
-          this.courseService.presentCourseParticipation(req.user.token, participation),
-        ),
+      const sortedCourseParticipations = await this.courseService.getAndPresentParticipationsByPerson(
+        req.user.token,
+        person.prisonNumber,
       )
 
-      const summaryListsOptions = courseParticipationsPresenter.map(participation =>
+      const summaryListsOptions = sortedCourseParticipations.map(participation =>
         CourseParticipationUtils.summaryListOptions(participation, referralId),
       )
 

--- a/server/controllers/refer/referralsController.test.ts
+++ b/server/controllers/refer/referralsController.test.ts
@@ -2,7 +2,6 @@ import type { DeepMocked } from '@golevelup/ts-jest'
 import { createMock } from '@golevelup/ts-jest'
 import type { NextFunction, Request, Response } from 'express'
 import createError from 'http-errors'
-import { when } from 'jest-when'
 
 import ReferralsController from './referralsController'
 import { referPaths } from '../../paths'
@@ -239,32 +238,25 @@ describe('ReferralsController', () => {
 
       const addedByUser = userFactory.build()
 
-      const earliestCourseParticipation = courseParticipationFactory.build({
-        addedBy: addedByUser.username,
-        createdAt: '2022-01-01T12:00:00.000Z',
-      })
       const earliestCourseParticipationPresenter: CourseParticipationPresenter = {
-        ...earliestCourseParticipation,
+        ...courseParticipationFactory.build({
+          addedBy: addedByUser.username,
+          createdAt: '2022-01-01T12:00:00.000Z',
+        }),
         addedByDisplayName: StringUtils.convertToTitleCase(addedByUser.name),
       }
-      const latestCourseParticipation = courseParticipationFactory.build({
-        addedBy: addedByUser.username,
-        createdAt: '2023-01-01T12:00:00.000Z',
-      })
-      courseService.getParticipationsByPerson.mockResolvedValue([
-        latestCourseParticipation,
-        earliestCourseParticipation,
-      ])
+
       const latestCourseParticipationPresenter: CourseParticipationPresenter = {
-        ...latestCourseParticipation,
+        ...courseParticipationFactory.build({
+          addedBy: addedByUser.username,
+          createdAt: '2023-01-01T12:00:00.000Z',
+        }),
         addedByDisplayName: StringUtils.convertToTitleCase(addedByUser.name),
       }
-      when(courseService.presentCourseParticipation)
-        .calledWith(token, earliestCourseParticipation)
-        .mockResolvedValue(earliestCourseParticipationPresenter)
-      when(courseService.presentCourseParticipation)
-        .calledWith(token, latestCourseParticipation)
-        .mockResolvedValue(latestCourseParticipationPresenter)
+
+      const courseParticipationPresenters = [earliestCourseParticipationPresenter, latestCourseParticipationPresenter]
+
+      courseService.getAndPresentParticipationsByPerson.mockResolvedValue(courseParticipationPresenters)
 
       const summaryListOptions = 'summary list options'
       ;(CourseParticipationUtils.summaryListOptions as jest.Mock).mockImplementation(

--- a/server/controllers/refer/referralsController.ts
+++ b/server/controllers/refer/referralsController.ts
@@ -40,16 +40,12 @@ export default class ReferralsController {
       const organisation = await this.organisationService.getOrganisation(req.user.token, courseOffering.organisationId)
       const course = await this.courseService.getCourseByOffering(req.user.token, referral.offeringId)
 
-      const sortedCourseParticipations = (
-        await this.courseService.getParticipationsByPerson(req.user.token, person.prisonNumber)
-      ).sort((participationA, participationB) => participationA.createdAt.localeCompare(participationB.createdAt))
-
-      const courseParticipationsPresenter = await Promise.all(
-        sortedCourseParticipations.map(participation =>
-          this.courseService.presentCourseParticipation(req.user.token, participation),
-        ),
+      const courseParticipations = await this.courseService.getAndPresentParticipationsByPerson(
+        req.user.token,
+        person.prisonNumber,
       )
-      const participationSummaryListsOptions = courseParticipationsPresenter.map(participation =>
+
+      const participationSummaryListsOptions = courseParticipations.map(participation =>
         CourseParticipationUtils.summaryListOptions(participation, referralId, { change: true, remove: false }),
       )
       const coursePresenter = CourseUtils.presentCourse(course)

--- a/server/controllers/refer/referralsController.ts
+++ b/server/controllers/refer/referralsController.ts
@@ -3,7 +3,7 @@ import createError from 'http-errors'
 
 import { referPaths } from '../../paths'
 import type { CourseService, OrganisationService, PersonService, ReferralService } from '../../services'
-import { CourseParticipationUtils, CourseUtils, FormUtils, PersonUtils, ReferralUtils, TypeUtils } from '../../utils'
+import { CourseUtils, FormUtils, PersonUtils, ReferralUtils, TypeUtils } from '../../utils'
 import type { CreatedReferralResponse } from '@accredited-programmes/models'
 
 export default class ReferralsController {
@@ -40,14 +40,13 @@ export default class ReferralsController {
       const organisation = await this.organisationService.getOrganisation(req.user.token, courseOffering.organisationId)
       const course = await this.courseService.getCourseByOffering(req.user.token, referral.offeringId)
 
-      const courseParticipations = await this.courseService.getAndPresentParticipationsByPerson(
+      const participationSummaryListsOptions = await this.courseService.getAndPresentParticipationsByPerson(
         req.user.token,
         person.prisonNumber,
+        referralId,
+        { change: true, remove: false },
       )
 
-      const participationSummaryListsOptions = courseParticipations.map(participation =>
-        CourseParticipationUtils.summaryListOptions(participation, referralId, { change: true, remove: false }),
-      )
       const coursePresenter = CourseUtils.presentCourse(course)
 
       FormUtils.setFieldErrors(req, res, ['confirmation'])

--- a/server/services/courseService.ts
+++ b/server/services/courseService.ts
@@ -36,6 +36,19 @@ export default class CourseService {
     return courseClient.destroyParticipation(courseParticipationId)
   }
 
+  async getAndPresentParticipationsByPerson(
+    token: Express.User['token'],
+    prisonNumber: Person['prisonNumber'],
+  ): Promise<Array<CourseParticipationPresenter>> {
+    const sortedCourseParticipations = (await this.getParticipationsByPerson(token, prisonNumber)).sort(
+      (participationA, participationB) => participationA.createdAt.localeCompare(participationB.createdAt),
+    )
+
+    return Promise.all(
+      sortedCourseParticipations.map(participation => this.presentCourseParticipation(token, participation)),
+    )
+  }
+
   async getCourse(token: Express.User['token'], courseId: Course['id']): Promise<Course> {
     const courseClient = this.courseClientBuilder(token)
     return courseClient.find(courseId)

--- a/server/services/courseService.ts
+++ b/server/services/courseService.ts
@@ -3,15 +3,16 @@ import type { ResponseError } from 'superagent'
 
 import type UserService from './userService'
 import type { CourseClient, RestClientBuilder } from '../data'
-import { StringUtils } from '../utils'
+import { CourseParticipationUtils, StringUtils } from '../utils'
 import type {
   Course,
   CourseOffering,
   CourseParticipation,
   CourseParticipationUpdate,
   Person,
+  Referral,
 } from '@accredited-programmes/models'
-import type { CourseParticipationPresenter } from '@accredited-programmes/ui'
+import type { GovukFrontendSummaryListWithRowsWithValues } from '@accredited-programmes/ui'
 
 export default class CourseService {
   constructor(
@@ -39,13 +40,20 @@ export default class CourseService {
   async getAndPresentParticipationsByPerson(
     token: Express.User['token'],
     prisonNumber: Person['prisonNumber'],
-  ): Promise<Array<CourseParticipationPresenter>> {
+    referralId: Referral['id'],
+    withActions?: {
+      change: boolean
+      remove: boolean
+    },
+  ): Promise<Array<GovukFrontendSummaryListWithRowsWithValues>> {
     const sortedCourseParticipations = (await this.getParticipationsByPerson(token, prisonNumber)).sort(
       (participationA, participationB) => participationA.createdAt.localeCompare(participationB.createdAt),
     )
 
     return Promise.all(
-      sortedCourseParticipations.map(participation => this.presentCourseParticipation(token, participation)),
+      sortedCourseParticipations.map(participation =>
+        this.presentCourseParticipation(token, participation, referralId, withActions),
+      ),
     )
   }
 
@@ -114,10 +122,17 @@ export default class CourseService {
   async presentCourseParticipation(
     token: Express.User['token'],
     courseParticipation: CourseParticipation,
-  ): Promise<CourseParticipationPresenter> {
+    referralId: Referral['id'],
+    withActions = { change: true, remove: true },
+  ): Promise<GovukFrontendSummaryListWithRowsWithValues> {
     const addedByUser = await this.userService.getUserFromUsername(token, courseParticipation.addedBy)
 
-    return { ...courseParticipation, addedByDisplayName: StringUtils.convertToTitleCase(addedByUser.name) }
+    const courseParticipationPresenter = {
+      ...courseParticipation,
+      addedByDisplayName: StringUtils.convertToTitleCase(addedByUser.name),
+    }
+
+    return CourseParticipationUtils.summaryListOptions(courseParticipationPresenter, referralId, withActions)
   }
 
   async updateParticipation(


### PR DESCRIPTION
## Context

<!-- Is there a Trello ticket you can link to? -->
https://trello.com/c/1Ihtlxml/893-add-page-for-viewing-a-referrals-programme-history-m

<!-- Do you need to add any environment variables? -->
<!-- Is an ADR required? An ADR should be added if this PR introduces a change to the architecture. -->

We're about to add a new page for viewing a programme's Course Participations. There's a fair bit of code we can DRY up for use when building that page, both in terms of implementation and tests.

## Changes in this PR

Encapsulates the logic for converting Course Participations into a summary list in a service method, rather than calling it separately in multiple controllers.

There may be a bit of tidying up to do here, but I'm opening this to get feedback while people are around this week!

## Release checklist

[Release process documentation](../doc/how-to/perform-a-release.md)

As part of our continuous deployment strategy we must ensure that this work is
ready to be released once merged.

### Pre-merge

- [ ] There are changes required to the Accredited Programmes API for this change to work...
  - [ ] ... and they have been released to production already

### Post-merge

<!-- The outer checkboxes can be completed pre-merge -->

- [ ] This adds, extends or meaningfully modifies a feature...
  - [ ] ... and I have written or updated an end-to-end test for the happy path in the [Accredited Programmes E2E repo](https://github.com/ministryofjustice/hmpps-accredited-programmes-e2e)
- [ ] This makes new expectations of the API...
  - [ ] ... and I have notified the API developer(s) of changes to the contract tests (Pact), or the API is already compliant
- [ ] [Manually approve](../doc/how-to/perform-a-release.md#releasing-to-the-preprod-environment) release to preprod
- [ ] [Manually approve](../doc/how-to/perform-a-release.md#releasing-to-the-production-environment) release to prod

<!-- Should a release fail at any step, you as the author should now lead the work to
fix it as soon as possible. You can monitor deployment failures in CircleCI
itself and application errors are found in
[Sentry](https://ministryofjustice.sentry.io/projects/hmpps-accredited-programmes-ui/?project=4505330122686464&referrer=sidebar&statsPeriod=24h). -->
