### PR TITLE
(678) Hide "Make a referral" on non-referable courses

### DIFF
--- a/integration_tests/e2e/refer/new/create.cy.ts
+++ b/integration_tests/e2e/refer/new/create.cy.ts
@@ -18,7 +18,7 @@ import {
 } from '../../../pages/refer'
 
 context('Searching for a person and creating a referral', () => {
-  const course = courseFactory.build()
+  const course = courseFactory.build({ referable: true })
   const courseOffering = courseOfferingFactory.build()
   const prison = prisonFactory.build({ prisonId: courseOffering.organisationId })
   const organisation = OrganisationUtils.organisationFromPrison(prison)

--- a/server/@types/models/Course.ts
+++ b/server/@types/models/Course.ts
@@ -8,4 +8,5 @@ export type Course = {
   coursePrerequisites: Array<CoursePrerequisite>
   description: string
   name: string
+  referable: boolean
 }

--- a/server/controllers/refer/new/referralsController.test.ts
+++ b/server/controllers/refer/new/referralsController.test.ts
@@ -409,7 +409,7 @@ describe('NewReferralsController', () => {
         request.params.referralId = referralId
 
         const requestHandler = controller.complete()
-        const expectedError = createError(400)
+        const expectedError = createError(400, 'Referral has not been submitted.')
 
         expect(() => requestHandler(request, response, next)).rejects.toThrowError(expectedError)
         expect(referralService.getReferral).toHaveBeenCalledWith(username, referralId)

--- a/server/controllers/refer/new/referralsController.ts
+++ b/server/controllers/refer/new/referralsController.ts
@@ -97,6 +97,11 @@ export default class NewReferralsController {
       const { courseOfferingId, prisonNumber } = req.body
       const { username, userId } = req.user
 
+      const course = await this.courseService.getCourseByOffering(req.user.username, courseOfferingId)
+      if (!course.referable) {
+        throw createError(400, 'Course is not referable.')
+      }
+
       const createdReferralResponse: CreatedReferralResponse = await this.referralService.createReferral(
         username,
         courseOfferingId,

--- a/server/controllers/refer/new/referralsController.ts
+++ b/server/controllers/refer/new/referralsController.ts
@@ -79,9 +79,7 @@ export default class NewReferralsController {
       const referral = await this.referralService.getReferral(req.user.username, referralId)
 
       if (referral.status !== 'referral_submitted') {
-        throw createError(400, {
-          userMessage: 'Referral has not been submitted.',
-        })
+        throw createError(400, 'Referral has not been submitted.')
       }
 
       res.render('referrals/new/complete', {

--- a/server/services/personService.ts
+++ b/server/services/personService.ts
@@ -133,9 +133,7 @@ export default class PersonService {
         throw knownError
       }
 
-      throw createError(knownError.status || 500, knownError, {
-        userMessage: `Error fetching prisoner ${prisonNumber}.`,
-      })
+      throw createError(knownError.status || 500, knownError, `Error fetching prisoner ${prisonNumber}.`)
     }
   }
 }

--- a/server/testutils/factories/course.ts
+++ b/server/testutils/factories/course.ts
@@ -23,5 +23,6 @@ export default Factory.define<Course>(({ params }) => {
     ],
     description: faker.lorem.sentences(),
     name,
+    referable: faker.datatype.boolean(),
   }
 })

--- a/server/views/courses/offerings/show.njk
+++ b/server/views/courses/offerings/show.njk
@@ -29,7 +29,7 @@
         rows: organisation.summaryListRows
       }) }}
 
-      {% if referEnabled and user.hasReferrerRole %}
+      {% if referEnabled and user.hasReferrerRole and course.referable %}
         {{ govukButton({
             text: "Make a referral",
             href: referPaths.new.start({ courseOfferingId: courseOffering.id })


### PR DESCRIPTION
## Context

<!-- Is there a Trello ticket you can link to? -->
<!-- Do you need to add any environment variables? -->
<!-- Is an ADR required? An ADR should be added if this PR introduces a change to the architecture. -->

We have some non-referable courses, but currently you can make a referral to them

## Changes in this PR

- Hide "Make a referral" button for non-referable courses
- Guard against request to create a referral to a non-referable course

This doesn't prevent users from manually going to the Refer pages with the ID of an offering that's for a non-referable course, but it does guard against requests made to create one. Later work could redirect back to the offering if the user has accessed the `start`, `new`, or `create` referrals actions, or the `find` and `show` new referrals people actions, with a flashed message explaining the redirect

## Release checklist

[Release process documentation](../doc/how-to/perform-a-release.md)

As part of our continuous deployment strategy we must ensure that this work is
ready to be released once merged.

### Pre-merge

- [ ] There are changes required to the Accredited Programmes API for this change to work...
  - [ ] ... and they have been released to production already

### Post-merge

<!-- The outer checkboxes can be completed pre-merge -->

- [ ] This adds, extends or meaningfully modifies a feature...
  - [ ] ... and I have written or updated an end-to-end test for the happy path in the [Accredited Programmes E2E repo](https://github.com/ministryofjustice/hmpps-accredited-programmes-e2e)
- [ ] This makes new expectations of the API...
  - [ ] ... and I have notified the API developer(s) of changes to the contract tests (Pact), or the API is already compliant
- [ ] [Manually approve](../doc/how-to/perform-a-release.md#releasing-to-the-preprod-environment) release to preprod
- [ ] [Manually approve](../doc/how-to/perform-a-release.md#releasing-to-the-production-environment) release to prod

<!-- Should a release fail at any step, you as the author should now lead the work to
fix it as soon as possible. You can monitor deployment failures in CircleCI
itself and application errors are found in
[Sentry](https://ministryofjustice.sentry.io/projects/hmpps-accredited-programmes-ui/?project=4505330122686464&referrer=sidebar&statsPeriod=24h). -->
