### PR TITLE
Specify referral status in pact test

### DIFF
--- a/server/data/accreditedProgrammesApi/referralClient.test.ts
+++ b/server/data/accreditedProgrammesApi/referralClient.test.ts
@@ -82,7 +82,7 @@ pactWith({ consumer: 'Accredited Programmes UI', provider: 'Accredited Programme
   describe('findReferralSummaries', () => {
     describe('without query parameters', () => {
       const paginatedReferralSummaries: Paginated<ReferralSummary> = {
-        content: referralSummaryFactory.buildList(2),
+        content: [referralSummaryFactory.build({ status: 'referral_submitted' })],
         pageIsEmpty: false,
         pageNumber: 0,
         pageSize: 10,


### PR DESCRIPTION
## Changes in this PR

Add status to factory-built referrals in Pact test. This is failing due to checking the `submittedOn` date for `null` in the API. If we specify the status, we check the non-null value here.

## Release checklist

[Release process documentation](../doc/how-to/perform-a-release.md)

As part of our continuous deployment strategy we must ensure that this work is
ready to be released once merged.

### Pre-merge

- [ ] There are changes required to the Accredited Programmes API for this change to work...
  - [ ] ... and they have been released to production already

### Post-merge

<!-- The outer checkboxes can be completed pre-merge -->

- [ ] This adds, extends or meaningfully modifies a feature...
  - [ ] ... and I have written or updated an end-to-end test for the happy path in the [Accredited Programmes E2E repo](https://github.com/ministryofjustice/hmpps-accredited-programmes-e2e)
- [ ] This makes new expectations of the API...
  - [ ] ... and I have notified the API developer(s) of changes to the contract tests (Pact), or the API is already compliant
- [ ] [Manually approve](../doc/how-to/perform-a-release.md#releasing-to-the-preprod-environment) release to preprod
- [ ] [Manually approve](../doc/how-to/perform-a-release.md#releasing-to-the-production-environment) release to prod

<!-- Should a release fail at any step, you as the author should now lead the work to
fix it as soon as possible. You can monitor deployment failures in CircleCI
itself and application errors are found in
[Sentry](https://ministryofjustice.sentry.io/projects/hmpps-accredited-programmes-ui/?project=4505330122686464&referrer=sidebar&statsPeriod=24h). -->
