### PR TITLE
(1057) Restrict show referral access

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,16 +48,15 @@ script/server --mock-api
 
 API endpoint stubbing is set up in `/wiremock/scripts/stubApis.ts`.
 
-
 ### Local user accounts
 
 There are three user accounts with different roles that can be used when running the application locally:
 
-| Username | Description | Roles | Password |
-| ---- | ---- | ---- | ---- |
-| `ACP_POM_USER` | Prisoner Offender Manager user - responsible for making referrals and viewing the progress of a referral  | `POM`, `ACP_REFERRER` | `password123456` |
-| `ACP_PT_USER`  | Programme Team user - responsible for assessing the suitability of a person to an Accredited Programme and updating the status of referrals | `ACP_PROGRAMME_TEAM` | `password123456` |
-| `ACP_PT_REFERRER_USER` | Programme Team user - all the responsibilities of a Programme Team user above, but with the ability to also make referrals | `ACP_PROGRAMME_TEAM`, `ACP_REFERRER` | `password123456` |
+| Username               | Description                                                                                                                                 | Roles                                | Password         |
+| ---------------------- | ------------------------------------------------------------------------------------------------------------------------------------------- | ------------------------------------ | ---------------- |
+| `ACP_POM_USER`         | Prisoner Offender Manager user - responsible for making referrals and viewing the progress of a referral                                    | `POM`, `ACP_REFERRER`                | `password123456` |
+| `ACP_PT_USER`          | Programme Team user - responsible for assessing the suitability of a person to an Accredited Programme and updating the status of referrals | `ACP_PROGRAMME_TEAM`                 | `password123456` |
+| `ACP_PT_REFERRER_USER` | Programme Team user - all the responsibilities of a Programme Team user above, but with the ability to also make referrals                  | `ACP_PROGRAMME_TEAM`, `ACP_REFERRER` | `password123456` |
 
 ### Seeded resources
 

--- a/README.md
+++ b/README.md
@@ -61,9 +61,14 @@ There are three user accounts with different roles that can be used when running
 
 ### Seeded resources
 
-The local copy of the Accredited Programmes API has various seeds in place providing data to work with in local development. These include courses, course offerings, and associated data, as well as one referral. This referral is at the stage of having just been created, and can be used to jump to the task list part of the Refer journey.
+The local copy of the Accredited Programmes API has various seeds in place providing data to work with in local development. These include courses, course offerings, and associated data, as well as one draft and one submitted referral.
 
-Seeded referral ID and local server link: [c11fab18-dc8d-420c-9c82-d0edd373732d](http://localhost:3000/refer/referrals/new/c11fab18-dc8d-420c-9c82-d0edd373732d)
+The draft referral is at the stage of having just been created, and can be used to jump to the task list part of the Refer journey. The submitted referral has additional information, but may not have programme history: the person is the same as in the draft referral, so the draft referral link can be used to add to the programme history if needed.
+
+| Status    | ID                                     | Links                                                                                                                                                                                                                            |
+| --------- | -------------------------------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| Draft     | `c11fab18-dc8d-420c-9c82-d0edd373732d` | Task list: [Refer](http://localhost:3000/refer/referrals/new/c11fab18-dc8d-420c-9c82-d0edd373732d)                                                                                                                               |
+| Submitted | `9d38204c-bfe9-42e6-b751-f46cec067e57` | Personal details: [Refer](http://localhost:3000/refer/referrals/9d38204c-bfe9-42e6-b751-f46cec067e57/personal-details) \| [Assess](http://localhost:3000/assess/referrals/9d38204c-bfe9-42e6-b751-f46cec067e57/personal-details) |
 
 ## Running the tests
 

--- a/integration_tests/e2e/assess.cy.ts
+++ b/integration_tests/e2e/assess.cy.ts
@@ -5,7 +5,7 @@ import Page from '../pages/page'
 
 context('General Assess functionality', () => {
   describe('When the user does not have the `ROLE_ACP_PROGRAMME_TEAM` role', () => {
-    it('shows the authentication error page', () => {
+    it('shows the auth error page', () => {
       cy.task('stubSignIn', { authorities: [ApplicationRoles.ACP_REFERRER] })
       cy.signIn()
 

--- a/integration_tests/e2e/assess/show.cy.ts
+++ b/integration_tests/e2e/assess/show.cy.ts
@@ -47,4 +47,10 @@ context('Viewing a submitted referral', () => {
       sharedTests.referrals.showsAdditionalInformationPage(ApplicationRoles.ACP_PROGRAMME_TEAM)
     })
   })
+
+  describe('When the referral is not submitted', () => {
+    it('shows the auth error page', () => {
+      sharedTests.referrals.showsErrorPageIfReferralNotSubmitted(ApplicationRoles.ACP_PROGRAMME_TEAM)
+    })
+  })
 })

--- a/integration_tests/e2e/refer.cy.ts
+++ b/integration_tests/e2e/refer.cy.ts
@@ -13,7 +13,7 @@ context('General Refer functionality', () => {
   })
 
   describe('When the user does not have the `ROLE_ACP_REFERRER` role', () => {
-    it('shows the authentication error page', () => {
+    it('shows the auth error page', () => {
       cy.task('stubSignIn', { authorities: [ApplicationRoles.ACP_PROGRAMME_TEAM] })
       cy.signIn()
 

--- a/integration_tests/e2e/refer/show.cy.ts
+++ b/integration_tests/e2e/refer/show.cy.ts
@@ -55,4 +55,10 @@ context('Viewing a submitted referral', () => {
       sharedTests.referrals.showsAdditionalInformationPage(ApplicationRoles.ACP_REFERRER)
     })
   })
+
+  describe('When the referral is not submitted', () => {
+    it('shows the auth error page', () => {
+      sharedTests.referrals.showsErrorPageIfReferralNotSubmitted(ApplicationRoles.ACP_REFERRER)
+    })
+  })
 })

--- a/integration_tests/pages/badRequest.ts
+++ b/integration_tests/pages/badRequest.ts
@@ -1,0 +1,11 @@
+import Page from './page'
+
+export default class BadRequestPage extends Page {
+  constructor(args: { errorMessage: string }) {
+    super(args.errorMessage, { customPageTitleEnd: 'Error' })
+  }
+
+  shouldContain400Heading() {
+    cy.get('h2').should('contain.text', '400')
+  }
+}

--- a/server/@types/prisonApi/imported/index.d.ts
+++ b/server/@types/prisonApi/imported/index.d.ts
@@ -641,18 +641,6 @@ export interface paths {
      */
     post: operations["getBasicInmateDetailsForOffenders"];
   };
-  "/api/bookings/offenderNo/{offenderNo}/relationships": {
-    /**
-     * The contact details and their relationship to the offender
-     * @description The contact details and their relationship to the offender
-     */
-    get: operations["getRelationshipsByOffenderNo"];
-    /**
-     * Create a relationship with an offender
-     * @description Create a relationship with an offender
-     */
-    post: operations["createRelationshipByOffenderNo"];
-  };
   "/api/bookings/offenderNo/{agencyId}/alerts": {
     /**
      * Get alerts for a list of offenders at a prison
@@ -1743,13 +1731,6 @@ export interface paths {
      */
     get: operations["getBookingActivities"];
   };
-  "/api/bookings/{bookingId}/activities/today": {
-    /**
-     * Today's scheduled activities for offender.
-     * @description Today's scheduled activities for offender.<p>This endpoint uses the REPLICA database.</p>
-     */
-    get: operations["getBookingActivitiesForToday"];
-  };
   "/api/bookings/v2": {
     /**
      * Prisoners Booking Summary
@@ -1782,7 +1763,7 @@ export interface paths {
     /**
      * Key worker details.
      * @deprecated
-     * @description Key worker details. This should not be used - call keywork API instead
+     * @description Key worker details. This should not be used - call keyworker API instead
      */
     get: operations["getKeyworkerByOffenderNo"];
   };
@@ -7159,8 +7140,8 @@ export interface components {
       pageSize?: number;
       /** Format: int32 */
       pageNumber?: number;
-      unpaged?: boolean;
       paged?: boolean;
+      unpaged?: boolean;
     };
     SortObject: {
       empty?: boolean;
@@ -14885,73 +14866,6 @@ export interface operations {
     };
   };
   /**
-   * The contact details and their relationship to the offender
-   * @description The contact details and their relationship to the offender
-   */
-  getRelationshipsByOffenderNo: {
-    parameters: {
-      query: {
-        /** @description filter by the relationship type */
-        relationshipType: string;
-      };
-      path: {
-        /** @description The offender Offender No */
-        offenderNo: string;
-      };
-    };
-    responses: {
-      /** @description OK */
-      200: {
-        content: {
-          "application/json": components["schemas"]["Contact"][];
-        };
-      };
-      /** @description Invalid request. */
-      400: {
-        content: {
-          "application/json": components["schemas"]["ErrorResponse"];
-        };
-      };
-      /** @description Requested resource not found. */
-      404: {
-        content: {
-          "application/json": components["schemas"]["ErrorResponse"];
-        };
-      };
-      /** @description Unrecoverable error occurred whilst processing request. */
-      500: {
-        content: {
-          "application/json": components["schemas"]["ErrorResponse"];
-        };
-      };
-    };
-  };
-  /**
-   * Create a relationship with an offender
-   * @description Create a relationship with an offender
-   */
-  createRelationshipByOffenderNo: {
-    parameters: {
-      path: {
-        /** @description The offender Offender No */
-        offenderNo: string;
-      };
-    };
-    requestBody: {
-      content: {
-        "application/json": components["schemas"]["OffenderRelationship"];
-      };
-    };
-    responses: {
-      /** @description If successful the Contact object is returned. */
-      201: {
-        content: {
-          "application/json": components["schemas"]["Contact"];
-        };
-      };
-    };
-  };
-  /**
    * Get alerts for a list of offenders at a prison
    * @description <p>This endpoint uses the REPLICA database.</p>
    */
@@ -21482,50 +21396,6 @@ export interface operations {
     };
   };
   /**
-   * Today's scheduled activities for offender.
-   * @description Today's scheduled activities for offender.<p>This endpoint uses the REPLICA database.</p>
-   */
-  getBookingActivitiesForToday: {
-    parameters: {
-      header?: {
-        /** @description Comma separated list of one or more of the following fields - <b>eventDate, startTime, endTime, eventLocation</b> */
-        "Sort-Fields"?: string;
-        /** @description Sort order (ASC or DESC) - defaults to ASC. */
-        "Sort-Order"?: "ASC" | "DESC";
-      };
-      path: {
-        /** @description The offender booking id */
-        bookingId: number;
-      };
-    };
-    responses: {
-      /** @description OK */
-      200: {
-        content: {
-          "application/json": components["schemas"]["ScheduledEvent"][];
-        };
-      };
-      /** @description Invalid request. */
-      400: {
-        content: {
-          "application/json": components["schemas"]["ErrorResponse"];
-        };
-      };
-      /** @description Requested resource not found. */
-      404: {
-        content: {
-          "application/json": components["schemas"]["ErrorResponse"];
-        };
-      };
-      /** @description Unrecoverable error occurred whilst processing request. */
-      500: {
-        content: {
-          "application/json": components["schemas"]["ErrorResponse"];
-        };
-      };
-    };
-  };
-  /**
    * Prisoners Booking Summary
    * @description Returns data that is available to the users caseload privileges, at least one attribute of a prisonId, bookingId or offenderNo must be specified
    */
@@ -21707,7 +21577,7 @@ export interface operations {
   /**
    * Key worker details.
    * @deprecated
-   * @description Key worker details. This should not be used - call keywork API instead
+   * @description Key worker details. This should not be used - call keyworker API instead
    */
   getKeyworkerByOffenderNo: {
     parameters: {

--- a/server/controllers/shared/referralsController.test.ts
+++ b/server/controllers/shared/referralsController.test.ts
@@ -1,6 +1,7 @@
 import type { DeepMocked } from '@golevelup/ts-jest'
 import { createMock } from '@golevelup/ts-jest'
 import type { NextFunction, Request, Response } from 'express'
+import createError from 'http-errors'
 
 import SubmittedReferralsController from './referralsController'
 import { referPaths } from '../../paths'
@@ -91,6 +92,18 @@ describe('ReferralsController', () => {
         submittedText: `Submitted in referral on ${DateUtils.govukFormattedFullDateString(referral.submittedOn)}.`,
       })
     })
+
+    describe('when the referral has not been submitted', () => {
+      it('responds with a 400', async () => {
+        referral.status = 'referral_started'
+        request.path = referPaths.show.additionalInformation({ referralId: referral.id })
+
+        const requestHandler = controller.additionalInformation()
+        const expectedError = createError(400, 'Referral has not been submitted.')
+
+        expect(() => requestHandler(request, response, next)).rejects.toThrowError(expectedError)
+      })
+    })
   })
 
   describe('offenceHistory', () => {
@@ -152,6 +165,18 @@ describe('ReferralsController', () => {
         })
       })
     })
+
+    describe('when the referral has not been submitted', () => {
+      it('responds with a 400', async () => {
+        referral.status = 'referral_started'
+        request.path = referPaths.show.offenceHistory({ referralId: referral.id })
+
+        const requestHandler = controller.offenceHistory()
+        const expectedError = createError(400, 'Referral has not been submitted.')
+
+        expect(() => requestHandler(request, response, next)).rejects.toThrowError(expectedError)
+      })
+    })
   })
 
   describe('personalDetails', () => {
@@ -168,6 +193,18 @@ describe('ReferralsController', () => {
         importedFromText: `Imported from Nomis on ${DateUtils.govukFormattedFullDateString()}.`,
         navigationItems: ReferralUtils.viewReferralNavigationItems(request.path, referral.id),
         personSummaryListRows: PersonUtils.summaryListRows(person),
+      })
+    })
+
+    describe('when the referral has not been submitted', () => {
+      it('responds with a 400', async () => {
+        referral.status = 'referral_started'
+        request.path = referPaths.show.personalDetails({ referralId: referral.id })
+
+        const requestHandler = controller.personalDetails()
+        const expectedError = createError(400, 'Referral has not been submitted.')
+
+        expect(() => requestHandler(request, response, next)).rejects.toThrowError(expectedError)
       })
     })
   })
@@ -197,6 +234,18 @@ describe('ReferralsController', () => {
         ...sharedPageData,
         courseParticipationSummaryListsOptions,
         navigationItems: ReferralUtils.viewReferralNavigationItems(request.path, referral.id),
+      })
+    })
+
+    describe('when the referral has not been submitted', () => {
+      it('responds with a 400', async () => {
+        referral.status = 'referral_started'
+        request.path = referPaths.show.programmeHistory({ referralId: referral.id })
+
+        const requestHandler = controller.programmeHistory()
+        const expectedError = createError(400, 'Referral has not been submitted.')
+
+        expect(() => requestHandler(request, response, next)).rejects.toThrowError(expectedError)
       })
     })
   })
@@ -286,6 +335,18 @@ describe('ReferralsController', () => {
           navigationItems: ReferralUtils.viewReferralNavigationItems(request.path, referral.id),
           releaseDatesSummaryListRows: PersonUtils.releaseDatesSummaryListRows(sharedPageData.person),
         })
+      })
+    })
+
+    describe('when the referral has not been submitted', () => {
+      it('responds with a 400', async () => {
+        referral.status = 'referral_started'
+        request.path = referPaths.show.sentenceInformation({ referralId: referral.id })
+
+        const requestHandler = controller.sentenceInformation()
+        const expectedError = createError(400, 'Referral has not been submitted.')
+
+        expect(() => requestHandler(request, response, next)).rejects.toThrowError(expectedError)
       })
     })
   })

--- a/server/controllers/shared/referralsController.test.ts
+++ b/server/controllers/shared/referralsController.test.ts
@@ -87,7 +87,6 @@ describe('ReferralsController', () => {
 
       expect(response.render).toHaveBeenCalledWith('referrals/show/additionalInformation', {
         ...sharedPageData,
-        additionalInformation: referral.additionalInformation,
         navigationItems: ReferralUtils.viewReferralNavigationItems(request.path, referral.id),
         submittedText: `Submitted in referral on ${DateUtils.govukFormattedFullDateString(referral.submittedOn)}.`,
       })

--- a/server/controllers/shared/referralsController.ts
+++ b/server/controllers/shared/referralsController.ts
@@ -1,4 +1,5 @@
 import type { Request, Response, TypedRequestHandler } from 'express'
+import createError from 'http-errors'
 
 import type { CourseService, OrganisationService, PersonService, ReferralService } from '../../services'
 import {
@@ -25,10 +26,13 @@ export default class ReferralsController {
       TypeUtils.assertHasUser(req)
 
       const sharedPageData = await this.sharedPageData(req, res)
-
       const { referral } = sharedPageData
 
-      res.render('referrals/show/additionalInformation', {
+      if (referral.status === 'referral_started') {
+        throw createError(400, 'Referral has not been submitted.')
+      }
+
+      return res.render('referrals/show/additionalInformation', {
         ...sharedPageData,
         submittedText: `Submitted in referral on ${DateUtils.govukFormattedFullDateString(referral.submittedOn)}.`,
       })
@@ -40,13 +44,18 @@ export default class ReferralsController {
       TypeUtils.assertHasUser(req)
 
       const sharedPageData = await this.sharedPageData(req, res)
+      const { referral } = sharedPageData
+
+      if (referral.status === 'referral_started') {
+        throw createError(400, 'Referral has not been submitted.')
+      }
 
       const { additionalOffences, indexOffence } = await this.personService.getOffenceHistory(
         req.user.username,
         sharedPageData.person.prisonNumber,
       )
 
-      res.render('referrals/show/offenceHistory', {
+      return res.render('referrals/show/offenceHistory', {
         ...sharedPageData,
         additionalOffencesSummaryLists: additionalOffences.map(offence => ({
           summaryListRows: OffenceUtils.summaryListRows(offence),
@@ -64,8 +73,13 @@ export default class ReferralsController {
       TypeUtils.assertHasUser(req)
 
       const sharedPageData = await this.sharedPageData(req, res)
+      const { referral } = sharedPageData
 
-      res.render('referrals/show/personalDetails', {
+      if (referral.status === 'referral_started') {
+        throw createError(400, 'Referral has not been submitted.')
+      }
+
+      return res.render('referrals/show/personalDetails', {
         ...sharedPageData,
         importedFromText: `Imported from Nomis on ${DateUtils.govukFormattedFullDateString()}.`,
         personSummaryListRows: PersonUtils.summaryListRows(sharedPageData.person),
@@ -78,6 +92,11 @@ export default class ReferralsController {
       TypeUtils.assertHasUser(req)
 
       const sharedPageData = await this.sharedPageData(req, res)
+      const { referral } = sharedPageData
+
+      if (referral.status === 'referral_started') {
+        throw createError(400, 'Referral has not been submitted.')
+      }
 
       const courseParticipationSummaryListsOptions = await this.courseService.getAndPresentParticipationsByPerson(
         req.user.username,
@@ -87,7 +106,7 @@ export default class ReferralsController {
         { change: false, remove: false },
       )
 
-      res.render('referrals/show/programmeHistory', {
+      return res.render('referrals/show/programmeHistory', {
         ...sharedPageData,
         courseParticipationSummaryListsOptions,
       })
@@ -99,6 +118,11 @@ export default class ReferralsController {
       TypeUtils.assertHasUser(req)
 
       const sharedPageData = await this.sharedPageData(req, res)
+      const { referral } = sharedPageData
+
+      if (referral.status === 'referral_started') {
+        throw createError(400, 'Referral has not been submitted.')
+      }
 
       const offenderSentenceAndOffences = await this.personService.getOffenderSentenceAndOffences(
         req.user.token,
@@ -109,7 +133,7 @@ export default class ReferralsController {
         sharedPageData.person.sentenceStartDate || offenderSentenceAndOffences.sentenceTypeDescription
       )
 
-      res.render('referrals/show/sentenceInformation', {
+      return res.render('referrals/show/sentenceInformation', {
         ...sharedPageData,
         detailsSummaryListRows: hasSentenceDetails
           ? SentenceInformationUtils.detailsSummaryListRows(

--- a/server/controllers/shared/referralsController.ts
+++ b/server/controllers/shared/referralsController.ts
@@ -30,7 +30,6 @@ export default class ReferralsController {
 
       res.render('referrals/show/additionalInformation', {
         ...sharedPageData,
-        additionalInformation: sharedPageData.referral.additionalInformation,
         submittedText: `Submitted in referral on ${DateUtils.govukFormattedFullDateString(referral.submittedOn)}.`,
       })
     }

--- a/server/views/referrals/show/additionalInformation.njk
+++ b/server/views/referrals/show/additionalInformation.njk
@@ -14,5 +14,5 @@
     }
   }) }}
 
-  {{ keylessSummaryCard("Additional information", bodyText=additionalInformation, testId="additional-information-summary-card") }}
+  {{ keylessSummaryCard("Additional information", bodyText=referral.additionalInformation, testId="additional-information-summary-card") }}
 {% endblock submittedReferralContent %}


### PR DESCRIPTION
## Context

Currently you can access referral show pages (meant for submitted referrals) with a draft referral

## Changes in this PR

- Redirect to relevant page if the referral is a draft, which will automatically auth error for non-referrers

## Release checklist

[Release process documentation](../doc/how-to/perform-a-release.md)

As part of our continuous deployment strategy we must ensure that this work is
ready to be released once merged.

### Pre-merge

- [ ] There are changes required to the Accredited Programmes API for this change to work...
  - [ ] ... and they have been released to production already

### Post-merge

<!-- The outer checkboxes can be completed pre-merge -->

- [ ] This adds, extends or meaningfully modifies a feature...
  - [ ] ... and I have written or updated an end-to-end test for the happy path in the [Accredited Programmes E2E repo](https://github.com/ministryofjustice/hmpps-accredited-programmes-e2e)
- [ ] This makes new expectations of the API...
  - [ ] ... and I have notified the API developer(s) of changes to the contract tests (Pact), or the API is already compliant
- [ ] [Manually approve](../doc/how-to/perform-a-release.md#releasing-to-the-preprod-environment) release to preprod
- [ ] [Manually approve](../doc/how-to/perform-a-release.md#releasing-to-the-production-environment) release to prod

<!-- Should a release fail at any step, you as the author should now lead the work to
fix it as soon as possible. You can monitor deployment failures in CircleCI
itself and application errors are found in
[Sentry](https://ministryofjustice.sentry.io/projects/hmpps-accredited-programmes-ui/?project=4505330122686464&referrer=sidebar&statsPeriod=24h). -->
