### PR TITLE
Tweak message for no Accredited Programme history

### DIFF
--- a/integration_tests/pages/refer/new/checkAnswers.ts
+++ b/integration_tests/pages/refer/new/checkAnswers.ts
@@ -103,7 +103,7 @@ export default class NewReferralCheckAnswersPage extends Page {
   shouldNotHaveProgrammeHistory(): void {
     cy.get('[data-testid="programme-history"] .govuk-body').should(
       'have.text',
-      `There is no record of Accredited Programmes for ${this.person.name}.`,
+      `There is no Accredited Programme history for ${this.person.name}.`,
     )
   }
 }

--- a/integration_tests/pages/refer/new/programmeHistory.ts
+++ b/integration_tests/pages/refer/new/programmeHistory.ts
@@ -28,7 +28,7 @@ export default class NewReferralProgrammeHistoryPage extends Page {
   shouldContainNoHistoryHeading() {
     cy.get('[data-testid="no-history-heading"]').should(
       'have.text',
-      `There is no record of Accredited Programmes for ${this.person.name}.`,
+      `There is no Accredited Programme history for ${this.person.name}.`,
     )
   }
 

--- a/server/views/referrals/new/checkAnswers.njk
+++ b/server/views/referrals/new/checkAnswers.njk
@@ -71,7 +71,7 @@
             {{ govukSummaryList(summaryListOptions) }}
           {% endfor %}
         {% else %}
-          <p class="govuk-body">There is no record of Accredited Programmes for {{ person.name }}.</p>
+          <p class="govuk-body">There is no Accredited Programme history for {{ person.name }}.</p>
         {% endif %}
       </section>
 

--- a/server/views/referrals/new/courseParticipations/index.njk
+++ b/server/views/referrals/new/courseParticipations/index.njk
@@ -63,7 +63,7 @@
 
         {{ actionForm(secondaryActionText="Add another") }}
       {% else %}
-        <h2 class="govuk-heading-m" data-testid="no-history-heading">There is no record of Accredited Programmes for {{ person.name }}.</h2>
+        <h2 class="govuk-heading-m" data-testid="no-history-heading">There is no Accredited Programme history for {{ person.name }}.</h2>
 
         <p class="govuk-body" data-testid="no-history-paragraph">The programme team may use information about a person's Accredited Programme history to assess whether they are suitable. You can add a programme to this history or continue with the referral if the {{ person.name }}'s history is unknown.</p>
 


### PR DESCRIPTION
## Changes in this PR

Updates text on the Check your answers and Programme History index pages to brings the messaging in line with the text we'll show on the submitted referral page (added in #322) when there's no programme history to show.


## Release checklist

[Release process documentation](../doc/how-to/perform-a-release.md)

As part of our continuous deployment strategy we must ensure that this work is
ready to be released once merged.

### Pre-merge

- [ ] There are changes required to the Accredited Programmes API for this change to work...
  - [ ] ... and they have been released to production already

### Post-merge

<!-- The outer checkboxes can be completed pre-merge -->

- [ ] This adds, extends or meaningfully modifies a feature...
  - [ ] ... and I have written or updated an end-to-end test for the happy path in the [Accredited Programmes E2E repo](https://github.com/ministryofjustice/hmpps-accredited-programmes-e2e)
- [ ] This makes new expectations of the API...
  - [ ] ... and I have notified the API developer(s) of changes to the contract tests (Pact), or the API is already compliant
- [ ] [Manually approve](../doc/how-to/perform-a-release.md#releasing-to-the-preprod-environment) release to preprod
- [ ] [Manually approve](../doc/how-to/perform-a-release.md#releasing-to-the-production-environment) release to prod

<!-- Should a release fail at any step, you as the author should now lead the work to
fix it as soon as possible. You can monitor deployment failures in CircleCI
itself and application errors are found in
[Sentry](https://ministryofjustice.sentry.io/projects/hmpps-accredited-programmes-ui/?project=4505330122686464&referrer=sidebar&statsPeriod=24h). -->
