### PR TITLE
(1109) Add no release dates message on sentence information page

### DIFF
--- a/integration_tests/e2e/refer/show.cy.ts
+++ b/integration_tests/e2e/refer/show.cy.ts
@@ -9,13 +9,13 @@ context('Viewing a submitted referral', () => {
   })
 
   describe('When reviewing programme history', () => {
-    describe('and there are CourseParticipation records for that user', () => {
+    describe('and there are CourseParticipation records for that person', () => {
       it('shows the correct information, including the CourseParticipation records', () => {
         sharedTests.referrals.showsProgrammeHistoryPage(ApplicationRoles.ACP_REFERRER)
       })
     })
 
-    describe('and there are no CourseParticipation records for that user', () => {
+    describe('and there are no CourseParticipation records for that person', () => {
       it('shows the correct information, including a message that there are no CourseParticipation records', () => {
         sharedTests.referrals.showsEmptyProgrammeHistoryPage(ApplicationRoles.ACP_REFERRER)
       })
@@ -37,15 +37,15 @@ context('Viewing a submitted referral', () => {
   })
 
   describe('When reviewing sentence information', () => {
-    describe('and there are sentence details and release dates for that user', () => {
+    describe('and there are sentence details and release dates for that person', () => {
       it('shows the correct information, including the sentence details and release dates', () => {
         sharedTests.referrals.showsSentenceInformationPageWithAllData(ApplicationRoles.ACP_REFERRER)
       })
     })
 
-    describe('and there are release dates but no sentence details for that user', () => {
-      it('shows the correct information, including the release dates, and a message for the missing sentence details', () => {
-        sharedTests.referrals.showsSentenceInformationPageWithoutSentenceDetails(ApplicationRoles.ACP_REFERRER)
+    describe('and there are no sentence details and no release dates for that person', () => {
+      it('shows the correct information, including a message for the missing sentence details and a message for the missing release dates', () => {
+        sharedTests.referrals.showsSentenceInformationPageWithoutAllData(ApplicationRoles.ACP_REFERRER)
       })
     })
   })

--- a/integration_tests/pages/shared/showReferral/sentenceInformation.ts
+++ b/integration_tests/pages/shared/showReferral/sentenceInformation.ts
@@ -25,6 +25,16 @@ export default class SentenceInformationPage extends Page {
     )
   }
 
+  shouldContainNoReleaseDatesSummaryCard(): void {
+    cy.get('[data-testid="no-release-dates-summary-card"]').then(summaryCardElement => {
+      this.shouldContainKeylessSummaryCard(
+        'Release dates',
+        'There are no release dates for this person.',
+        summaryCardElement,
+      )
+    })
+  }
+
   shouldContainNoSentenceDetailsSummaryCard(): void {
     cy.get('[data-testid="no-sentence-information-summary-card"]').then(summaryCardElement => {
       this.shouldContainKeylessSummaryCard(

--- a/integration_tests/support/sharedTests.ts
+++ b/integration_tests/support/sharedTests.ts
@@ -15,6 +15,7 @@ import {
   userFactory,
 } from '../../server/testutils/factories'
 import { CourseUtils, OrganisationUtils, StringUtils } from '../../server/utils'
+import { releaseDateFields } from '../../server/utils/personUtils'
 import BadRequestPage from '../pages/badRequest'
 import Page from '../pages/page'
 import {
@@ -327,10 +328,15 @@ const sharedTests = {
       sentenceInformationPage.shouldContainReleaseDatesSummaryCard()
     },
 
-    showsSentenceInformationPageWithoutSentenceDetails: (role: ApplicationRole): void => {
+    showsSentenceInformationPageWithoutAllData: (role: ApplicationRole): void => {
+      let undefinedReleaseDates = {}
+      releaseDateFields.forEach(date => {
+        undefinedReleaseDates = { ...undefinedReleaseDates, [date]: undefined }
+      })
+
       sharedTests.referrals.beforeEach(role, {
-        person: { ...defaultPerson, sentenceStartDate: undefined },
-        prisoner: { ...defaultPrisoner, sentenceStartDate: undefined },
+        person: { ...defaultPerson, sentenceStartDate: undefined, ...undefinedReleaseDates },
+        prisoner: { ...defaultPrisoner, sentenceStartDate: undefined, ...undefinedReleaseDates },
       })
       const offenderSentenceAndOffences = offenderSentenceAndOffencesFactory.build({
         sentenceTypeDescription: undefined,
@@ -353,7 +359,7 @@ const sharedTests = {
       sentenceInformationPage.shouldContainSubmittedReferralSideNavigation(path, referral.id)
       sentenceInformationPage.shouldContainImportedFromText()
       sentenceInformationPage.shouldContainNoSentenceDetailsSummaryCard()
-      sentenceInformationPage.shouldContainReleaseDatesSummaryCard()
+      sentenceInformationPage.shouldContainNoReleaseDatesSummaryCard()
     },
   },
 }

--- a/server/controllers/shared/referralsController.test.ts
+++ b/server/controllers/shared/referralsController.test.ts
@@ -17,6 +17,7 @@ import {
 } from '../../testutils/factories'
 import Helpers from '../../testutils/helpers'
 import { CourseUtils, DateUtils, OffenceUtils, PersonUtils, ReferralUtils, SentenceInformationUtils } from '../../utils'
+import { releaseDateFields } from '../../utils/personUtils'
 import type { Person, Referral } from '@accredited-programmes/models'
 import type {
   GovukFrontendSummaryListRowWithKeyAndValue,
@@ -276,6 +277,7 @@ describe('ReferralsController', () => {
         expect(response.render).toHaveBeenCalledWith('referrals/show/sentenceInformation', {
           ...sharedPageData,
           detailsSummaryListRows,
+          hasReleaseDates: true,
           hasSentenceDetails: true,
           importedFromText: `Imported from OASys on ${DateUtils.govukFormattedFullDateString()}.`,
           navigationItems: ReferralUtils.viewReferralNavigationItems(request.path, referral.id),
@@ -284,8 +286,9 @@ describe('ReferralsController', () => {
       })
     })
 
-    describe('when there are some but not all sentence details', () => {
-      it('renders the sentence information template with the present sentence details', async () => {
+    describe('when there are some but not all sentence details and release dates', () => {
+      it('renders the sentence information template with the present sentence details and release dates', async () => {
+        person.conditionalReleaseDate = undefined
         person.sentenceStartDate = '2023-01-02'
         const offenderSentenceAndOffences = offenderSentenceAndOffencesFactory.build({
           sentenceTypeDescription: undefined,
@@ -305,6 +308,7 @@ describe('ReferralsController', () => {
         expect(response.render).toHaveBeenCalledWith('referrals/show/sentenceInformation', {
           ...sharedPageData,
           detailsSummaryListRows,
+          hasReleaseDates: true,
           hasSentenceDetails: true,
           importedFromText: `Imported from OASys on ${DateUtils.govukFormattedFullDateString()}.`,
           navigationItems: ReferralUtils.viewReferralNavigationItems(request.path, referral.id),
@@ -313,8 +317,11 @@ describe('ReferralsController', () => {
       })
     })
 
-    describe('when there are no sentence details', () => {
-      it('renders the sentence information template with no sentence details', async () => {
+    describe('when there are no sentence details or release dates', () => {
+      it('renders the sentence information template with no sentence details and no release dates', async () => {
+        releaseDateFields.forEach(field => {
+          person[field] = undefined
+        })
         person.sentenceStartDate = undefined
         const offenderSentenceAndOffences = offenderSentenceAndOffencesFactory.build({
           sentenceTypeDescription: undefined,
@@ -330,10 +337,11 @@ describe('ReferralsController', () => {
         expect(response.render).toHaveBeenCalledWith('referrals/show/sentenceInformation', {
           ...sharedPageData,
           detailsSummaryListRows: [],
+          hasReleaseDates: false,
           hasSentenceDetails: false,
           importedFromText: `Imported from OASys on ${DateUtils.govukFormattedFullDateString()}.`,
           navigationItems: ReferralUtils.viewReferralNavigationItems(request.path, referral.id),
-          releaseDatesSummaryListRows: PersonUtils.releaseDatesSummaryListRows(sharedPageData.person),
+          releaseDatesSummaryListRows: [],
         })
       })
     })

--- a/server/utils/personUtils.ts
+++ b/server/utils/personUtils.ts
@@ -5,6 +5,14 @@ import type { GovukFrontendSummaryListRowWithKeyAndValue } from '@accredited-pro
 import type { GovukFrontendSummaryListRowKey } from '@govuk-frontend'
 import type { Prisoner } from '@prisoner-search'
 
+export const releaseDateFields = [
+  'conditionalReleaseDate',
+  'homeDetentionCurfewEligibilityDate',
+  'paroleEligibilityDate',
+  'sentenceExpiryDate',
+  'tariffDate',
+] as const
+
 export default class PersonUtils {
   static personFromPrisoner(prisoner: Prisoner): Person {
     const unavailable = 'Not entered'
@@ -32,12 +40,7 @@ export default class PersonUtils {
   static releaseDatesSummaryListRows(person: Person): Array<GovukFrontendSummaryListRowWithKeyAndValue> {
     const summaryListRows: Array<GovukFrontendSummaryListRowWithKeyAndValue> = []
 
-    type ReleaseDateField =
-      | 'conditionalReleaseDate'
-      | 'homeDetentionCurfewEligibilityDate'
-      | 'paroleEligibilityDate'
-      | 'sentenceExpiryDate'
-      | 'tariffDate'
+    type ReleaseDateField = (typeof releaseDateFields)[number]
 
     let earliestReleaseDateField: Omit<ReleaseDateField, 'homeDetentionCurfewEligibilityDate' | 'sentenceExpiryDate'>
 

--- a/server/views/referrals/show/sentenceInformation.njk
+++ b/server/views/referrals/show/sentenceInformation.njk
@@ -30,15 +30,19 @@
     {{ keylessSummaryCard("Sentence details", bodyText="There are no sentence details for this person.", testId="no-sentence-information-summary-card") }}
   {% endif %}
 
-  {{ govukSummaryList({
-    card: {
-      title: {
-        text: "Release dates"
+  {% if hasReleaseDates %}
+    {{ govukSummaryList({
+      card: {
+        title: {
+          text: "Release dates"
+        },
+        attributes: {
+          "data-testid": "release-dates-summary-card"
+        }
       },
-      attributes: {
-        "data-testid": "release-dates-summary-card"
-      }
-    },
-    rows: releaseDatesSummaryListRows
-  }) }}
+      rows: releaseDatesSummaryListRows
+    }) }}
+  {% else %}
+    {{ keylessSummaryCard("Release dates", bodyText="There are no release dates for this person.", testId="no-release-dates-summary-card") }}
+  {% endif %}
 {% endblock submittedReferralContent %}


### PR DESCRIPTION
## Context

We need to display a general no release dates message when there are no release dates at all, instead of an individual message for each release date.

## Changes in this PR
If all of the below fields are `undefined` then display `There are no release dates for this person` message.

- `conditionalReleaseDate`
- `homeDetentionCurfewEligibilityDate`
- `paroleEligibilityDate`
- `sentenceExpiryDate`
- `tariffDate`


## Screenshots of UI changes

<img width="755" alt="image" src="https://github.com/ministryofjustice/hmpps-accredited-programmes-ui/assets/1067537/f9c0d281-20be-4bf1-9746-729ea7fd41c7">



## Release checklist

[Release process documentation](../doc/how-to/perform-a-release.md)

As part of our continuous deployment strategy we must ensure that this work is
ready to be released once merged.

### Pre-merge

- [ ] There are changes required to the Accredited Programmes API for this change to work...
  - [ ] ... and they have been released to production already

### Post-merge

<!-- The outer checkboxes can be completed pre-merge -->

- [ ] This adds, extends or meaningfully modifies a feature...
  - [ ] ... and I have written or updated an end-to-end test for the happy path in the [Accredited Programmes E2E repo](https://github.com/ministryofjustice/hmpps-accredited-programmes-e2e)
- [ ] This makes new expectations of the API...
  - [ ] ... and I have notified the API developer(s) of changes to the contract tests (Pact), or the API is already compliant
- [ ] [Manually approve](../doc/how-to/perform-a-release.md#releasing-to-the-preprod-environment) release to preprod
- [ ] [Manually approve](../doc/how-to/perform-a-release.md#releasing-to-the-production-environment) release to prod

<!-- Should a release fail at any step, you as the author should now lead the work to
fix it as soon as possible. You can monitor deployment failures in CircleCI
itself and application errors are found in
[Sentry](https://ministryofjustice.sentry.io/projects/hmpps-accredited-programmes-ui/?project=4505330122686464&referrer=sidebar&statsPeriod=24h). -->
