### PR TITLE
(1110) Add `keylessSummaryCard` macro

### DIFF
--- a/integration_tests/pages/refer/new/checkAnswers.ts
+++ b/integration_tests/pages/refer/new/checkAnswers.ts
@@ -1,5 +1,6 @@
 import { referPaths } from '../../../../server/paths'
 import { CourseUtils, ReferralUtils } from '../../../../server/utils'
+import Helpers from '../../../support/helpers'
 import Page from '../../page'
 import type { Course, CourseOffering, Organisation, Person, Referral } from '@accredited-programmes/models'
 import type { CourseParticipationPresenter, CoursePresenter } from '@accredited-programmes/ui'
@@ -65,7 +66,16 @@ export default class NewReferralCheckAnswersPage extends Page {
       'Change additional information',
       referPaths.new.additionalInformation.show({ referralId: this.referral.id }),
     )
-    cy.get('[data-testid="additional-information"]').should('have.text', this.referral.additionalInformation)
+
+    cy.get('[data-testid="additional-information-summary-list"] .govuk-summary-list__value').then(
+      keylessSummaryListBodyElement => {
+        const { actual, expected } = Helpers.parseHtml(
+          keylessSummaryListBodyElement,
+          this.referral.additionalInformation,
+        )
+        expect(actual).to.equal(expected)
+      },
+    )
   }
 
   shouldHaveApplicationSummary() {
@@ -91,7 +101,15 @@ export default class NewReferralCheckAnswersPage extends Page {
   }
 
   shouldHaveOasysConfirmation(): void {
-    cy.get('[data-testid="oasys-confirmation"]').should('have.text', 'I confirm that the information is up to date.')
+    cy.get('[data-testid="oasys-confirmation-summary-list"] .govuk-summary-list__value').then(
+      keylessSummaryListBodyElement => {
+        const { actual, expected } = Helpers.parseHtml(
+          keylessSummaryListBodyElement,
+          'I confirm that the information is up to date.',
+        )
+        expect(actual).to.equal(expected)
+      },
+    )
   }
 
   shouldHaveProgrammeHistory(): void {

--- a/server/views/partials/keylessSummaryCard.njk
+++ b/server/views/partials/keylessSummaryCard.njk
@@ -1,0 +1,21 @@
+{% from "govuk/components/summary-list/macro.njk" import govukSummaryList %}
+
+{% macro keylessSummaryCard(title, actionItems = [], bodyText = undefined, bodyHtml = undefined, testid = '') %}
+  {{ govukSummaryList({
+    card: {
+      title: {
+        text: title
+      },
+      actions: {
+        items: actionItems
+      }
+    },
+    rows: [{
+      key: { text: "", classes: "govuk-visually-hidden" },
+      value: { text: bodyText, html: bodyHtml, classes: "govuk-!-width-full" }
+    }],
+    attributes: {
+      "data-testid": testid
+    }
+  }) }}
+{% endmacro %}

--- a/server/views/referrals/new/checkAnswers.njk
+++ b/server/views/referrals/new/checkAnswers.njk
@@ -4,6 +4,8 @@
 {% from "govuk/components/error-summary/macro.njk" import govukErrorSummary %}
 {% from "govuk/components/summary-list/macro.njk" import govukSummaryList %}
 
+{% from "../../partials/keylessSummaryCard.njk" import keylessSummaryCard %}
+
 {% extends "../../partials/layout.njk" %}
 
 {% block personBanner %}
@@ -77,32 +79,19 @@
 
       <h2 class="govuk-heading-m">OASys information</h2>
 
-      <div class="govuk-summary-card">
-        <div class="govuk-summary-card__title-wrapper">
-          <h2 class="govuk-summary-card__title">Confirm OASys information</h2>
-        </div>
-        <div class="govuk-summary-card__content">
-          <p class="govuk-!-margin-bottom-0" data-testid="oasys-confirmation">I confirm that the information is up to date.</p>
-        </div>
-      </div>
+      {{ keylessSummaryCard("Confirm OASys information", bodyText="I confirm that the information is up to date.", testid="oasys-confirmation-summary-list") }}
 
       <h2 class="govuk-heading-m">Additional information</h2>
 
-      <div class="govuk-summary-card">
-        <div class="govuk-summary-card__title-wrapper">
-          <h2 class="govuk-summary-card__title">Add Additional information</h2>
-          <ul class="govuk-summary-card__actions">
-            <li class="govuk-summary-card__action">
-              <a class="govuk-link govuk-link--no-visited-state" href="{{ referPaths.new.additionalInformation.show({ referralId: referralId }) }}">
-                Change<span class="govuk-visually-hidden"> additional information</span>
-              </a>
-            </li>
-          </ul>
-        </div>
-        <div class="govuk-summary-card__content">
-          <p class="maintain-white-space govuk-!-margin-bottom-0" data-testid="additional-information">{{ additionalInformation }}</p>
-        </div>
-      </div>
+      {{ keylessSummaryCard(
+        "Add additional information",
+        actionItems=[{
+          html: 'Change<span class="govuk-visually-hidden"> additional information</span>',
+          href: referPaths.new.additionalInformation.show({ referralId: referralId })
+        }],
+        bodyText=additionalInformation,
+        testid="additional-information-summary-list"
+      ) }}
 
       <hr class="govuk-section-break govuk-section-break--visible govuk-!-margin-bottom-6">
 


### PR DESCRIPTION
## Changes in this PR

We have more uses for keyless summary cards now*, so this extracts the logic for building one of these into a macro that wraps around the GOV.UK summary list macro. This avoids us adding in a lot of literal HTML across the codebase and the potential for us to become out of sync with any GOV.UK Frontend macro changes

\* they will be needed for the sentence details and release dates summary cards (in the view referral sentence information page) when they have no data

We don't have a need for formatted text (using the `html` key instead of `text`) in the body of the card yet, but the macro has been written such that it supports that

## Screenshots of UI changes

Minor change in vertical spacing, more in line with other summary cards

## Release checklist

[Release process documentation](../doc/how-to/perform-a-release.md)

As part of our continuous deployment strategy we must ensure that this work is
ready to be released once merged.

### Pre-merge

- [ ] There are changes required to the Accredited Programmes API for this change to work...
  - [ ] ... and they have been released to production already

### Post-merge

<!-- The outer checkboxes can be completed pre-merge -->

- [ ] This adds, extends or meaningfully modifies a feature...
  - [ ] ... and I have written or updated an end-to-end test for the happy path in the [Accredited Programmes E2E repo](https://github.com/ministryofjustice/hmpps-accredited-programmes-e2e)
- [ ] This makes new expectations of the API...
  - [ ] ... and I have notified the API developer(s) of changes to the contract tests (Pact), or the API is already compliant
- [ ] [Manually approve](../doc/how-to/perform-a-release.md#releasing-to-the-preprod-environment) release to preprod
- [ ] [Manually approve](../doc/how-to/perform-a-release.md#releasing-to-the-production-environment) release to prod

<!-- Should a release fail at any step, you as the author should now lead the work to
fix it as soon as possible. You can monitor deployment failures in CircleCI
itself and application errors are found in
[Sentry](https://ministryofjustice.sentry.io/projects/hmpps-accredited-programmes-ui/?project=4505330122686464&referrer=sidebar&statsPeriod=24h). -->
