### PR TITLE
Make pacts line up with API side

### DIFF
--- a/server/data/accreditedProgrammesApi/courseClient.test.ts
+++ b/server/data/accreditedProgrammesApi/courseClient.test.ts
@@ -195,7 +195,10 @@ pactWith({ consumer: 'Accredited Programmes UI', provider: 'Accredited Programme
   describe('findOfferings', () => {
     const courseOfferings = [
       courseOfferingFactory.build({ id: '790a2dfe-7de5-4504-bb9c-83e6e53a6537' }),
-      courseOfferingFactory.build({ id: '7fffcc6a-11f8-4713-be35-cf5ff1aee517' }),
+      courseOfferingFactory.build({
+        id: '7fffcc6a-11f8-4713-be35-cf5ff1aee517',
+        secondaryContactEmail: 'nobody2-mdi@digital.justice.gov.uk',
+      }),
     ]
 
     beforeEach(() => {

--- a/server/data/accreditedProgrammesApi/referralClient.test.ts
+++ b/server/data/accreditedProgrammesApi/referralClient.test.ts
@@ -56,7 +56,7 @@ pactWith({ consumer: 'Accredited Programmes UI', provider: 'Accredited Programme
 
     beforeEach(() => {
       provider.addInteraction({
-        state: 'Referral 0c46ed09-170b-4c0f-aee8-a24eeaeeddaa exists with a status of referral_started',
+        state: 'Referral 0c46ed09-170b-4c0f-aee8-a24eeaeeddaa exists with status REFERRAL_STARTED',
         uponReceiving: 'A request for referral 0c46ed09-170b-4c0f-aee8-a24eeaeeddaa',
         willRespondWith: {
           body: Matchers.like(referral),
@@ -167,7 +167,7 @@ pactWith({ consumer: 'Accredited Programmes UI', provider: 'Accredited Programme
   describe('submit', () => {
     beforeEach(() => {
       provider.addInteraction({
-        state: 'Referral 0c46ed09-170b-4c0f-aee8-a24eeaeeddaa exists with status referral_started',
+        state: 'Referral 0c46ed09-170b-4c0f-aee8-a24eeaeeddaa exists with status REFERRAL_STARTED',
         uponReceiving: 'A request to submit referral 0c46ed09-170b-4c0f-aee8-a24eeaeeddaa',
         willRespondWith: {
           status: 204,
@@ -196,7 +196,7 @@ pactWith({ consumer: 'Accredited Programmes UI', provider: 'Accredited Programme
 
     beforeEach(() => {
       provider.addInteraction({
-        state: 'Referral 0c46ed09-170b-4c0f-aee8-a24eeaeeddaa exists with status referral_started',
+        state: 'Referral 0c46ed09-170b-4c0f-aee8-a24eeaeeddaa exists with status REFERRAL_STARTED',
         uponReceiving: 'A request to update referral 0c46ed09-170b-4c0f-aee8-a24eeaeeddaa',
         willRespondWith: {
           status: 204,
@@ -224,7 +224,7 @@ pactWith({ consumer: 'Accredited Programmes UI', provider: 'Accredited Programme
 
     beforeEach(() => {
       provider.addInteraction({
-        state: 'Referral 0c46ed09-170b-4c0f-aee8-a24eeaeeddaa exists with status referral_started',
+        state: 'Referral 0c46ed09-170b-4c0f-aee8-a24eeaeeddaa exists with status REFERRAL_STARTED',
         uponReceiving:
           "A request to update a referral 0c46ed09-170b-4c0f-aee8-a24eeaeeddaa's status to referral_submitted",
         willRespondWith: {


### PR DESCRIPTION
## Changes in this PR

Pacts are still failing - due to nullable reasons and statuses not lining up. This is another attempt at fixing them.

## Release checklist

[Release process documentation](../doc/how-to/perform-a-release.md)

As part of our continuous deployment strategy we must ensure that this work is
ready to be released once merged.

### Pre-merge

- [ ] There are changes required to the Accredited Programmes API for this change to work...
  - [ ] ... and they have been released to production already

### Post-merge

<!-- The outer checkboxes can be completed pre-merge -->

- [ ] This adds, extends or meaningfully modifies a feature...
  - [ ] ... and I have written or updated an end-to-end test for the happy path in the [Accredited Programmes E2E repo](https://github.com/ministryofjustice/hmpps-accredited-programmes-e2e)
- [ ] This makes new expectations of the API...
  - [ ] ... and I have notified the API developer(s) of changes to the contract tests (Pact), or the API is already compliant
- [ ] [Manually approve](../doc/how-to/perform-a-release.md#releasing-to-the-preprod-environment) release to preprod
- [ ] [Manually approve](../doc/how-to/perform-a-release.md#releasing-to-the-production-environment) release to prod

<!-- Should a release fail at any step, you as the author should now lead the work to
fix it as soon as possible. You can monitor deployment failures in CircleCI
itself and application errors are found in
[Sentry](https://ministryofjustice.sentry.io/projects/hmpps-accredited-programmes-ui/?project=4505330122686464&referrer=sidebar&statsPeriod=24h). -->
