### PR TITLE
(886c) Add new Prison API client methods for offence history details

### DIFF
--- a/server/@types/prisonApi/index.d.ts
+++ b/server/@types/prisonApi/index.d.ts
@@ -1,7 +1,10 @@
 import type { components } from './imported'
 
 type Caseload = components['schemas']['CaseLoad']
-
+type InmateDetail = components['schemas']['InmateDetail']
+type OffenceHistoryDetail = components['schemas']['OffenceHistoryDetail']
+type OffenceDto = components['schemas']['OffenceDto']
 type OffenderSentenceAndOffences = components['schemas']['OffenderSentenceAndOffences']
+type PageOffenceDto = components['schemas']['PageOffenceDto']
 
-export type { Caseload, OffenderSentenceAndOffences }
+export type { Caseload, InmateDetail, OffenceDto, OffenceHistoryDetail, OffenderSentenceAndOffences, PageOffenceDto }

--- a/server/data/prisonApiClient.test.ts
+++ b/server/data/prisonApiClient.test.ts
@@ -3,7 +3,12 @@ import nock from 'nock'
 import PrisonApiClient from './prisonApiClient'
 import config from '../config'
 import { prisonApiPaths } from '../paths'
-import { caseloadFactory, prisonerFactory, sentenceAndOffenceDetailsFactory } from '../testutils/factories'
+import {
+  caseloadFactory,
+  inmateDetailFactory,
+  prisonerFactory,
+  sentenceAndOffenceDetailsFactory,
+} from '../testutils/factories'
 import type { Caseload } from '@prison-api'
 import type { Prisoner } from '@prisoner-search'
 
@@ -38,6 +43,21 @@ describe('PrisonApiClient', () => {
 
       const output = await prisonApiClient.findCurrentUserCaseloads()
       expect(output).toEqual(caseloads)
+    })
+  })
+
+  describe('findOffenderBookingByOffenderNo', () => {
+    const offenderNo = 'A1234AA'
+    const offenderBooking = inmateDetailFactory.build()
+
+    it('fetches an offender booking by offender number', async () => {
+      fakePrisonApi
+        .get(prisonApiPaths.offenderBookingDetail({ offenderNo }))
+        .query({ extraInfo: 'true' })
+        .reply(200, offenderBooking)
+
+      const output = await prisonApiClient.findOffenderBookingByOffenderNo(offenderNo)
+      expect(output).toEqual(offenderBooking)
     })
   })
 

--- a/server/data/prisonApiClient.test.ts
+++ b/server/data/prisonApiClient.test.ts
@@ -6,6 +6,7 @@ import { prisonApiPaths } from '../paths'
 import {
   caseloadFactory,
   inmateDetailFactory,
+  offenceDtoFactory,
   prisonerFactory,
   sentenceAndOffenceDetailsFactory,
 } from '../testutils/factories'
@@ -43,6 +44,18 @@ describe('PrisonApiClient', () => {
 
       const output = await prisonApiClient.findCurrentUserCaseloads()
       expect(output).toEqual(caseloads)
+    })
+  })
+
+  describe('findOffencesThatStartWith', () => {
+    const offenceCode = 'ABC123'
+    const offence = offenceDtoFactory.build()
+
+    it('fetches an offence by offence code', async () => {
+      fakePrisonApi.get(prisonApiPaths.offenceCode({ offenceCode })).reply(200, { content: [offence] })
+
+      const output = await prisonApiClient.findOffencesThatStartWith(offenceCode)
+      expect(output).toEqual({ content: [offence] })
     })
   })
 

--- a/server/data/prisonApiClient.ts
+++ b/server/data/prisonApiClient.ts
@@ -2,7 +2,7 @@ import RestClient from './restClient'
 import type { ApiConfig } from '../config'
 import config from '../config'
 import { prisonApiPaths } from '../paths'
-import type { Caseload, OffenderSentenceAndOffences } from '@prison-api'
+import type { Caseload, InmateDetail, OffenderSentenceAndOffences } from '@prison-api'
 import type { Prisoner } from '@prisoner-search'
 
 export default class PrisonApiClient {
@@ -16,6 +16,15 @@ export default class PrisonApiClient {
     return (await this.restClient.get({
       path: prisonApiPaths.caseloads.currentUser({}),
     })) as Array<Caseload>
+  }
+
+  async findOffenderBookingByOffenderNo(offenderNo: Prisoner['prisonerNumber']): Promise<InmateDetail> {
+    return (await this.restClient.get({
+      path: prisonApiPaths.offenderBookingDetail({ offenderNo }),
+      query: {
+        extraInfo: 'true',
+      },
+    })) as InmateDetail
   }
 
   async findSentenceAndOffenceDetails(bookingId: Prisoner['bookingId']): Promise<OffenderSentenceAndOffences> {

--- a/server/data/prisonApiClient.ts
+++ b/server/data/prisonApiClient.ts
@@ -2,7 +2,7 @@ import RestClient from './restClient'
 import type { ApiConfig } from '../config'
 import config from '../config'
 import { prisonApiPaths } from '../paths'
-import type { Caseload, InmateDetail, OffenderSentenceAndOffences } from '@prison-api'
+import type { Caseload, InmateDetail, OffenceDto, OffenderSentenceAndOffences, PageOffenceDto } from '@prison-api'
 import type { Prisoner } from '@prisoner-search'
 
 export default class PrisonApiClient {
@@ -16,6 +16,12 @@ export default class PrisonApiClient {
     return (await this.restClient.get({
       path: prisonApiPaths.caseloads.currentUser({}),
     })) as Array<Caseload>
+  }
+
+  async findOffencesThatStartWith(offenceCode: OffenceDto['code']): Promise<PageOffenceDto> {
+    return (await this.restClient.get({
+      path: prisonApiPaths.offenceCode({ offenceCode }),
+    })) as PageOffenceDto
   }
 
   async findOffenderBookingByOffenderNo(offenderNo: Prisoner['prisonerNumber']): Promise<InmateDetail> {

--- a/server/paths/prisonApi.ts
+++ b/server/paths/prisonApi.ts
@@ -2,11 +2,15 @@ import { path } from 'static-path'
 
 const apiBasePath = path('/api')
 const caseloadsPath = apiBasePath.path('users/me/caseLoads')
+const offenceCodePath = apiBasePath.path('offences/code/:offenceCode')
+const offenderBookingDetailPath = apiBasePath.path('bookings/offenderNo/:offenderNo')
 const sentenceAndOffenceDetailsPath = apiBasePath.path('offender-sentences/booking/:bookingId/sentences-and-offences')
 
 export default {
   caseloads: {
     currentUser: caseloadsPath,
   },
+  offenceCode: offenceCodePath,
+  offenderBookingDetail: offenderBookingDetailPath,
   sentenceAndOffenceDetails: sentenceAndOffenceDetailsPath,
 }

--- a/server/testutils/factories/index.ts
+++ b/server/testutils/factories/index.ts
@@ -5,6 +5,7 @@ import courseOfferingFactory from './courseOffering'
 import courseParticipationFactory from './courseParticipation'
 import coursePrerequisiteFactory from './coursePrerequisite'
 import inmateDetailFactory from './inmateDetail'
+import offenceDtoFactory from './offenceDto'
 import offenceHistoryDetailFactory from './offenceHistoryDetail'
 import organisationFactory from './organisation'
 import organisationAddressFactory from './organisationAddress'
@@ -24,6 +25,7 @@ export {
   courseParticipationFactory,
   coursePrerequisiteFactory,
   inmateDetailFactory,
+  offenceDtoFactory,
   offenceHistoryDetailFactory,
   organisationAddressFactory,
   organisationFactory,

--- a/server/testutils/factories/index.ts
+++ b/server/testutils/factories/index.ts
@@ -4,6 +4,7 @@ import courseAudienceFactory from './courseAudience'
 import courseOfferingFactory from './courseOffering'
 import courseParticipationFactory from './courseParticipation'
 import coursePrerequisiteFactory from './coursePrerequisite'
+import inmateDetailFactory from './inmateDetail'
 import offenceHistoryDetailFactory from './offenceHistoryDetail'
 import organisationFactory from './organisation'
 import organisationAddressFactory from './organisationAddress'
@@ -22,6 +23,7 @@ export {
   courseOfferingFactory,
   courseParticipationFactory,
   coursePrerequisiteFactory,
+  inmateDetailFactory,
   offenceHistoryDetailFactory,
   organisationAddressFactory,
   organisationFactory,

--- a/server/testutils/factories/index.ts
+++ b/server/testutils/factories/index.ts
@@ -4,6 +4,7 @@ import courseAudienceFactory from './courseAudience'
 import courseOfferingFactory from './courseOffering'
 import courseParticipationFactory from './courseParticipation'
 import coursePrerequisiteFactory from './coursePrerequisite'
+import offenceHistoryDetailFactory from './offenceHistoryDetail'
 import organisationFactory from './organisation'
 import organisationAddressFactory from './organisationAddress'
 import personFactory from './person'
@@ -21,6 +22,7 @@ export {
   courseOfferingFactory,
   courseParticipationFactory,
   coursePrerequisiteFactory,
+  offenceHistoryDetailFactory,
   organisationAddressFactory,
   organisationFactory,
   personFactory,

--- a/server/testutils/factories/inmateDetail.ts
+++ b/server/testutils/factories/inmateDetail.ts
@@ -1,0 +1,15 @@
+import { faker } from '@faker-js/faker/locale/en_GB'
+import { Factory } from 'fishery'
+
+import FactoryHelpers from './factoryHelpers'
+import offenceHistoryDetail from './offenceHistoryDetail'
+import type { InmateDetail } from '@prison-api'
+
+export default Factory.define<Partial<InmateDetail>>(() => {
+  const offenceHistory = [offenceHistoryDetail.build({ mostSerious: true }), offenceHistoryDetail.build()]
+
+  return {
+    offenceHistory: FactoryHelpers.optionalArrayElement([offenceHistory]),
+    offenderNo: FactoryHelpers.optionalArrayElement(faker.string.alphanumeric({ casing: 'upper', length: 7 })),
+  }
+})

--- a/server/testutils/factories/offenceDto.ts
+++ b/server/testutils/factories/offenceDto.ts
@@ -1,0 +1,15 @@
+import { faker } from '@faker-js/faker/locale/en_GB'
+import { Factory } from 'fishery'
+
+import type { OffenceDto } from '@prison-api'
+
+export default Factory.define<Partial<OffenceDto>>(() => ({
+  code: faker.string.alphanumeric({ casing: 'upper', length: 6 }),
+  description: faker.lorem.sentence(),
+  statuteCode: {
+    activeFlag: 'Y',
+    code: faker.string.alphanumeric({ casing: 'upper', length: 4 }),
+    description: faker.lorem.sentence(),
+    legislatingBodyCode: faker.string.alphanumeric({ casing: 'upper', length: 3 }),
+  },
+}))

--- a/server/testutils/factories/offenceHistoryDetail.ts
+++ b/server/testutils/factories/offenceHistoryDetail.ts
@@ -1,0 +1,11 @@
+import { faker } from '@faker-js/faker/locale/en_GB'
+import { Factory } from 'fishery'
+
+import FactoryHelpers from './factoryHelpers'
+import type { OffenceHistoryDetail } from '@prison-api'
+
+export default Factory.define<Partial<OffenceHistoryDetail>>(() => ({
+  mostSerious: FactoryHelpers.optionalArrayElement(false),
+  offenceCode: FactoryHelpers.optionalArrayElement(faker.string.alphanumeric({ casing: 'upper', length: 6 })),
+  offenceDate: FactoryHelpers.optionalArrayElement(faker.date.past({ years: 1 }).toISOString().substring(0, 10)),
+}))


### PR DESCRIPTION
## Context

We need to use a couple of new endpoints to display a persons offence history with further offence detail.

## Changes in this PR
After some digging and discussions we have agreed to use the endpoints added in this PR.

- Use `{{prison_api}}/api/bookings/offenderNo/:offenderNo?extraInfo=true` to get the details for a person/offender with `offenceHistory`.
- Then use `{{prison_api}}/api/offences/code/:offenceCode` to get further information for an offence.


## Release checklist

[Release process documentation](../doc/how-to/perform-a-release.md)

As part of our continuous deployment strategy we must ensure that this work is
ready to be released once merged.

### Pre-merge

- [ ] There are changes required to the Accredited Programmes API for this change to work...
  - [ ] ... and they have been released to production already

### Post-merge

<!-- The outer checkboxes can be completed pre-merge -->

- [ ] This adds, extends or meaningfully modifies a feature...
  - [ ] ... and I have written or updated an end-to-end test for the happy path in the [Accredited Programmes E2E repo](https://github.com/ministryofjustice/hmpps-accredited-programmes-e2e)
- [ ] This makes new expectations of the API...
  - [ ] ... and I have notified the API developer(s) of changes to the contract tests (Pact), or the API is already compliant
- [ ] [Manually approve](../doc/how-to/perform-a-release.md#releasing-to-the-preprod-environment) release to preprod
- [ ] [Manually approve](../doc/how-to/perform-a-release.md#releasing-to-the-production-environment) release to prod

<!-- Should a release fail at any step, you as the author should now lead the work to
fix it as soon as possible. You can monitor deployment failures in CircleCI
itself and application errors are found in
[Sentry](https://ministryofjustice.sentry.io/projects/hmpps-accredited-programmes-ui/?project=4505330122686464&referrer=sidebar&statsPeriod=24h). -->
