### PR TITLE
(1141) Add `activeCaseLoadId` property to `res.locals.user`

### DIFF
--- a/server/controllers/shared/caseListController.test.ts
+++ b/server/controllers/shared/caseListController.test.ts
@@ -5,13 +5,11 @@ import type { NextFunction, Request, Response } from 'express'
 import CaseListController from './caseListController'
 import { assessPaths } from '../../paths'
 import type { ReferralService } from '../../services'
-import { caseloadFactory, referralSummaryFactory } from '../../testutils/factories'
+import { referralSummaryFactory } from '../../testutils/factories'
 import { ReferralUtils } from '../../utils'
 import type { Paginated, ReferralSummary } from '@accredited-programmes/models'
-import type { Caseload } from '@prison-api'
 
 describe('CaseListController', () => {
-  let caseloads: Array<Caseload>
   const username = 'USERNAME'
   const activeCaseLoadId = 'MDI'
 
@@ -25,11 +23,6 @@ describe('CaseListController', () => {
   let controller: CaseListController
 
   beforeEach(() => {
-    caseloads = [
-      caseloadFactory.build({ caseLoadId: activeCaseLoadId, currentlyActive: true }),
-      caseloadFactory.build({ currentlyActive: false }),
-    ]
-
     const referralSummaries = referralSummaryFactory.buildList(3)
     paginatedReferralSummaries = {
       content: referralSummaries,
@@ -45,7 +38,7 @@ describe('CaseListController', () => {
     controller = new CaseListController(referralService)
 
     request = createMock<Request>({ user: { username } })
-    response = createMock<Response>({ locals: { user: { caseloads, username } } })
+    response = createMock<Response>({ locals: { user: { activeCaseLoadId, username } } })
   })
 
   afterEach(() => {

--- a/server/controllers/shared/caseListController.ts
+++ b/server/controllers/shared/caseListController.ts
@@ -2,7 +2,6 @@ import type { Request, Response, TypedRequestHandler } from 'express'
 
 import type { ReferralService } from '../../services'
 import { ReferralUtils, TypeUtils } from '../../utils'
-import type { Caseload } from '@prison-api'
 
 export default class CaseListController {
   constructor(private readonly referralService: ReferralService) {}
@@ -11,10 +10,7 @@ export default class CaseListController {
     return async (req: Request, res: Response) => {
       TypeUtils.assertHasUser(req)
 
-      const { caseloads, username } = res.locals.user
-
-      const activeCaseLoadId: Caseload['caseLoadId'] = caseloads.find((caseload: Caseload) => caseload.currentlyActive)
-        ?.caseLoadId
+      const { activeCaseLoadId, username } = res.locals.user
 
       const paginatedReferralSummaries = await this.referralService.getReferralSummaries(username, activeCaseLoadId)
 

--- a/server/middleware/populateCurrentUser.test.ts
+++ b/server/middleware/populateCurrentUser.test.ts
@@ -30,7 +30,11 @@ describe('populateCurrentUser', () => {
   })
 
   describe('when the user variable is set', () => {
-    const caseloads = [caseloadFactory.build()]
+    const activeCaseLoadId = 'MDI'
+    const caseloads = [
+      caseloadFactory.active().build({ caseLoadId: activeCaseLoadId }),
+      caseloadFactory.inactive().build(),
+    ]
     const res: DeepMocked<Response> = createMock<Response>({
       locals: {
         user: {
@@ -60,6 +64,7 @@ describe('populateCurrentUser', () => {
 
           expect(res.locals.user).toEqual({
             active: true,
+            activeCaseLoadId,
             authSource: 'nomis',
             caseloads,
             displayName: 'Del Hatton',

--- a/server/middleware/populateCurrentUser.ts
+++ b/server/middleware/populateCurrentUser.ts
@@ -12,11 +12,14 @@ export default function populateCurrentUser(userService: UserService): RequestHa
         const { token: userToken } = res.locals.user
         req.session.user ||= await userService.getCurrentUserWithDetails(userToken)
 
+        const activeCaseLoadId = req.session.user?.caseloads.find(caseload => caseload.currentlyActive)?.caseLoadId
+
         if (req.session.user) {
           const roles = UserUtils.getUserRolesFromToken(userToken)
           res.locals.user = {
             ...res.locals.user,
             ...req.session.user,
+            activeCaseLoadId,
             hasReferrerRole: roles?.includes(ApplicationRoles.ACP_REFERRER),
             roles,
           }


### PR DESCRIPTION
## Context

The `activeCaseloadId` has been recently deprecated in the Manage Users API response, and we’re advised to read this from the Prison API.

https://trello.com/c/Y9nDk05S/1141-add-activecaseloadid-to-userdetails-when-populating-current-user-m

## Changes in this PR
Add an `activeCaseLoadId` property to `res.locals.user` so we can use this elsewhere such as the `CaseListController`.


## Release checklist

[Release process documentation](../doc/how-to/perform-a-release.md)

As part of our continuous deployment strategy we must ensure that this work is
ready to be released once merged.

### Pre-merge

- [ ] There are changes required to the Accredited Programmes API for this change to work...
  - [ ] ... and they have been released to production already

### Post-merge

<!-- The outer checkboxes can be completed pre-merge -->

- [ ] This adds, extends or meaningfully modifies a feature...
  - [ ] ... and I have written or updated an end-to-end test for the happy path in the [Accredited Programmes E2E repo](https://github.com/ministryofjustice/hmpps-accredited-programmes-e2e)
- [ ] This makes new expectations of the API...
  - [ ] ... and I have notified the API developer(s) of changes to the contract tests (Pact), or the API is already compliant
- [ ] [Manually approve](../doc/how-to/perform-a-release.md#releasing-to-the-preprod-environment) release to preprod
- [ ] [Manually approve](../doc/how-to/perform-a-release.md#releasing-to-the-production-environment) release to prod

<!-- Should a release fail at any step, you as the author should now lead the work to
fix it as soon as possible. You can monitor deployment failures in CircleCI
itself and application errors are found in
[Sentry](https://ministryofjustice.sentry.io/projects/hmpps-accredited-programmes-ui/?project=4505330122686464&referrer=sidebar&statsPeriod=24h). -->
