### PR TITLE
Fix `awaiting_assessment` typo and flakey test file

### DIFF
--- a/integration_tests/e2e/assess/caseList.cy.ts
+++ b/integration_tests/e2e/assess/caseList.cy.ts
@@ -20,7 +20,7 @@ context('Referral case lists', () => {
     referralSummaries = [
       referralSummaryFactory.build({ prisonNumber: 'ABC123', status: 'assessment_started' }),
       referralSummaryFactory.build({ prisonNumber: 'ABC789', status: 'referral_started' }),
-      referralSummaryFactory.build({ prisonNumber: 'ABC456', status: 'awaiting_assesment' }),
+      referralSummaryFactory.build({ prisonNumber: 'ABC456', status: 'awaiting_assessment' }),
       referralSummaryFactory.build({ prisonNumber: 'ABC000', status: 'referral_submitted' }),
     ]
 

--- a/server/@types/models/Referral.ts
+++ b/server/@types/models/Referral.ts
@@ -24,7 +24,7 @@ type ReferralUpdate = {
   additionalInformation?: Referral['additionalInformation']
 }
 
-type ReferralStatus = 'assessment_started' | 'awaiting_assesment' | 'referral_started' | 'referral_submitted'
+type ReferralStatus = 'assessment_started' | 'awaiting_assessment' | 'referral_started' | 'referral_submitted'
 
 type ReferralSummary = {
   id: Referral['id'] // eslint-disable-next-line @typescript-eslint/member-ordering

--- a/server/controllers/shared/referralsController.test.ts
+++ b/server/controllers/shared/referralsController.test.ts
@@ -254,42 +254,11 @@ describe('ReferralsController', () => {
   describe('sentenceInformation', () => {
     const detailsSummaryListRows = [createMock<GovukFrontendSummaryListRowWithKeyAndValue>()]
 
-    describe('when all sentence information is present', () => {
-      it('renders the sentence information template with the correct response locals', async () => {
-        person.sentenceStartDate = '2023-01-02'
-        const offenderSentenceAndOffences = offenderSentenceAndOffencesFactory.build({
-          sentenceTypeDescription: 'a description',
-        })
-        personService.getOffenderSentenceAndOffences.mockResolvedValue(offenderSentenceAndOffences)
-        ;(SentenceInformationUtils.detailsSummaryListRows as jest.Mock).mockReturnValue(detailsSummaryListRows)
-
-        request.path = referPaths.show.sentenceInformation({ referralId: referral.id })
-
-        const requestHandler = controller.sentenceInformation()
-        await requestHandler(request, response, next)
-
-        assertSharedDataServicesAreCalledWithExpectedArguments()
-
-        expect(SentenceInformationUtils.detailsSummaryListRows).toHaveBeenCalledWith(
-          sharedPageData.person.sentenceStartDate,
-          offenderSentenceAndOffences.sentenceTypeDescription,
-        )
-        expect(response.render).toHaveBeenCalledWith('referrals/show/sentenceInformation', {
-          ...sharedPageData,
-          detailsSummaryListRows,
-          hasReleaseDates: true,
-          hasSentenceDetails: true,
-          importedFromText: `Imported from OASys on ${DateUtils.govukFormattedFullDateString()}.`,
-          navigationItems: ReferralUtils.viewReferralNavigationItems(request.path, referral.id),
-          releaseDatesSummaryListRows: PersonUtils.releaseDatesSummaryListRows(sharedPageData.person),
-        })
-      })
-    })
-
-    describe('when there are some but not all sentence details and release dates', () => {
+    describe('when there are some sentence details and release dates', () => {
       it('renders the sentence information template with the present sentence details and release dates', async () => {
         person.conditionalReleaseDate = undefined
         person.paroleEligibilityDate = '2024-01-02'
+
         person.sentenceStartDate = '2023-01-02'
         const offenderSentenceAndOffences = offenderSentenceAndOffencesFactory.build({
           sentenceTypeDescription: undefined,

--- a/server/testutils/factories/referral.ts
+++ b/server/testutils/factories/referral.ts
@@ -36,7 +36,7 @@ class ReferralFactory extends Factory<Referral> {
 }
 
 export const status = faker.helpers.arrayElement([
-  'awaiting_assesment',
+  'awaiting_assessment',
   'assessment_started',
   'referral_started',
   'referral_submitted',

--- a/server/utils/referralUtils.test.ts
+++ b/server/utils/referralUtils.test.ts
@@ -183,7 +183,7 @@ describe('ReferralUtils', () => {
   describe('statusTagHtml', () => {
     it.each([
       ['assessment_started', 'yellow', 'Assessment started'],
-      ['awaiting_assesment', 'orange', 'Awaiting assessment'],
+      ['awaiting_assessment', 'orange', 'Awaiting assessment'],
       ['referral_submitted', 'red', 'Referral submitted'],
       ['referral_started', 'grey', 'referral_started'],
     ])(

--- a/server/utils/referralUtils.ts
+++ b/server/utils/referralUtils.ts
@@ -119,7 +119,7 @@ export default class ReferralUtils {
         colour = 'yellow'
         text = 'Assessment started'
         break
-      case 'awaiting_assesment':
+      case 'awaiting_assessment':
         colour = 'orange'
         text = 'Awaiting assessment'
         break


### PR DESCRIPTION
## Context

Just spotted this when working on the case list filters.

## Release checklist

[Release process documentation](../doc/how-to/perform-a-release.md)

As part of our continuous deployment strategy we must ensure that this work is
ready to be released once merged.

### Pre-merge

- [ ] There are changes required to the Accredited Programmes API for this change to work...
  - [ ] ... and they have been released to production already

### Post-merge

<!-- The outer checkboxes can be completed pre-merge -->

- [ ] This adds, extends or meaningfully modifies a feature...
  - [ ] ... and I have written or updated an end-to-end test for the happy path in the [Accredited Programmes E2E repo](https://github.com/ministryofjustice/hmpps-accredited-programmes-e2e)
- [ ] This makes new expectations of the API...
  - [ ] ... and I have notified the API developer(s) of changes to the contract tests (Pact), or the API is already compliant
- [ ] [Manually approve](../doc/how-to/perform-a-release.md#releasing-to-the-preprod-environment) release to preprod
- [ ] [Manually approve](../doc/how-to/perform-a-release.md#releasing-to-the-production-environment) release to prod

<!-- Should a release fail at any step, you as the author should now lead the work to
fix it as soon as possible. You can monitor deployment failures in CircleCI
itself and application errors are found in
[Sentry](https://ministryofjustice.sentry.io/projects/hmpps-accredited-programmes-ui/?project=4505330122686464&referrer=sidebar&statsPeriod=24h). -->
