### PR TITLE
Migrating project to use groups in allowlist

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,7 +1,7 @@
 version: 2.1
 
 orbs:
-  hmpps: ministryofjustice/hmpps@7.2.1
+  hmpps: ministryofjustice/hmpps@7
   slack: circleci/slack@4.12.1
   node: circleci/node@4.5.2
 
@@ -48,7 +48,8 @@ jobs:
             export BUILD_NUMBER=${DATE}.${CIRCLE_BUILD_NUM}
             export GIT_REF="$CIRCLE_SHA1"
             npm run record-build-info
-      - run: # Run linter after build because the integration test code depend on compiled typescript...
+      - run:
+          # Run linter after build because the integration test code depend on compiled typescript...
           name: Linter check
           command: npm run lint:ci
       - run: npm run typecheck
@@ -273,8 +274,8 @@ workflows:
       - tag_pact_version:
           name: 'tag_pact_version_dev'
           tag: 'deployed:dev'
-          requires: [deploy_dev]
-          context: [hmpps-common-vars]
+          requires: [ deploy_dev ]
+          context: [ hmpps-common-vars ]
 
       - request-preprod-approval:
           type: approval
@@ -292,8 +293,8 @@ workflows:
       - tag_pact_version:
           name: 'tag_pact_version_preprod'
           tag: 'deployed:preprod'
-          requires: [deploy_preprod]
-          context: [hmpps-common-vars]
+          requires: [ deploy_preprod ]
+          context: [ hmpps-common-vars ]
 
       - request-prod-approval:
           type: approval
@@ -312,8 +313,8 @@ workflows:
       - tag_pact_version:
           name: 'tag_pact_version_prod'
           tag: 'deployed:prod'
-          requires: [deploy_prod]
-          context: [hmpps-common-vars]
+          requires: [ deploy_prod ]
+          context: [ hmpps-common-vars ]
 
   security:
     triggers:

--- a/helm_deploy/hmpps-accredited-programmes-ui/Chart.yaml
+++ b/helm_deploy/hmpps-accredited-programmes-ui/Chart.yaml
@@ -5,7 +5,7 @@ name: hmpps-accredited-programmes-ui
 version: 0.2.0
 dependencies:
   - name: generic-service
-    version: 2.8.1
+    version: "2.8"
     repository: https://ministryofjustice.github.io/hmpps-helm-charts
   - name: generic-prometheus-alerts
     version: 1.3.3


### PR DESCRIPTION
This PR migrates the project to use groups of IPs in their allowlist.

By referring to groups to IP addresses, we can centralize the definition of groups of ip addresses.
If these lists require changing in the future, we can change the definition once and future deploys across all services will automatically include these new IPs.

0 allowlist(s) have been detected that can be migrated.


