### PR TITLE
(803b) Use system token rather than user token for calls to Accredited Programmes API - Course Client

### DIFF
--- a/server/controllers/refer/new/courseParticipationDetailsController.test.ts
+++ b/server/controllers/refer/new/courseParticipationDetailsController.test.ts
@@ -19,7 +19,6 @@ jest.mock('../../../utils/formUtils')
 jest.mock('../../../utils/courseParticipationUtils')
 
 describe('NewReferralsCourseParticipationDetailsController', () => {
-  const userToken = 'SOME_TOKEN'
   const username = 'SOME_USERNAME'
   let request: DeepMocked<Request>
   let response: DeepMocked<Response>
@@ -44,7 +43,7 @@ describe('NewReferralsCourseParticipationDetailsController', () => {
         courseParticipationId,
         referralId,
       },
-      user: { token: userToken, username },
+      user: { username },
     })
     response = Helpers.createMockResponseWithCaseloads()
 
@@ -192,13 +191,13 @@ describe('NewReferralsCourseParticipationDetailsController', () => {
       await requestHandler(request, response, next)
 
       expect(referralService.getReferral).toHaveBeenCalledWith(username, referralId)
-      expect(courseService.getParticipation).toHaveBeenCalledWith(userToken, courseParticipationId)
+      expect(courseService.getParticipation).toHaveBeenCalledWith(username, courseParticipationId)
       expect(CourseParticipationUtils.processDetailsFormData).toHaveBeenCalledWith(
         request,
         courseParticipation.courseName,
       )
       expect(courseService.updateParticipation).toHaveBeenCalledWith(
-        userToken,
+        username,
         courseParticipationId,
         courseParticipationUpdate,
       )
@@ -229,7 +228,7 @@ describe('NewReferralsCourseParticipationDetailsController', () => {
         await requestHandler(request, response, next)
 
         expect(referralService.getReferral).toHaveBeenCalledWith(username, referralId)
-        expect(courseService.getParticipation).toHaveBeenCalledWith(userToken, courseParticipationId)
+        expect(courseService.getParticipation).toHaveBeenCalledWith(username, courseParticipationId)
         expect(CourseParticipationUtils.processDetailsFormData).toHaveBeenCalledWith(
           request,
           courseParticipation.courseName,

--- a/server/controllers/refer/new/courseParticipationDetailsController.ts
+++ b/server/controllers/refer/new/courseParticipationDetailsController.ts
@@ -23,7 +23,7 @@ export default class NewReferralsCourseParticipationDetailsController {
       }
 
       const { detail, outcome, setting, source } = await this.courseService.getParticipation(
-        req.user.token,
+        req.user.username,
         courseParticipationId,
       )
 
@@ -68,7 +68,7 @@ export default class NewReferralsCourseParticipationDetailsController {
         return res.redirect(referPaths.new.complete({ referralId }))
       }
 
-      const courseParticipation = await this.courseService.getParticipation(req.user.token, courseParticipationId)
+      const courseParticipation = await this.courseService.getParticipation(req.user.username, courseParticipationId)
 
       const processedFormData = CourseParticipationUtils.processDetailsFormData(req, courseParticipation.courseName)
 
@@ -77,7 +77,7 @@ export default class NewReferralsCourseParticipationDetailsController {
       }
 
       await this.courseService.updateParticipation(
-        req.user.token,
+        req.user.username,
         courseParticipationId,
         processedFormData.courseParticipationUpdate,
       )

--- a/server/controllers/refer/new/courseParticipationsController.test.ts
+++ b/server/controllers/refer/new/courseParticipationsController.test.ts
@@ -77,11 +77,7 @@ describe('NewReferralsCourseParticipationsController', () => {
           request.body.otherCourseName,
           request,
         )
-        expect(courseService.createParticipation).toHaveBeenCalledWith(
-          userToken,
-          draftReferral.prisonNumber,
-          courseName,
-        )
+        expect(courseService.createParticipation).toHaveBeenCalledWith(username, draftReferral.prisonNumber, courseName)
         expect(request.flash).toHaveBeenCalledWith('successMessage', 'You have successfully added a programme.')
         expect(response.redirect).toHaveBeenCalledWith(
           referPaths.new.programmeHistory.details.show({
@@ -117,7 +113,7 @@ describe('NewReferralsCourseParticipationsController', () => {
           request,
         )
         expect(courseService.createParticipation).toHaveBeenCalledWith(
-          userToken,
+          username,
           draftReferral.prisonNumber,
           otherCourseName,
         )
@@ -189,7 +185,7 @@ describe('NewReferralsCourseParticipationsController', () => {
       await requestHandler(request, response, next)
 
       expect(referralService.getReferral).toHaveBeenCalledWith(username, request.params.referralId)
-      expect(courseService.getParticipation).toHaveBeenCalledWith(userToken, courseParticipationId)
+      expect(courseService.getParticipation).toHaveBeenCalledWith(username, courseParticipationId)
       expect(courseService.presentCourseParticipation).toHaveBeenCalledWith(
         userToken,
         courseParticipation,
@@ -232,7 +228,7 @@ describe('NewReferralsCourseParticipationsController', () => {
       await requestHandler(request, response, next)
 
       expect(referralService.getReferral).toHaveBeenCalledWith(username, referralId)
-      expect(courseService.deleteParticipation).toHaveBeenCalledWith(userToken, courseParticipationId)
+      expect(courseService.deleteParticipation).toHaveBeenCalledWith(username, courseParticipationId)
       expect(request.flash).toHaveBeenCalledWith('successMessage', 'You have successfully removed a programme.')
       expect(response.redirect).toHaveBeenCalledWith(referPaths.new.programmeHistory.index({ referralId }))
     })
@@ -332,6 +328,7 @@ describe('NewReferralsCourseParticipationsController', () => {
 
       expect(referralService.getReferral).toHaveBeenCalledWith(username, referralId)
       expect(courseService.getAndPresentParticipationsByPerson).toHaveBeenCalledWith(
+        username,
         userToken,
         person.prisonNumber,
         referralId,
@@ -462,14 +459,14 @@ describe('NewReferralsCourseParticipationsController', () => {
         await requestHandler(request, response, next)
 
         expect(referralService.getReferral).toHaveBeenCalledWith(username, referralId)
-        expect(courseService.getParticipation).toHaveBeenCalledWith(userToken, request.params.courseParticipationId)
+        expect(courseService.getParticipation).toHaveBeenCalledWith(username, request.params.courseParticipationId)
         expect(CourseParticipationUtils.processCourseFormData).toHaveBeenCalledWith(
           request.body.courseName,
           request.body.otherCourseName,
           request,
         )
         expect(courseService.updateParticipation).toHaveBeenCalledWith(
-          userToken,
+          username,
           courseParticipation.id,
           courseParticipationUpdate,
         )
@@ -514,7 +511,7 @@ describe('NewReferralsCourseParticipationsController', () => {
         await requestHandler(request, response, next)
 
         expect(referralService.getReferral).toHaveBeenCalledWith(username, referralId)
-        expect(courseService.getParticipation).toHaveBeenCalledWith(userToken, request.params.courseParticipationId)
+        expect(courseService.getParticipation).toHaveBeenCalledWith(username, request.params.courseParticipationId)
         expect(CourseParticipationUtils.processCourseFormData).toHaveBeenCalledWith(
           request.body.courseName,
           request.body.otherCourseName,

--- a/server/controllers/refer/new/courseParticipationsController.ts
+++ b/server/controllers/refer/new/courseParticipationsController.ts
@@ -35,7 +35,7 @@ export default class NewReferralsCourseParticipationsController {
       }
 
       const courseParticipation = await this.courseService.createParticipation(
-        req.user.token,
+        req.user.username,
         referral.prisonNumber,
         courseName as CourseParticipation['courseName'],
       )
@@ -63,7 +63,7 @@ export default class NewReferralsCourseParticipationsController {
         return res.redirect(referPaths.new.complete({ referralId }))
       }
 
-      const courseParticipation = await this.courseService.getParticipation(req.user.token, courseParticipationId)
+      const courseParticipation = await this.courseService.getParticipation(req.user.username, courseParticipationId)
       const summaryListOptions = await this.courseService.presentCourseParticipation(
         req.user.token,
         courseParticipation,
@@ -98,7 +98,7 @@ export default class NewReferralsCourseParticipationsController {
         return res.redirect(referPaths.new.complete({ referralId }))
       }
 
-      await this.courseService.deleteParticipation(req.user.token, courseParticipationId)
+      await this.courseService.deleteParticipation(req.user.username, courseParticipationId)
 
       req.flash('successMessage', 'You have successfully removed a programme.')
 
@@ -122,13 +122,13 @@ export default class NewReferralsCourseParticipationsController {
         return res.redirect(referPaths.new.complete({ referralId }))
       }
 
-      const courseParticipation = await this.courseService.getParticipation(req.user.token, courseParticipationId)
+      const courseParticipation = await this.courseService.getParticipation(req.user.username, courseParticipationId)
       const person = await this.personService.getPerson(
         req.user.username,
         referral.prisonNumber,
         res.locals.user.caseloads,
       )
-      const courseNames = await this.courseService.getCourseNames(req.user.token)
+      const courseNames = await this.courseService.getCourseNames(req.user.username)
 
       FormUtils.setFieldErrors(req, res, ['courseName', 'otherCourseName'])
 
@@ -168,6 +168,7 @@ export default class NewReferralsCourseParticipationsController {
       )
 
       const summaryListsOptions = await this.courseService.getAndPresentParticipationsByPerson(
+        req.user.username,
         req.user.token,
         person.prisonNumber,
         referralId,
@@ -197,7 +198,7 @@ export default class NewReferralsCourseParticipationsController {
         return res.redirect(referPaths.new.complete({ referralId }))
       }
 
-      const courseNames = await this.courseService.getCourseNames(req.user.token)
+      const courseNames = await this.courseService.getCourseNames(req.user.username)
       const person = await this.personService.getPerson(
         req.user.username,
         referral.prisonNumber,
@@ -231,7 +232,7 @@ export default class NewReferralsCourseParticipationsController {
       }
 
       const currentCourseParticipation = await this.courseService.getParticipation(
-        req.user.token,
+        req.user.username,
         courseParticipationId,
       )
 
@@ -252,7 +253,7 @@ export default class NewReferralsCourseParticipationsController {
 
       const { detail, outcome, setting, source } = currentCourseParticipation
 
-      await this.courseService.updateParticipation(req.user.token, courseParticipationId, {
+      await this.courseService.updateParticipation(req.user.username, courseParticipationId, {
         courseName: courseName as CourseParticipation['courseName'],
         detail,
         outcome,

--- a/server/controllers/refer/new/referralsController.test.ts
+++ b/server/controllers/refer/new/referralsController.test.ts
@@ -240,6 +240,7 @@ describe('NewReferralsController', () => {
       expect(referralService.getReferral).toHaveBeenCalledWith(username, referralId)
       expect(FormUtils.setFieldErrors).toHaveBeenCalledWith(request, response, ['confirmation'])
       expect(courseService.getAndPresentParticipationsByPerson).toHaveBeenCalledWith(
+        username,
         userToken,
         person.prisonNumber,
         referralId,

--- a/server/controllers/refer/new/referralsController.ts
+++ b/server/controllers/refer/new/referralsController.ts
@@ -41,6 +41,7 @@ export default class NewReferralsController {
       const course = await this.courseService.getCourseByOffering(req.user.token, referral.offeringId)
 
       const participationSummaryListsOptions = await this.courseService.getAndPresentParticipationsByPerson(
+        req.user.username,
         req.user.token,
         person.prisonNumber,
         referralId,

--- a/server/controllers/shared/referralsController.test.ts
+++ b/server/controllers/shared/referralsController.test.ts
@@ -74,15 +74,7 @@ describe('ReferralsController', () => {
       const requestHandler = controller.additionalInformation()
       await requestHandler(request, response, next)
 
-      expect(referralService.getReferral).toHaveBeenCalledWith(username, referral.id)
-      expect(courseService.getCourseByOffering).toHaveBeenCalledWith(username, referral.offeringId)
-      expect(courseService.getOffering).toHaveBeenCalledWith(username, referral.offeringId)
-      expect(personService.getPerson).toHaveBeenCalledWith(
-        username,
-        person.prisonNumber,
-        response.locals.user.caseloads,
-      )
-      expect(organisationService.getOrganisation).toHaveBeenCalledWith(userToken, organisation.id)
+      assertSharedDataServicesAreCalledWithExpectedArguments()
 
       expect(response.render).toHaveBeenCalledWith('referrals/show/additionalInformation', {
         ...sharedPageData,
@@ -100,15 +92,7 @@ describe('ReferralsController', () => {
       const requestHandler = controller.personalDetails()
       await requestHandler(request, response, next)
 
-      expect(referralService.getReferral).toHaveBeenCalledWith(username, referral.id)
-      expect(courseService.getCourseByOffering).toHaveBeenCalledWith(username, referral.offeringId)
-      expect(courseService.getOffering).toHaveBeenCalledWith(username, referral.offeringId)
-      expect(personService.getPerson).toHaveBeenCalledWith(
-        username,
-        person.prisonNumber,
-        response.locals.user.caseloads,
-      )
-      expect(organisationService.getOrganisation).toHaveBeenCalledWith(userToken, organisation.id)
+      assertSharedDataServicesAreCalledWithExpectedArguments()
 
       expect(response.render).toHaveBeenCalledWith('referrals/show/personalDetails', {
         ...sharedPageData,
@@ -130,15 +114,8 @@ describe('ReferralsController', () => {
       const requestHandler = controller.programmeHistory()
       await requestHandler(request, response, next)
 
-      expect(referralService.getReferral).toHaveBeenCalledWith(username, referral.id)
-      expect(courseService.getCourseByOffering).toHaveBeenCalledWith(username, referral.offeringId)
-      expect(courseService.getOffering).toHaveBeenCalledWith(username, referral.offeringId)
-      expect(personService.getPerson).toHaveBeenCalledWith(
-        username,
-        person.prisonNumber,
-        response.locals.user.caseloads,
-      )
-      expect(organisationService.getOrganisation).toHaveBeenCalledWith(userToken, organisation.id)
+      assertSharedDataServicesAreCalledWithExpectedArguments()
+
       expect(courseService.getAndPresentParticipationsByPerson).toHaveBeenCalledWith(
         username,
         userToken,
@@ -164,15 +141,7 @@ describe('ReferralsController', () => {
       const requestHandler = controller.sentenceInformation()
       await requestHandler(request, response, next)
 
-      expect(referralService.getReferral).toHaveBeenCalledWith(username, referral.id)
-      expect(courseService.getCourseByOffering).toHaveBeenCalledWith(username, referral.offeringId)
-      expect(courseService.getOffering).toHaveBeenCalledWith(username, referral.offeringId)
-      expect(personService.getPerson).toHaveBeenCalledWith(
-        username,
-        person.prisonNumber,
-        response.locals.user.caseloads,
-      )
-      expect(organisationService.getOrganisation).toHaveBeenCalledWith(userToken, organisation.id)
+      assertSharedDataServicesAreCalledWithExpectedArguments()
 
       expect(response.render).toHaveBeenCalledWith('referrals/show/sentenceInformation', {
         ...sharedPageData,
@@ -186,4 +155,12 @@ describe('ReferralsController', () => {
       })
     })
   })
+
+  function assertSharedDataServicesAreCalledWithExpectedArguments() {
+    expect(referralService.getReferral).toHaveBeenCalledWith(username, referral.id)
+    expect(courseService.getCourseByOffering).toHaveBeenCalledWith(username, referral.offeringId)
+    expect(courseService.getOffering).toHaveBeenCalledWith(username, referral.offeringId)
+    expect(personService.getPerson).toHaveBeenCalledWith(username, person.prisonNumber, response.locals.user.caseloads)
+    expect(organisationService.getOrganisation).toHaveBeenCalledWith(userToken, organisation.id)
+  }
 })

--- a/server/controllers/shared/referralsController.test.ts
+++ b/server/controllers/shared/referralsController.test.ts
@@ -51,7 +51,7 @@ describe('ReferralsController', () => {
   let controller: SubmittedReferralsController
 
   beforeEach(() => {
-    request = createMock<Request>({ user: { token: userToken, username } })
+    request = createMock<Request>({ params: { referralId: referral.id }, user: { token: userToken, username } })
     response = Helpers.createMockResponseWithCaseloads()
 
     courseService.getCourseByOffering.mockResolvedValue(course)
@@ -74,6 +74,7 @@ describe('ReferralsController', () => {
       const requestHandler = controller.additionalInformation()
       await requestHandler(request, response, next)
 
+      expect(referralService.getReferral).toHaveBeenCalledWith(username, referral.id)
       expect(courseService.getCourseByOffering).toHaveBeenCalledWith(username, referral.offeringId)
       expect(courseService.getOffering).toHaveBeenCalledWith(username, referral.offeringId)
       expect(personService.getPerson).toHaveBeenCalledWith(
@@ -99,6 +100,7 @@ describe('ReferralsController', () => {
       const requestHandler = controller.personalDetails()
       await requestHandler(request, response, next)
 
+      expect(referralService.getReferral).toHaveBeenCalledWith(username, referral.id)
       expect(courseService.getCourseByOffering).toHaveBeenCalledWith(username, referral.offeringId)
       expect(courseService.getOffering).toHaveBeenCalledWith(username, referral.offeringId)
       expect(personService.getPerson).toHaveBeenCalledWith(
@@ -128,6 +130,7 @@ describe('ReferralsController', () => {
       const requestHandler = controller.programmeHistory()
       await requestHandler(request, response, next)
 
+      expect(referralService.getReferral).toHaveBeenCalledWith(username, referral.id)
       expect(courseService.getCourseByOffering).toHaveBeenCalledWith(username, referral.offeringId)
       expect(courseService.getOffering).toHaveBeenCalledWith(username, referral.offeringId)
       expect(personService.getPerson).toHaveBeenCalledWith(
@@ -161,6 +164,7 @@ describe('ReferralsController', () => {
       const requestHandler = controller.sentenceInformation()
       await requestHandler(request, response, next)
 
+      expect(referralService.getReferral).toHaveBeenCalledWith(username, referral.id)
       expect(courseService.getCourseByOffering).toHaveBeenCalledWith(username, referral.offeringId)
       expect(courseService.getOffering).toHaveBeenCalledWith(username, referral.offeringId)
       expect(personService.getPerson).toHaveBeenCalledWith(

--- a/server/controllers/shared/referralsController.test.ts
+++ b/server/controllers/shared/referralsController.test.ts
@@ -19,6 +19,7 @@ import type { GovukFrontendSummaryListWithRowsWithKeysAndValues } from '@accredi
 
 describe('ReferralsController', () => {
   const userToken = 'SOME_TOKEN'
+  const username = 'USERNAME'
 
   let request: DeepMocked<Request>
   let response: DeepMocked<Response>
@@ -50,7 +51,7 @@ describe('ReferralsController', () => {
   let controller: SubmittedReferralsController
 
   beforeEach(() => {
-    request = createMock<Request>({ user: { token: userToken } })
+    request = createMock<Request>({ user: { token: userToken, username } })
     response = Helpers.createMockResponseWithCaseloads()
 
     courseService.getCourseByOffering.mockResolvedValue(course)
@@ -73,6 +74,15 @@ describe('ReferralsController', () => {
       const requestHandler = controller.additionalInformation()
       await requestHandler(request, response, next)
 
+      expect(courseService.getCourseByOffering).toHaveBeenCalledWith(username, referral.offeringId)
+      expect(courseService.getOffering).toHaveBeenCalledWith(username, referral.offeringId)
+      expect(personService.getPerson).toHaveBeenCalledWith(
+        username,
+        person.prisonNumber,
+        response.locals.user.caseloads,
+      )
+      expect(organisationService.getOrganisation).toHaveBeenCalledWith(userToken, organisation.id)
+
       expect(response.render).toHaveBeenCalledWith('referrals/show/additionalInformation', {
         ...sharedPageData,
         additionalInformation: referral.additionalInformation,
@@ -88,6 +98,15 @@ describe('ReferralsController', () => {
 
       const requestHandler = controller.personalDetails()
       await requestHandler(request, response, next)
+
+      expect(courseService.getCourseByOffering).toHaveBeenCalledWith(username, referral.offeringId)
+      expect(courseService.getOffering).toHaveBeenCalledWith(username, referral.offeringId)
+      expect(personService.getPerson).toHaveBeenCalledWith(
+        username,
+        person.prisonNumber,
+        response.locals.user.caseloads,
+      )
+      expect(organisationService.getOrganisation).toHaveBeenCalledWith(userToken, organisation.id)
 
       expect(response.render).toHaveBeenCalledWith('referrals/show/personalDetails', {
         ...sharedPageData,
@@ -109,8 +128,17 @@ describe('ReferralsController', () => {
       const requestHandler = controller.programmeHistory()
       await requestHandler(request, response, next)
 
+      expect(courseService.getCourseByOffering).toHaveBeenCalledWith(username, referral.offeringId)
+      expect(courseService.getOffering).toHaveBeenCalledWith(username, referral.offeringId)
+      expect(personService.getPerson).toHaveBeenCalledWith(
+        username,
+        person.prisonNumber,
+        response.locals.user.caseloads,
+      )
+      expect(organisationService.getOrganisation).toHaveBeenCalledWith(userToken, organisation.id)
       expect(courseService.getAndPresentParticipationsByPerson).toHaveBeenCalledWith(
-        request.user!.token,
+        username,
+        userToken,
         sharedPageData.person.prisonNumber,
         sharedPageData.referral.id,
         { change: false, remove: false },
@@ -132,6 +160,15 @@ describe('ReferralsController', () => {
 
       const requestHandler = controller.sentenceInformation()
       await requestHandler(request, response, next)
+
+      expect(courseService.getCourseByOffering).toHaveBeenCalledWith(username, referral.offeringId)
+      expect(courseService.getOffering).toHaveBeenCalledWith(username, referral.offeringId)
+      expect(personService.getPerson).toHaveBeenCalledWith(
+        username,
+        person.prisonNumber,
+        response.locals.user.caseloads,
+      )
+      expect(organisationService.getOrganisation).toHaveBeenCalledWith(userToken, organisation.id)
 
       expect(response.render).toHaveBeenCalledWith('referrals/show/sentenceInformation', {
         ...sharedPageData,

--- a/server/controllers/shared/referralsController.ts
+++ b/server/controllers/shared/referralsController.ts
@@ -106,7 +106,7 @@ export default class ReferralsController {
     const { referralId } = req.params
     const { token, username } = req.user
 
-    const referral = await this.referralService.getReferral(token, referralId)
+    const referral = await this.referralService.getReferral(username, referralId)
     const [course, courseOffering, person] = await Promise.all([
       this.courseService.getCourseByOffering(username, referral.offeringId),
       this.courseService.getOffering(username, referral.offeringId),

--- a/server/controllers/shared/referralsController.ts
+++ b/server/controllers/shared/referralsController.ts
@@ -104,7 +104,7 @@ export default class ReferralsController {
     TypeUtils.assertHasUser(req)
 
     const { referralId } = req.params
-    const { token, username } = req.user
+    const { token: userToken, username } = req.user
 
     const referral = await this.referralService.getReferral(username, referralId)
     const [course, courseOffering, person] = await Promise.all([
@@ -113,7 +113,7 @@ export default class ReferralsController {
       this.personService.getPerson(username, referral.prisonNumber, res.locals.user.caseloads),
     ])
 
-    const organisation = await this.organisationService.getOrganisation(token, courseOffering.organisationId)
+    const organisation = await this.organisationService.getOrganisation(userToken, courseOffering.organisationId)
 
     const coursePresenter = CourseUtils.presentCourse(course)
 

--- a/server/controllers/shared/referralsController.ts
+++ b/server/controllers/shared/referralsController.ts
@@ -53,6 +53,7 @@ export default class ReferralsController {
       const sharedPageData = await this.sharedPageData(req, res)
 
       const courseParticipationSummaryListsOptions = await this.courseService.getAndPresentParticipationsByPerson(
+        req.user.username,
         req.user.token,
         sharedPageData.person.prisonNumber,
         sharedPageData.referral.id,
@@ -107,8 +108,8 @@ export default class ReferralsController {
 
     const referral = await this.referralService.getReferral(token, referralId)
     const [course, courseOffering, person] = await Promise.all([
-      this.courseService.getCourseByOffering(token, referral.offeringId),
-      this.courseService.getOffering(token, referral.offeringId),
+      this.courseService.getCourseByOffering(username, referral.offeringId),
+      this.courseService.getOffering(username, referral.offeringId),
       this.personService.getPerson(username, referral.prisonNumber, res.locals.user.caseloads),
     ])
 

--- a/server/data/accreditedProgrammesApi/courseClient.test.ts
+++ b/server/data/accreditedProgrammesApi/courseClient.test.ts
@@ -15,10 +15,10 @@ import type { CourseParticipationUpdate } from '@accredited-programmes/models'
 pactWith({ consumer: 'Accredited Programmes UI', provider: 'Accredited Programmes API' }, provider => {
   let courseClient: CourseClient
 
-  const userToken = 'token-1'
+  const systemToken = 'token-1'
 
   beforeEach(() => {
-    courseClient = new CourseClient(userToken)
+    courseClient = new CourseClient(systemToken)
     config.apis.accreditedProgrammesApi.url = provider.mockService.baseUrl
   })
 
@@ -64,7 +64,7 @@ pactWith({ consumer: 'Accredited Programmes UI', provider: 'Accredited Programme
         },
         withRequest: {
           headers: {
-            authorization: `Bearer ${userToken}`,
+            authorization: `Bearer ${systemToken}`,
           },
           method: 'GET',
           path: apiPaths.courses.index({}),
@@ -96,7 +96,7 @@ pactWith({ consumer: 'Accredited Programmes UI', provider: 'Accredited Programme
         withRequest: {
           body: { courseName, prisonNumber },
           headers: {
-            authorization: `Bearer ${userToken}`,
+            authorization: `Bearer ${systemToken}`,
           },
           method: 'POST',
           path: apiPaths.participations.create({}),
@@ -126,7 +126,7 @@ pactWith({ consumer: 'Accredited Programmes UI', provider: 'Accredited Programme
         },
         withRequest: {
           headers: {
-            authorization: `Bearer ${userToken}`,
+            authorization: `Bearer ${systemToken}`,
           },
           method: 'DELETE',
           path: apiPaths.participations.delete({ courseParticipationId: courseParticipationToDestroy.id }),
@@ -150,7 +150,7 @@ pactWith({ consumer: 'Accredited Programmes UI', provider: 'Accredited Programme
         },
         withRequest: {
           headers: {
-            authorization: `Bearer ${userToken}`,
+            authorization: `Bearer ${systemToken}`,
           },
           method: 'GET',
           path: apiPaths.courses.show({ courseId: course1.id }),
@@ -176,7 +176,7 @@ pactWith({ consumer: 'Accredited Programmes UI', provider: 'Accredited Programme
         },
         withRequest: {
           headers: {
-            authorization: `Bearer ${userToken}`,
+            authorization: `Bearer ${systemToken}`,
           },
           method: 'GET',
           path: apiPaths.offerings.course({ courseOfferingId: courseOffering1.id }),
@@ -202,7 +202,7 @@ pactWith({ consumer: 'Accredited Programmes UI', provider: 'Accredited Programme
         },
         withRequest: {
           headers: {
-            authorization: `Bearer ${userToken}`,
+            authorization: `Bearer ${systemToken}`,
           },
           method: 'GET',
           path: apiPaths.courses.offerings({ courseId: course1.id }),
@@ -230,7 +230,7 @@ pactWith({ consumer: 'Accredited Programmes UI', provider: 'Accredited Programme
         },
         withRequest: {
           headers: {
-            authorization: `Bearer ${userToken}`,
+            authorization: `Bearer ${systemToken}`,
           },
           method: 'GET',
           path: apiPaths.courses.names({}),
@@ -256,7 +256,7 @@ pactWith({ consumer: 'Accredited Programmes UI', provider: 'Accredited Programme
         },
         withRequest: {
           headers: {
-            authorization: `Bearer ${userToken}`,
+            authorization: `Bearer ${systemToken}`,
           },
           method: 'GET',
           path: apiPaths.offerings.show({ courseOfferingId: courseOffering1.id }),
@@ -284,7 +284,7 @@ pactWith({ consumer: 'Accredited Programmes UI', provider: 'Accredited Programme
         },
         withRequest: {
           headers: {
-            authorization: `Bearer ${userToken}`,
+            authorization: `Bearer ${systemToken}`,
           },
           method: 'GET',
           path: apiPaths.participations.show({ courseParticipationId: courseParticipation.id }),
@@ -311,7 +311,7 @@ pactWith({ consumer: 'Accredited Programmes UI', provider: 'Accredited Programme
         },
         withRequest: {
           headers: {
-            authorization: `Bearer ${userToken}`,
+            authorization: `Bearer ${systemToken}`,
           },
           method: 'GET',
           path: apiPaths.people.participations({ prisonNumber }),
@@ -353,7 +353,7 @@ pactWith({ consumer: 'Accredited Programmes UI', provider: 'Accredited Programme
         withRequest: {
           body: courseParticipationUpdate,
           headers: {
-            authorization: `Bearer ${userToken}`,
+            authorization: `Bearer ${systemToken}`,
           },
           method: 'PUT',
           path: apiPaths.participations.update({ courseParticipationId: courseParticipation.id }),

--- a/server/data/accreditedProgrammesApi/courseClient.ts
+++ b/server/data/accreditedProgrammesApi/courseClient.ts
@@ -9,12 +9,13 @@ import type {
   CourseParticipationUpdate,
   Person,
 } from '@accredited-programmes/models'
+import type { SystemToken } from '@hmpps-auth'
 
 export default class CourseClient {
   restClient: RestClient
 
-  constructor(userToken: Express.User['token']) {
-    this.restClient = new RestClient('courseClient', config.apis.accreditedProgrammesApi as ApiConfig, userToken)
+  constructor(systemToken: SystemToken) {
+    this.restClient = new RestClient('courseClient', config.apis.accreditedProgrammesApi as ApiConfig, systemToken)
   }
 
   async all(): Promise<Array<Course>> {

--- a/server/middleware/populateCurrentUser.ts
+++ b/server/middleware/populateCurrentUser.ts
@@ -9,11 +9,11 @@ export default function populateCurrentUser(userService: UserService): RequestHa
   return async (req, res, next) => {
     try {
       if (res.locals.user) {
-        const { token } = res.locals.user
-        req.session.user ||= await userService.getCurrentUserWithDetails(token)
+        const { token: userToken } = res.locals.user
+        req.session.user ||= await userService.getCurrentUserWithDetails(userToken)
 
         if (req.session.user) {
-          const roles = UserUtils.getUserRolesFromToken(token)
+          const roles = UserUtils.getUserRolesFromToken(userToken)
           res.locals.user = {
             ...res.locals.user,
             ...req.session.user,

--- a/server/services/courseService.test.ts
+++ b/server/services/courseService.test.ts
@@ -5,7 +5,8 @@ import { when } from 'jest-when'
 
 import CourseService from './courseService'
 import type UserService from './userService'
-import { CourseClient } from '../data'
+import type { RedisClient } from '../data'
+import { CourseClient, HmppsAuthClient, TokenStore } from '../data'
 import {
   courseFactory,
   courseOfferingFactory,
@@ -17,20 +18,32 @@ import { CourseParticipationUtils, StringUtils } from '../utils'
 import type { CourseParticipationUpdate } from '@accredited-programmes/models'
 
 jest.mock('../data/accreditedProgrammesApi/courseClient')
+jest.mock('../data/hmppsAuthClient')
 jest.mock('../utils/courseParticipationUtils')
+
+const redisClient = createMock<RedisClient>({})
+const tokenStore = new TokenStore(redisClient) as jest.Mocked<TokenStore>
 
 describe('CourseService', () => {
   const courseClient = new CourseClient('token') as jest.Mocked<CourseClient>
   const courseClientBuilder = jest.fn()
 
-  const userService = createMock<UserService>()
-  const service = new CourseService(courseClientBuilder, userService)
+  const hmppsAuthClient = new HmppsAuthClient(tokenStore) as jest.Mocked<HmppsAuthClient>
+  const hmppsAuthClientBuilder = jest.fn()
 
-  const userToken = 'token'
+  const userService = createMock<UserService>()
+  const service = new CourseService(courseClientBuilder, hmppsAuthClientBuilder, userService)
+
+  const userToken = 'user token'
+  const systemToken = 'system token'
+  const username = 'USERNAME'
 
   beforeEach(() => {
     jest.resetAllMocks()
+
     courseClientBuilder.mockReturnValue(courseClient)
+    hmppsAuthClientBuilder.mockReturnValue(hmppsAuthClient)
+    hmppsAuthClient.getSystemClientToken.mockResolvedValue(systemToken)
   })
 
   describe('createParticipation', () => {
@@ -43,11 +56,11 @@ describe('CourseService', () => {
         .calledWith(person.prisonNumber, courseName)
         .mockResolvedValue(courseParticipation)
 
-      const result = await service.createParticipation(userToken, person.prisonNumber, courseName)
+      const result = await service.createParticipation(username, person.prisonNumber, courseName)
 
       expect(result).toEqual(courseParticipation)
 
-      expect(courseClientBuilder).toHaveBeenCalledWith(userToken)
+      expect(courseClientBuilder).toHaveBeenCalledWith(systemToken)
       expect(courseClient.createParticipation).toHaveBeenCalledWith(person.prisonNumber, courseName)
     })
   })
@@ -56,9 +69,9 @@ describe('CourseService', () => {
     it('asks the client to delete a course participation', async () => {
       const courseParticipation = courseParticipationFactory.build()
 
-      await service.deleteParticipation(userToken, courseParticipation.id)
+      await service.deleteParticipation(username, courseParticipation.id)
 
-      expect(courseClientBuilder).toHaveBeenCalledWith(userToken)
+      expect(courseClientBuilder).toHaveBeenCalledWith(systemToken)
       expect(courseClient.destroyParticipation).toHaveBeenCalledWith(courseParticipation.id)
     })
   })
@@ -69,11 +82,11 @@ describe('CourseService', () => {
       const courseNames = courses.map(course => course.name)
       courseClient.findCourseNames.mockResolvedValue(courseNames)
 
-      const result = await service.getCourseNames(userToken)
+      const result = await service.getCourseNames(username)
 
       expect(result).toEqual(courseNames)
 
-      expect(courseClientBuilder).toHaveBeenCalledWith(userToken)
+      expect(courseClientBuilder).toHaveBeenCalledWith(systemToken)
       expect(courseClient.findCourseNames).toHaveBeenCalled()
     })
   })
@@ -119,6 +132,7 @@ describe('CourseService', () => {
           .mockReturnValue('course participation 2 options')
 
         const result = await service.getAndPresentParticipationsByPerson(
+          username,
           userToken,
           person.prisonNumber,
           'a-referral-id',
@@ -130,7 +144,7 @@ describe('CourseService', () => {
 
     describe('when actions are passed', () => {
       it('uses the specified actions when creating options for the summary list Nunjucks macro', async () => {
-        await service.getAndPresentParticipationsByPerson(userToken, person.prisonNumber, 'a-referral-id', {
+        await service.getAndPresentParticipationsByPerson(username, userToken, person.prisonNumber, 'a-referral-id', {
           change: false,
           remove: false,
         })
@@ -163,11 +177,11 @@ describe('CourseService', () => {
       const courses = courseFactory.buildList(3)
       courseClient.all.mockResolvedValue(courses)
 
-      const result = await service.getCourses(userToken)
+      const result = await service.getCourses(username)
 
       expect(result).toEqual(courses)
 
-      expect(courseClientBuilder).toHaveBeenCalledWith(userToken)
+      expect(courseClientBuilder).toHaveBeenCalledWith(systemToken)
       expect(courseClient.all).toHaveBeenCalled()
     })
   })
@@ -177,11 +191,11 @@ describe('CourseService', () => {
       const course = courseFactory.build()
       when(courseClient.find).calledWith(course.id).mockResolvedValue(course)
 
-      const result = await service.getCourse(userToken, course.id)
+      const result = await service.getCourse(username, course.id)
 
       expect(result).toEqual(course)
 
-      expect(courseClientBuilder).toHaveBeenCalledWith(userToken)
+      expect(courseClientBuilder).toHaveBeenCalledWith(systemToken)
       expect(courseClient.find).toHaveBeenCalledWith(course.id)
     })
   })
@@ -192,11 +206,11 @@ describe('CourseService', () => {
       const courseOffering = courseOfferingFactory.build()
       when(courseClient.findCourseByOffering).calledWith(courseOffering.id).mockResolvedValue(course)
 
-      const result = await service.getCourseByOffering(userToken, courseOffering.id)
+      const result = await service.getCourseByOffering(username, courseOffering.id)
 
       expect(result).toEqual(course)
 
-      expect(courseClientBuilder).toHaveBeenCalledWith(userToken)
+      expect(courseClientBuilder).toHaveBeenCalledWith(systemToken)
       expect(courseClient.findCourseByOffering).toHaveBeenCalledWith(courseOffering.id)
     })
   })
@@ -207,11 +221,11 @@ describe('CourseService', () => {
       const courseOfferings = courseOfferingFactory.buildList(3)
       when(courseClient.findOfferings).calledWith(course.id).mockResolvedValue(courseOfferings)
 
-      const result = await service.getOfferingsByCourse(userToken, course.id)
+      const result = await service.getOfferingsByCourse(username, course.id)
 
       expect(result).toEqual(courseOfferings)
 
-      expect(courseClientBuilder).toHaveBeenCalledWith(userToken)
+      expect(courseClientBuilder).toHaveBeenCalledWith(systemToken)
       expect(courseClient.findOfferings).toHaveBeenCalledWith(course.id)
     })
   })
@@ -222,11 +236,11 @@ describe('CourseService', () => {
 
       when(courseClient.findOffering).calledWith(courseOffering.id).mockResolvedValue(courseOffering)
 
-      const result = await service.getOffering(userToken, courseOffering.id)
+      const result = await service.getOffering(username, courseOffering.id)
 
       expect(result).toEqual(courseOffering)
 
-      expect(courseClientBuilder).toHaveBeenCalledWith(userToken)
+      expect(courseClientBuilder).toHaveBeenCalledWith(systemToken)
       expect(courseClient.findOffering).toHaveBeenCalledWith(courseOffering.id)
     })
   })
@@ -237,11 +251,11 @@ describe('CourseService', () => {
 
       when(courseClient.findParticipation).calledWith(courseParticipation.id).mockResolvedValue(courseParticipation)
 
-      const result = await service.getParticipation(userToken, courseParticipation.id)
+      const result = await service.getParticipation(username, courseParticipation.id)
 
       expect(result).toEqual(courseParticipation)
 
-      expect(courseClientBuilder).toHaveBeenCalledWith(userToken)
+      expect(courseClientBuilder).toHaveBeenCalledWith(systemToken)
       expect(courseClient.findParticipation).toHaveBeenCalledWith(courseParticipation.id)
     })
 
@@ -252,11 +266,11 @@ describe('CourseService', () => {
 
         const notFoundCourseParticipationId = 'NOT-FOUND'
 
-        await expect(() => service.getParticipation(userToken, notFoundCourseParticipationId)).rejects.toThrowError(
+        await expect(() => service.getParticipation(username, notFoundCourseParticipationId)).rejects.toThrowError(
           `Course participation with ID ${notFoundCourseParticipationId} not found.`,
         )
 
-        expect(courseClientBuilder).toHaveBeenCalledWith(userToken)
+        expect(courseClientBuilder).toHaveBeenCalledWith(systemToken)
         expect(courseClient.findParticipation).toHaveBeenCalledWith(notFoundCourseParticipationId)
       })
     })
@@ -268,11 +282,11 @@ describe('CourseService', () => {
 
         const courseParticipationId = faker.string.uuid()
 
-        await expect(() => service.getParticipation(userToken, courseParticipationId)).rejects.toThrowError(
+        await expect(() => service.getParticipation(username, courseParticipationId)).rejects.toThrowError(
           `Error fetching course participation with ID ${courseParticipationId}.`,
         )
 
-        expect(courseClientBuilder).toHaveBeenCalledWith(userToken)
+        expect(courseClientBuilder).toHaveBeenCalledWith(systemToken)
         expect(courseClient.findParticipation).toHaveBeenCalledWith(courseParticipationId)
       })
     })
@@ -291,11 +305,11 @@ describe('CourseService', () => {
         .calledWith(person.prisonNumber)
         .mockResolvedValue(courseParticipations)
 
-      const result = await service.getParticipationsByPerson(userToken, person.prisonNumber)
+      const result = await service.getParticipationsByPerson(username, person.prisonNumber)
 
       expect(result).toEqual(courseParticipations)
 
-      expect(courseClientBuilder).toHaveBeenCalledWith(userToken)
+      expect(courseClientBuilder).toHaveBeenCalledWith(systemToken)
       expect(courseClient.findParticipationsByPerson).toHaveBeenCalledWith(person.prisonNumber)
     })
 
@@ -303,11 +317,11 @@ describe('CourseService', () => {
       it('returns an empty array', async () => {
         when(courseClient.findParticipationsByPerson).calledWith(person.prisonNumber).mockResolvedValue([])
 
-        const result = await service.getParticipationsByPerson(userToken, person.prisonNumber)
+        const result = await service.getParticipationsByPerson(username, person.prisonNumber)
 
         expect(result).toEqual([])
 
-        expect(courseClientBuilder).toHaveBeenCalledWith(userToken)
+        expect(courseClientBuilder).toHaveBeenCalledWith(systemToken)
         expect(courseClient.findParticipationsByPerson).toHaveBeenCalledWith(person.prisonNumber)
       })
     })
@@ -359,11 +373,11 @@ describe('CourseService', () => {
         .calledWith(courseParticipation.id, courseParticipationUpdate)
         .mockResolvedValue(updatedCourseParticipation)
 
-      const result = await service.updateParticipation(userToken, courseParticipation.id, courseParticipationUpdate)
+      const result = await service.updateParticipation(username, courseParticipation.id, courseParticipationUpdate)
 
       expect(result).toEqual(updatedCourseParticipation)
 
-      expect(courseClientBuilder).toHaveBeenCalledWith(userToken)
+      expect(courseClientBuilder).toHaveBeenCalledWith(systemToken)
       expect(courseClient.updateParticipation).toHaveBeenCalledWith(courseParticipation.id, courseParticipationUpdate)
     })
   })

--- a/server/services/courseService.test.ts
+++ b/server/services/courseService.test.ts
@@ -25,7 +25,11 @@ const redisClient = createMock<RedisClient>({})
 const tokenStore = new TokenStore(redisClient) as jest.Mocked<TokenStore>
 
 describe('CourseService', () => {
-  const courseClient = new CourseClient('token') as jest.Mocked<CourseClient>
+  const userToken = 'user token'
+  const systemToken = 'system token'
+  const username = 'USERNAME'
+
+  const courseClient = new CourseClient(systemToken) as jest.Mocked<CourseClient>
   const courseClientBuilder = jest.fn()
 
   const hmppsAuthClient = new HmppsAuthClient(tokenStore) as jest.Mocked<HmppsAuthClient>
@@ -33,10 +37,6 @@ describe('CourseService', () => {
 
   const userService = createMock<UserService>()
   const service = new CourseService(courseClientBuilder, hmppsAuthClientBuilder, userService)
-
-  const userToken = 'user token'
-  const systemToken = 'system token'
-  const username = 'USERNAME'
 
   beforeEach(() => {
     jest.resetAllMocks()

--- a/server/services/index.ts
+++ b/server/services/index.ts
@@ -21,7 +21,7 @@ const services = () => {
   const personService = new PersonService(hmppsAuthClientBuilder, prisonApiClientBuilder, prisonerSearchClientBuilder)
   const referralService = new ReferralService(hmppsAuthClientBuilder, referralClientBuilder)
   const userService = new UserService(hmppsManageUsersClientBuilder, prisonApiClientBuilder)
-  const courseService = new CourseService(courseClientBuilder, userService)
+  const courseService = new CourseService(courseClientBuilder, hmppsAuthClientBuilder, userService)
 
   return {
     courseService,

--- a/server/services/organisationService.test.ts
+++ b/server/services/organisationService.test.ts
@@ -9,12 +9,12 @@ import { OrganisationUtils } from '../utils'
 jest.mock('../data/prisonRegisterApiClient')
 
 describe('OrganisationService', () => {
-  const prisonRegisterApiClient = new PrisonRegisterApiClient('token') as jest.Mocked<PrisonRegisterApiClient>
+  const userToken = 'token'
+
+  const prisonRegisterApiClient = new PrisonRegisterApiClient(userToken) as jest.Mocked<PrisonRegisterApiClient>
   const prisonRegisterApiClientBuilder = jest.fn()
 
   const service = new OrganisationService(prisonRegisterApiClientBuilder)
-
-  const userToken = 'token'
 
   beforeEach(() => {
     jest.resetAllMocks()

--- a/server/services/referralService.test.ts
+++ b/server/services/referralService.test.ts
@@ -16,7 +16,7 @@ const systemToken = 'some system token'
 const username = 'USERNAME'
 
 describe('ReferralService', () => {
-  const referralClient = new ReferralClient('token') as jest.Mocked<ReferralClient>
+  const referralClient = new ReferralClient(systemToken) as jest.Mocked<ReferralClient>
   const referralClientBuilder = jest.fn()
 
   const hmppsAuthClient = new HmppsAuthClient(tokenStore) as jest.Mocked<HmppsAuthClient>


### PR DESCRIPTION
## Context

<!-- Is there a Trello ticket you can link to? -->

https://trello.com/c/VxKOqk1u/803-use-system-token-to-communicate-with-api-m
<!-- Do you need to add any environment variables? -->
<!-- Is an ADR required? An ADR should be added if this PR introduces a change to the architecture. -->

We've had a new role added to secure our API endpoints (`ACCREDITED_PROGRAMMES_API`). This will require authenticating with client credentials, so we need to use our system token rather than the usual user token.

## Changes in this PR

This is the second half of #343.

Uses the system token rather than the user token for the Course Client methods, and updates services & controllers to generate and pass the correct token. 

I've split this PR up into lots of commits to hopefully keep it easier to review, but I'll squash them together once it's been approved to ensure we don't have any failing tests on a commit.

There may be a few clashes with #350 here, particularly with renaming, so we'll need to tidy some things up depending on which one is merged first.

## Release checklist

[Release process documentation](../doc/how-to/perform-a-release.md)

As part of our continuous deployment strategy we must ensure that this work is
ready to be released once merged.

### Pre-merge

- [ ] There are changes required to the Accredited Programmes API for this change to work...
  - [ ] ... and they have been released to production already

### Post-merge

<!-- The outer checkboxes can be completed pre-merge -->

- [ ] This adds, extends or meaningfully modifies a feature...
  - [ ] ... and I have written or updated an end-to-end test for the happy path in the [Accredited Programmes E2E repo](https://github.com/ministryofjustice/hmpps-accredited-programmes-e2e)
- [ ] This makes new expectations of the API...
  - [ ] ... and I have notified the API developer(s) of changes to the contract tests (Pact), or the API is already compliant
- [ ] [Manually approve](../doc/how-to/perform-a-release.md#releasing-to-the-preprod-environment) release to preprod
- [ ] [Manually approve](../doc/how-to/perform-a-release.md#releasing-to-the-production-environment) release to prod

<!-- Should a release fail at any step, you as the author should now lead the work to
fix it as soon as possible. You can monitor deployment failures in CircleCI
itself and application errors are found in
[Sentry](https://ministryofjustice.sentry.io/projects/hmpps-accredited-programmes-ui/?project=4505330122686464&referrer=sidebar&statsPeriod=24h). -->
