### PR TITLE
(1076) Use `sentenceStartDate` instead of `sentenceDate`

### DIFF
--- a/server/@types/prisonApi/index.d.ts
+++ b/server/@types/prisonApi/index.d.ts
@@ -7,7 +7,7 @@ type Caseload = {
 }
 
 type SentenceAndOffenceDetails = {
-  sentenceDate: string
+  sentenceStartDate: string
   sentenceTypeDescription: string
 }
 

--- a/server/testutils/factories/sentenceAndOffenceDetails.ts
+++ b/server/testutils/factories/sentenceAndOffenceDetails.ts
@@ -4,6 +4,6 @@ import { Factory } from 'fishery'
 import type { SentenceAndOffenceDetails } from '@prison-api'
 
 export default Factory.define<SentenceAndOffenceDetails>(() => ({
-  sentenceDate: `${faker.date.past({ years: 20 })}`.substring(0, 10),
+  sentenceStartDate: `${faker.date.past({ years: 20 })}`.substring(0, 10),
   sentenceTypeDescription: faker.word.words({ count: { max: 5, min: 1 } }),
 }))

--- a/server/utils/sentenceInformationUtils.test.ts
+++ b/server/utils/sentenceInformationUtils.test.ts
@@ -5,7 +5,7 @@ describe('SentenceInformationUtils', () => {
   describe('detailsSummaryListRows', () => {
     it('formats sentence detailsin the appropriate format for passing to a GOV.UK Summary List nunjucks macro', () => {
       const sentenceAndOffenceDetails = sentenceAndOffenceDetailsFactory.build({
-        sentenceDate: '2010-10-31',
+        sentenceStartDate: '2010-10-31',
         sentenceTypeDescription: 'Concurrent determinate sentence',
       })
 
@@ -15,7 +15,7 @@ describe('SentenceInformationUtils', () => {
           value: { text: 'Concurrent determinate sentence' },
         },
         {
-          key: { text: 'Sentence date' },
+          key: { text: 'Sentence start date' },
           value: { text: '31 October 2010' },
         },
       ])

--- a/server/utils/sentenceInformationUtils.ts
+++ b/server/utils/sentenceInformationUtils.ts
@@ -12,8 +12,8 @@ export default class SentenceInformationUtils {
         value: { text: sentenceAndOffenceDetails.sentenceTypeDescription },
       },
       {
-        key: { text: 'Sentence date' },
-        value: { text: DateUtils.govukFormattedFullDateString(sentenceAndOffenceDetails.sentenceDate) },
+        key: { text: 'Sentence start date' },
+        value: { text: DateUtils.govukFormattedFullDateString(sentenceAndOffenceDetails.sentenceStartDate) },
       },
     ]
   }

--- a/wiremock/stubs/sentenceAndOffenceDetails.json
+++ b/wiremock/stubs/sentenceAndOffenceDetails.json
@@ -1,4 +1,4 @@
 {
-  "sentenceDate": "2010-10-31",
+  "sentenceStartDate": "2010-10-31",
   "sentenceTypeDescription": "Concurrent determinate sentence"
 }


### PR DESCRIPTION
## Context

<!-- Is there a Trello ticket you can link to? -->
https://trello.com/c/kCnxzy9H/1076-use-sentencestartdate-rather-than-sentencedate-for-sentence-information-page-xs
<!-- Do you need to add any environment variables? -->
<!-- Is an ADR required? An ADR should be added if this PR introduces a change to the architecture. -->

We previously read the `sentenceDate` field returned on a person's sentence information returned from NOMIS.

## Changes in this PR

We now read the `sentenceStartDate` instead. This is clearer to users and more likely to have a value set in NOMIS.


## Screenshots of UI changes

### Before

<img width="1298" alt="image" src="https://github.com/ministryofjustice/hmpps-accredited-programmes-ui/assets/19826940/cbab6b16-44df-46da-ab56-b7826478a835">

### After

<img width="1345" alt="image" src="https://github.com/ministryofjustice/hmpps-accredited-programmes-ui/assets/19826940/e7fa6e7f-e09c-401a-b9f1-abc76a9723e9">

## Release checklist

[Release process documentation](../doc/how-to/perform-a-release.md)

As part of our continuous deployment strategy we must ensure that this work is
ready to be released once merged.

### Pre-merge

- [ ] There are changes required to the Accredited Programmes API for this change to work...
  - [ ] ... and they have been released to production already

### Post-merge

<!-- The outer checkboxes can be completed pre-merge -->

- [ ] This adds, extends or meaningfully modifies a feature...
  - [ ] ... and I have written or updated an end-to-end test for the happy path in the [Accredited Programmes E2E repo](https://github.com/ministryofjustice/hmpps-accredited-programmes-e2e)
- [ ] This makes new expectations of the API...
  - [ ] ... and I have notified the API developer(s) of changes to the contract tests (Pact), or the API is already compliant
- [ ] [Manually approve](../doc/how-to/perform-a-release.md#releasing-to-the-preprod-environment) release to preprod
- [ ] [Manually approve](../doc/how-to/perform-a-release.md#releasing-to-the-production-environment) release to prod

<!-- Should a release fail at any step, you as the author should now lead the work to
fix it as soon as possible. You can monitor deployment failures in CircleCI
itself and application errors are found in
[Sentry](https://ministryofjustice.sentry.io/projects/hmpps-accredited-programmes-ui/?project=4505330122686464&referrer=sidebar&statsPeriod=24h). -->
