### PR TITLE
Fix empty sentence start date displaying as today's date

### DIFF
--- a/server/utils/sentenceInformationUtils.test.ts
+++ b/server/utils/sentenceInformationUtils.test.ts
@@ -20,5 +20,25 @@ describe('SentenceInformationUtils', () => {
         },
       ])
     })
+
+    describe('when there is no sentence start date', () => {
+      it('returns an empty string against that field', () => {
+        const sentenceAndOffenceDetails = sentenceAndOffenceDetailsFactory.build({
+          sentenceStartDate: undefined,
+          sentenceTypeDescription: 'Concurrent determinate sentence',
+        })
+
+        expect(SentenceInformationUtils.detailsSummaryListRows(sentenceAndOffenceDetails)).toEqual([
+          {
+            key: { text: 'Sentence type' },
+            value: { text: 'Concurrent determinate sentence' },
+          },
+          {
+            key: { text: 'Sentence start date' },
+            value: { text: '' },
+          },
+        ])
+      })
+    })
   })
 })

--- a/server/utils/sentenceInformationUtils.ts
+++ b/server/utils/sentenceInformationUtils.ts
@@ -6,6 +6,8 @@ export default class SentenceInformationUtils {
   static detailsSummaryListRows(
     sentenceAndOffenceDetails: SentenceAndOffenceDetails,
   ): Array<GovukFrontendSummaryListRowWithValue> {
+    const { sentenceStartDate } = sentenceAndOffenceDetails
+
     return [
       {
         key: { text: 'Sentence type' },
@@ -13,7 +15,11 @@ export default class SentenceInformationUtils {
       },
       {
         key: { text: 'Sentence start date' },
-        value: { text: DateUtils.govukFormattedFullDateString(sentenceAndOffenceDetails.sentenceStartDate) },
+        value: {
+          text: sentenceStartDate
+            ? DateUtils.govukFormattedFullDateString(sentenceAndOffenceDetails.sentenceStartDate)
+            : '',
+        },
       },
     ]
   }


### PR DESCRIPTION
## Changes in this PR

We refactored the `DateUtils.govukFormattedFullDateString` function to either format the date passed in, or return today's date. This meant that we were incorrectly showing today's date on the sentence start date page field here when the field comes back empty.

We'll hopefully have some nicer content to show here than an empty row, but this at least means we're not displaying inaccurate information.

## Release checklist

[Release process documentation](../doc/how-to/perform-a-release.md)

As part of our continuous deployment strategy we must ensure that this work is
ready to be released once merged.

### Pre-merge

- [ ] There are changes required to the Accredited Programmes API for this change to work...
  - [ ] ... and they have been released to production already

### Post-merge

<!-- The outer checkboxes can be completed pre-merge -->

- [ ] This adds, extends or meaningfully modifies a feature...
  - [ ] ... and I have written or updated an end-to-end test for the happy path in the [Accredited Programmes E2E repo](https://github.com/ministryofjustice/hmpps-accredited-programmes-e2e)
- [ ] This makes new expectations of the API...
  - [ ] ... and I have notified the API developer(s) of changes to the contract tests (Pact), or the API is already compliant
- [ ] [Manually approve](../doc/how-to/perform-a-release.md#releasing-to-the-preprod-environment) release to preprod
- [ ] [Manually approve](../doc/how-to/perform-a-release.md#releasing-to-the-production-environment) release to prod

<!-- Should a release fail at any step, you as the author should now lead the work to
fix it as soon as possible. You can monitor deployment failures in CircleCI
itself and application errors are found in
[Sentry](https://ministryofjustice.sentry.io/projects/hmpps-accredited-programmes-ui/?project=4505330122686464&referrer=sidebar&statsPeriod=24h). -->
