### PR TITLE
(1066a) Add release dates to prisoner/person

### DIFF
--- a/integration_tests/e2e/refer/show.cy.ts
+++ b/integration_tests/e2e/refer/show.cy.ts
@@ -30,6 +30,7 @@ context('Viewing a submitted referral', () => {
     dateOfBirth: '1980-01-01',
     firstName: 'Del',
     lastName: 'Hatton',
+    sentenceStartDate: '2010-10-31',
   })
   const person = personFactory.build({
     currentPrison: prisoner.prisonName,
@@ -39,6 +40,7 @@ context('Viewing a submitted referral', () => {
     name: 'Del Hatton',
     prisonNumber: prisoner.prisonerNumber,
     religionOrBelief: prisoner.religion,
+    sentenceStartDate: '2010-10-31',
     setting: 'Custody',
   })
   const referral = referralFactory.submitted().build({

--- a/server/@types/models/Person.ts
+++ b/server/@types/models/Person.ts
@@ -8,5 +8,11 @@ export type Person = {
   prisonNumber: string
   religionOrBelief: string
   setting: 'Custody'
+  conditionalReleaseDate?: string
+  earliestReleaseDate?: string
+  homeDetentionCurfewEligibilityDate?: string
+  paroleEligibilityDate?: string
+  sentenceExpiryDate?: string
   sentenceStartDate?: string
+  tariffDate?: string
 }

--- a/server/@types/prisonerSearch/index.d.ts
+++ b/server/@types/prisonerSearch/index.d.ts
@@ -6,7 +6,13 @@ export type Prisoner = {
   lastName: string
   prisonerNumber: string
   prisonName: string
+  conditionalReleaseDate?: string
   ethnicity?: string
+  homeDetentionCurfewEligibilityDate?: string
+  indeterminateSentence?: boolean
+  paroleEligibilityDate?: string
   religion?: string
+  sentenceExpiryDate?: string
   sentenceStartDate?: string
+  tariffDate?: string
 }

--- a/server/testutils/factories/factoryHelpers.ts
+++ b/server/testutils/factories/factoryHelpers.ts
@@ -12,4 +12,8 @@ export default class FactoryHelpers {
     const fullOptions: Array<T | undefined> = [undefined]
     return faker.helpers.arrayElement(fullOptions.concat(options))
   }
+
+  static optionalRandomFutureDateString(): string | undefined {
+    return FactoryHelpers.optionalArrayElement([`${faker.date.future({ years: 20 })}`.substring(0, 10)])
+  }
 }

--- a/server/testutils/factories/person.ts
+++ b/server/testutils/factories/person.ts
@@ -7,17 +7,28 @@ import type { Person } from '@accredited-programmes/models'
 export default Factory.define<Person>(({ params }) => {
   const county = faker.location.county()
   const currentPrison = params.currentPrison || `${county} (HMP)`
+  const conditionalReleaseDate =
+    'conditionalReleaseDate' in params ? params.conditionalReleaseDate : FactoryHelpers.optionalRandomFutureDateString()
+  const paroleEligibilityDate =
+    'paroleEligibilityDate' in params ? params.conditionalReleaseDate : FactoryHelpers.optionalRandomFutureDateString()
+  const tariffDate = 'tariffDate' in params ? params.tariffDate : FactoryHelpers.optionalRandomFutureDateString()
 
   return {
     bookingId: faker.string.numeric({ length: 10 }),
+    conditionalReleaseDate,
     currentPrison,
     dateOfBirth: faker.date.birthdate().toDateString(),
+    earliestReleaseDate: faker.helpers.arrayElement([conditionalReleaseDate, paroleEligibilityDate, tariffDate]),
     ethnicity: faker.lorem.word(),
     gender: faker.person.gender(),
+    homeDetentionCurfewEligibilityDate: FactoryHelpers.optionalRandomFutureDateString(),
     name: `${faker.person.firstName()} ${faker.person.lastName()}`,
+    paroleEligibilityDate,
     prisonNumber: faker.string.alphanumeric({ length: 7 }),
     religionOrBelief: faker.lorem.word(),
+    sentenceExpiryDate: FactoryHelpers.optionalRandomFutureDateString(),
     sentenceStartDate: FactoryHelpers.optionalArrayElement([`${faker.date.past({ years: 20 })}`.substring(0, 10)]),
     setting: 'Custody',
+    tariffDate,
   }
 })

--- a/server/testutils/factories/prisoner.ts
+++ b/server/testutils/factories/prisoner.ts
@@ -15,14 +15,20 @@ export default Factory.define<Prisoner>(({ params }) => {
 
   return {
     bookingId: faker.string.numeric({ length: 10 }),
+    conditionalReleaseDate: FactoryHelpers.optionalRandomFutureDateString(),
     dateOfBirth: [year, month, day].join('-'),
     ethnicity: faker.lorem.word(),
     firstName: faker.person.firstName(),
     gender: faker.person.gender(),
+    homeDetentionCurfewEligibilityDate: FactoryHelpers.optionalRandomFutureDateString(),
+    indeterminateSentence: FactoryHelpers.optionalArrayElement([faker.datatype.boolean()]),
     lastName: faker.person.lastName(),
+    paroleEligibilityDate: FactoryHelpers.optionalRandomFutureDateString(),
     prisonName,
     prisonerNumber: faker.string.alphanumeric({ length: 7 }),
     religion: faker.lorem.word(),
+    sentenceExpiryDate: FactoryHelpers.optionalRandomFutureDateString(),
     sentenceStartDate: FactoryHelpers.optionalArrayElement([`${faker.date.past({ years: 20 })}`.substring(0, 10)]),
+    tariffDate: FactoryHelpers.optionalRandomFutureDateString(),
   }
 })

--- a/server/utils/personUtils.test.ts
+++ b/server/utils/personUtils.test.ts
@@ -15,6 +15,7 @@ describe('PersonUtils', () => {
           prisonName: 'HMP Hewell',
           prisonerNumber: 'ABC1234',
           religion: 'Christian',
+          sentenceStartDate: '2010-10-31',
         })
 
         expect(PersonUtils.personFromPrisoner(prisoner)).toEqual({
@@ -26,6 +27,7 @@ describe('PersonUtils', () => {
           name: 'Del Hatton',
           prisonNumber: 'ABC1234',
           religionOrBelief: 'Christian',
+          sentenceStartDate: '2010-10-31',
           setting: 'Custody',
         })
       })
@@ -40,7 +42,7 @@ describe('PersonUtils', () => {
     })
 
     describe('when fields are missing on a Prisoner Search "Prisoner"', () => {
-      it('returns a "Person" with those "Not entered" for those fields', () => {
+      it('returns a "Person" with "Not entered" or `undefined` for those fields as appropriate', () => {
         const prisoner = prisonerFactory.build({
           bookingId: '1234567890',
           dateOfBirth: '1971-07-05',
@@ -51,6 +53,7 @@ describe('PersonUtils', () => {
           prisonName: 'HMP Hewell',
           prisonerNumber: 'ABC1234',
           religion: undefined,
+          sentenceStartDate: undefined,
         })
 
         expect(PersonUtils.personFromPrisoner(prisoner)).toEqual({
@@ -62,6 +65,7 @@ describe('PersonUtils', () => {
           name: 'Del Hatton',
           prisonNumber: 'ABC1234',
           religionOrBelief: 'Not entered',
+          sentenceStartDate: undefined,
           setting: 'Custody',
         })
       })

--- a/server/utils/personUtils.ts
+++ b/server/utils/personUtils.ts
@@ -17,6 +17,7 @@ export default class PersonUtils {
       name: StringUtils.convertToTitleCase(`${prisoner.firstName} ${prisoner.lastName}`),
       prisonNumber: prisoner.prisonerNumber,
       religionOrBelief: prisoner.religion || unavailable,
+      sentenceStartDate: prisoner.sentenceStartDate,
       setting: 'Custody',
     }
   }

--- a/server/utils/personUtils.ts
+++ b/server/utils/personUtils.ts
@@ -7,18 +7,31 @@ import type { Prisoner } from '@prisoner-search'
 export default class PersonUtils {
   static personFromPrisoner(prisoner: Prisoner): Person {
     const unavailable = 'Not entered'
+    let earliestReleaseDate: Person['earliestReleaseDate']
+
+    if (prisoner.indeterminateSentence) {
+      earliestReleaseDate = prisoner.tariffDate
+    } else {
+      earliestReleaseDate = prisoner.paroleEligibilityDate || prisoner.conditionalReleaseDate
+    }
 
     return {
       bookingId: prisoner.bookingId,
+      conditionalReleaseDate: prisoner.conditionalReleaseDate,
       currentPrison: prisoner.prisonName,
       dateOfBirth: DateUtils.govukFormattedFullDateString(prisoner.dateOfBirth),
+      earliestReleaseDate,
       ethnicity: prisoner.ethnicity || unavailable,
       gender: prisoner.gender,
+      homeDetentionCurfewEligibilityDate: prisoner.homeDetentionCurfewEligibilityDate,
       name: StringUtils.convertToTitleCase(`${prisoner.firstName} ${prisoner.lastName}`),
+      paroleEligibilityDate: prisoner.paroleEligibilityDate,
       prisonNumber: prisoner.prisonerNumber,
       religionOrBelief: prisoner.religion || unavailable,
+      sentenceExpiryDate: prisoner.sentenceExpiryDate,
       sentenceStartDate: prisoner.sentenceStartDate,
       setting: 'Custody',
+      tariffDate: prisoner.tariffDate,
     }
   }
 

--- a/wiremock/stubs/prisoners.json
+++ b/wiremock/stubs/prisoners.json
@@ -1,24 +1,38 @@
 [
   {
-    "bookingId": "0001234567",
-    "firstName": "Del",
-    "lastName": "Hatton",
     "prisonerNumber": "ABC1234",
+    "bookingId": "0001234567",
+    "conditionalReleaseDate": "2024-10-31",
     "dateOfBirth": "1980-01-01",
     "ethnicity": "White",
+    "firstName": "Del",
     "gender": "Male",
+    "homeDetentionCurfewEligibilityDate": "2025-10-31",
+    "indeterminateSentence": false,
+    "lastName": "Hatton",
+    "paroleEligibilityDate": "2026-10-31",
+    "prisonName": "Whatton (HMP)",
     "religion": "Christian",
-    "prisonName": "Whatton (HMP)"
+    "sentenceExpiryDate": "2027-10-31",
+    "sentenceStartDate": "2010-10-31",
+    "tariffDate": "2028-10-31"
   },
   {
-    "bookingId": "0000123456",
-    "firstName": "John",
-    "lastName": "Smith",
     "prisonerNumber": "DEF1234",
+    "bookingId": "0000123456",
+    "conditionalReleaseDate": "2025-01-31",
     "dateOfBirth": "1990-10-10",
     "ethnicity": "White",
+    "firstName": "John",
     "gender": "Male",
+    "homeDetentionCurfewEligibilityDate": "2026-01-31",
+    "indeterminateSentence": true,
+    "lastName": "Smith",
+    "paroleEligibilityDate": "2027-01-31",
+    "prisonName": "Stocken (HMP)",
     "religion": "Atheist",
-    "prisonName": "Stocken (HMP)"
+    "sentenceExpiryDate": "2028-01-31",
+    "sentenceStartDate": "2014-01-31",
+    "tariffDate": "2029-01-31"
   }
 ]


### PR DESCRIPTION
## Context

<!-- Is there a Trello ticket you can link to? -->
<!-- Do you need to add any environment variables? -->
<!-- Is an ADR required? An ADR should be added if this PR introduces a change to the architecture. -->

We need to show various release dates when viewing details about a referral

## Changes in this PR

- Fix missing `sentenceStartDate` on generated people
- Add release dates and life sentence status to prisoner model
- Add prisoner release dates and calculate earliest release date on person model

## Release checklist

[Release process documentation](../doc/how-to/perform-a-release.md)

As part of our continuous deployment strategy we must ensure that this work is
ready to be released once merged.

### Pre-merge

- [ ] There are changes required to the Accredited Programmes API for this change to work...
  - [ ] ... and they have been released to production already

### Post-merge

<!-- The outer checkboxes can be completed pre-merge -->

- [ ] This adds, extends or meaningfully modifies a feature...
  - [ ] ... and I have written or updated an end-to-end test for the happy path in the [Accredited Programmes E2E repo](https://github.com/ministryofjustice/hmpps-accredited-programmes-e2e)
- [ ] This makes new expectations of the API...
  - [ ] ... and I have notified the API developer(s) of changes to the contract tests (Pact), or the API is already compliant
- [ ] [Manually approve](../doc/how-to/perform-a-release.md#releasing-to-the-preprod-environment) release to preprod
- [ ] [Manually approve](../doc/how-to/perform-a-release.md#releasing-to-the-production-environment) release to prod

<!-- Should a release fail at any step, you as the author should now lead the work to
fix it as soon as possible. You can monitor deployment failures in CircleCI
itself and application errors are found in
[Sentry](https://ministryofjustice.sentry.io/projects/hmpps-accredited-programmes-ui/?project=4505330122686464&referrer=sidebar&statsPeriod=24h). -->
