### PR TITLE
(1086a) Add client and service methods for upcoming case list page

### DIFF
--- a/server/@types/models/Paginated.ts
+++ b/server/@types/models/Paginated.ts
@@ -1,0 +1,8 @@
+export type Paginated<T> = {
+  content: Array<T>
+  pageIsEmpty: boolean
+  pageNumber: number
+  pageSize: number
+  totalElements: number
+  totalPages: number
+}

--- a/server/@types/models/Referral.ts
+++ b/server/@types/models/Referral.ts
@@ -1,3 +1,4 @@
+import type { Course } from './Course'
 import type { CourseOffering } from './CourseOffering'
 import type { Person } from './Person'
 
@@ -25,4 +26,13 @@ type ReferralUpdate = {
 
 type ReferralStatus = 'assessment_started' | 'awaiting_assesment' | 'referral_started' | 'referral_submitted'
 
-export type { CreatedReferralResponse, Referral, ReferralStatus, ReferralUpdate }
+type ReferralSummary = {
+  id: Referral['id'] // eslint-disable-next-line @typescript-eslint/member-ordering
+  audiences: Course['audiences']
+  courseName: Course['name']
+  prisonNumber: Person['prisonNumber']
+  status: ReferralStatus
+  submittedOn?: Referral['submittedOn']
+}
+
+export type { CreatedReferralResponse, Referral, ReferralStatus, ReferralSummary, ReferralUpdate }

--- a/server/@types/models/index.d.ts
+++ b/server/@types/models/index.d.ts
@@ -10,8 +10,9 @@ import type {
 import type { CoursePrerequisite } from './CoursePrerequisite'
 import type { Organisation } from './Organisation'
 import type { OrganisationAddress } from './OrganisationAddress'
+import type { Paginated } from './Paginated'
 import type { Person } from './Person'
-import type { CreatedReferralResponse, Referral, ReferralStatus, ReferralUpdate } from './Referral'
+import type { CreatedReferralResponse, Referral, ReferralStatus, ReferralSummary, ReferralUpdate } from './Referral'
 
 export type {
   Course,
@@ -25,8 +26,10 @@ export type {
   CreatedReferralResponse,
   Organisation,
   OrganisationAddress,
+  Paginated,
   Person,
   Referral,
   ReferralStatus,
+  ReferralSummary,
   ReferralUpdate,
 }

--- a/server/data/accreditedProgrammesApi/referralClient.ts
+++ b/server/data/accreditedProgrammesApi/referralClient.ts
@@ -2,7 +2,14 @@ import type { ApiConfig } from '../../config'
 import config from '../../config'
 import { apiPaths } from '../../paths'
 import RestClient from '../restClient'
-import type { CreatedReferralResponse, Referral, ReferralStatus, ReferralUpdate } from '@accredited-programmes/models'
+import type {
+  CreatedReferralResponse,
+  Paginated,
+  Referral,
+  ReferralStatus,
+  ReferralSummary,
+  ReferralUpdate,
+} from '@accredited-programmes/models'
 import type { SystemToken } from '@hmpps-auth'
 
 export default class ReferralClient {
@@ -27,6 +34,15 @@ export default class ReferralClient {
     return (await this.restClient.get({
       path: apiPaths.referrals.show({ referralId }),
     })) as Referral
+  }
+
+  async findReferralSummaries(organisationId: string): Promise<Paginated<ReferralSummary>> {
+    return (await this.restClient.get({
+      path: apiPaths.referrals.dashboard({ organisationId }),
+      query: {
+        size: '999',
+      },
+    })) as Paginated<ReferralSummary>
   }
 
   async submit(referralId: Referral['id']): Promise<void> {

--- a/server/paths/api.ts
+++ b/server/paths/api.ts
@@ -12,6 +12,7 @@ const referralsPath = path('/referrals')
 const referralPath = referralsPath.path(':referralId')
 const updateStatusPath = referralPath.path('status')
 const submitPath = referralPath.path('submit')
+const dashboardPath = referralsPath.path('organisation/:organisationId/dashboard')
 
 const participationsByPersonPath = path('/people/:prisonNumber/course-participations')
 const participationsPath = path('/course-participations')
@@ -39,6 +40,7 @@ export default {
   },
   referrals: {
     create: referralsPath,
+    dashboard: dashboardPath,
     show: referralPath,
     submit: submitPath,
     update: referralPath,

--- a/server/services/referralService.test.ts
+++ b/server/services/referralService.test.ts
@@ -4,7 +4,7 @@ import { when } from 'jest-when'
 import ReferralService from './referralService'
 import type { RedisClient } from '../data'
 import { HmppsAuthClient, ReferralClient, TokenStore } from '../data'
-import { referralFactory } from '../testutils/factories'
+import { referralFactory, referralSummaryFactory } from '../testutils/factories'
 import type { CreatedReferralResponse, ReferralStatus, ReferralUpdate } from '@accredited-programmes/models'
 
 jest.mock('../data/accreditedProgrammesApi/referralClient')
@@ -76,6 +76,36 @@ describe('ReferralService', () => {
 
       expect(referralClientBuilder).toHaveBeenCalledWith(systemToken)
       expect(referralClient.find).toHaveBeenCalledWith(referral.id)
+    })
+  })
+
+  describe('getReferralSummaries', () => {
+    const organisationId = 'organisation-id'
+
+    it('returns a list of referral summaries for a given organisation', async () => {
+      const referralSummaries = referralSummaryFactory.buildList(3)
+      const paginatedReferralSummariesResponse = {
+        content: referralSummaries,
+        pageIsEmpty: false,
+        pageNumber: 1,
+        pageSize: 10,
+        totalElements: referralSummaries.length,
+        totalPages: 1,
+      }
+
+      when(referralClient.findReferralSummaries)
+        .calledWith(organisationId)
+        .mockResolvedValue(paginatedReferralSummariesResponse)
+
+      const result = await service.getReferralSummaries(username, organisationId)
+
+      expect(result).toEqual(paginatedReferralSummariesResponse)
+
+      expect(hmppsAuthClientBuilder).toHaveBeenCalled()
+      expect(hmppsAuthClient.getSystemClientToken).toHaveBeenCalledWith(username)
+
+      expect(referralClientBuilder).toHaveBeenCalledWith(systemToken)
+      expect(referralClient.findReferralSummaries).toHaveBeenCalledWith(organisationId)
     })
   })
 

--- a/server/services/referralService.ts
+++ b/server/services/referralService.ts
@@ -1,5 +1,13 @@
 import type { HmppsAuthClient, ReferralClient, RestClientBuilder, RestClientBuilderWithoutToken } from '../data'
-import type { CreatedReferralResponse, Referral, ReferralStatus, ReferralUpdate } from '@accredited-programmes/models'
+import type {
+  CreatedReferralResponse,
+  Organisation,
+  Paginated,
+  Referral,
+  ReferralStatus,
+  ReferralSummary,
+  ReferralUpdate,
+} from '@accredited-programmes/models'
 
 export default class ReferralService {
   constructor(
@@ -26,6 +34,17 @@ export default class ReferralService {
     const referralClient = this.referralClientBuilder(systemToken)
 
     return referralClient.find(referralId)
+  }
+
+  async getReferralSummaries(
+    username: Express.User['username'],
+    organisationId: Organisation['id'],
+  ): Promise<Paginated<ReferralSummary>> {
+    const hmppsAuthClient = this.hmppsAuthClientBuilder()
+    const systemToken = await hmppsAuthClient.getSystemClientToken(username)
+    const referralClient = this.referralClientBuilder(systemToken)
+
+    return referralClient.findReferralSummaries(organisationId)
   }
 
   async submitReferral(username: Express.User['username'], referralId: Referral['id']): Promise<void> {

--- a/server/testutils/factories/index.ts
+++ b/server/testutils/factories/index.ts
@@ -16,6 +16,7 @@ import prisonFactory from './prison'
 import prisonAddressFactory from './prisonAddress'
 import prisonerFactory from './prisoner'
 import referralFactory from './referral'
+import referralSummaryFactory from './referralSummary'
 import userFactory from './user'
 
 export {
@@ -37,5 +38,6 @@ export {
   prisonFactory,
   prisonerFactory,
   referralFactory,
+  referralSummaryFactory,
   userFactory,
 }

--- a/server/testutils/factories/referral.ts
+++ b/server/testutils/factories/referral.ts
@@ -35,7 +35,7 @@ class ReferralFactory extends Factory<Referral> {
   }
 }
 
-const status = faker.helpers.arrayElement([
+export const status = faker.helpers.arrayElement([
   'awaiting_assesment',
   'assessment_started',
   'referral_started',

--- a/server/testutils/factories/referralSummary.ts
+++ b/server/testutils/factories/referralSummary.ts
@@ -1,0 +1,17 @@
+import { faker } from '@faker-js/faker'
+import { Factory } from 'fishery'
+
+import courseAudienceFactory from './courseAudience'
+import FactoryHelpers from './factoryHelpers'
+import { status } from './referral'
+import { StringUtils } from '../../utils'
+import type { ReferralSummary } from '@accredited-programmes/models'
+
+export default Factory.define<ReferralSummary>(({ params }) => ({
+  id: faker.string.uuid(), // eslint-disable-next-line sort-keys
+  audiences: FactoryHelpers.buildListBetween(courseAudienceFactory, { max: 3, min: 1 }),
+  courseName: `${StringUtils.convertToTitleCase(faker.color.human())} Course`,
+  prisonNumber: faker.string.alphanumeric({ length: 7 }),
+  status,
+  submittedOn: (params.status || status) !== 'referral_started' ? faker.date.past().toISOString() : undefined,
+}))


### PR DESCRIPTION
## Context

We need to display the referrals for organisation in a table for the case list/dashboard view.

## Changes in this PR

- Add new types and client method to use the `{{accredited_programmes_api}}/referrals/organisation/:organisationId/dashboard` endpoint.
- Add new type and service to get the dashboard content as well as the person details to create the case list.

Pagination to be handled at a later date.

More columns to be added soon too but this gets a basic list working.

## Release checklist

[Release process documentation](../doc/how-to/perform-a-release.md)

As part of our continuous deployment strategy we must ensure that this work is
ready to be released once merged.

### Pre-merge

- [ ] There are changes required to the Accredited Programmes API for this change to work...
  - [ ] ... and they have been released to production already

### Post-merge

<!-- The outer checkboxes can be completed pre-merge -->

- [ ] This adds, extends or meaningfully modifies a feature...
  - [ ] ... and I have written or updated an end-to-end test for the happy path in the [Accredited Programmes E2E repo](https://github.com/ministryofjustice/hmpps-accredited-programmes-e2e)
- [ ] This makes new expectations of the API...
  - [ ] ... and I have notified the API developer(s) of changes to the contract tests (Pact), or the API is already compliant
- [ ] [Manually approve](../doc/how-to/perform-a-release.md#releasing-to-the-preprod-environment) release to preprod
- [ ] [Manually approve](../doc/how-to/perform-a-release.md#releasing-to-the-production-environment) release to prod

<!-- Should a release fail at any step, you as the author should now lead the work to
fix it as soon as possible. You can monitor deployment failures in CircleCI
itself and application errors are found in
[Sentry](https://ministryofjustice.sentry.io/projects/hmpps-accredited-programmes-ui/?project=4505330122686464&referrer=sidebar&statsPeriod=24h). -->
