### PR TITLE
Fix external token usage

### DIFF
--- a/server/controllers/find/courseOfferingsController.test.ts
+++ b/server/controllers/find/courseOfferingsController.test.ts
@@ -9,7 +9,7 @@ import { CourseUtils, OrganisationUtils } from '../../utils'
 
 describe('CoursesOfferingsController', () => {
   describe('show', () => {
-    const token = 'SOME_TOKEN'
+    const userToken = 'SOME_TOKEN'
     let request: DeepMocked<Request>
     let response: DeepMocked<Response>
     const next: DeepMocked<NextFunction> = createMock<NextFunction>({})
@@ -24,7 +24,7 @@ describe('CoursesOfferingsController', () => {
     courseService.getOffering.mockResolvedValue(courseOffering)
 
     beforeEach(() => {
-      request = createMock<Request>({ user: { token } })
+      request = createMock<Request>({ user: { token: userToken } })
       response = createMock<Response>({})
       controller = new CourseOfferingsController(courseService, organisationService)
     })

--- a/server/controllers/find/coursesController.test.ts
+++ b/server/controllers/find/coursesController.test.ts
@@ -10,7 +10,7 @@ import type { Course, CourseOffering } from '@accredited-programmes/models'
 import type { OrganisationWithOfferingId } from '@accredited-programmes/ui'
 
 describe('CoursesController', () => {
-  const token = 'SOME_TOKEN'
+  const userToken = 'SOME_TOKEN'
   let request: DeepMocked<Request>
   let response: DeepMocked<Response>
   const next: DeepMocked<NextFunction> = createMock<NextFunction>({})
@@ -20,7 +20,7 @@ describe('CoursesController', () => {
   let controller: CoursesController
 
   beforeEach(() => {
-    request = createMock<Request>({ user: { token } })
+    request = createMock<Request>({ user: { token: userToken } })
     response = createMock<Response>({})
     controller = new CoursesController(courseService, organisationService)
   })
@@ -42,7 +42,7 @@ describe('CoursesController', () => {
         pageHeading: 'List of accredited programmes',
       })
 
-      expect(courseService.getCourses).toHaveBeenCalledWith(token)
+      expect(courseService.getCourses).toHaveBeenCalledWith(userToken)
     })
   })
 
@@ -74,7 +74,7 @@ describe('CoursesController', () => {
         await requestHandler(request, response, next)
 
         const organisationIds = organisations.map(organisation => organisation.id)
-        expect(organisationService.getOrganisations).toHaveBeenCalledWith(token, organisationIds)
+        expect(organisationService.getOrganisations).toHaveBeenCalledWith(userToken, organisationIds)
 
         const coursePresenter = CourseUtils.presentCourse(course)
         expect(response.render).toHaveBeenCalledWith('courses/show', {
@@ -113,7 +113,7 @@ describe('CoursesController', () => {
         await requestHandler(request, response, next)
 
         const allOrganisationIds = allOrganisations.map(organisation => organisation.id)
-        expect(organisationService.getOrganisations).toHaveBeenCalledWith(token, allOrganisationIds)
+        expect(organisationService.getOrganisations).toHaveBeenCalledWith(userToken, allOrganisationIds)
 
         const coursePresenter = CourseUtils.presentCourse(course)
         expect(response.render).toHaveBeenCalledWith('courses/show', {

--- a/server/controllers/refer/new/courseParticipationDetailsController.test.ts
+++ b/server/controllers/refer/new/courseParticipationDetailsController.test.ts
@@ -19,7 +19,7 @@ jest.mock('../../../utils/formUtils')
 jest.mock('../../../utils/courseParticipationUtils')
 
 describe('NewReferralsCourseParticipationDetailsController', () => {
-  const token = 'SOME_TOKEN'
+  const userToken = 'SOME_TOKEN'
   const username = 'SOME_USERNAME'
   let request: DeepMocked<Request>
   let response: DeepMocked<Response>
@@ -44,7 +44,7 @@ describe('NewReferralsCourseParticipationDetailsController', () => {
         courseParticipationId,
         referralId,
       },
-      user: { token, username },
+      user: { token: userToken, username },
     })
     response = Helpers.createMockResponseWithCaseloads()
 
@@ -192,13 +192,13 @@ describe('NewReferralsCourseParticipationDetailsController', () => {
       await requestHandler(request, response, next)
 
       expect(referralService.getReferral).toHaveBeenCalledWith(username, referralId)
-      expect(courseService.getParticipation).toHaveBeenCalledWith(token, courseParticipationId)
+      expect(courseService.getParticipation).toHaveBeenCalledWith(userToken, courseParticipationId)
       expect(CourseParticipationUtils.processDetailsFormData).toHaveBeenCalledWith(
         request,
         courseParticipation.courseName,
       )
       expect(courseService.updateParticipation).toHaveBeenCalledWith(
-        token,
+        userToken,
         courseParticipationId,
         courseParticipationUpdate,
       )
@@ -229,7 +229,7 @@ describe('NewReferralsCourseParticipationDetailsController', () => {
         await requestHandler(request, response, next)
 
         expect(referralService.getReferral).toHaveBeenCalledWith(username, referralId)
-        expect(courseService.getParticipation).toHaveBeenCalledWith(token, courseParticipationId)
+        expect(courseService.getParticipation).toHaveBeenCalledWith(userToken, courseParticipationId)
         expect(CourseParticipationUtils.processDetailsFormData).toHaveBeenCalledWith(
           request,
           courseParticipation.courseName,

--- a/server/controllers/refer/new/courseParticipationsController.test.ts
+++ b/server/controllers/refer/new/courseParticipationsController.test.ts
@@ -22,7 +22,7 @@ jest.mock('../../../utils/courseParticipationUtils')
 
 describe('NewReferralsCourseParticipationsController', () => {
   const username = 'SOME_USERNAME'
-  const token = 'SOME_TOKEN'
+  const userToken = 'SOME_TOKEN'
   let request: DeepMocked<Request>
   let response: DeepMocked<Response>
   const next: DeepMocked<NextFunction> = createMock<NextFunction>({})
@@ -40,7 +40,7 @@ describe('NewReferralsCourseParticipationsController', () => {
   const submittedReferral = referralFactory.submitted().build({ id: referralId, prisonNumber: person.prisonNumber })
 
   beforeEach(() => {
-    request = createMock<Request>({ params: { referralId }, user: { token, username } })
+    request = createMock<Request>({ params: { referralId }, user: { token: userToken, username } })
     response = Helpers.createMockResponseWithCaseloads()
 
     controller = new NewReferralsCourseParticipationsController(courseService, personService, referralService)
@@ -77,7 +77,11 @@ describe('NewReferralsCourseParticipationsController', () => {
           request.body.otherCourseName,
           request,
         )
-        expect(courseService.createParticipation).toHaveBeenCalledWith(token, draftReferral.prisonNumber, courseName)
+        expect(courseService.createParticipation).toHaveBeenCalledWith(
+          userToken,
+          draftReferral.prisonNumber,
+          courseName,
+        )
         expect(request.flash).toHaveBeenCalledWith('successMessage', 'You have successfully added a programme.')
         expect(response.redirect).toHaveBeenCalledWith(
           referPaths.new.programmeHistory.details.show({
@@ -113,7 +117,7 @@ describe('NewReferralsCourseParticipationsController', () => {
           request,
         )
         expect(courseService.createParticipation).toHaveBeenCalledWith(
-          token,
+          userToken,
           draftReferral.prisonNumber,
           otherCourseName,
         )
@@ -185,11 +189,16 @@ describe('NewReferralsCourseParticipationsController', () => {
       await requestHandler(request, response, next)
 
       expect(referralService.getReferral).toHaveBeenCalledWith(username, request.params.referralId)
-      expect(courseService.getParticipation).toHaveBeenCalledWith(token, courseParticipationId)
-      expect(courseService.presentCourseParticipation).toHaveBeenCalledWith(token, courseParticipation, referralId, {
-        change: false,
-        remove: false,
-      })
+      expect(courseService.getParticipation).toHaveBeenCalledWith(userToken, courseParticipationId)
+      expect(courseService.presentCourseParticipation).toHaveBeenCalledWith(
+        userToken,
+        courseParticipation,
+        referralId,
+        {
+          change: false,
+          remove: false,
+        },
+      )
       expect(response.render).toHaveBeenCalledWith('referrals/new/courseParticipations/delete', {
         action: `${referPaths.new.programmeHistory.destroy({ courseParticipationId, referralId })}?_method=DELETE`,
         pageHeading: 'Remove programme',
@@ -223,7 +232,7 @@ describe('NewReferralsCourseParticipationsController', () => {
       await requestHandler(request, response, next)
 
       expect(referralService.getReferral).toHaveBeenCalledWith(username, referralId)
-      expect(courseService.deleteParticipation).toHaveBeenCalledWith(token, courseParticipationId)
+      expect(courseService.deleteParticipation).toHaveBeenCalledWith(userToken, courseParticipationId)
       expect(request.flash).toHaveBeenCalledWith('successMessage', 'You have successfully removed a programme.')
       expect(response.redirect).toHaveBeenCalledWith(referPaths.new.programmeHistory.index({ referralId }))
     })
@@ -323,7 +332,7 @@ describe('NewReferralsCourseParticipationsController', () => {
 
       expect(referralService.getReferral).toHaveBeenCalledWith(username, referralId)
       expect(courseService.getAndPresentParticipationsByPerson).toHaveBeenCalledWith(
-        token,
+        userToken,
         person.prisonNumber,
         referralId,
       )
@@ -453,14 +462,14 @@ describe('NewReferralsCourseParticipationsController', () => {
         await requestHandler(request, response, next)
 
         expect(referralService.getReferral).toHaveBeenCalledWith(username, referralId)
-        expect(courseService.getParticipation).toHaveBeenCalledWith(token, request.params.courseParticipationId)
+        expect(courseService.getParticipation).toHaveBeenCalledWith(userToken, request.params.courseParticipationId)
         expect(CourseParticipationUtils.processCourseFormData).toHaveBeenCalledWith(
           request.body.courseName,
           request.body.otherCourseName,
           request,
         )
         expect(courseService.updateParticipation).toHaveBeenCalledWith(
-          token,
+          userToken,
           courseParticipation.id,
           courseParticipationUpdate,
         )
@@ -505,7 +514,7 @@ describe('NewReferralsCourseParticipationsController', () => {
         await requestHandler(request, response, next)
 
         expect(referralService.getReferral).toHaveBeenCalledWith(username, referralId)
-        expect(courseService.getParticipation).toHaveBeenCalledWith(token, request.params.courseParticipationId)
+        expect(courseService.getParticipation).toHaveBeenCalledWith(userToken, request.params.courseParticipationId)
         expect(CourseParticipationUtils.processCourseFormData).toHaveBeenCalledWith(
           request.body.courseName,
           request.body.otherCourseName,

--- a/server/controllers/refer/new/peopleController.test.ts
+++ b/server/controllers/refer/new/peopleController.test.ts
@@ -13,7 +13,7 @@ import PersonUtils from '../../../utils/personUtils'
 jest.mock('../../../utils/personUtils')
 
 describe('NewReferralsPeopleController', () => {
-  const token = 'SOME_TOKEN'
+  const username = 'VBASHIR123'
   let request: DeepMocked<Request>
   let response: DeepMocked<Response>
   const next: DeepMocked<NextFunction> = createMock<NextFunction>({})
@@ -23,7 +23,7 @@ describe('NewReferralsPeopleController', () => {
   let controller: NewReferralsPeopleController
 
   beforeEach(() => {
-    request = createMock<Request>({ user: { token } })
+    request = createMock<Request>({ user: { username } })
     response = Helpers.createMockResponseWithCaseloads()
     controller = new NewReferralsPeopleController(personService)
   })

--- a/server/controllers/refer/new/referralsController.test.ts
+++ b/server/controllers/refer/new/referralsController.test.ts
@@ -24,7 +24,7 @@ jest.mock('../../../utils/formUtils')
 jest.mock('../../../utils/referralUtils')
 
 describe('NewReferralsController', () => {
-  const token = 'SOME_TOKEN'
+  const userToken = 'SOME_TOKEN'
   const username = 'SOME_USERNAME'
   let request: DeepMocked<Request>
   let response: DeepMocked<Response>
@@ -54,7 +54,7 @@ describe('NewReferralsController', () => {
   let controller: NewReferralsController
 
   beforeEach(() => {
-    request = createMock<Request>({ user: { token, username } })
+    request = createMock<Request>({ user: { token: userToken, username } })
     response = Helpers.createMockResponseWithCaseloads()
     controller = new NewReferralsController(courseService, organisationService, personService, referralService)
     courseService.getCourseByOffering.mockResolvedValue(course)
@@ -240,7 +240,7 @@ describe('NewReferralsController', () => {
       expect(referralService.getReferral).toHaveBeenCalledWith(username, referralId)
       expect(FormUtils.setFieldErrors).toHaveBeenCalledWith(request, response, ['confirmation'])
       expect(courseService.getAndPresentParticipationsByPerson).toHaveBeenCalledWith(
-        token,
+        userToken,
         person.prisonNumber,
         referralId,
         { change: true, remove: false },

--- a/server/controllers/shared/referralsController.test.ts
+++ b/server/controllers/shared/referralsController.test.ts
@@ -18,7 +18,7 @@ import { CourseUtils, DateUtils, PersonUtils, ReferralUtils, SentenceInformation
 import type { GovukFrontendSummaryListWithRowsWithKeysAndValues } from '@accredited-programmes/ui'
 
 describe('ReferralsController', () => {
-  const token = 'SOME_TOKEN'
+  const userToken = 'SOME_TOKEN'
 
   let request: DeepMocked<Request>
   let response: DeepMocked<Response>
@@ -50,7 +50,7 @@ describe('ReferralsController', () => {
   let controller: SubmittedReferralsController
 
   beforeEach(() => {
-    request = createMock<Request>({ user: { token } })
+    request = createMock<Request>({ user: { token: userToken } })
     response = Helpers.createMockResponseWithCaseloads()
 
     courseService.getCourseByOffering.mockResolvedValue(course)

--- a/server/data/accreditedProgrammesApi/courseClient.test.ts
+++ b/server/data/accreditedProgrammesApi/courseClient.test.ts
@@ -15,10 +15,10 @@ import type { CourseParticipationUpdate } from '@accredited-programmes/models'
 pactWith({ consumer: 'Accredited Programmes UI', provider: 'Accredited Programmes API' }, provider => {
   let courseClient: CourseClient
 
-  const token = 'token-1'
+  const userToken = 'token-1'
 
   beforeEach(() => {
-    courseClient = new CourseClient(token)
+    courseClient = new CourseClient(userToken)
     config.apis.accreditedProgrammesApi.url = provider.mockService.baseUrl
   })
 
@@ -64,7 +64,7 @@ pactWith({ consumer: 'Accredited Programmes UI', provider: 'Accredited Programme
         },
         withRequest: {
           headers: {
-            authorization: `Bearer ${token}`,
+            authorization: `Bearer ${userToken}`,
           },
           method: 'GET',
           path: apiPaths.courses.index({}),
@@ -96,7 +96,7 @@ pactWith({ consumer: 'Accredited Programmes UI', provider: 'Accredited Programme
         withRequest: {
           body: { courseName, prisonNumber },
           headers: {
-            authorization: `Bearer ${token}`,
+            authorization: `Bearer ${userToken}`,
           },
           method: 'POST',
           path: apiPaths.participations.create({}),
@@ -126,7 +126,7 @@ pactWith({ consumer: 'Accredited Programmes UI', provider: 'Accredited Programme
         },
         withRequest: {
           headers: {
-            authorization: `Bearer ${token}`,
+            authorization: `Bearer ${userToken}`,
           },
           method: 'DELETE',
           path: apiPaths.participations.delete({ courseParticipationId: courseParticipationToDestroy.id }),
@@ -150,7 +150,7 @@ pactWith({ consumer: 'Accredited Programmes UI', provider: 'Accredited Programme
         },
         withRequest: {
           headers: {
-            authorization: `Bearer ${token}`,
+            authorization: `Bearer ${userToken}`,
           },
           method: 'GET',
           path: apiPaths.courses.show({ courseId: course1.id }),
@@ -176,7 +176,7 @@ pactWith({ consumer: 'Accredited Programmes UI', provider: 'Accredited Programme
         },
         withRequest: {
           headers: {
-            authorization: `Bearer ${token}`,
+            authorization: `Bearer ${userToken}`,
           },
           method: 'GET',
           path: apiPaths.offerings.course({ courseOfferingId: courseOffering1.id }),
@@ -202,7 +202,7 @@ pactWith({ consumer: 'Accredited Programmes UI', provider: 'Accredited Programme
         },
         withRequest: {
           headers: {
-            authorization: `Bearer ${token}`,
+            authorization: `Bearer ${userToken}`,
           },
           method: 'GET',
           path: apiPaths.courses.offerings({ courseId: course1.id }),
@@ -230,7 +230,7 @@ pactWith({ consumer: 'Accredited Programmes UI', provider: 'Accredited Programme
         },
         withRequest: {
           headers: {
-            authorization: `Bearer ${token}`,
+            authorization: `Bearer ${userToken}`,
           },
           method: 'GET',
           path: apiPaths.courses.names({}),
@@ -256,7 +256,7 @@ pactWith({ consumer: 'Accredited Programmes UI', provider: 'Accredited Programme
         },
         withRequest: {
           headers: {
-            authorization: `Bearer ${token}`,
+            authorization: `Bearer ${userToken}`,
           },
           method: 'GET',
           path: apiPaths.offerings.show({ courseOfferingId: courseOffering1.id }),
@@ -284,7 +284,7 @@ pactWith({ consumer: 'Accredited Programmes UI', provider: 'Accredited Programme
         },
         withRequest: {
           headers: {
-            authorization: `Bearer ${token}`,
+            authorization: `Bearer ${userToken}`,
           },
           method: 'GET',
           path: apiPaths.participations.show({ courseParticipationId: courseParticipation.id }),
@@ -311,7 +311,7 @@ pactWith({ consumer: 'Accredited Programmes UI', provider: 'Accredited Programme
         },
         withRequest: {
           headers: {
-            authorization: `Bearer ${token}`,
+            authorization: `Bearer ${userToken}`,
           },
           method: 'GET',
           path: apiPaths.people.participations({ prisonNumber }),
@@ -353,7 +353,7 @@ pactWith({ consumer: 'Accredited Programmes UI', provider: 'Accredited Programme
         withRequest: {
           body: courseParticipationUpdate,
           headers: {
-            authorization: `Bearer ${token}`,
+            authorization: `Bearer ${userToken}`,
           },
           method: 'PUT',
           path: apiPaths.participations.update({ courseParticipationId: courseParticipation.id }),

--- a/server/data/accreditedProgrammesApi/courseClient.ts
+++ b/server/data/accreditedProgrammesApi/courseClient.ts
@@ -13,8 +13,8 @@ import type {
 export default class CourseClient {
   restClient: RestClient
 
-  constructor(token: Express.User['token']) {
-    this.restClient = new RestClient('courseClient', config.apis.accreditedProgrammesApi as ApiConfig, token)
+  constructor(userToken: Express.User['token']) {
+    this.restClient = new RestClient('courseClient', config.apis.accreditedProgrammesApi as ApiConfig, userToken)
   }
 
   async all(): Promise<Array<Course>> {

--- a/server/data/accreditedProgrammesApi/referralClient.test.ts
+++ b/server/data/accreditedProgrammesApi/referralClient.test.ts
@@ -10,10 +10,10 @@ import type { CreatedReferralResponse, ReferralUpdate } from '@accredited-progra
 pactWith({ consumer: 'Accredited Programmes UI', provider: 'Accredited Programmes API' }, provider => {
   let referralClient: ReferralClient
 
-  const token = 'token-1'
+  const userToken = 'token-1'
 
   beforeEach(() => {
-    referralClient = new ReferralClient(token)
+    referralClient = new ReferralClient(userToken)
     config.apis.accreditedProgrammesApi.url = provider.mockService.baseUrl
   })
 
@@ -39,7 +39,7 @@ pactWith({ consumer: 'Accredited Programmes UI', provider: 'Accredited Programme
             referrerId,
           },
           headers: {
-            authorization: `Bearer ${token}`,
+            authorization: `Bearer ${userToken}`,
           },
           method: 'POST',
           path: apiPaths.referrals.create({}),
@@ -65,7 +65,7 @@ pactWith({ consumer: 'Accredited Programmes UI', provider: 'Accredited Programme
         },
         withRequest: {
           headers: {
-            authorization: `Bearer ${token}`,
+            authorization: `Bearer ${userToken}`,
           },
           method: 'GET',
           path: apiPaths.referrals.show({ referralId: referral.id }),
@@ -90,7 +90,7 @@ pactWith({ consumer: 'Accredited Programmes UI', provider: 'Accredited Programme
         },
         withRequest: {
           headers: {
-            authorization: `Bearer ${token}`,
+            authorization: `Bearer ${userToken}`,
           },
           method: 'POST',
           path: apiPaths.referrals.submit({ referralId: referral.id }),
@@ -122,7 +122,7 @@ pactWith({ consumer: 'Accredited Programmes UI', provider: 'Accredited Programme
             ...referralUpdate,
           },
           headers: {
-            authorization: `Bearer ${token}`,
+            authorization: `Bearer ${userToken}`,
           },
           method: 'PUT',
           path: apiPaths.referrals.update({ referralId: referral.id }),
@@ -150,7 +150,7 @@ pactWith({ consumer: 'Accredited Programmes UI', provider: 'Accredited Programme
             status,
           },
           headers: {
-            authorization: `Bearer ${token}`,
+            authorization: `Bearer ${userToken}`,
           },
           method: 'PUT',
           path: apiPaths.referrals.updateStatus({ referralId: referral.id }),

--- a/server/data/accreditedProgrammesApi/referralClient.ts
+++ b/server/data/accreditedProgrammesApi/referralClient.ts
@@ -8,8 +8,8 @@ import type { SystemToken } from '@hmpps-auth'
 export default class ReferralClient {
   restClient: RestClient
 
-  constructor(token: SystemToken) {
-    this.restClient = new RestClient('referralClient', config.apis.accreditedProgrammesApi as ApiConfig, token)
+  constructor(systemToken: SystemToken) {
+    this.restClient = new RestClient('referralClient', config.apis.accreditedProgrammesApi as ApiConfig, systemToken)
   }
 
   async create(

--- a/server/data/hmppsAuthClient.ts
+++ b/server/data/hmppsAuthClient.ts
@@ -37,9 +37,9 @@ export default class HmppsAuthClient {
   async getSystemClientToken(username?: string): Promise<SystemToken> {
     const key = username || '%ANONYMOUS%'
 
-    const token = await this.tokenStore.getToken(key)
-    if (token) {
-      return token
+    const systemToken = await this.tokenStore.getToken(key)
+    if (systemToken) {
+      return systemToken
     }
 
     const newToken = await getSystemClientTokenFromHmppsAuth(username)

--- a/server/data/hmppsManageUsersClient.test.ts
+++ b/server/data/hmppsManageUsersClient.test.ts
@@ -6,7 +6,7 @@ import type { User } from '@manage-users-api'
 
 jest.mock('./tokenStore')
 
-const token = 'token-1'
+const userToken = 'token-1'
 
 describe('HmppsManageUsersClient', () => {
   let fakeManageUsersApiUrl: nock.Scope
@@ -14,7 +14,7 @@ describe('HmppsManageUsersClient', () => {
 
   beforeEach(() => {
     fakeManageUsersApiUrl = nock(config.apis.hmppsManageUsers.url)
-    hmppsManageUsersClient = new HmppsManageUsersClient(token)
+    hmppsManageUsersClient = new HmppsManageUsersClient(userToken)
   })
 
   afterEach(() => {
@@ -30,7 +30,7 @@ describe('HmppsManageUsersClient', () => {
     it("should return the logged-in user's username from the API", async () => {
       const response: Pick<User, 'username'> = { username: 'DEL_HATTON' }
 
-      fakeManageUsersApiUrl.get('/users/me').matchHeader('authorization', `Bearer ${token}`).reply(200, response)
+      fakeManageUsersApiUrl.get('/users/me').matchHeader('authorization', `Bearer ${userToken}`).reply(200, response)
 
       const output = await hmppsManageUsersClient.getCurrentUsername()
       expect(output).toEqual(response)
@@ -49,7 +49,7 @@ describe('HmppsManageUsersClient', () => {
 
       fakeManageUsersApiUrl
         .get('/users/JOHN_SMITH')
-        .matchHeader('authorization', `Bearer ${token}`)
+        .matchHeader('authorization', `Bearer ${userToken}`)
         .reply(200, response)
 
       const output = await hmppsManageUsersClient.getUserFromUsername('JOHN_SMITH')

--- a/server/data/hmppsManageUsersClient.ts
+++ b/server/data/hmppsManageUsersClient.ts
@@ -5,8 +5,8 @@ import type { User } from '@manage-users-api'
 export default class HmppsManageUsersClient {
   restClient: RestClient
 
-  constructor(token: Express.User['token']) {
-    this.restClient = new RestClient('HMPPS Manage Users Client', config.apis.hmppsManageUsers, token)
+  constructor(userToken: Express.User['token']) {
+    this.restClient = new RestClient('HMPPS Manage Users Client', config.apis.hmppsManageUsers, userToken)
   }
 
   getCurrentUsername(): Promise<Pick<User, 'username'>> {

--- a/server/data/index.ts
+++ b/server/data/index.ts
@@ -32,16 +32,18 @@ type RestClientBuilderWithoutToken<T> = () => T
 
 const hmppsAuthClientBuilder: RestClientBuilderWithoutToken<HmppsAuthClient> = () =>
   new HmppsAuthClient(new TokenStore(createRedisClient()))
-const hmppsManageUsersClientBuilder: RestClientBuilder<HmppsManageUsersClient> = (token: Express.User['token']) =>
-  new HmppsManageUsersClient(token)
-const courseClientBuilder: RestClientBuilder<CourseClient> = (token: Express.User['token']) => new CourseClient(token)
-const prisonRegisterApiClientBuilder: RestClientBuilder<PrisonRegisterApiClient> = (token: Express.User['token']) =>
-  new PrisonRegisterApiClient(token)
-const prisonerSearchClientBuilder: RestClientBuilder<PrisonerSearchClient> = (token: SystemToken) =>
-  new PrisonerSearchClient(token)
-const referralClientBuilder: RestClientBuilder<ReferralClient> = (token: Express.User['token']) =>
-  new ReferralClient(token)
-const prisonApiClientBuilder: RestClientBuilder<PrisonApiClient> = (token: SystemToken) => new PrisonApiClient(token)
+const hmppsManageUsersClientBuilder: RestClientBuilder<HmppsManageUsersClient> = (userToken: Express.User['token']) =>
+  new HmppsManageUsersClient(userToken)
+const courseClientBuilder: RestClientBuilder<CourseClient> = (userToken: Express.User['token']) =>
+  new CourseClient(userToken)
+const prisonRegisterApiClientBuilder: RestClientBuilder<PrisonRegisterApiClient> = (userToken: Express.User['token']) =>
+  new PrisonRegisterApiClient(userToken)
+const prisonerSearchClientBuilder: RestClientBuilder<PrisonerSearchClient> = (systemToken: SystemToken) =>
+  new PrisonerSearchClient(systemToken)
+const referralClientBuilder: RestClientBuilder<ReferralClient> = (userToken: Express.User['token']) =>
+  new ReferralClient(userToken)
+const prisonApiClientBuilder: RestClientBuilder<PrisonApiClient> = (systemToken: SystemToken) =>
+  new PrisonApiClient(systemToken)
 
 export {
   CourseClient,

--- a/server/data/index.ts
+++ b/server/data/index.ts
@@ -5,6 +5,7 @@
  * Do appinsights first as it does some magic instrumentation work, i.e. it affects other 'require's
  * In particular, applicationinsights automatically collects bunyan logs
  */
+import type { SystemToken } from '@hmpps-auth'
 import AppInsightsUtils from '../utils/appInsightsUtils'
 
 AppInsightsUtils.initialiseAppInsights()
@@ -26,7 +27,7 @@ import TokenStore from './tokenStore'
 import type { TokenVerifier } from './tokenVerification'
 import verifyToken from './tokenVerification'
 
-type RestClientBuilder<T> = (token: Express.User['token']) => T
+type RestClientBuilder<T> = (token: Express.User['token'] | SystemToken) => T
 type RestClientBuilderWithoutToken<T> = () => T
 
 const hmppsAuthClientBuilder: RestClientBuilderWithoutToken<HmppsAuthClient> = () =>
@@ -36,12 +37,11 @@ const hmppsManageUsersClientBuilder: RestClientBuilder<HmppsManageUsersClient> =
 const courseClientBuilder: RestClientBuilder<CourseClient> = (token: Express.User['token']) => new CourseClient(token)
 const prisonRegisterApiClientBuilder: RestClientBuilder<PrisonRegisterApiClient> = (token: Express.User['token']) =>
   new PrisonRegisterApiClient(token)
-const prisonerSearchClientBuilder: RestClientBuilder<PrisonerSearchClient> = (token: Express.User['token']) =>
+const prisonerSearchClientBuilder: RestClientBuilder<PrisonerSearchClient> = (token: SystemToken) =>
   new PrisonerSearchClient(token)
 const referralClientBuilder: RestClientBuilder<ReferralClient> = (token: Express.User['token']) =>
   new ReferralClient(token)
-const prisonApiClientBuilder: RestClientBuilder<PrisonApiClient> = (token: Express.User['token']) =>
-  new PrisonApiClient(token)
+const prisonApiClientBuilder: RestClientBuilder<PrisonApiClient> = (token: SystemToken) => new PrisonApiClient(token)
 
 export {
   CourseClient,

--- a/server/data/prisonApiClient.test.ts
+++ b/server/data/prisonApiClient.test.ts
@@ -17,11 +17,11 @@ describe('PrisonApiClient', () => {
   let fakePrisonApi: nock.Scope
   let prisonApiClient: PrisonApiClient
 
-  const token = 'token-1'
+  const systemToken = 'token-1'
 
   beforeEach(() => {
     fakePrisonApi = nock(config.apis.prisonApi.url)
-    prisonApiClient = new PrisonApiClient(token)
+    prisonApiClient = new PrisonApiClient(systemToken)
   })
 
   afterEach(() => {
@@ -39,7 +39,7 @@ describe('PrisonApiClient', () => {
     it('fetches all Caseloads for the logged in user', async () => {
       fakePrisonApi
         .get(prisonApiPaths.caseloads.currentUser({}))
-        .matchHeader('authorization', `Bearer ${token}`)
+        .matchHeader('authorization', `Bearer ${systemToken}`)
         .reply(200, caseloads)
 
       const output = await prisonApiClient.findCurrentUserCaseloads()
@@ -81,7 +81,7 @@ describe('PrisonApiClient', () => {
     it("searches for a prisoner's sentence and offence details by booking ID", async () => {
       fakePrisonApi
         .get(prisonApiPaths.offenderSentenceAndOffences({ bookingId: prisoner.bookingId }))
-        .matchHeader('authorization', `Bearer ${token}`)
+        .matchHeader('authorization', `Bearer ${systemToken}`)
         .reply(200, offenderSentenceAndOffences)
 
       const output = await prisonApiClient.findSentenceAndOffenceDetails(prisoner.bookingId)

--- a/server/data/prisonApiClient.ts
+++ b/server/data/prisonApiClient.ts
@@ -9,8 +9,8 @@ import type { Prisoner } from '@prisoner-search'
 export default class PrisonApiClient {
   restClient: RestClient
 
-  constructor(token: SystemToken) {
-    this.restClient = new RestClient('prisonApiClient', config.apis.prisonApi as ApiConfig, token)
+  constructor(systemToken: SystemToken) {
+    this.restClient = new RestClient('prisonApiClient', config.apis.prisonApi as ApiConfig, systemToken)
   }
 
   async findCurrentUserCaseloads(): Promise<Array<Caseload>> {

--- a/server/data/prisonApiClient.ts
+++ b/server/data/prisonApiClient.ts
@@ -2,13 +2,14 @@ import RestClient from './restClient'
 import type { ApiConfig } from '../config'
 import config from '../config'
 import { prisonApiPaths } from '../paths'
+import type { SystemToken } from '@hmpps-auth'
 import type { Caseload, InmateDetail, OffenceDto, OffenderSentenceAndOffences, PageOffenceDto } from '@prison-api'
 import type { Prisoner } from '@prisoner-search'
 
 export default class PrisonApiClient {
   restClient: RestClient
 
-  constructor(token: Express.User['token']) {
+  constructor(token: SystemToken) {
     this.restClient = new RestClient('prisonApiClient', config.apis.prisonApi as ApiConfig, token)
   }
 

--- a/server/data/prisonRegisterApiClient.test.ts
+++ b/server/data/prisonRegisterApiClient.test.ts
@@ -9,11 +9,11 @@ describe('PrisonRegisterApiClient', () => {
   let fakePrisonRegisterApi: nock.Scope
   let prisonRegisterApiClient: PrisonRegisterApiClient
 
-  const token = 'token-1'
+  const userToken = 'token-1'
 
   beforeEach(() => {
     fakePrisonRegisterApi = nock(config.apis.prisonRegisterApi.url)
-    prisonRegisterApiClient = new PrisonRegisterApiClient(token)
+    prisonRegisterApiClient = new PrisonRegisterApiClient(userToken)
   })
 
   afterEach(() => {
@@ -31,7 +31,7 @@ describe('PrisonRegisterApiClient', () => {
     it('fetches the given prison', async () => {
       fakePrisonRegisterApi
         .get(`/prisons/id/${prison.prisonId}`)
-        .matchHeader('authorization', `Bearer ${token}`)
+        .matchHeader('authorization', `Bearer ${userToken}`)
         .reply(200, prison)
 
       const output = await prisonRegisterApiClient.find(prison.prisonId)

--- a/server/data/prisonRegisterApiClient.ts
+++ b/server/data/prisonRegisterApiClient.ts
@@ -7,8 +7,8 @@ import type { Prison } from '@prison-register-api'
 export default class PrisonRegisterApiClient {
   restClient: RestClient
 
-  constructor(token: Express.User['token']) {
-    this.restClient = new RestClient('prisonRegisterApiClient', config.apis.prisonRegisterApi as ApiConfig, token)
+  constructor(userToken: Express.User['token']) {
+    this.restClient = new RestClient('prisonRegisterApiClient', config.apis.prisonRegisterApi as ApiConfig, userToken)
   }
 
   async find(prisonId: string): Promise<Prison> {

--- a/server/data/prisonerSearchClient.test.ts
+++ b/server/data/prisonerSearchClient.test.ts
@@ -10,11 +10,11 @@ describe('PrisonerSearchClient', () => {
   let fakePrisonerSearch: nock.Scope
   let prisonerSearchClient: PrisonerSearchClient
 
-  const token = 'token-1'
+  const systemToken = 'token-1'
 
   beforeEach(() => {
     fakePrisonerSearch = nock(config.apis.prisonerSearch.url)
-    prisonerSearchClient = new PrisonerSearchClient(token)
+    prisonerSearchClient = new PrisonerSearchClient(systemToken)
   })
 
   afterEach(() => {
@@ -32,7 +32,7 @@ describe('PrisonerSearchClient', () => {
     it('searches for a prisoner by prison number and caseload IDs and returns the first match on the assumption that there will never be multiple matches', async () => {
       fakePrisonerSearch
         .post(prisonerSearchPaths.prisoner.search({}))
-        .matchHeader('authorization', `Bearer ${token}`)
+        .matchHeader('authorization', `Bearer ${systemToken}`)
         .reply(200, [prisoner])
 
       const output = await prisonerSearchClient.find(prisoner.prisonerNumber, ['BXI', 'MDI'])
@@ -43,7 +43,7 @@ describe('PrisonerSearchClient', () => {
       it('returns null', async () => {
         fakePrisonerSearch
           .post(prisonerSearchPaths.prisoner.search({}))
-          .matchHeader('authorization', `Bearer ${token}`)
+          .matchHeader('authorization', `Bearer ${systemToken}`)
           .reply(200, [])
 
         const output = await prisonerSearchClient.find(prisoner.prisonerNumber, ['BXI', 'MDI'])

--- a/server/data/prisonerSearchClient.ts
+++ b/server/data/prisonerSearchClient.ts
@@ -9,8 +9,8 @@ import type { Prisoner } from '@prisoner-search'
 export default class PrisonerSearchClient {
   restClient: RestClient
 
-  constructor(token: SystemToken) {
-    this.restClient = new RestClient('prisonerSearchClient', config.apis.prisonerSearch as ApiConfig, token)
+  constructor(systemToken: SystemToken) {
+    this.restClient = new RestClient('prisonerSearchClient', config.apis.prisonerSearch as ApiConfig, systemToken)
   }
 
   async find(

--- a/server/data/restClient.ts
+++ b/server/data/restClient.ts
@@ -9,6 +9,7 @@ import logger from '../../logger'
 import type { ApiConfig } from '../config'
 import type { UnsanitisedError } from '../sanitisedError'
 import sanitiseError from '../sanitisedError'
+import type { SystemToken } from '@hmpps-auth'
 
 interface GetRequest {
   headers?: Record<string, string>
@@ -42,7 +43,7 @@ export default class RestClient {
   constructor(
     private readonly name: string,
     private readonly config: ApiConfig,
-    private readonly token: Express.User['token'],
+    private readonly token: Express.User['token'] | SystemToken,
   ) {
     this.agent = config.url.startsWith('https') ? new HttpsAgent(config.agent) : new Agent(config.agent)
   }

--- a/server/data/tokenStore.ts
+++ b/server/data/tokenStore.ts
@@ -17,9 +17,9 @@ export default class TokenStore {
     return this.client.get(`${this.prefix}${key}`)
   }
 
-  public async setToken(key: string, token: Express.User['token'], durationSeconds: number): Promise<void> {
+  public async setToken(key: string, userToken: Express.User['token'], durationSeconds: number): Promise<void> {
     await this.ensureConnected()
-    await this.client.set(`${this.prefix}${key}`, token, { EX: durationSeconds })
+    await this.client.set(`${this.prefix}${key}`, userToken, { EX: durationSeconds })
   }
 
   private async ensureConnected() {

--- a/server/data/tokenVerification.ts
+++ b/server/data/tokenVerification.ts
@@ -8,10 +8,10 @@ import config from '../config'
 import sanitiseError from '../sanitisedError'
 import { TypeUtils } from '../utils'
 
-function getApiClientToken(token: Express.User['token']) {
+function getApiClientToken(userToken: Express.User['token']) {
   return superagent
     .post(`${config.apis.tokenVerification.url}/token/verify`)
-    .auth(token, { type: 'bearer' })
+    .auth(userToken, { type: 'bearer' })
     .timeout(config.apis.tokenVerification.timeout)
     .then(response => Boolean(response.body && response.body.active))
     .catch(error => {

--- a/server/middleware/authorisationMiddleware.ts
+++ b/server/middleware/authorisationMiddleware.ts
@@ -6,9 +6,9 @@ import UserUtils from '../utils/userUtils'
 
 export default function authorisationMiddleware(authorisedRoles: Array<string> = []): RequestHandler {
   return asyncMiddleware((req, res, next) => {
-    const token = res.locals.user?.token
-    if (token) {
-      const roles = UserUtils.getUserRolesFromToken(token)
+    const userToken = res.locals.user?.token
+    if (userToken) {
+      const roles = UserUtils.getUserRolesFromToken(userToken)
 
       if (authorisedRoles.length && !roles?.some(role => authorisedRoles.includes(role))) {
         logger.error('User is not authorised to access this')

--- a/server/services/courseService.test.ts
+++ b/server/services/courseService.test.ts
@@ -26,7 +26,7 @@ describe('CourseService', () => {
   const userService = createMock<UserService>()
   const service = new CourseService(courseClientBuilder, userService)
 
-  const token = 'token'
+  const userToken = 'token'
 
   beforeEach(() => {
     jest.resetAllMocks()
@@ -43,11 +43,11 @@ describe('CourseService', () => {
         .calledWith(person.prisonNumber, courseName)
         .mockResolvedValue(courseParticipation)
 
-      const result = await service.createParticipation(token, person.prisonNumber, courseName)
+      const result = await service.createParticipation(userToken, person.prisonNumber, courseName)
 
       expect(result).toEqual(courseParticipation)
 
-      expect(courseClientBuilder).toHaveBeenCalledWith(token)
+      expect(courseClientBuilder).toHaveBeenCalledWith(userToken)
       expect(courseClient.createParticipation).toHaveBeenCalledWith(person.prisonNumber, courseName)
     })
   })
@@ -56,9 +56,9 @@ describe('CourseService', () => {
     it('asks the client to delete a course participation', async () => {
       const courseParticipation = courseParticipationFactory.build()
 
-      await service.deleteParticipation(token, courseParticipation.id)
+      await service.deleteParticipation(userToken, courseParticipation.id)
 
-      expect(courseClientBuilder).toHaveBeenCalledWith(token)
+      expect(courseClientBuilder).toHaveBeenCalledWith(userToken)
       expect(courseClient.destroyParticipation).toHaveBeenCalledWith(courseParticipation.id)
     })
   })
@@ -69,11 +69,11 @@ describe('CourseService', () => {
       const courseNames = courses.map(course => course.name)
       courseClient.findCourseNames.mockResolvedValue(courseNames)
 
-      const result = await service.getCourseNames(token)
+      const result = await service.getCourseNames(userToken)
 
       expect(result).toEqual(courseNames)
 
-      expect(courseClientBuilder).toHaveBeenCalledWith(token)
+      expect(courseClientBuilder).toHaveBeenCalledWith(userToken)
       expect(courseClient.findCourseNames).toHaveBeenCalled()
     })
   })
@@ -118,7 +118,11 @@ describe('CourseService', () => {
           })
           .mockReturnValue('course participation 2 options')
 
-        const result = await service.getAndPresentParticipationsByPerson(token, person.prisonNumber, 'a-referral-id')
+        const result = await service.getAndPresentParticipationsByPerson(
+          userToken,
+          person.prisonNumber,
+          'a-referral-id',
+        )
 
         expect(result).toEqual(['course participation 1 options', 'course participation 2 options'])
       })
@@ -126,7 +130,7 @@ describe('CourseService', () => {
 
     describe('when actions are passed', () => {
       it('uses the specified actions when creating options for the summary list Nunjucks macro', async () => {
-        await service.getAndPresentParticipationsByPerson(token, person.prisonNumber, 'a-referral-id', {
+        await service.getAndPresentParticipationsByPerson(userToken, person.prisonNumber, 'a-referral-id', {
           change: false,
           remove: false,
         })
@@ -159,11 +163,11 @@ describe('CourseService', () => {
       const courses = courseFactory.buildList(3)
       courseClient.all.mockResolvedValue(courses)
 
-      const result = await service.getCourses(token)
+      const result = await service.getCourses(userToken)
 
       expect(result).toEqual(courses)
 
-      expect(courseClientBuilder).toHaveBeenCalledWith(token)
+      expect(courseClientBuilder).toHaveBeenCalledWith(userToken)
       expect(courseClient.all).toHaveBeenCalled()
     })
   })
@@ -173,11 +177,11 @@ describe('CourseService', () => {
       const course = courseFactory.build()
       when(courseClient.find).calledWith(course.id).mockResolvedValue(course)
 
-      const result = await service.getCourse(token, course.id)
+      const result = await service.getCourse(userToken, course.id)
 
       expect(result).toEqual(course)
 
-      expect(courseClientBuilder).toHaveBeenCalledWith(token)
+      expect(courseClientBuilder).toHaveBeenCalledWith(userToken)
       expect(courseClient.find).toHaveBeenCalledWith(course.id)
     })
   })
@@ -188,11 +192,11 @@ describe('CourseService', () => {
       const courseOffering = courseOfferingFactory.build()
       when(courseClient.findCourseByOffering).calledWith(courseOffering.id).mockResolvedValue(course)
 
-      const result = await service.getCourseByOffering(token, courseOffering.id)
+      const result = await service.getCourseByOffering(userToken, courseOffering.id)
 
       expect(result).toEqual(course)
 
-      expect(courseClientBuilder).toHaveBeenCalledWith(token)
+      expect(courseClientBuilder).toHaveBeenCalledWith(userToken)
       expect(courseClient.findCourseByOffering).toHaveBeenCalledWith(courseOffering.id)
     })
   })
@@ -203,11 +207,11 @@ describe('CourseService', () => {
       const courseOfferings = courseOfferingFactory.buildList(3)
       when(courseClient.findOfferings).calledWith(course.id).mockResolvedValue(courseOfferings)
 
-      const result = await service.getOfferingsByCourse(token, course.id)
+      const result = await service.getOfferingsByCourse(userToken, course.id)
 
       expect(result).toEqual(courseOfferings)
 
-      expect(courseClientBuilder).toHaveBeenCalledWith(token)
+      expect(courseClientBuilder).toHaveBeenCalledWith(userToken)
       expect(courseClient.findOfferings).toHaveBeenCalledWith(course.id)
     })
   })
@@ -218,11 +222,11 @@ describe('CourseService', () => {
 
       when(courseClient.findOffering).calledWith(courseOffering.id).mockResolvedValue(courseOffering)
 
-      const result = await service.getOffering(token, courseOffering.id)
+      const result = await service.getOffering(userToken, courseOffering.id)
 
       expect(result).toEqual(courseOffering)
 
-      expect(courseClientBuilder).toHaveBeenCalledWith(token)
+      expect(courseClientBuilder).toHaveBeenCalledWith(userToken)
       expect(courseClient.findOffering).toHaveBeenCalledWith(courseOffering.id)
     })
   })
@@ -233,11 +237,11 @@ describe('CourseService', () => {
 
       when(courseClient.findParticipation).calledWith(courseParticipation.id).mockResolvedValue(courseParticipation)
 
-      const result = await service.getParticipation(token, courseParticipation.id)
+      const result = await service.getParticipation(userToken, courseParticipation.id)
 
       expect(result).toEqual(courseParticipation)
 
-      expect(courseClientBuilder).toHaveBeenCalledWith(token)
+      expect(courseClientBuilder).toHaveBeenCalledWith(userToken)
       expect(courseClient.findParticipation).toHaveBeenCalledWith(courseParticipation.id)
     })
 
@@ -248,11 +252,11 @@ describe('CourseService', () => {
 
         const notFoundCourseParticipationId = 'NOT-FOUND'
 
-        await expect(() => service.getParticipation(token, notFoundCourseParticipationId)).rejects.toThrowError(
+        await expect(() => service.getParticipation(userToken, notFoundCourseParticipationId)).rejects.toThrowError(
           `Course participation with ID ${notFoundCourseParticipationId} not found.`,
         )
 
-        expect(courseClientBuilder).toHaveBeenCalledWith(token)
+        expect(courseClientBuilder).toHaveBeenCalledWith(userToken)
         expect(courseClient.findParticipation).toHaveBeenCalledWith(notFoundCourseParticipationId)
       })
     })
@@ -264,11 +268,11 @@ describe('CourseService', () => {
 
         const courseParticipationId = faker.string.uuid()
 
-        await expect(() => service.getParticipation(token, courseParticipationId)).rejects.toThrowError(
+        await expect(() => service.getParticipation(userToken, courseParticipationId)).rejects.toThrowError(
           `Error fetching course participation with ID ${courseParticipationId}.`,
         )
 
-        expect(courseClientBuilder).toHaveBeenCalledWith(token)
+        expect(courseClientBuilder).toHaveBeenCalledWith(userToken)
         expect(courseClient.findParticipation).toHaveBeenCalledWith(courseParticipationId)
       })
     })
@@ -287,11 +291,11 @@ describe('CourseService', () => {
         .calledWith(person.prisonNumber)
         .mockResolvedValue(courseParticipations)
 
-      const result = await service.getParticipationsByPerson(token, person.prisonNumber)
+      const result = await service.getParticipationsByPerson(userToken, person.prisonNumber)
 
       expect(result).toEqual(courseParticipations)
 
-      expect(courseClientBuilder).toHaveBeenCalledWith(token)
+      expect(courseClientBuilder).toHaveBeenCalledWith(userToken)
       expect(courseClient.findParticipationsByPerson).toHaveBeenCalledWith(person.prisonNumber)
     })
 
@@ -299,11 +303,11 @@ describe('CourseService', () => {
       it('returns an empty array', async () => {
         when(courseClient.findParticipationsByPerson).calledWith(person.prisonNumber).mockResolvedValue([])
 
-        const result = await service.getParticipationsByPerson(token, person.prisonNumber)
+        const result = await service.getParticipationsByPerson(userToken, person.prisonNumber)
 
         expect(result).toEqual([])
 
-        expect(courseClientBuilder).toHaveBeenCalledWith(token)
+        expect(courseClientBuilder).toHaveBeenCalledWith(userToken)
         expect(courseClient.findParticipationsByPerson).toHaveBeenCalledWith(person.prisonNumber)
       })
     })
@@ -317,7 +321,7 @@ describe('CourseService', () => {
 
     it('fetches the creator, then formats the participation and creator in the appropriate for passing to a GOV.UK summary list Nunjucks macro', async () => {
       when(userService.getUserFromUsername)
-        .calledWith(token, courseParticipation.addedBy)
+        .calledWith(userToken, courseParticipation.addedBy)
         .mockResolvedValue(addedByUser)
 
       when(CourseParticipationUtils.summaryListOptions as jest.Mock)
@@ -327,7 +331,7 @@ describe('CourseService', () => {
         })
         .mockReturnValue('course participation 1 options')
 
-      const result = await service.presentCourseParticipation(token, courseParticipation, referralId)
+      const result = await service.presentCourseParticipation(userToken, courseParticipation, referralId)
 
       expect(result).toEqual('course participation 1 options')
     })
@@ -355,11 +359,11 @@ describe('CourseService', () => {
         .calledWith(courseParticipation.id, courseParticipationUpdate)
         .mockResolvedValue(updatedCourseParticipation)
 
-      const result = await service.updateParticipation(token, courseParticipation.id, courseParticipationUpdate)
+      const result = await service.updateParticipation(userToken, courseParticipation.id, courseParticipationUpdate)
 
       expect(result).toEqual(updatedCourseParticipation)
 
-      expect(courseClientBuilder).toHaveBeenCalledWith(token)
+      expect(courseClientBuilder).toHaveBeenCalledWith(userToken)
       expect(courseClient.updateParticipation).toHaveBeenCalledWith(courseParticipation.id, courseParticipationUpdate)
     })
   })

--- a/server/services/courseService.ts
+++ b/server/services/courseService.ts
@@ -21,24 +21,24 @@ export default class CourseService {
   ) {}
 
   async createParticipation(
-    token: Express.User['token'],
+    userToken: Express.User['token'],
     prisonNumber: CourseParticipation['prisonNumber'],
     courseName: CourseParticipation['courseName'],
   ): Promise<CourseParticipation> {
-    const courseClient = this.courseClientBuilder(token)
+    const courseClient = this.courseClientBuilder(userToken)
     return courseClient.createParticipation(prisonNumber, courseName)
   }
 
   async deleteParticipation(
-    token: Express.User['token'],
+    userToken: Express.User['token'],
     courseParticipationId: CourseParticipation['id'],
   ): Promise<void> {
-    const courseClient = this.courseClientBuilder(token)
+    const courseClient = this.courseClientBuilder(userToken)
     return courseClient.destroyParticipation(courseParticipationId)
   }
 
   async getAndPresentParticipationsByPerson(
-    token: Express.User['token'],
+    userToken: Express.User['token'],
     prisonNumber: Person['prisonNumber'],
     referralId: Referral['id'],
     withActions?: {
@@ -46,52 +46,52 @@ export default class CourseService {
       remove: boolean
     },
   ): Promise<Array<GovukFrontendSummaryListWithRowsWithKeysAndValues>> {
-    const sortedCourseParticipations = (await this.getParticipationsByPerson(token, prisonNumber)).sort(
+    const sortedCourseParticipations = (await this.getParticipationsByPerson(userToken, prisonNumber)).sort(
       (participationA, participationB) => participationA.createdAt.localeCompare(participationB.createdAt),
     )
 
     return Promise.all(
       sortedCourseParticipations.map(participation =>
-        this.presentCourseParticipation(token, participation, referralId, withActions),
+        this.presentCourseParticipation(userToken, participation, referralId, withActions),
       ),
     )
   }
 
-  async getCourse(token: Express.User['token'], courseId: Course['id']): Promise<Course> {
-    const courseClient = this.courseClientBuilder(token)
+  async getCourse(userToken: Express.User['token'], courseId: Course['id']): Promise<Course> {
+    const courseClient = this.courseClientBuilder(userToken)
     return courseClient.find(courseId)
   }
 
-  async getCourseByOffering(token: Express.User['token'], courseOfferingId: CourseOffering['id']) {
-    const courseClient = this.courseClientBuilder(token)
+  async getCourseByOffering(userToken: Express.User['token'], courseOfferingId: CourseOffering['id']) {
+    const courseClient = this.courseClientBuilder(userToken)
     return courseClient.findCourseByOffering(courseOfferingId)
   }
 
-  async getCourseNames(token: Express.User['token']): Promise<Array<Course['name']>> {
-    const courseClient = this.courseClientBuilder(token)
+  async getCourseNames(userToken: Express.User['token']): Promise<Array<Course['name']>> {
+    const courseClient = this.courseClientBuilder(userToken)
     return courseClient.findCourseNames()
   }
 
-  async getCourses(token: Express.User['token']): Promise<Array<Course>> {
-    const courseClient = this.courseClientBuilder(token)
+  async getCourses(userToken: Express.User['token']): Promise<Array<Course>> {
+    const courseClient = this.courseClientBuilder(userToken)
     return courseClient.all()
   }
 
-  async getOffering(token: Express.User['token'], courseOfferingId: CourseOffering['id']): Promise<CourseOffering> {
-    const courseClient = this.courseClientBuilder(token)
+  async getOffering(userToken: Express.User['token'], courseOfferingId: CourseOffering['id']): Promise<CourseOffering> {
+    const courseClient = this.courseClientBuilder(userToken)
     return courseClient.findOffering(courseOfferingId)
   }
 
-  async getOfferingsByCourse(token: Express.User['token'], courseId: Course['id']): Promise<Array<CourseOffering>> {
-    const courseClient = this.courseClientBuilder(token)
+  async getOfferingsByCourse(userToken: Express.User['token'], courseId: Course['id']): Promise<Array<CourseOffering>> {
+    const courseClient = this.courseClientBuilder(userToken)
     return courseClient.findOfferings(courseId)
   }
 
   async getParticipation(
-    token: Express.User['token'],
+    userToken: Express.User['token'],
     courseParticipationId: CourseParticipation['id'],
   ): Promise<CourseParticipation> {
-    const courseClient = this.courseClientBuilder(token)
+    const courseClient = this.courseClientBuilder(userToken)
 
     try {
       const courseParticipation = await courseClient.findParticipation(courseParticipationId)
@@ -112,20 +112,20 @@ export default class CourseService {
   }
 
   async getParticipationsByPerson(
-    token: Express.User['token'],
+    userToken: Express.User['token'],
     prisonNumber: Person['prisonNumber'],
   ): Promise<Array<CourseParticipation>> {
-    const courseClient = this.courseClientBuilder(token)
+    const courseClient = this.courseClientBuilder(userToken)
     return courseClient.findParticipationsByPerson(prisonNumber)
   }
 
   async presentCourseParticipation(
-    token: Express.User['token'],
+    userToken: Express.User['token'],
     courseParticipation: CourseParticipation,
     referralId: Referral['id'],
     withActions = { change: true, remove: true },
   ): Promise<GovukFrontendSummaryListWithRowsWithKeysAndValues> {
-    const addedByUser = await this.userService.getUserFromUsername(token, courseParticipation.addedBy)
+    const addedByUser = await this.userService.getUserFromUsername(userToken, courseParticipation.addedBy)
 
     const courseParticipationPresenter = {
       ...courseParticipation,
@@ -136,11 +136,11 @@ export default class CourseService {
   }
 
   async updateParticipation(
-    token: Express.User['token'],
+    userToken: Express.User['token'],
     courseParticipationId: CourseParticipation['id'],
     courseParticipationUpdate: CourseParticipationUpdate,
   ): Promise<CourseParticipation> {
-    const courseClient = this.courseClientBuilder(token)
+    const courseClient = this.courseClientBuilder(userToken)
     return courseClient.updateParticipation(courseParticipationId, courseParticipationUpdate)
   }
 }

--- a/server/services/organisationService.test.ts
+++ b/server/services/organisationService.test.ts
@@ -14,7 +14,7 @@ describe('OrganisationService', () => {
 
   const service = new OrganisationService(prisonRegisterApiClientBuilder)
 
-  const token = 'token'
+  const userToken = 'token'
 
   beforeEach(() => {
     jest.resetAllMocks()
@@ -30,7 +30,7 @@ describe('OrganisationService', () => {
 
           prisonRegisterApiClient.find.mockResolvedValue(prison)
 
-          const result = await service.getOrganisation(token, prison.prisonId)
+          const result = await service.getOrganisation(userToken, prison.prisonId)
 
           expect(result).toEqual({
             id: prison.prisonId, // eslint-disable-next-line sort-keys
@@ -46,7 +46,7 @@ describe('OrganisationService', () => {
             name: prison.prisonName,
           })
 
-          expect(prisonRegisterApiClientBuilder).toHaveBeenCalledWith(token)
+          expect(prisonRegisterApiClientBuilder).toHaveBeenCalledWith(userToken)
           expect(prisonRegisterApiClient.find).toHaveBeenCalledWith(prison.prisonId)
         })
       })
@@ -57,9 +57,9 @@ describe('OrganisationService', () => {
           prisonRegisterApiClient.find.mockResolvedValue(prison)
 
           const expectedError = createError(404, `Active organisation with ID ${prison.prisonId} not found.`)
-          expect(() => service.getOrganisation(token, prison.prisonId)).rejects.toThrowError(expectedError)
+          expect(() => service.getOrganisation(userToken, prison.prisonId)).rejects.toThrowError(expectedError)
 
-          expect(prisonRegisterApiClientBuilder).toHaveBeenCalledWith(token)
+          expect(prisonRegisterApiClientBuilder).toHaveBeenCalledWith(userToken)
           expect(prisonRegisterApiClient.find).toHaveBeenCalledWith(prison.prisonId)
         })
       })
@@ -73,9 +73,9 @@ describe('OrganisationService', () => {
         const notFoundPrisonId = 'NOT-FOUND'
 
         const expectedError = createError(404, `Active organisation with ID ${notFoundPrisonId} not found.`)
-        expect(() => service.getOrganisation(token, notFoundPrisonId)).rejects.toThrowError(expectedError)
+        expect(() => service.getOrganisation(userToken, notFoundPrisonId)).rejects.toThrowError(expectedError)
 
-        expect(prisonRegisterApiClientBuilder).toHaveBeenCalledWith(token)
+        expect(prisonRegisterApiClientBuilder).toHaveBeenCalledWith(userToken)
         expect(prisonRegisterApiClient.find).toHaveBeenCalledWith(notFoundPrisonId)
       })
     })
@@ -88,9 +88,9 @@ describe('OrganisationService', () => {
         const prisonId = '04aba287-86ac-4b2c-b98e-048b5eefddbc'
 
         const expectedError = createError(500, `Error fetching organisation ${prisonId}.`)
-        expect(() => service.getOrganisation(token, prisonId)).rejects.toThrowError(expectedError)
+        expect(() => service.getOrganisation(userToken, prisonId)).rejects.toThrowError(expectedError)
 
-        expect(prisonRegisterApiClientBuilder).toHaveBeenCalledWith(token)
+        expect(prisonRegisterApiClientBuilder).toHaveBeenCalledWith(userToken)
         expect(prisonRegisterApiClient.find).toHaveBeenCalledWith(prisonId)
       })
     })
@@ -116,7 +116,7 @@ describe('OrganisationService', () => {
 
       const allIds = [...activePrisonIds, inactivePrisonId, notFoundPrisonId]
 
-      const result = await service.getOrganisations(token, allIds)
+      const result = await service.getOrganisations(userToken, allIds)
 
       const activeOrganisations = activePrisons.map(prison => OrganisationUtils.organisationFromPrison(prison))
       expect(result).toEqual(activeOrganisations)
@@ -136,7 +136,7 @@ describe('OrganisationService', () => {
         const allIds = [otherErrorPrisonId]
 
         const expectedError = createError(500, `Error fetching organisation ${otherErrorPrisonId}.`)
-        expect(() => service.getOrganisations(token, allIds)).rejects.toThrowError(expectedError)
+        expect(() => service.getOrganisations(userToken, allIds)).rejects.toThrowError(expectedError)
       })
     })
   })

--- a/server/services/organisationService.ts
+++ b/server/services/organisationService.ts
@@ -9,8 +9,8 @@ import type { Prison } from '@prison-register-api'
 export default class OrganisationService {
   constructor(private readonly prisonRegisterApiClientBuilder: RestClientBuilder<PrisonRegisterApiClient>) {}
 
-  async getOrganisation(token: Express.User['token'], organisationId: Organisation['id']): Promise<Organisation> {
-    const prisonRegisterApiClient = this.prisonRegisterApiClientBuilder(token)
+  async getOrganisation(userToken: Express.User['token'], organisationId: Organisation['id']): Promise<Organisation> {
+    const prisonRegisterApiClient = this.prisonRegisterApiClientBuilder(userToken)
 
     try {
       const prison = await prisonRegisterApiClient.find(organisationId)
@@ -37,10 +37,10 @@ export default class OrganisationService {
   }
 
   async getOrganisations(
-    token: Express.User['token'],
+    userToken: Express.User['token'],
     organisationIds: Array<Organisation['id']>,
   ): Promise<Array<Organisation>> {
-    const prisonRegisterApiClient = this.prisonRegisterApiClientBuilder(token)
+    const prisonRegisterApiClient = this.prisonRegisterApiClientBuilder(userToken)
 
     const prisonResults: Array<Prison | null> = await Promise.all(
       organisationIds.map(async organisationId => {

--- a/server/services/personService.ts
+++ b/server/services/personService.ts
@@ -82,11 +82,14 @@ export default class PersonService {
   }
 
   async getOffenderSentenceAndOffences(
-    token: Express.User['token'],
+    username: Express.User['username'],
     bookingId: Person['bookingId'],
   ): Promise<OffenderSentenceAndOffences> {
     try {
-      const prisonApiClient = this.prisonApiClientBuilder(token)
+      const hmppsAuthClient = this.hmppsAuthClientBuilder()
+      const systemToken = await hmppsAuthClient.getSystemClientToken(username)
+      const prisonApiClient = this.prisonApiClientBuilder(systemToken)
+
       return await prisonApiClient.findSentenceAndOffenceDetails(bookingId)
     } catch (error) {
       const knownError = error as ResponseError

--- a/server/services/userService.ts
+++ b/server/services/userService.ts
@@ -15,17 +15,20 @@ export default class UserService {
     private readonly prisonApiClientBuilder: RestClientBuilder<PrisonApiClient>,
   ) {}
 
-  async getCurrentUserWithDetails(token: Express.User['token']): Promise<UserDetails> {
-    const hmppsManageUsersClient = this.hmppsManageUsersClientBuilder(token)
+  async getCurrentUserWithDetails(userToken: Express.User['token']): Promise<UserDetails> {
+    const hmppsManageUsersClient = this.hmppsManageUsersClientBuilder(userToken)
     const { username } = await hmppsManageUsersClient.getCurrentUsername()
 
-    const [user, caseloads] = await Promise.all([this.getUserFromUsername(token, username), this.getCaseloads(token)])
+    const [user, caseloads] = await Promise.all([
+      this.getUserFromUsername(userToken, username),
+      this.getCaseloads(userToken),
+    ])
 
     return { ...user, caseloads, displayName: StringUtils.convertToTitleCase(user.name) }
   }
 
-  async getUserFromUsername(token: Express.User['token'], username: User['username']): Promise<User> {
-    const hmppsManageUsersClient = this.hmppsManageUsersClientBuilder(token)
+  async getUserFromUsername(userToken: Express.User['token'], username: User['username']): Promise<User> {
+    const hmppsManageUsersClient = this.hmppsManageUsersClientBuilder(userToken)
 
     try {
       return await hmppsManageUsersClient.getUserFromUsername(username)
@@ -43,8 +46,8 @@ export default class UserService {
     }
   }
 
-  private async getCaseloads(token: SystemToken): Promise<Array<Caseload>> {
-    const prisonApiClient = this.prisonApiClientBuilder(token)
+  private async getCaseloads(systemToken: SystemToken): Promise<Array<Caseload>> {
+    const prisonApiClient = this.prisonApiClientBuilder(systemToken)
 
     let cases: Array<Caseload> = []
 

--- a/server/services/userService.ts
+++ b/server/services/userService.ts
@@ -5,6 +5,7 @@ import logger from '../../logger'
 import type { HmppsManageUsersClient, PrisonApiClient, RestClientBuilder } from '../data'
 import { StringUtils } from '../utils'
 import type { UserDetails } from '@accredited-programmes/users'
+import type { SystemToken } from '@hmpps-auth'
 import type { User } from '@manage-users-api'
 import type { Caseload } from '@prison-api'
 
@@ -42,7 +43,7 @@ export default class UserService {
     }
   }
 
-  private async getCaseloads(token: Express.User['token']): Promise<Array<Caseload>> {
+  private async getCaseloads(token: SystemToken): Promise<Array<Caseload>> {
     const prisonApiClient = this.prisonApiClientBuilder(token)
 
     let cases: Array<Caseload> = []

--- a/server/utils/userUtils.ts
+++ b/server/utils/userUtils.ts
@@ -1,7 +1,7 @@
 import { jwtDecode } from 'jwt-decode'
 
 export default class UserUtils {
-  static getUserRolesFromToken(token: Express.User['token']): Array<string> | undefined {
-    return (jwtDecode(token) as { authorities?: Array<string> }).authorities
+  static getUserRolesFromToken(userToken: Express.User['token']): Array<string> | undefined {
+    return (jwtDecode(userToken) as { authorities?: Array<string> }).authorities
   }
 }


### PR DESCRIPTION
## Context

<!-- Is there a Trello ticket you can link to? -->
<!-- Do you need to add any environment variables? -->
<!-- Is an ADR required? An ADR should be added if this PR introduces a change to the architecture. -->

In one or two places, we're using a user token or user token type where we should be using a system token or system token type. The use of `token` on its own as a name throughout the codebase is a little confusing

## Changes in this PR

- Update token/token type usage
- Update naming to be more explicit, hopefully making the use of a particular token type more intentional

## Release checklist

[Release process documentation](../doc/how-to/perform-a-release.md)

As part of our continuous deployment strategy we must ensure that this work is
ready to be released once merged.

### Pre-merge

- [ ] There are changes required to the Accredited Programmes API for this change to work...
  - [ ] ... and they have been released to production already

### Post-merge

<!-- The outer checkboxes can be completed pre-merge -->

- [ ] This adds, extends or meaningfully modifies a feature...
  - [ ] ... and I have written or updated an end-to-end test for the happy path in the [Accredited Programmes E2E repo](https://github.com/ministryofjustice/hmpps-accredited-programmes-e2e)
- [ ] This makes new expectations of the API...
  - [ ] ... and I have notified the API developer(s) of changes to the contract tests (Pact), or the API is already compliant
- [ ] [Manually approve](../doc/how-to/perform-a-release.md#releasing-to-the-preprod-environment) release to preprod
- [ ] [Manually approve](../doc/how-to/perform-a-release.md#releasing-to-the-production-environment) release to prod

<!-- Should a release fail at any step, you as the author should now lead the work to
fix it as soon as possible. You can monitor deployment failures in CircleCI
itself and application errors are found in
[Sentry](https://ministryofjustice.sentry.io/projects/hmpps-accredited-programmes-ui/?project=4505330122686464&referrer=sidebar&statsPeriod=24h). -->
