### PR TITLE
Update view referral side navigation so it works correctly with the `/assess` path

### DIFF
--- a/integration_tests/pages/page.ts
+++ b/integration_tests/pages/page.ts
@@ -1,6 +1,8 @@
 import type { AxeRules } from '@accredited-programmes/integration-tests'
 
 import { referPaths } from '../../server/paths'
+import { assessPathBase } from '../../server/paths/assess'
+import { referPathBase } from '../../server/paths/refer'
 import { CourseParticipationUtils, PersonUtils, ReferralUtils } from '../../server/utils'
 import Helpers from '../support/helpers'
 import type { Organisation, Person, Referral } from '@accredited-programmes/models'
@@ -216,7 +218,10 @@ export default abstract class Page {
   }
 
   shouldContainSubmittedReferralSideNavigation(currentPath: string, referralId: Referral['id']): void {
-    const navigationItems = ReferralUtils.viewReferralNavigationItems('/', referralId)
+    const currentBasePath = currentPath.startsWith(assessPathBase.pattern)
+      ? assessPathBase.pattern
+      : referPathBase.pattern
+    const navigationItems = ReferralUtils.viewReferralNavigationItems(currentBasePath, referralId)
 
     cy.get('.moj-side-navigation__item').each((navigationItemElement, navigationItemElementIndex) => {
       const { href, text } = navigationItems[navigationItemElementIndex]

--- a/server/paths/assess.ts
+++ b/server/paths/assess.ts
@@ -11,3 +11,5 @@ export default {
     sentenceInformation: referralShowPathBase.path('sentence-information'),
   },
 }
+
+export { assessPathBase }

--- a/server/paths/refer.ts
+++ b/server/paths/refer.ts
@@ -62,3 +62,5 @@ export default {
     sentenceInformation: referralShowPathBase.path('sentence-information'),
   },
 }
+
+export { referPathBase }

--- a/server/utils/referralUtils.test.ts
+++ b/server/utils/referralUtils.test.ts
@@ -1,6 +1,6 @@
 import CourseUtils from './courseUtils'
 import ReferralUtils from './referralUtils'
-import { referPaths } from '../paths'
+import { assessPaths, referPaths } from '../paths'
 import {
   courseFactory,
   courseOfferingFactory,
@@ -247,32 +247,64 @@ describe('ReferralUtils', () => {
   })
 
   describe('viewReferralNavigationItems', () => {
-    it('returns navigation items for the view referral pages and sets the requested page as active', () => {
-      const mockReferralId = 'mock-referral-id'
-      const currentRequestPath = referPaths.show.personalDetails({ referralId: mockReferralId })
+    const mockReferralId = 'mock-referral-id'
 
-      expect(ReferralUtils.viewReferralNavigationItems(currentRequestPath, mockReferralId)).toEqual([
-        {
-          active: true,
-          href: referPaths.show.personalDetails({ referralId: mockReferralId }),
-          text: 'Personal details',
-        },
-        {
-          active: false,
-          href: referPaths.show.programmeHistory({ referralId: mockReferralId }),
-          text: 'Programme history',
-        },
-        {
-          active: false,
-          href: referPaths.show.sentenceInformation({ referralId: mockReferralId }),
-          text: 'Sentence information',
-        },
-        {
-          active: false,
-          href: referPaths.show.additionalInformation({ referralId: mockReferralId }),
-          text: 'Additional information',
-        },
-      ])
+    describe('when viewing the referral on the refer journey', () => {
+      it('returns navigation items for the view referral pages with the refer paths and sets the requested page as active', () => {
+        const currentRequestPath = referPaths.show.personalDetails({ referralId: mockReferralId })
+
+        expect(ReferralUtils.viewReferralNavigationItems(currentRequestPath, mockReferralId)).toEqual([
+          {
+            active: true,
+            href: referPaths.show.personalDetails({ referralId: mockReferralId }),
+            text: 'Personal details',
+          },
+          {
+            active: false,
+            href: referPaths.show.programmeHistory({ referralId: mockReferralId }),
+            text: 'Programme history',
+          },
+          {
+            active: false,
+            href: referPaths.show.sentenceInformation({ referralId: mockReferralId }),
+            text: 'Sentence information',
+          },
+          {
+            active: false,
+            href: referPaths.show.additionalInformation({ referralId: mockReferralId }),
+            text: 'Additional information',
+          },
+        ])
+      })
+    })
+
+    describe('when viewing the referral on the assess journey', () => {
+      it('returns navigation items for the view referral pages with the assess paths and sets the requested page as active', () => {
+        const currentRequestPath = assessPaths.show.personalDetails({ referralId: mockReferralId })
+
+        expect(ReferralUtils.viewReferralNavigationItems(currentRequestPath, mockReferralId)).toEqual([
+          {
+            active: true,
+            href: assessPaths.show.personalDetails({ referralId: mockReferralId }),
+            text: 'Personal details',
+          },
+          {
+            active: false,
+            href: assessPaths.show.programmeHistory({ referralId: mockReferralId }),
+            text: 'Programme history',
+          },
+          {
+            active: false,
+            href: assessPaths.show.sentenceInformation({ referralId: mockReferralId }),
+            text: 'Sentence information',
+          },
+          {
+            active: false,
+            href: assessPaths.show.additionalInformation({ referralId: mockReferralId }),
+            text: 'Additional information',
+          },
+        ])
+      })
     })
   })
 })

--- a/server/utils/referralUtils.ts
+++ b/server/utils/referralUtils.ts
@@ -1,7 +1,8 @@
 import type { Request } from 'express'
 
 import DateUtils from './dateUtils'
-import { referPaths } from '../paths'
+import { assessPaths, referPaths } from '../paths'
+import { assessPathBase } from '../paths/assess'
 import type { CourseOffering, Organisation, Person, Referral } from '@accredited-programmes/models'
 import type {
   CoursePresenter,
@@ -146,21 +147,23 @@ export default class ReferralUtils {
     currentPath: Request['path'],
     referralId: Referral['id'],
   ): Array<MojFrontendSideNavigationItem> {
+    const paths = currentPath.startsWith(assessPathBase.pattern) ? assessPaths : referPaths
+
     const navigationItems = [
       {
-        href: referPaths.show.personalDetails({ referralId }),
+        href: paths.show.personalDetails({ referralId }),
         text: 'Personal details',
       },
       {
-        href: referPaths.show.programmeHistory({ referralId }),
+        href: paths.show.programmeHistory({ referralId }),
         text: 'Programme history',
       },
       {
-        href: referPaths.show.sentenceInformation({ referralId }),
+        href: paths.show.sentenceInformation({ referralId }),
         text: 'Sentence information',
       },
       {
-        href: referPaths.show.additionalInformation({ referralId }),
+        href: paths.show.additionalInformation({ referralId }),
         text: 'Additional information',
       },
     ]


### PR DESCRIPTION
## Context

When viewing a referral on the assess path, the links in the sidebar don't work correctly. They link back to refer and also don't show the active state.

## Changes in this PR
Update `ReferralUtils.viewReferralNavigationItems` to use assess paths if current path begins with `/assess`.

## Screenshots of UI changes

### Before
![image](https://github.com/ministryofjustice/hmpps-accredited-programmes-ui/assets/1067537/84385075-e734-48a4-a404-cf6c9932a8aa)


### After
![image](https://github.com/ministryofjustice/hmpps-accredited-programmes-ui/assets/1067537/2bfa2306-eb37-4aad-a29b-4cfeb1cade36)



## Release checklist

[Release process documentation](../doc/how-to/perform-a-release.md)

As part of our continuous deployment strategy we must ensure that this work is
ready to be released once merged.

### Pre-merge

- [ ] There are changes required to the Accredited Programmes API for this change to work...
  - [ ] ... and they have been released to production already

### Post-merge

<!-- The outer checkboxes can be completed pre-merge -->

- [ ] This adds, extends or meaningfully modifies a feature...
  - [ ] ... and I have written or updated an end-to-end test for the happy path in the [Accredited Programmes E2E repo](https://github.com/ministryofjustice/hmpps-accredited-programmes-e2e)
- [ ] This makes new expectations of the API...
  - [ ] ... and I have notified the API developer(s) of changes to the contract tests (Pact), or the API is already compliant
- [ ] [Manually approve](../doc/how-to/perform-a-release.md#releasing-to-the-preprod-environment) release to preprod
- [ ] [Manually approve](../doc/how-to/perform-a-release.md#releasing-to-the-production-environment) release to prod

<!-- Should a release fail at any step, you as the author should now lead the work to
fix it as soon as possible. You can monitor deployment failures in CircleCI
itself and application errors are found in
[Sentry](https://ministryofjustice.sentry.io/projects/hmpps-accredited-programmes-ui/?project=4505330122686464&referrer=sidebar&statsPeriod=24h). -->
