### PR TITLE
Nest internal clients

### DIFF
--- a/server/data/accreditedProgrammesApi/courseClient.test.ts
+++ b/server/data/accreditedProgrammesApi/courseClient.test.ts
@@ -2,9 +2,14 @@ import { Matchers } from '@pact-foundation/pact'
 import { pactWith } from 'jest-pact'
 
 import CourseClient from './courseClient'
-import config from '../config'
-import { apiPaths } from '../paths'
-import { courseFactory, courseOfferingFactory, courseParticipationFactory, personFactory } from '../testutils/factories'
+import config from '../../config'
+import { apiPaths } from '../../paths'
+import {
+  courseFactory,
+  courseOfferingFactory,
+  courseParticipationFactory,
+  personFactory,
+} from '../../testutils/factories'
 import type { CourseParticipationUpdate } from '@accredited-programmes/models'
 
 pactWith({ consumer: 'Accredited Programmes UI', provider: 'Accredited Programmes API' }, provider => {

--- a/server/data/accreditedProgrammesApi/courseClient.ts
+++ b/server/data/accreditedProgrammesApi/courseClient.ts
@@ -1,7 +1,7 @@
-import RestClient from './restClient'
-import type { ApiConfig } from '../config'
-import config from '../config'
-import { apiPaths } from '../paths'
+import type { ApiConfig } from '../../config'
+import config from '../../config'
+import { apiPaths } from '../../paths'
+import RestClient from '../restClient'
 import type {
   Course,
   CourseOffering,

--- a/server/data/accreditedProgrammesApi/referralClient.test.ts
+++ b/server/data/accreditedProgrammesApi/referralClient.test.ts
@@ -2,9 +2,9 @@ import { Matchers } from '@pact-foundation/pact'
 import { pactWith } from 'jest-pact'
 
 import ReferralClient from './referralClient'
-import config from '../config'
-import { apiPaths } from '../paths'
-import { referralFactory } from '../testutils/factories'
+import config from '../../config'
+import { apiPaths } from '../../paths'
+import { referralFactory } from '../../testutils/factories'
 import type { CreatedReferralResponse, ReferralUpdate } from '@accredited-programmes/models'
 
 pactWith({ consumer: 'Accredited Programmes UI', provider: 'Accredited Programmes API' }, provider => {

--- a/server/data/accreditedProgrammesApi/referralClient.ts
+++ b/server/data/accreditedProgrammesApi/referralClient.ts
@@ -1,7 +1,7 @@
-import RestClient from './restClient'
-import type { ApiConfig } from '../config'
-import config from '../config'
-import { apiPaths } from '../paths'
+import type { ApiConfig } from '../../config'
+import config from '../../config'
+import { apiPaths } from '../../paths'
+import RestClient from '../restClient'
 import type { CreatedReferralResponse, Referral, ReferralStatus, ReferralUpdate } from '@accredited-programmes/models'
 
 export default class ReferralClient {

--- a/server/data/index.ts
+++ b/server/data/index.ts
@@ -12,7 +12,8 @@ AppInsightsUtils.buildClient()
 
 /* eslint-enable import/order */
 
-import CourseClient from './courseClient'
+import CourseClient from './accreditedProgrammesApi/courseClient'
+import ReferralClient from './accreditedProgrammesApi/referralClient'
 import { serviceCheckFactory } from './healthCheck'
 import HmppsAuthClient from './hmppsAuthClient'
 import HmppsManageUsersClient from './hmppsManageUsersClient'
@@ -21,7 +22,6 @@ import PrisonRegisterApiClient from './prisonRegisterApiClient'
 import PrisonerSearchClient from './prisonerSearchClient'
 import type { RedisClient } from './redisClient'
 import { createRedisClient } from './redisClient'
-import ReferralClient from './referralClient'
 import TokenStore from './tokenStore'
 import type { TokenVerifier } from './tokenVerification'
 import verifyToken from './tokenVerification'

--- a/server/services/courseService.test.ts
+++ b/server/services/courseService.test.ts
@@ -16,7 +16,7 @@ import {
 import { CourseParticipationUtils, StringUtils } from '../utils'
 import type { CourseParticipationUpdate } from '@accredited-programmes/models'
 
-jest.mock('../data/courseClient')
+jest.mock('../data/accreditedProgrammesApi/courseClient')
 jest.mock('../utils/courseParticipationUtils')
 
 describe('CourseService', () => {

--- a/server/services/referralService.test.ts
+++ b/server/services/referralService.test.ts
@@ -5,7 +5,7 @@ import { ReferralClient } from '../data'
 import { referralFactory } from '../testutils/factories'
 import type { CreatedReferralResponse, ReferralStatus, ReferralUpdate } from '@accredited-programmes/models'
 
-jest.mock('../data/referralClient')
+jest.mock('../data/accreditedProgrammesApi/referralClient')
 
 describe('ReferralService', () => {
   const referralClient = new ReferralClient('token') as jest.Mocked<ReferralClient>


### PR DESCRIPTION
## Context

<!-- Is there a Trello ticket you can link to? -->
<!-- Do you need to add any environment variables? -->
<!-- Is an ADR required? An ADR should be added if this PR introduces a change to the architecture. -->

We recently moved to mapping clients to APIs more consistently. We want to avoid creating a very large client for our internal API, so to loosely follow the same principle we're nesting the relevant clients in an `accreditedProgrammesApi` folder

## Changes in this PR

- Nest internal API clients

## Release checklist

[Release process documentation](../doc/how-to/perform-a-release.md)

As part of our continuous deployment strategy we must ensure that this work is
ready to be released once merged.

### Pre-merge

- [ ] There are changes required to the Accredited Programmes API for this change to work...
  - [ ] ... and they have been released to production already

### Post-merge

<!-- The outer checkboxes can be completed pre-merge -->

- [ ] This adds, extends or meaningfully modifies a feature...
  - [ ] ... and I have written or updated an end-to-end test for the happy path in the [Accredited Programmes E2E repo](https://github.com/ministryofjustice/hmpps-accredited-programmes-e2e)
- [ ] This makes new expectations of the API...
  - [ ] ... and I have notified the API developer(s) of changes to the contract tests (Pact), or the API is already compliant
- [ ] [Manually approve](../doc/how-to/perform-a-release.md#releasing-to-the-preprod-environment) release to preprod
- [ ] [Manually approve](../doc/how-to/perform-a-release.md#releasing-to-the-production-environment) release to prod

<!-- Should a release fail at any step, you as the author should now lead the work to
fix it as soon as possible. You can monitor deployment failures in CircleCI
itself and application errors are found in
[Sentry](https://ministryofjustice.sentry.io/projects/hmpps-accredited-programmes-ui/?project=4505330122686464&referrer=sidebar&statsPeriod=24h). -->
