### PR TITLE
(1167b) WET pact

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -147,6 +147,7 @@
         "semi": false
       }
     ],
+    "quotes": ["error", "single", { "avoidEscape": true }],
     "semi": "off",
     "sort-exports/sort-exports": ["error", { "sortExportKindFirst": "value" }],
     "sort-imports": [

--- a/integration_tests/pages/refer/new/selectProgramme.ts
+++ b/integration_tests/pages/refer/new/selectProgramme.ts
@@ -26,20 +26,20 @@ export default class NewReferralSelectProgrammePage extends Page {
 
   shouldDisplayOtherCourseInput() {
     cy.get('[data-testid="other-course-option"]').check()
-    cy.get(`input[name="otherCourseName"]`).should('be.visible')
+    cy.get('input[name="otherCourseName"]').should('be.visible')
   }
 
   shouldHaveSelectedCourse(courseName: CourseParticipation['courseName'], isKnownCourse: boolean) {
     if (isKnownCourse) {
       cy.get(`.govuk-radios__input[value="${courseName}"]`).should('be.checked')
     } else {
-      cy.get(`.govuk-radios__input[value="Other"]`).should('be.checked')
+      cy.get('.govuk-radios__input[value="Other"]').should('be.checked')
       cy.get('#otherCourseName').should('have.value', courseName)
     }
   }
 
   shouldNotDisplayOtherCourseInput() {
-    cy.get(`input[name="otherCourseName"]`).should('not.be.visible')
+    cy.get('input[name="otherCourseName"]').should('not.be.visible')
   }
 
   submitSelection(courseParticipation: CourseParticipation, selectedCourseName: Course['name']) {

--- a/server/data/accreditedProgrammesApi/courseClient.test.ts
+++ b/server/data/accreditedProgrammesApi/courseClient.test.ts
@@ -159,6 +159,34 @@ pactWith({ consumer: 'Accredited Programmes UI', provider: 'Accredited Programme
     })
   })
 
+  describe('findCourseNames', () => {
+    const courseNames = ['Super Course', 'Custom Course', 'RAPID Course']
+
+    beforeEach(() => {
+      provider.addInteraction({
+        state: 'In order, the names of all the courses are Super Course, Custom Course, and RAPID Course',
+        uponReceiving: 'A request for all course names',
+        willRespondWith: {
+          body: Matchers.like(courseNames),
+          status: 200,
+        },
+        withRequest: {
+          headers: {
+            authorization: `Bearer ${systemToken}`,
+          },
+          method: 'GET',
+          path: apiPaths.courses.names({}),
+        },
+      })
+    })
+
+    it('fetches all course names', async () => {
+      const result = await courseClient.findCourseNames()
+
+      expect(result).toEqual(courseNames)
+    })
+  })
+
   describe('findOfferings', () => {
     const courseOfferings = [
       courseOfferingFactory.build({ id: '790a2dfe-7de5-4504-bb9c-83e6e53a6537' }),
@@ -188,34 +216,6 @@ pactWith({ consumer: 'Accredited Programmes UI', provider: 'Accredited Programme
       const result = await courseClient.findOfferings('d3abc217-75ee-46e9-a010-368f30282367')
 
       expect(result).toEqual(courseOfferings)
-    })
-  })
-
-  describe('findCourseNames', () => {
-    const courseNames = ['Super Course', 'Custom Course', 'RAPID Course']
-
-    beforeEach(() => {
-      provider.addInteraction({
-        state: 'In order, the names of all the courses are Super Course, Custom Course, and RAPID Course',
-        uponReceiving: 'A request for all course names',
-        willRespondWith: {
-          body: Matchers.like(courseNames),
-          status: 200,
-        },
-        withRequest: {
-          headers: {
-            authorization: `Bearer ${systemToken}`,
-          },
-          method: 'GET',
-          path: apiPaths.courses.names({}),
-        },
-      })
-    })
-
-    it('fetches all course names', async () => {
-      const result = await courseClient.findCourseNames()
-
-      expect(result).toEqual(courseNames)
     })
   })
 

--- a/server/data/accreditedProgrammesApi/courseClient.test.ts
+++ b/server/data/accreditedProgrammesApi/courseClient.test.ts
@@ -4,12 +4,7 @@ import { pactWith } from 'jest-pact'
 import CourseClient from './courseClient'
 import config from '../../config'
 import { apiPaths } from '../../paths'
-import {
-  courseFactory,
-  courseOfferingFactory,
-  courseParticipationFactory,
-  personFactory,
-} from '../../testutils/factories'
+import { courseFactory, courseOfferingFactory, courseParticipationFactory } from '../../testutils/factories'
 import type { CourseParticipationUpdate } from '@accredited-programmes/models'
 
 pactWith({ consumer: 'Accredited Programmes UI', provider: 'Accredited Programmes API' }, provider => {
@@ -22,61 +17,20 @@ pactWith({ consumer: 'Accredited Programmes UI', provider: 'Accredited Programme
     config.apis.accreditedProgrammesApi.url = provider.mockService.baseUrl
   })
 
-  const course1 = courseFactory.build({
-    id: 'd3abc217-75ee-46e9-a010-368f30282367', // eslint-disable-next-line sort-keys
-    alternateName: 'AC++',
-  })
-  const course2 = courseFactory.build({
-    id: '28e47d30-30bf-4dab-a8eb-9fda3f6400e8', // eslint-disable-next-line sort-keys
-    alternateName: 'LC',
-  })
-  const course3 = courseFactory.build({
-    id: '1811faa6-d568-4fc4-83ce-41118b90242e', // eslint-disable-next-line sort-keys
-    alternateName: null,
-  })
-  const allCourses = [course1, course2, course3]
-
-  const courseOffering1 = courseOfferingFactory.build({ id: '790a2dfe-7de5-4504-bb9c-83e6e53a6537' })
-  const courseOffering2 = courseOfferingFactory.build({ id: '39b77a2f-7398-4d5f-b744-cdcefca12671' })
-  const courseOffering3 = courseOfferingFactory.build({
-    id: '7fffcc6a-11f8-4713-be35-cf5ff1aee517',
-    secondaryContactEmail: 'nobody2-mdi@digital.justice.gov.uk',
-  })
-  const courseOffering4 = courseOfferingFactory.build({
-    id: '7f98826a-616c-4414-a278-525fc02505a0',
-    secondaryContactEmail: 'nobody2-mdi@digital.justice.gov.uk',
-  })
-  const courseOffering5 = courseOfferingFactory.build({
-    id: 'fee62dde-87f5-4dfd-9a44-e80d48f64be9',
-    secondaryContactEmail: 'nobody2-mdi@digital.justice.gov.uk',
-  })
-  const courseOffering6 = courseOfferingFactory.build({
-    id: 'be1d407c-3cb5-4c7e-bfee-d104bc79213f',
-    secondaryContactEmail: 'nobody2-mdi@digital.justice.gov.uk',
-  })
-  const allCourseOfferings = [
-    courseOffering1,
-    courseOffering2,
-    courseOffering3,
-    courseOffering4,
-    courseOffering5,
-    courseOffering6,
-  ]
-
-  const person = personFactory.build({ prisonNumber: 'A1234AA' })
-  const courseParticipations = [
-    courseParticipationFactory.build({ id: '0cff5da9-1e90-4ee2-a5cb-94dc49c4b004', prisonNumber: person.prisonNumber }),
-    courseParticipationFactory.build({ id: '9372880f-95ba-4cde-a71a-01e2a06a0644', prisonNumber: person.prisonNumber }),
-    courseParticipationFactory.build({ id: 'eb357e5d-5416-43bf-a8d2-0dc8fd92162e', prisonNumber: person.prisonNumber }),
-  ]
-
   describe('all', () => {
+    const courses = [
+      courseFactory.build({ id: 'd3abc217-75ee-46e9-a010-368f30282367' }),
+      courseFactory.build({ id: '28e47d30-30bf-4dab-a8eb-9fda3f6400e8' }),
+      courseFactory.build({ id: '1811faa6-d568-4fc4-83ce-41118b90242e' }),
+    ]
+
     beforeEach(() => {
       provider.addInteraction({
-        state: 'Courses exist on the API',
+        state:
+          'Courses d3abc217-75ee-46e9-a010-368f30282367, 28e47d30-30bf-4dab-a8eb-9fda3f6400e8, and 1811faa6-d568-4fc4-83ce-41118b90242e and no others exist',
         uponReceiving: 'A request for all courses',
         willRespondWith: {
-          body: Matchers.like(allCourses),
+          body: Matchers.like(courses),
           status: 200,
         },
         withRequest: {
@@ -92,20 +46,18 @@ pactWith({ consumer: 'Accredited Programmes UI', provider: 'Accredited Programme
     it('fetches all courses', async () => {
       const result = await courseClient.all()
 
-      expect(result).toEqual(allCourses)
+      expect(result).toEqual(courses)
     })
   })
 
   describe('createParticipation', () => {
-    const courseParticipation = courseParticipationFactory
-      .new()
-      .build({ id: 'c35c5c3c-7d97-40e6-a744-9526d68495d0', prisonNumber: person.prisonNumber })
+    const courseParticipation = courseParticipationFactory.new().build()
     const { courseName, prisonNumber } = courseParticipation
 
     beforeEach(() => {
       provider.addInteraction({
-        state: `A person exists with prison number ${prisonNumber}`,
-        uponReceiving: `A request to create a course participation for person "${prisonNumber}"`,
+        state: 'A participation can be created',
+        uponReceiving: 'A request to create a participation',
         willRespondWith: {
           body: Matchers.like(courseParticipation),
           status: 201,
@@ -121,7 +73,7 @@ pactWith({ consumer: 'Accredited Programmes UI', provider: 'Accredited Programme
       })
     })
 
-    it('creates a course participation', async () => {
+    it('creates a participation for the given person', async () => {
       const result = await courseClient.createParticipation(prisonNumber, courseName)
 
       expect(result).toEqual(courseParticipation)
@@ -129,15 +81,10 @@ pactWith({ consumer: 'Accredited Programmes UI', provider: 'Accredited Programme
   })
 
   describe('destroyParticipation', () => {
-    const courseParticipationToDestroy = courseParticipationFactory.build({
-      id: '9372880f-95ba-4cde-a71a-01e2a06a0644',
-      prisonNumber: person.prisonNumber,
-    })
-
     beforeEach(() => {
       provider.addInteraction({
-        state: `A course exists with ID ${course1.id}`,
-        uponReceiving: `A request to destroy course participation "${courseParticipationToDestroy.id}"`,
+        state: 'Course participation 0cff5da9-1e90-4ee2-a5cb-94dc49c4b004 exists',
+        uponReceiving: 'A request to destroy participation 0cff5da9-1e90-4ee2-a5cb-94dc49c4b004',
         willRespondWith: {
           status: 204,
         },
@@ -146,23 +93,25 @@ pactWith({ consumer: 'Accredited Programmes UI', provider: 'Accredited Programme
             authorization: `Bearer ${systemToken}`,
           },
           method: 'DELETE',
-          path: apiPaths.participations.delete({ courseParticipationId: courseParticipationToDestroy.id }),
+          path: apiPaths.participations.delete({ courseParticipationId: '0cff5da9-1e90-4ee2-a5cb-94dc49c4b004' }),
         },
       })
     })
 
-    it('destroys a course participation', async () => {
-      await courseClient.destroyParticipation(courseParticipationToDestroy.id)
+    it('destroys the given participation', async () => {
+      await courseClient.destroyParticipation('0cff5da9-1e90-4ee2-a5cb-94dc49c4b004')
     })
   })
 
   describe('find', () => {
+    const course = courseFactory.build({ id: 'd3abc217-75ee-46e9-a010-368f30282367' })
+
     beforeEach(() => {
       provider.addInteraction({
-        state: `A course exists with ID ${course1.id}`,
-        uponReceiving: `A request for course "${course1.id}"`,
+        state: 'Course d3abc217-75ee-46e9-a010-368f30282367 exists',
+        uponReceiving: 'A request for course d3abc217-75ee-46e9-a010-368f30282367',
         willRespondWith: {
-          body: Matchers.like(course1),
+          body: Matchers.like(course),
           status: 200,
         },
         withRequest: {
@@ -170,25 +119,27 @@ pactWith({ consumer: 'Accredited Programmes UI', provider: 'Accredited Programme
             authorization: `Bearer ${systemToken}`,
           },
           method: 'GET',
-          path: apiPaths.courses.show({ courseId: course1.id }),
+          path: apiPaths.courses.show({ courseId: 'd3abc217-75ee-46e9-a010-368f30282367' }),
         },
       })
     })
 
     it('fetches the given course', async () => {
-      const result = await courseClient.find(course1.id)
+      const result = await courseClient.find('d3abc217-75ee-46e9-a010-368f30282367')
 
-      expect(result).toEqual(course1)
+      expect(result).toEqual(course)
     })
   })
 
   describe('findCourseByOffering', () => {
+    const course = courseFactory.build({ id: 'd3abc217-75ee-46e9-a010-368f30282367' })
+
     beforeEach(() => {
       provider.addInteraction({
-        state: `An offering with ID ${courseOffering1.id} exists and has an associated course`,
-        uponReceiving: `A request for offering "${courseOffering1.id}"'s course`,
+        state: 'Offering 790a2dfe-7de5-4504-bb9c-83e6e53a6537 exists for course d3abc217-75ee-46e9-a010-368f30282367',
+        uponReceiving: "A request for offering 790a2dfe-7de5-4504-bb9c-83e6e53a6537's course",
         willRespondWith: {
-          body: Matchers.like(course1),
+          body: Matchers.like(course),
           status: 200,
         },
         withRequest: {
@@ -196,25 +147,31 @@ pactWith({ consumer: 'Accredited Programmes UI', provider: 'Accredited Programme
             authorization: `Bearer ${systemToken}`,
           },
           method: 'GET',
-          path: apiPaths.offerings.course({ courseOfferingId: courseOffering1.id }),
+          path: apiPaths.offerings.course({ courseOfferingId: '790a2dfe-7de5-4504-bb9c-83e6e53a6537' }),
         },
       })
     })
 
     it("fetches the given offering's course", async () => {
-      const result = await courseClient.findCourseByOffering(courseOffering1.id)
+      const result = await courseClient.findCourseByOffering('790a2dfe-7de5-4504-bb9c-83e6e53a6537')
 
-      expect(result).toEqual(course1)
+      expect(result).toEqual(course)
     })
   })
 
   describe('findOfferings', () => {
+    const courseOfferings = [
+      courseOfferingFactory.build({ id: '790a2dfe-7de5-4504-bb9c-83e6e53a6537' }),
+      courseOfferingFactory.build({ id: '7fffcc6a-11f8-4713-be35-cf5ff1aee517' }),
+    ]
+
     beforeEach(() => {
       provider.addInteraction({
-        state: `Offerings exist for a course with ID ${course1.id}`,
-        uponReceiving: `A request for course "${course1.id}"'s offerings`,
+        state:
+          'Course d3abc217-75ee-46e9-a010-368f30282367 has offerings 790a2dfe-7de5-4504-bb9c-83e6e53a6537 and 7fffcc6a-11f8-4713-be35-cf5ff1aee517',
+        uponReceiving: "A request for course d3abc217-75ee-46e9-a010-368f30282367's offerings",
         willRespondWith: {
-          body: Matchers.like(allCourseOfferings),
+          body: Matchers.like(courseOfferings),
           status: 200,
         },
         withRequest: {
@@ -222,24 +179,24 @@ pactWith({ consumer: 'Accredited Programmes UI', provider: 'Accredited Programme
             authorization: `Bearer ${systemToken}`,
           },
           method: 'GET',
-          path: apiPaths.courses.offerings({ courseId: course1.id }),
+          path: apiPaths.courses.offerings({ courseId: 'd3abc217-75ee-46e9-a010-368f30282367' }),
         },
       })
     })
 
     it("fetches the given course's offerings", async () => {
-      const result = await courseClient.findOfferings(course1.id)
+      const result = await courseClient.findOfferings('d3abc217-75ee-46e9-a010-368f30282367')
 
-      expect(result).toEqual(allCourseOfferings)
+      expect(result).toEqual(courseOfferings)
     })
   })
 
   describe('findCourseNames', () => {
-    const courseNames = allCourses.map(course => course.name)
+    const courseNames = ['Super Course', 'Custom Course', 'RAPID Course']
 
     beforeEach(() => {
       provider.addInteraction({
-        state: 'Course names exist on the API',
+        state: 'In order, the names of all the courses are Super Course, Custom Course, and RAPID Course',
         uponReceiving: 'A request for all course names',
         willRespondWith: {
           body: Matchers.like(courseNames),
@@ -263,12 +220,14 @@ pactWith({ consumer: 'Accredited Programmes UI', provider: 'Accredited Programme
   })
 
   describe('findOffering', () => {
+    const courseOffering = courseOfferingFactory.build({ id: '790a2dfe-7de5-4504-bb9c-83e6e53a6537' })
+
     beforeEach(() => {
       provider.addInteraction({
-        state: `An offering exists with ID ${courseOffering1.id}`,
-        uponReceiving: `A request for course offering "${courseOffering1.id}"`,
+        state: 'Offering 790a2dfe-7de5-4504-bb9c-83e6e53a6537 exists',
+        uponReceiving: 'A request for offering 790a2dfe-7de5-4504-bb9c-83e6e53a6537',
         willRespondWith: {
-          body: Matchers.like(courseOffering1),
+          body: Matchers.like(courseOffering),
           status: 200,
         },
         withRequest: {
@@ -276,25 +235,25 @@ pactWith({ consumer: 'Accredited Programmes UI', provider: 'Accredited Programme
             authorization: `Bearer ${systemToken}`,
           },
           method: 'GET',
-          path: apiPaths.offerings.show({ courseOfferingId: courseOffering1.id }),
+          path: apiPaths.offerings.show({ courseOfferingId: '790a2dfe-7de5-4504-bb9c-83e6e53a6537' }),
         },
       })
     })
 
-    it('fetches the given course offering', async () => {
-      const result = await courseClient.findOffering(courseOffering1.id)
+    it('fetches the given offering', async () => {
+      const result = await courseClient.findOffering('790a2dfe-7de5-4504-bb9c-83e6e53a6537')
 
-      expect(result).toEqual(courseOffering1)
+      expect(result).toEqual(courseOffering)
     })
   })
 
   describe('findParticipation', () => {
-    const courseParticipation = courseParticipations[0]
+    const courseParticipation = courseParticipationFactory.build({ id: '0cff5da9-1e90-4ee2-a5cb-94dc49c4b004' })
 
     beforeEach(() => {
       provider.addInteraction({
-        state: `A course participation exists with ID ${courseParticipation.id}`,
-        uponReceiving: `A request for course participation "${courseParticipation.id}"`,
+        state: 'Participation 0cff5da9-1e90-4ee2-a5cb-94dc49c4b004 exists',
+        uponReceiving: 'A request for participation 0cff5da9-1e90-4ee2-a5cb-94dc49c4b004',
         willRespondWith: {
           body: Matchers.like(courseParticipation),
           status: 200,
@@ -304,24 +263,35 @@ pactWith({ consumer: 'Accredited Programmes UI', provider: 'Accredited Programme
             authorization: `Bearer ${systemToken}`,
           },
           method: 'GET',
-          path: apiPaths.participations.show({ courseParticipationId: courseParticipation.id }),
+          path: apiPaths.participations.show({ courseParticipationId: '0cff5da9-1e90-4ee2-a5cb-94dc49c4b004' }),
         },
       })
     })
 
-    it('fetches the given course participation', async () => {
-      const result = await courseClient.findParticipation(courseParticipation.id)
+    it('fetches the given participation', async () => {
+      const result = await courseClient.findParticipation('0cff5da9-1e90-4ee2-a5cb-94dc49c4b004')
 
       expect(result).toEqual(courseParticipation)
     })
   })
 
   describe('findParticipationsByPerson', () => {
-    const prisonNumber = 'B1234BB'
+    const courseParticipations = [
+      courseParticipationFactory.build({
+        id: '0cff5da9-1e90-4ee2-a5cb-94dc49c4b004',
+        prisonNumber: 'A1234AA',
+      }),
+      courseParticipationFactory.build({
+        id: 'eb357e5d-5416-43bf-a8d2-0dc8fd92162e',
+        prisonNumber: 'A1234AA',
+      }),
+    ]
+
     beforeEach(() => {
       provider.addInteraction({
-        state: `Participations exist for a person with prison number ${prisonNumber}`,
-        uponReceiving: `A request for person "${prisonNumber}"'s participations`,
+        state:
+          'Person A1234AA has participations 0cff5da9-1e90-4ee2-a5cb-94dc49c4b004 and eb357e5d-5416-43bf-a8d2-0dc8fd92162e and no others',
+        uponReceiving: "A request for person A1234AA's participations",
         willRespondWith: {
           body: Matchers.like(courseParticipations),
           status: 200,
@@ -331,22 +301,22 @@ pactWith({ consumer: 'Accredited Programmes UI', provider: 'Accredited Programme
             authorization: `Bearer ${systemToken}`,
           },
           method: 'GET',
-          path: apiPaths.people.participations({ prisonNumber }),
+          path: apiPaths.people.participations({ prisonNumber: 'A1234AA' }),
         },
       })
     })
 
-    it("fetches the given person's course participations", async () => {
-      const result = await courseClient.findParticipationsByPerson(prisonNumber)
+    it("fetches the given person's participations", async () => {
+      const result = await courseClient.findParticipationsByPerson('A1234AA')
 
       expect(result).toEqual(courseParticipations)
     })
   })
 
   describe('updateParticipation', () => {
-    const courseParticipation = courseParticipationFactory.build({ id: '1c0fbebe-7768-4dbe-ae58-6036183dbeff' })
+    const courseParticipation = courseParticipationFactory.build({ id: '0cff5da9-1e90-4ee2-a5cb-94dc49c4b004' })
     const courseParticipationUpdate: CourseParticipationUpdate = {
-      courseName: courseParticipation.courseName,
+      courseName: 'learnings that are good',
       detail: 'nice',
       outcome: {
         status: 'complete',
@@ -358,13 +328,14 @@ pactWith({ consumer: 'Accredited Programmes UI', provider: 'Accredited Programme
       },
       source: 'somewhere',
     }
+    const updatedCourseParticipation = { ...courseParticipation, ...courseParticipationUpdate }
 
     beforeEach(() => {
       provider.addInteraction({
-        state: `A course participation exists with ID ${courseParticipation.id}`,
-        uponReceiving: `A request to update course participation "${courseParticipation.id}"`,
+        state: 'Participation 0cff5da9-1e90-4ee2-a5cb-94dc49c4b004 exists',
+        uponReceiving: 'A request to update participation 0cff5da9-1e90-4ee2-a5cb-94dc49c4b004',
         willRespondWith: {
-          body: Matchers.like(courseParticipation),
+          body: Matchers.like(updatedCourseParticipation),
           status: 200,
         },
         withRequest: {
@@ -373,15 +344,18 @@ pactWith({ consumer: 'Accredited Programmes UI', provider: 'Accredited Programme
             authorization: `Bearer ${systemToken}`,
           },
           method: 'PUT',
-          path: apiPaths.participations.update({ courseParticipationId: courseParticipation.id }),
+          path: apiPaths.participations.update({ courseParticipationId: '0cff5da9-1e90-4ee2-a5cb-94dc49c4b004' }),
         },
       })
     })
 
-    it('updates the given course participation', async () => {
-      const result = await courseClient.updateParticipation(courseParticipation.id, courseParticipationUpdate)
+    it('updates the given participation', async () => {
+      const result = await courseClient.updateParticipation(
+        '0cff5da9-1e90-4ee2-a5cb-94dc49c4b004',
+        courseParticipationUpdate,
+      )
 
-      expect(result).toEqual(courseParticipation)
+      expect(result).toEqual(updatedCourseParticipation)
     })
   })
 })

--- a/server/data/hmppsAuthClient.test.ts
+++ b/server/data/hmppsAuthClient.test.ts
@@ -48,7 +48,7 @@ describe('hmppsAuthClient', () => {
         tokenStore.getToken.mockResolvedValue(null)
 
         fakeHmppsAuthApi
-          .post(`/oauth/token`, 'grant_type=client_credentials&username=Bob')
+          .post('/oauth/token', 'grant_type=client_credentials&username=Bob')
           .basicAuth({ pass: config.apis.hmppsAuth.systemClientSecret, user: config.apis.hmppsAuth.systemClientId })
           .matchHeader('Content-Type', 'application/x-www-form-urlencoded')
           .reply(200, token)
@@ -65,7 +65,7 @@ describe('hmppsAuthClient', () => {
         tokenStore.getToken.mockResolvedValue(null)
 
         fakeHmppsAuthApi
-          .post(`/oauth/token`, 'grant_type=client_credentials')
+          .post('/oauth/token', 'grant_type=client_credentials')
           .basicAuth({ pass: config.apis.hmppsAuth.systemClientSecret, user: config.apis.hmppsAuth.systemClientId })
           .matchHeader('Content-Type', 'application/x-www-form-urlencoded')
           .reply(200, token)

--- a/server/data/tokenStore.ts
+++ b/server/data/tokenStore.ts
@@ -8,7 +8,7 @@ export default class TokenStore {
 
   constructor(private readonly client: RedisClient) {
     client.on('error', error => {
-      logger.error(error, `Redis error`)
+      logger.error(error, 'Redis error')
     })
   }
 

--- a/server/middleware/populateCurrentUser.test.ts
+++ b/server/middleware/populateCurrentUser.test.ts
@@ -174,7 +174,7 @@ describe('populateCurrentUser', () => {
       userService.getCurrentUserWithDetails.mockRejectedValue(error)
       await populateCurrentUser(userService)(req, res, next)
 
-      expect(logger.error).toBeCalledWith(error, `Failed to retrieve user for: MY_USERNAME`)
+      expect(logger.error).toBeCalledWith(error, 'Failed to retrieve user for: MY_USERNAME')
       expect(next).toHaveBeenCalled()
     })
   })

--- a/server/middleware/setUpWebSession.ts
+++ b/server/middleware/setUpWebSession.ts
@@ -10,7 +10,7 @@ import { createRedisClient } from '../data'
 
 export default function setUpWebSession(): Router {
   const client = createRedisClient()
-  client.connect().catch((err: Error) => logger.error(`Error connecting to Redis`, err))
+  client.connect().catch((err: Error) => logger.error('Error connecting to Redis', err))
 
   const router = express.Router()
   router.use(


### PR DESCRIPTION
## Context

<!-- Is there a Trello ticket you can link to? -->
<!-- Do you need to add any environment variables? -->
<!-- Is an ADR required? An ADR should be added if this PR introduces a change to the architecture. -->

Keeping the API and UI in line with Pact tests is becoming a burden, and the DRYness of the tests on the UI side is making it hard to spot the difference

Related API PR: https://github.com/ministryofjustice/hmpps-accredited-programmes-api/pull/178

## Changes in this PR

- WET Pact tests
- Linting changes from #378

## Release checklist

[Release process documentation](../doc/how-to/perform-a-release.md)

As part of our continuous deployment strategy we must ensure that this work is
ready to be released once merged.

### Pre-merge

- [ ] There are changes required to the Accredited Programmes API for this change to work...
  - [ ] ... and they have been released to production already

### Post-merge

<!-- The outer checkboxes can be completed pre-merge -->

- [ ] This adds, extends or meaningfully modifies a feature...
  - [ ] ... and I have written or updated an end-to-end test for the happy path in the [Accredited Programmes E2E repo](https://github.com/ministryofjustice/hmpps-accredited-programmes-e2e)
- [ ] This makes new expectations of the API...
  - [ ] ... and I have notified the API developer(s) of changes to the contract tests (Pact), or the API is already compliant
- [ ] [Manually approve](../doc/how-to/perform-a-release.md#releasing-to-the-preprod-environment) release to preprod
- [ ] [Manually approve](../doc/how-to/perform-a-release.md#releasing-to-the-production-environment) release to prod

<!-- Should a release fail at any step, you as the author should now lead the work to
fix it as soon as possible. You can monitor deployment failures in CircleCI
itself and application errors are found in
[Sentry](https://ministryofjustice.sentry.io/projects/hmpps-accredited-programmes-ui/?project=4505330122686464&referrer=sidebar&statsPeriod=24h). -->
