### PR TITLE
Miscellaneous pact fixes

### DIFF
--- a/server/data/accreditedProgrammesApi/courseClient.test.ts
+++ b/server/data/accreditedProgrammesApi/courseClient.test.ts
@@ -231,7 +231,10 @@ pactWith({ consumer: 'Accredited Programmes UI', provider: 'Accredited Programme
   })
 
   describe('findOffering', () => {
-    const courseOffering = courseOfferingFactory.build({ id: '790a2dfe-7de5-4504-bb9c-83e6e53a6537' })
+    const courseOffering = courseOfferingFactory.build({
+      id: '790a2dfe-7de5-4504-bb9c-83e6e53a6537',
+      secondaryContactEmail: 'nobody2-bwn@digital.justice.gov.uk',
+    })
 
     beforeEach(() => {
       provider.addInteraction({
@@ -259,7 +262,10 @@ pactWith({ consumer: 'Accredited Programmes UI', provider: 'Accredited Programme
   })
 
   describe('findParticipation', () => {
-    const courseParticipation = courseParticipationFactory.build({ id: '0cff5da9-1e90-4ee2-a5cb-94dc49c4b004' })
+    const courseParticipation = courseParticipationFactory.build({
+      id: '0cff5da9-1e90-4ee2-a5cb-94dc49c4b004',
+      outcome: courseParticipationOutcomeFactory.incomplete().build(),
+    })
 
     beforeEach(() => {
       provider.addInteraction({
@@ -290,7 +296,7 @@ pactWith({ consumer: 'Accredited Programmes UI', provider: 'Accredited Programme
     const courseParticipations = [
       courseParticipationFactory.build({
         id: '0cff5da9-1e90-4ee2-a5cb-94dc49c4b004',
-        outcome: courseParticipationOutcomeFactory.complete().build(),
+        outcome: courseParticipationOutcomeFactory.incomplete().build(),
         prisonNumber: 'A1234AA',
       }),
       courseParticipationFactory.build({
@@ -327,7 +333,11 @@ pactWith({ consumer: 'Accredited Programmes UI', provider: 'Accredited Programme
   })
 
   describe('updateParticipation', () => {
-    const courseParticipation = courseParticipationFactory.build({ id: '0cff5da9-1e90-4ee2-a5cb-94dc49c4b004' })
+    const courseParticipation = courseParticipationFactory.build({
+      id: 'cc8eb19e-050a-4aa9-92e0-c654e5cfe281',
+      outcome: courseParticipationOutcomeFactory.incomplete().build(),
+    })
+
     const courseParticipationUpdate: CourseParticipationUpdate = {
       courseName: 'learnings that are good',
       detail: 'nice',
@@ -345,8 +355,8 @@ pactWith({ consumer: 'Accredited Programmes UI', provider: 'Accredited Programme
 
     beforeEach(() => {
       provider.addInteraction({
-        state: 'Participation 0cff5da9-1e90-4ee2-a5cb-94dc49c4b004 exists',
-        uponReceiving: 'A request to update participation 0cff5da9-1e90-4ee2-a5cb-94dc49c4b004',
+        state: 'Participation cc8eb19e-050a-4aa9-92e0-c654e5cfe281 exists',
+        uponReceiving: 'A request to update participation cc8eb19e-050a-4aa9-92e0-c654e5cfe281',
         willRespondWith: {
           body: Matchers.like(updatedCourseParticipation),
           status: 200,
@@ -357,14 +367,14 @@ pactWith({ consumer: 'Accredited Programmes UI', provider: 'Accredited Programme
             authorization: `Bearer ${systemToken}`,
           },
           method: 'PUT',
-          path: apiPaths.participations.update({ courseParticipationId: '0cff5da9-1e90-4ee2-a5cb-94dc49c4b004' }),
+          path: apiPaths.participations.update({ courseParticipationId: 'cc8eb19e-050a-4aa9-92e0-c654e5cfe281' }),
         },
       })
     })
 
     it('updates the given participation', async () => {
       const result = await courseClient.updateParticipation(
-        '0cff5da9-1e90-4ee2-a5cb-94dc49c4b004',
+        'cc8eb19e-050a-4aa9-92e0-c654e5cfe281',
         courseParticipationUpdate,
       )
 

--- a/server/data/accreditedProgrammesApi/referralClient.test.ts
+++ b/server/data/accreditedProgrammesApi/referralClient.test.ts
@@ -25,14 +25,14 @@ pactWith({ consumer: 'Accredited Programmes UI', provider: 'Accredited Programme
 
     beforeEach(() => {
       provider.addInteraction({
-        state: 'Offering 790a2dfe-7de5-4504-bb9c-83e6e53a6537 exists',
-        uponReceiving: 'A request to create a referral to offering 790a2dfe-7de5-4504-bb9c-83e6e53a6537',
+        state: 'Offering 7fffcc6a-11f8-4713-be35-cf5ff1aee517 exists',
+        uponReceiving: 'A request to create a referral to offering 7fffcc6a-11f8-4713-be35-cf5ff1aee517',
         willRespondWith: {
           body: Matchers.like(createdReferralResponse),
           status: 201,
         },
         withRequest: {
-          body: { offeringId: '790a2dfe-7de5-4504-bb9c-83e6e53a6537', prisonNumber, referrerId },
+          body: { offeringId: '7fffcc6a-11f8-4713-be35-cf5ff1aee517', prisonNumber, referrerId },
           headers: {
             authorization: `Bearer ${userToken}`,
           },
@@ -43,7 +43,7 @@ pactWith({ consumer: 'Accredited Programmes UI', provider: 'Accredited Programme
     })
 
     it('creates a referral and returns a referral ID wrapper', async () => {
-      const result = await referralClient.create('790a2dfe-7de5-4504-bb9c-83e6e53a6537', prisonNumber, referrerId)
+      const result = await referralClient.create('7fffcc6a-11f8-4713-be35-cf5ff1aee517', prisonNumber, referrerId)
 
       expect(result).toEqual(createdReferralResponse)
     })
@@ -86,7 +86,7 @@ pactWith({ consumer: 'Accredited Programmes UI', provider: 'Accredited Programme
         pageIsEmpty: false,
         pageNumber: 0,
         pageSize: 10,
-        totalElements: 2,
+        totalElements: 1,
         totalPages: 1,
       }
 
@@ -112,7 +112,7 @@ pactWith({ consumer: 'Accredited Programmes UI', provider: 'Accredited Programme
       })
 
       it("fetches the given organisation's referral summaries", async () => {
-        const result = await referralClient.findReferralSummaries('BWN', {})
+        const result = await referralClient.findReferralSummaries('BWN')
 
         expect(result).toEqual(paginatedReferralSummaries)
       })

--- a/server/testutils/factories/courseParticipationOutcome.ts
+++ b/server/testutils/factories/courseParticipationOutcome.ts
@@ -14,12 +14,14 @@ const outcomeTypes = {
     return {
       status: 'complete',
       yearCompleted: FactoryHelpers.optionalArrayElement(randomValidYear()),
+      yearStarted: undefined,
     }
   },
 
   incomplete(): CourseParticipationOutcome {
     return {
       status: 'incomplete',
+      yearCompleted: undefined,
       yearStarted: FactoryHelpers.optionalArrayElement(randomValidYear()),
     }
   },


### PR DESCRIPTION
## Context

<!-- Is there a Trello ticket you can link to? -->
<!-- Do you need to add any environment variables? -->
<!-- Is an ADR required? An ADR should be added if this PR introduces a change to the architecture. -->

The Pact tests have been failing for a while and are incredibly brittle due to the way we set up state on the API before running them and then create/update/delete entities with state that persists between tests. We should definitely refactor this behaviour as soon as possible.

## Changes in this PR

While we wait for time to refactor, this PR updates the Pact contract tests to:

- Ensure we're never combining nullable and non nullable fields (e.g. `secondaryContactEmail` and `yearStarted`/`yearCompleted` in expected array responses, as Pact doesn't handle these well.
- Ensure we're not making assertions on created/updated/deleted entities like referrals and offerings in tests. This is due to the way state is handled in the API, as it's set up at the beginning of the test run. This has been incredibly painful to debug, and makes me very keen to refactor that behaviour so state isn't reused between tests on the API.

I've tested these against the API tests locally and they're all passing.

## Release checklist

[Release process documentation](../doc/how-to/perform-a-release.md)

As part of our continuous deployment strategy we must ensure that this work is
ready to be released once merged.

### Pre-merge

- [ ] There are changes required to the Accredited Programmes API for this change to work...
  - [ ] ... and they have been released to production already

### Post-merge

<!-- The outer checkboxes can be completed pre-merge -->

- [ ] This adds, extends or meaningfully modifies a feature...
  - [ ] ... and I have written or updated an end-to-end test for the happy path in the [Accredited Programmes E2E repo](https://github.com/ministryofjustice/hmpps-accredited-programmes-e2e)
- [ ] This makes new expectations of the API...
  - [ ] ... and I have notified the API developer(s) of changes to the contract tests (Pact), or the API is already compliant
- [ ] [Manually approve](../doc/how-to/perform-a-release.md#releasing-to-the-preprod-environment) release to preprod
- [ ] [Manually approve](../doc/how-to/perform-a-release.md#releasing-to-the-production-environment) release to prod

<!-- Should a release fail at any step, you as the author should now lead the work to
fix it as soon as possible. You can monitor deployment failures in CircleCI
itself and application errors are found in
[Sentry](https://ministryofjustice.sentry.io/projects/hmpps-accredited-programmes-ui/?project=4505330122686464&referrer=sidebar&statsPeriod=24h). -->
