### PR TITLE
Disallow redundant template literals

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -147,6 +147,7 @@
         "semi": false
       }
     ],
+    "quotes": ["error", "single", { "avoidEscape": true }],
     "semi": "off",
     "sort-exports/sort-exports": ["error", { "sortExportKindFirst": "value" }],
     "sort-imports": [

--- a/integration_tests/pages/refer/new/selectProgramme.ts
+++ b/integration_tests/pages/refer/new/selectProgramme.ts
@@ -26,20 +26,20 @@ export default class NewReferralSelectProgrammePage extends Page {
 
   shouldDisplayOtherCourseInput() {
     cy.get('[data-testid="other-course-option"]').check()
-    cy.get(`input[name="otherCourseName"]`).should('be.visible')
+    cy.get('input[name="otherCourseName"]').should('be.visible')
   }
 
   shouldHaveSelectedCourse(courseName: CourseParticipation['courseName'], isKnownCourse: boolean) {
     if (isKnownCourse) {
       cy.get(`.govuk-radios__input[value="${courseName}"]`).should('be.checked')
     } else {
-      cy.get(`.govuk-radios__input[value="Other"]`).should('be.checked')
+      cy.get('.govuk-radios__input[value="Other"]').should('be.checked')
       cy.get('#otherCourseName').should('have.value', courseName)
     }
   }
 
   shouldNotDisplayOtherCourseInput() {
-    cy.get(`input[name="otherCourseName"]`).should('not.be.visible')
+    cy.get('input[name="otherCourseName"]').should('not.be.visible')
   }
 
   submitSelection(courseParticipation: CourseParticipation, selectedCourseName: Course['name']) {

--- a/server/data/hmppsAuthClient.test.ts
+++ b/server/data/hmppsAuthClient.test.ts
@@ -48,7 +48,7 @@ describe('hmppsAuthClient', () => {
         tokenStore.getToken.mockResolvedValue(null)
 
         fakeHmppsAuthApi
-          .post(`/oauth/token`, 'grant_type=client_credentials&username=Bob')
+          .post('/oauth/token', 'grant_type=client_credentials&username=Bob')
           .basicAuth({ pass: config.apis.hmppsAuth.systemClientSecret, user: config.apis.hmppsAuth.systemClientId })
           .matchHeader('Content-Type', 'application/x-www-form-urlencoded')
           .reply(200, token)
@@ -65,7 +65,7 @@ describe('hmppsAuthClient', () => {
         tokenStore.getToken.mockResolvedValue(null)
 
         fakeHmppsAuthApi
-          .post(`/oauth/token`, 'grant_type=client_credentials')
+          .post('/oauth/token', 'grant_type=client_credentials')
           .basicAuth({ pass: config.apis.hmppsAuth.systemClientSecret, user: config.apis.hmppsAuth.systemClientId })
           .matchHeader('Content-Type', 'application/x-www-form-urlencoded')
           .reply(200, token)

--- a/server/data/tokenStore.ts
+++ b/server/data/tokenStore.ts
@@ -8,7 +8,7 @@ export default class TokenStore {
 
   constructor(private readonly client: RedisClient) {
     client.on('error', error => {
-      logger.error(error, `Redis error`)
+      logger.error(error, 'Redis error')
     })
   }
 

--- a/server/middleware/populateCurrentUser.test.ts
+++ b/server/middleware/populateCurrentUser.test.ts
@@ -174,7 +174,7 @@ describe('populateCurrentUser', () => {
       userService.getCurrentUserWithDetails.mockRejectedValue(error)
       await populateCurrentUser(userService)(req, res, next)
 
-      expect(logger.error).toBeCalledWith(error, `Failed to retrieve user for: MY_USERNAME`)
+      expect(logger.error).toBeCalledWith(error, 'Failed to retrieve user for: MY_USERNAME')
       expect(next).toHaveBeenCalled()
     })
   })

--- a/server/middleware/setUpWebSession.ts
+++ b/server/middleware/setUpWebSession.ts
@@ -10,7 +10,7 @@ import { createRedisClient } from '../data'
 
 export default function setUpWebSession(): Router {
   const client = createRedisClient()
-  client.connect().catch((err: Error) => logger.error(`Error connecting to Redis`, err))
+  client.connect().catch((err: Error) => logger.error('Error connecting to Redis', err))
 
   const router = express.Router()
   router.use(


### PR DESCRIPTION
## Context

<!-- Is there a Trello ticket you can link to? -->
<!-- Do you need to add any environment variables? -->
<!-- Is an ADR required? An ADR should be added if this PR introduces a change to the architecture. -->

This rule ensures single quotes are used whenever possible, with double quotes and template literals only used when an individual single quote string wouldn't suffice (template literals are still favoured over `'string' + variable`)

## Changes in this PR

- Disallow redundant template literals

## Release checklist

[Release process documentation](../doc/how-to/perform-a-release.md)

As part of our continuous deployment strategy we must ensure that this work is
ready to be released once merged.

### Pre-merge

- [ ] There are changes required to the Accredited Programmes API for this change to work...
  - [ ] ... and they have been released to production already

### Post-merge

<!-- The outer checkboxes can be completed pre-merge -->

- [ ] This adds, extends or meaningfully modifies a feature...
  - [ ] ... and I have written or updated an end-to-end test for the happy path in the [Accredited Programmes E2E repo](https://github.com/ministryofjustice/hmpps-accredited-programmes-e2e)
- [ ] This makes new expectations of the API...
  - [ ] ... and I have notified the API developer(s) of changes to the contract tests (Pact), or the API is already compliant
- [ ] [Manually approve](../doc/how-to/perform-a-release.md#releasing-to-the-preprod-environment) release to preprod
- [ ] [Manually approve](../doc/how-to/perform-a-release.md#releasing-to-the-production-environment) release to prod

<!-- Should a release fail at any step, you as the author should now lead the work to
fix it as soon as possible. You can monitor deployment failures in CircleCI
itself and application errors are found in
[Sentry](https://ministryofjustice.sentry.io/projects/hmpps-accredited-programmes-ui/?project=4505330122686464&referrer=sidebar&statsPeriod=24h). -->
