### PR TITLE
Fix release dates test for sentence information

### DIFF
--- a/server/controllers/shared/referralsController.test.ts
+++ b/server/controllers/shared/referralsController.test.ts
@@ -289,6 +289,7 @@ describe('ReferralsController', () => {
     describe('when there are some but not all sentence details and release dates', () => {
       it('renders the sentence information template with the present sentence details and release dates', async () => {
         person.conditionalReleaseDate = undefined
+        person.paroleEligibilityDate = '2024-01-02'
         person.sentenceStartDate = '2023-01-02'
         const offenderSentenceAndOffences = offenderSentenceAndOffencesFactory.build({
           sentenceTypeDescription: undefined,


### PR DESCRIPTION
## Context

A test for the sentence information page intermittently failed as the person factory could sometimes return a person with no release dates at all. 

## Changes in this PR
Updated the flakey test so it replicates when a person has some but not all release related dates.  `conditionalReleaseDate` will be `undefined` but `paroleEligibilityDate` will be `'2024-01-02'` so this will mean that `hasReleaseDates` is `true` and `releaseDatesSummaryListRows` is not an empty array.


## Release checklist

[Release process documentation](../doc/how-to/perform-a-release.md)

As part of our continuous deployment strategy we must ensure that this work is
ready to be released once merged.

### Pre-merge

- [ ] There are changes required to the Accredited Programmes API for this change to work...
  - [ ] ... and they have been released to production already

### Post-merge

<!-- The outer checkboxes can be completed pre-merge -->

- [ ] This adds, extends or meaningfully modifies a feature...
  - [ ] ... and I have written or updated an end-to-end test for the happy path in the [Accredited Programmes E2E repo](https://github.com/ministryofjustice/hmpps-accredited-programmes-e2e)
- [ ] This makes new expectations of the API...
  - [ ] ... and I have notified the API developer(s) of changes to the contract tests (Pact), or the API is already compliant
- [ ] [Manually approve](../doc/how-to/perform-a-release.md#releasing-to-the-preprod-environment) release to preprod
- [ ] [Manually approve](../doc/how-to/perform-a-release.md#releasing-to-the-production-environment) release to prod

<!-- Should a release fail at any step, you as the author should now lead the work to
fix it as soon as possible. You can monitor deployment failures in CircleCI
itself and application errors are found in
[Sentry](https://ministryofjustice.sentry.io/projects/hmpps-accredited-programmes-ui/?project=4505330122686464&referrer=sidebar&statsPeriod=24h). -->
