### PR TITLE
(1086c) Add `statusTagHtml` to `ReferralUtils`

### DIFF
--- a/server/utils/referralUtils.test.ts
+++ b/server/utils/referralUtils.test.ts
@@ -9,6 +9,7 @@ import {
   referralFactory,
   referralSummaryFactory,
 } from '../testutils/factories'
+import type { ReferralStatus } from '@accredited-programmes/models'
 import type { ReferralTaskListItem, ReferralTaskListSection } from '@accredited-programmes/ui'
 
 describe('ReferralUtils', () => {
@@ -88,7 +89,10 @@ describe('ReferralUtils', () => {
           },
           { text: 'N/A' },
           { text: 'Test Course 1' },
-          { text: 'referral_started' },
+          {
+            attributes: { 'data-sort-value': 'referral_started' },
+            html: ReferralUtils.statusTagHtml('referral_started'),
+          },
         ],
         [
           {
@@ -97,7 +101,10 @@ describe('ReferralUtils', () => {
           },
           { text: '1 January 2021' },
           { text: 'Test Course 2' },
-          { text: 'referral_submitted' },
+          {
+            attributes: { 'data-sort-value': 'referral_submitted' },
+            html: ReferralUtils.statusTagHtml('referral_submitted'),
+          },
         ],
       ])
     })
@@ -165,6 +172,22 @@ describe('ReferralUtils', () => {
 
       expect(ReferralUtils.isReadyForSubmission(submittableReferral)).toEqual(true)
     })
+  })
+
+  describe('statusTagHtml', () => {
+    it.each([
+      ['assessment_started', 'yellow', 'Assessment started'],
+      ['awaiting_assesment', 'orange', 'Awaiting assessment'],
+      ['referral_submitted', 'red', 'Referral submitted'],
+      ['referral_started', 'grey', 'referral_started'],
+    ])(
+      'should return the correct HTML for status "%s"',
+      (status: string, expectedColour: string, expectedText: string) => {
+        const result = ReferralUtils.statusTagHtml(status as ReferralStatus)
+
+        expect(result).toBe(`<strong class="govuk-tag govuk-tag--${expectedColour}">${expectedText}</strong>`)
+      },
+    )
   })
 
   describe('submissionSummaryListRows', () => {

--- a/server/utils/referralUtils.ts
+++ b/server/utils/referralUtils.ts
@@ -3,7 +3,14 @@ import type { Request } from 'express'
 import DateUtils from './dateUtils'
 import { assessPaths, referPaths } from '../paths'
 import { assessPathBase } from '../paths/assess'
-import type { CourseOffering, Organisation, Person, Referral, ReferralSummary } from '@accredited-programmes/models'
+import type {
+  CourseOffering,
+  Organisation,
+  Person,
+  Referral,
+  ReferralStatus,
+  ReferralSummary,
+} from '@accredited-programmes/models'
 import type {
   CoursePresenter,
   GovukFrontendSummaryListRowWithKeyAndValue,
@@ -11,6 +18,7 @@ import type {
   ReferralTaskListSection,
   ReferralTaskListStatusTag,
   ReferralTaskListStatusText,
+  TagColour,
 } from '@accredited-programmes/ui'
 import type { GovukFrontendTableRow } from '@govuk-frontend'
 
@@ -67,7 +75,10 @@ export default class ReferralUtils {
         text: summary.courseName,
       },
       {
-        text: summary.status,
+        attributes: {
+          'data-sort-value': summary.status,
+        },
+        html: this.statusTagHtml(summary.status),
       },
     ])
   }
@@ -94,6 +105,32 @@ export default class ReferralUtils {
 
   static isReadyForSubmission(referral: Referral): boolean {
     return referral.hasReviewedProgrammeHistory && referral.oasysConfirmed && !!referral.additionalInformation
+  }
+
+  static statusTagHtml(status: ReferralStatus): string {
+    let colour: TagColour
+    let text: string
+
+    switch (status) {
+      case 'assessment_started':
+        colour = 'yellow'
+        text = 'Assessment started'
+        break
+      case 'awaiting_assesment':
+        colour = 'orange'
+        text = 'Awaiting assessment'
+        break
+      case 'referral_submitted':
+        colour = 'red'
+        text = 'Referral submitted'
+        break
+      default:
+        colour = 'grey'
+        text = status
+        break
+    }
+
+    return `<strong class="govuk-tag govuk-tag--${colour}">${text}</strong>`
   }
 
   static submissionSummaryListRows(referral: Referral): Array<GovukFrontendSummaryListRowWithKeyAndValue> {


### PR DESCRIPTION
## Context

We need to display the status of a referral using https://design-system.service.gov.uk/components/tag/.

## Changes in this PR
Add `statusTagHtml` to `ReferralUtils` which provides a colour and formatted text for each of the required statuses and has a fallback to grey when there is no matching status.  We may decide to not show a tag at all but for now this is OK as I believe new statuses will be added in future.

Use newly added util in `caseListTableRows` method.


## Screenshots of UI changes

![image](https://github.com/ministryofjustice/hmpps-accredited-programmes-ui/assets/1067537/c82e2a6e-d08c-4a29-a4a3-e037050b4cd1)



## Release checklist

[Release process documentation](../doc/how-to/perform-a-release.md)

As part of our continuous deployment strategy we must ensure that this work is
ready to be released once merged.

### Pre-merge

- [ ] There are changes required to the Accredited Programmes API for this change to work...
  - [ ] ... and they have been released to production already

### Post-merge

<!-- The outer checkboxes can be completed pre-merge -->

- [ ] This adds, extends or meaningfully modifies a feature...
  - [ ] ... and I have written or updated an end-to-end test for the happy path in the [Accredited Programmes E2E repo](https://github.com/ministryofjustice/hmpps-accredited-programmes-e2e)
- [ ] This makes new expectations of the API...
  - [ ] ... and I have notified the API developer(s) of changes to the contract tests (Pact), or the API is already compliant
- [ ] [Manually approve](../doc/how-to/perform-a-release.md#releasing-to-the-preprod-environment) release to preprod
- [ ] [Manually approve](../doc/how-to/perform-a-release.md#releasing-to-the-production-environment) release to prod

<!-- Should a release fail at any step, you as the author should now lead the work to
fix it as soon as possible. You can monitor deployment failures in CircleCI
itself and application errors are found in
[Sentry](https://ministryofjustice.sentry.io/projects/hmpps-accredited-programmes-ui/?project=4505330122686464&referrer=sidebar&statsPeriod=24h). -->
