### PR TITLE
(886f) Add content for when there are missing offence details

### DIFF
--- a/integration_tests/pages/shared/showReferral/offenceHistory.ts
+++ b/integration_tests/pages/shared/showReferral/offenceHistory.ts
@@ -34,7 +34,7 @@ export default class OffenceHistoryPage extends Page {
 
       cy.get(`[data-testid="additional-offence-summary-card-${index + 1}"]`).then(summaryCardElement => {
         this.shouldContainSummaryCard(
-          `Additional offence (${offenceCode?.code})`,
+          `Additional offence${offenceCode?.code ? ` (${offenceCode.code})` : ''}`,
           [],
           OffenceUtils.summaryListRows({
             code: offenceCode?.code,

--- a/integration_tests/support/sharedTests.ts
+++ b/integration_tests/support/sharedTests.ts
@@ -199,6 +199,11 @@ const sharedTests = {
             offenceCode: offenceCodeTwo.code,
             offenceDate: '2023-02-02',
           }),
+          offenceHistoryDetailFactory.build({
+            mostSerious: false,
+            offenceCode: undefined,
+            offenceDate: undefined,
+          }),
         ],
         offenderNo: prisoner.prisonerNumber,
       })

--- a/server/controllers/shared/referralsController.test.ts
+++ b/server/controllers/shared/referralsController.test.ts
@@ -96,7 +96,10 @@ describe('ReferralsController', () => {
 
   describe('offenceHistory', () => {
     it('renders the offence history template with the correct response locals', async () => {
-      const additionalOffences = [offenceDetailsFactory.build({ mostSerious: false })]
+      const additionalOffences = [
+        offenceDetailsFactory.build({ code: 'RC123', mostSerious: false }),
+        offenceDetailsFactory.build({ code: undefined, mostSerious: false }),
+      ]
       const indexOffence = offenceDetailsFactory.build({ mostSerious: true })
 
       personService.getOffenceHistory.mockResolvedValue({
@@ -115,6 +118,10 @@ describe('ReferralsController', () => {
           {
             summaryListRows: OffenceUtils.summaryListRows(additionalOffences[0]),
             titleText: `Additional offence (${additionalOffences[0].code})`,
+          },
+          {
+            summaryListRows: OffenceUtils.summaryListRows(additionalOffences[1]),
+            titleText: 'Additional offence',
           },
         ],
         hasOffenceHistory: true,

--- a/server/controllers/shared/referralsController.ts
+++ b/server/controllers/shared/referralsController.ts
@@ -51,7 +51,7 @@ export default class ReferralsController {
         ...sharedPageData,
         additionalOffencesSummaryLists: additionalOffences.map(offence => ({
           summaryListRows: OffenceUtils.summaryListRows(offence),
-          titleText: `Additional offence (${offence.code})`,
+          titleText: `Additional offence${offence.code ? ` (${offence.code})` : ''}`,
         })),
         hasOffenceHistory: Boolean(indexOffence) || additionalOffences.length > 0,
         importedFromText: `Imported from Nomis on ${DateUtils.govukFormattedFullDateString()}.`,

--- a/server/utils/offenceUtils.test.ts
+++ b/server/utils/offenceUtils.test.ts
@@ -26,5 +26,31 @@ describe('OffenceUtils', () => {
         },
       ])
     })
+
+    describe('when there is missing offence data', () => {
+      it('formats a relevant message in the appropriate format for passing to a GOV.UK summary list Nunjucks macro', () => {
+        const offenceDetails = offenceDetailsFactory.build({
+          code: undefined,
+          date: undefined,
+          description: undefined,
+          statuteCodeDescription: undefined,
+        })
+
+        expect(OffenceUtils.summaryListRows(offenceDetails)).toEqual([
+          {
+            key: { text: 'Offence' },
+            value: { text: 'There are no offence details for this person.' },
+          },
+          {
+            key: { text: 'Category' },
+            value: { text: 'There is no offence category for this person.' },
+          },
+          {
+            key: { text: 'Offence date' },
+            value: { text: 'There is no offence date for this person.' },
+          },
+        ])
+      })
+    })
   })
 })

--- a/server/utils/offenceUtils.ts
+++ b/server/utils/offenceUtils.ts
@@ -6,15 +6,23 @@ export default class OffenceUtils {
     return [
       {
         key: { text: 'Offence' },
-        value: { text: `${offence.description} - ${offence.code}` },
+        value: {
+          text:
+            [offence.description, offence.code].filter(string => string).join(' - ') ||
+            'There are no offence details for this person.',
+        },
       },
       {
         key: { text: 'Category' },
-        value: { text: offence.statuteCodeDescription },
+        value: { text: offence.statuteCodeDescription || 'There is no offence category for this person.' },
       },
       {
         key: { text: 'Offence date' },
-        value: { text: DateUtils.govukFormattedFullDateString(offence.date) },
+        value: {
+          text: offence.date
+            ? DateUtils.govukFormattedFullDateString(offence.date)
+            : 'There is no offence date for this person.',
+        },
       },
     ]
   }

--- a/wiremock/stubs/offenderBookings.json
+++ b/wiremock/stubs/offenderBookings.json
@@ -30,6 +30,16 @@
         "primaryResultConviction": false,
         "secondaryResultConviction": true,
         "caseId": 2
+      },
+      {
+        "bookingId": 1234567,
+        "offenceDescription": "Cause another to use a vehicle where the seat belt buckle/other fastening was not maintained so that the belt could be readily fastened or unfastened/kept free from temporary or permanent obstruction/readily accessible to a person sitting in the seat.",
+        "mostSerious": false,
+        "secondaryResultCode": "1006",
+        "secondaryResultDescription": "Detention Centre",
+        "primaryResultConviction": false,
+        "secondaryResultConviction": true,
+        "caseId": 2
       }
     ]
   }


### PR DESCRIPTION
## Context

Need to display messaging when there are missing details for an offence on the offence history page.

## Changes in this PR

1. Display messaging when offence values are undefined
2. Also fixes issues where todays date would be shown if `offenceDate` is `undefined`



## Screenshots of UI changes

![image](https://github.com/ministryofjustice/hmpps-accredited-programmes-ui/assets/1067537/d37323d5-a89a-49da-8c92-9437da140a06)




## Release checklist

[Release process documentation](../doc/how-to/perform-a-release.md)

As part of our continuous deployment strategy we must ensure that this work is
ready to be released once merged.

### Pre-merge

- [ ] There are changes required to the Accredited Programmes API for this change to work...
  - [ ] ... and they have been released to production already

### Post-merge

<!-- The outer checkboxes can be completed pre-merge -->

- [ ] This adds, extends or meaningfully modifies a feature...
  - [ ] ... and I have written or updated an end-to-end test for the happy path in the [Accredited Programmes E2E repo](https://github.com/ministryofjustice/hmpps-accredited-programmes-e2e)
- [ ] This makes new expectations of the API...
  - [ ] ... and I have notified the API developer(s) of changes to the contract tests (Pact), or the API is already compliant
- [ ] [Manually approve](../doc/how-to/perform-a-release.md#releasing-to-the-preprod-environment) release to preprod
- [ ] [Manually approve](../doc/how-to/perform-a-release.md#releasing-to-the-production-environment) release to prod

<!-- Should a release fail at any step, you as the author should now lead the work to
fix it as soon as possible. You can monitor deployment failures in CircleCI
itself and application errors are found in
[Sentry](https://ministryofjustice.sentry.io/projects/hmpps-accredited-programmes-ui/?project=4505330122686464&referrer=sidebar&statsPeriod=24h). -->
