### PR TITLE
(1131) Assess referral case lists by course name

### DIFF
--- a/integration_tests/e2e/assess/caseList.cy.ts
+++ b/integration_tests/e2e/assess/caseList.cy.ts
@@ -3,18 +3,21 @@ import { assessPaths } from '../../../server/paths'
 import { courseFactory, referralSummaryFactory } from '../../../server/testutils/factories'
 import Page from '../../pages/page'
 import { CaseListPage } from '../../pages/shared'
-import type { ReferralSummary } from '@accredited-programmes/models'
+import type { Course, ReferralSummary } from '@accredited-programmes/models'
+
+const createReferralSummaries = (courseName: Course['name']): Array<ReferralSummary> => [
+  referralSummaryFactory.build({ courseName, prisonNumber: 'ABC123', status: 'assessment_started' }),
+  referralSummaryFactory.build({ courseName, prisonNumber: 'ABC789', status: 'referral_started' }),
+  referralSummaryFactory.build({ courseName, prisonNumber: 'ABC456', status: 'awaiting_assessment' }),
+  referralSummaryFactory.build({ courseName, prisonNumber: 'ABC000', status: 'referral_submitted' }),
+]
 
 context('Referral case lists', () => {
-  const courseName = 'Lime Course'
-  const course = courseFactory.build({ name: courseName })
-  const courses = [course, courseFactory.build({ name: 'Orange Course' })]
-  const referralSummaries: Array<ReferralSummary> = [
-    referralSummaryFactory.build({ courseName, prisonNumber: 'ABC123', status: 'assessment_started' }),
-    referralSummaryFactory.build({ courseName, prisonNumber: 'ABC789', status: 'referral_started' }),
-    referralSummaryFactory.build({ courseName, prisonNumber: 'ABC456', status: 'awaiting_assessment' }),
-    referralSummaryFactory.build({ courseName, prisonNumber: 'ABC000', status: 'referral_submitted' }),
-  ]
+  const limeCourse = courseFactory.build({ name: 'Lime Course' })
+  const orangeCourse = courseFactory.build({ name: 'Blue Course' })
+  const courses = [limeCourse, orangeCourse]
+  const limeCourseReferralSummaries = createReferralSummaries(limeCourse.name)
+  const orangeCourseReferralSummaries = createReferralSummaries(orangeCourse.name)
 
   beforeEach(() => {
     cy.task('reset')
@@ -26,9 +29,9 @@ context('Referral case lists', () => {
     cy.task('stubFindReferralSummaries', {
       organisationId: 'MRI',
       queryParameters: {
-        courseName: { equalTo: courseName },
+        courseName: { equalTo: limeCourse.name },
       },
-      referralSummaries,
+      referralSummaries: limeCourseReferralSummaries,
     })
   })
 
@@ -37,8 +40,8 @@ context('Referral case lists', () => {
     cy.visit(path)
 
     const caseListPage = Page.verifyOnPage(CaseListPage, {
-      course,
-      referralSummaries,
+      course: limeCourse,
+      referralSummaries: limeCourseReferralSummaries,
     })
     caseListPage.shouldContainCourseNavigation(path, courses)
     caseListPage.shouldHaveSelectedFilterValues('', '')
@@ -51,8 +54,8 @@ context('Referral case lists', () => {
       cy.visit(path)
 
       const caseListPage = Page.verifyOnPage(CaseListPage, {
-        course,
-        referralSummaries,
+        course: limeCourse,
+        referralSummaries: limeCourseReferralSummaries,
       })
       caseListPage.shouldContainCourseNavigation(path, courses)
       caseListPage.shouldHaveSelectedFilterValues('', '')
@@ -62,7 +65,8 @@ context('Referral case lists', () => {
       const referralStatusSelectedValue = 'assessment started'
       const filteredReferralSummaries = [
         referralSummaryFactory.build({
-          audiences: ['General offence'],
+          audiences: [programmeStrandSelectedValue],
+          courseName: limeCourse.name,
           prisonNumber: 'ABC123',
           status: 'assessment_started',
         }),
@@ -71,12 +75,35 @@ context('Referral case lists', () => {
       caseListPage.shouldFilter(programmeStrandSelectedValue, referralStatusSelectedValue, filteredReferralSummaries)
 
       const filteredCaseListPage = Page.verifyOnPage(CaseListPage, {
-        course,
+        course: limeCourse,
         referralSummaries: filteredReferralSummaries,
       })
       filteredCaseListPage.shouldContainCourseNavigation(path, courses)
       filteredCaseListPage.shouldHaveSelectedFilterValues(programmeStrandSelectedValue, referralStatusSelectedValue)
       filteredCaseListPage.shouldContainTableOfReferralSummaries()
+    })
+  })
+
+  describe('when visiting the index, without specifying a course', () => {
+    it('redirects to the correct course case list page', () => {
+      cy.task('stubFindReferralSummaries', {
+        organisationId: 'MRI',
+        queryParameters: {
+          courseName: { equalTo: orangeCourse.name },
+        },
+        referralSummaries: orangeCourseReferralSummaries,
+      })
+
+      const path = assessPaths.caseList.index({})
+      cy.visit(path)
+
+      const caseListPage = Page.verifyOnPage(CaseListPage, {
+        course: orangeCourse,
+        referralSummaries: orangeCourseReferralSummaries,
+      })
+      caseListPage.shouldContainCourseNavigation(assessPaths.caseList.show({ courseName: 'blue-course' }), courses)
+      caseListPage.shouldHaveSelectedFilterValues('', '')
+      caseListPage.shouldContainTableOfReferralSummaries()
     })
   })
 })

--- a/integration_tests/mockApis/courses.ts
+++ b/integration_tests/mockApis/courses.ts
@@ -3,6 +3,7 @@ import type { SuperAgentRequest } from 'superagent'
 import { apiPaths } from '../../server/paths'
 import { stubFor } from '../../wiremock'
 import type { Course, CourseOffering } from '@accredited-programmes/models'
+import type { Prison } from '@prison-register-api'
 
 export default {
   stubCourse: (course: Course): SuperAgentRequest =>
@@ -53,6 +54,22 @@ export default {
       response: {
         headers: { 'Content-Type': 'application/json;charset=UTF-8' },
         jsonBody: courses,
+        status: 200,
+      },
+    }),
+
+  stubCoursesForOrganisation: (args: {
+    courses: Array<Course>
+    organisationId: Prison['prisonId']
+  }): SuperAgentRequest =>
+    stubFor({
+      request: {
+        method: 'GET',
+        url: apiPaths.organisations.courses({ organisationId: args.organisationId }),
+      },
+      response: {
+        headers: { 'Content-Type': 'application/json;charset=UTF-8' },
+        jsonBody: args.courses,
         status: 200,
       },
     }),

--- a/server/@types/ui/index.d.ts
+++ b/server/@types/ui/index.d.ts
@@ -125,6 +125,12 @@ type ReferralTaskListSection = {
   items: Array<ReferralTaskListItem>
 }
 
+type MojFrontendPrimaryNavigationItem = {
+  active: boolean
+  href: string
+  text: string
+}
+
 type MojFrontendSideNavigationItem = {
   active: boolean
   href: string
@@ -147,6 +153,7 @@ export type {
   GovukFrontendTagWithText,
   HasHtmlString,
   HasTextString,
+  MojFrontendPrimaryNavigationItem,
   MojFrontendSideNavigationItem,
   OffenceDetails,
   OffenceHistory,

--- a/server/controllers/shared/caseListController.test.ts
+++ b/server/controllers/shared/caseListController.test.ts
@@ -28,6 +28,8 @@ describe('CaseListController', () => {
 
   let controller: CaseListController
 
+  const courses = [courseFactory.build({ name: 'Orange Course' }), courseFactory.build({ name: 'Lime Course' })]
+
   beforeEach(() => {
     const referralSummaries = referralSummaryFactory.buildList(3)
     paginatedReferralSummaries = {
@@ -49,6 +51,28 @@ describe('CaseListController', () => {
 
   afterEach(() => {
     jest.resetAllMocks()
+  })
+
+  describe('indexRedirect', () => {
+    it('redirects to the first course case list page', async () => {
+      when(courseService.getCoursesByOrganisation).calledWith(username, activeCaseLoadId).mockResolvedValue(courses)
+
+      const requestHandler = controller.indexRedirect()
+      await requestHandler(request, response, next)
+
+      expect(response.redirect).toHaveBeenCalledWith(assessPaths.caseList.show({ courseName: 'lime-course' }))
+    })
+
+    describe('when there are no courses', () => {
+      it('throws a 404 error', async () => {
+        when(courseService.getCoursesByOrganisation).calledWith(username, activeCaseLoadId).mockResolvedValue([])
+
+        const requestHandler = controller.indexRedirect()
+        const expectedError = createError(404, 'No courses found.')
+
+        expect(() => requestHandler(request, response, next)).rejects.toThrow(expectedError)
+      })
+    })
   })
 
   describe('filter', () => {
@@ -120,7 +144,6 @@ describe('CaseListController', () => {
   })
 
   describe('show', () => {
-    const courses = [courseFactory.build({ name: 'Lime Course' }), courseFactory.build({ name: 'Orange Course' })]
     const sortedCourses = courses.sort((courseA, courseB) => courseA.name.localeCompare(courseB.name))
 
     beforeEach(() => {

--- a/server/controllers/shared/caseListController.test.ts
+++ b/server/controllers/shared/caseListController.test.ts
@@ -1,11 +1,13 @@
 import type { DeepMocked } from '@golevelup/ts-jest'
 import { createMock } from '@golevelup/ts-jest'
 import type { NextFunction, Request, Response } from 'express'
+import createError from 'http-errors'
+import { when } from 'jest-when'
 
 import CaseListController from './caseListController'
 import { assessPaths } from '../../paths'
-import type { ReferralService } from '../../services'
-import { referralSummaryFactory } from '../../testutils/factories'
+import type { CourseService, ReferralService } from '../../services'
+import { courseFactory, referralSummaryFactory } from '../../testutils/factories'
 import { CaseListUtils, PathUtils } from '../../utils'
 import type { Paginated, ReferralSummary } from '@accredited-programmes/models'
 
@@ -14,11 +16,13 @@ jest.mock('../../utils/pathUtils')
 describe('CaseListController', () => {
   const username = 'USERNAME'
   const activeCaseLoadId = 'MDI'
+  const courseNameSlug = 'lime-course'
 
   let request: DeepMocked<Request>
   let response: DeepMocked<Response>
   const next: DeepMocked<NextFunction> = createMock<NextFunction>({})
 
+  const courseService = createMock<CourseService>({})
   const referralService = createMock<ReferralService>({})
   let paginatedReferralSummaries: Paginated<ReferralSummary>
 
@@ -37,7 +41,7 @@ describe('CaseListController', () => {
 
     referralService.getReferralSummaries.mockResolvedValue(paginatedReferralSummaries)
 
-    controller = new CaseListController(referralService)
+    controller = new CaseListController(courseService, referralService)
 
     request = createMock<Request>({ user: { username } })
     response = createMock<Response>({ locals: { user: { activeCaseLoadId, username } } })
@@ -48,13 +52,15 @@ describe('CaseListController', () => {
   })
 
   describe('filter', () => {
-    const redirectPathBase = assessPaths.caseList.show({})
+    const redirectPathBase = assessPaths.caseList.show({ courseName: courseNameSlug })
     const pathWithQuery = 'path-with-query'
     const audience = 'General violence offence'
     const status = 'ASSESSMENT_STARTED'
 
     beforeEach(() => {
       ;(PathUtils.pathWithQuery as jest.Mock).mockReturnValue(pathWithQuery)
+
+      request.params = { courseName: courseNameSlug }
     })
 
     describe('when `req.body.audience` and `req.body.status` are provided', () => {
@@ -114,29 +120,37 @@ describe('CaseListController', () => {
   })
 
   describe('show', () => {
-    it('renders the show template with the correct response locals', async () => {
-      request.path = assessPaths.caseList.show({})
+    const courses = [courseFactory.build({ name: 'Lime Course' }), courseFactory.build({ name: 'Orange Course' })]
+    const sortedCourses = courses.sort((courseA, courseB) => courseA.name.localeCompare(courseB.name))
 
+    beforeEach(() => {
+      request.params = { courseName: courseNameSlug }
+
+      when(courseService.getCoursesByOrganisation).calledWith(username, activeCaseLoadId).mockResolvedValue(courses)
+    })
+
+    it('renders the show template with the correct response locals', async () => {
       const requestHandler = controller.show()
       await requestHandler(request, response, next)
 
       expect(response.render).toHaveBeenCalledWith('referrals/caseList/show', {
-        action: assessPaths.caseList.filter({}),
+        action: assessPaths.caseList.filter({ courseName: courseNameSlug }),
         audienceSelectItems: CaseListUtils.audienceSelectItems(),
-        pageHeading: 'My referrals',
+        pageHeading: 'Lime Course (LC)',
+        primaryNavigationItems: CaseListUtils.caseListPrimaryNavigationItems(request.path, sortedCourses),
         referralStatusSelectItems: CaseListUtils.statusSelectItems(),
         tableRows: CaseListUtils.caseListTableRows(paginatedReferralSummaries.content),
       })
 
       expect(referralService.getReferralSummaries).toHaveBeenCalledWith(username, activeCaseLoadId, {
         audience: undefined,
+        courseName: 'Lime Course',
         status: undefined,
       })
     })
 
     describe('when there are query parameters', () => {
       it('renders the show template with the correct response locals', async () => {
-        request.path = assessPaths.caseList.show({})
         request.query = {
           status: 'referral submitted',
           strand: 'general offence',
@@ -146,17 +160,31 @@ describe('CaseListController', () => {
         await requestHandler(request, response, next)
 
         expect(response.render).toHaveBeenCalledWith('referrals/caseList/show', {
-          action: assessPaths.caseList.filter({}),
+          action: assessPaths.caseList.filter({ courseName: courseNameSlug }),
           audienceSelectItems: CaseListUtils.audienceSelectItems('general offence'),
-          pageHeading: 'My referrals',
+          pageHeading: 'Lime Course (LC)',
+          primaryNavigationItems: CaseListUtils.caseListPrimaryNavigationItems(request.path, sortedCourses),
           referralStatusSelectItems: CaseListUtils.statusSelectItems('referral submitted'),
           tableRows: CaseListUtils.caseListTableRows(paginatedReferralSummaries.content),
         })
 
         expect(referralService.getReferralSummaries).toHaveBeenCalledWith(username, activeCaseLoadId, {
           audience: 'General offence',
+          courseName: 'Lime Course',
           status: 'REFERRAL_SUBMITTED',
         })
+      })
+    })
+
+    describe('when the course name is not found', () => {
+      it('throws a 404 error', async () => {
+        request.params = { courseName: 'not-a-course' }
+
+        const requestHandler = controller.show()
+        const expectedError = createError(404, 'Not A Course not found.')
+
+        await expect(() => requestHandler(request, response, next)).rejects.toThrow(expectedError)
+        expect(referralService.getReferralSummaries).not.toHaveBeenCalled()
       })
     })
   })

--- a/server/controllers/shared/caseListController.ts
+++ b/server/controllers/shared/caseListController.ts
@@ -1,17 +1,22 @@
 import type { Request, Response, TypedRequestHandler } from 'express'
+import createError from 'http-errors'
 
 import { assessPaths } from '../../paths'
-import type { ReferralService } from '../../services'
-import { CaseListUtils, PathUtils, TypeUtils } from '../../utils'
+import type { CourseService, ReferralService } from '../../services'
+import { CaseListUtils, CourseUtils, PathUtils, StringUtils, TypeUtils } from '../../utils'
 import type { QueryParam } from '@accredited-programmes/ui'
 
 export default class CaseListController {
-  constructor(private readonly referralService: ReferralService) {}
+  constructor(
+    private readonly courseService: CourseService,
+    private readonly referralService: ReferralService,
+  ) {}
 
   filter(): TypedRequestHandler<Request, Response> {
     return async (req: Request, res: Response) => {
       TypeUtils.assertHasUser(req)
 
+      const { courseName } = req.params
       const queryParams: Array<QueryParam> = []
 
       if (req.body.audience) {
@@ -22,7 +27,7 @@ export default class CaseListController {
         queryParams.push({ key: 'status', value: req.body.status })
       }
 
-      return res.redirect(PathUtils.pathWithQuery(assessPaths.caseList.show({}), queryParams))
+      return res.redirect(PathUtils.pathWithQuery(assessPaths.caseList.show({ courseName }), queryParams))
     }
   }
 
@@ -30,19 +35,31 @@ export default class CaseListController {
     return async (req: Request, res: Response) => {
       TypeUtils.assertHasUser(req)
 
+      const { courseName } = req.params
       const { status, strand: audience } = req.query as Record<string, string>
 
       const { activeCaseLoadId, username } = res.locals.user
 
+      const courses = await this.courseService.getCoursesByOrganisation(username, activeCaseLoadId)
+
+      const formattedCourseName = StringUtils.convertFromUrlSlug(courseName)
+      const selectedCourse = courses.find(course => course.name === formattedCourseName)
+
+      if (!selectedCourse) {
+        throw createError(404, `${formattedCourseName} not found.`)
+      }
+
       const paginatedReferralSummaries = await this.referralService.getReferralSummaries(username, activeCaseLoadId, {
         audience: CaseListUtils.uiToApiAudienceQueryParam(audience),
+        courseName: selectedCourse.name,
         status: CaseListUtils.uiToApiStatusQueryParam(status),
       })
 
       return res.render('referrals/caseList/show', {
-        action: assessPaths.caseList.filter({}),
+        action: assessPaths.caseList.filter({ courseName }),
         audienceSelectItems: CaseListUtils.audienceSelectItems(audience),
-        pageHeading: 'My referrals',
+        pageHeading: CourseUtils.courseNameWithAlternateName(selectedCourse),
+        primaryNavigationItems: CaseListUtils.caseListPrimaryNavigationItems(req.path, courses),
         referralStatusSelectItems: CaseListUtils.statusSelectItems(status),
         tableRows: CaseListUtils.caseListTableRows(paginatedReferralSummaries.content),
       })

--- a/server/controllers/shared/caseListController.ts
+++ b/server/controllers/shared/caseListController.ts
@@ -31,6 +31,24 @@ export default class CaseListController {
     }
   }
 
+  indexRedirect(): TypedRequestHandler<Request, Response> {
+    return async (req: Request, res: Response) => {
+      TypeUtils.assertHasUser(req)
+      const { activeCaseLoadId, username } = res.locals.user
+
+      const courses = await this.courseService.getCoursesByOrganisation(username, activeCaseLoadId)
+
+      if (!courses.length) {
+        throw createError(404, 'No courses found.')
+      }
+
+      const sortedCourses = courses.sort((courseA, courseB) => courseA.name.localeCompare(courseB.name))
+      const firstCourseName = StringUtils.convertToUrlSlug(sortedCourses[0].name)
+
+      res.redirect(assessPaths.caseList.show({ courseName: firstCourseName }))
+    }
+  }
+
   show(): TypedRequestHandler<Request, Response> {
     return async (req: Request, res: Response) => {
       TypeUtils.assertHasUser(req)

--- a/server/controllers/shared/index.ts
+++ b/server/controllers/shared/index.ts
@@ -5,7 +5,7 @@ import ReferralsController from './referralsController'
 import type { Services } from '../../services'
 
 const controllers = (services: Services) => {
-  const caseListController = new CaseListController(services.referralService)
+  const caseListController = new CaseListController(services.courseService, services.referralService)
   const referralsController = new ReferralsController(
     services.courseService,
     services.organisationService,

--- a/server/data/accreditedProgrammesApi/courseClient.test.ts
+++ b/server/data/accreditedProgrammesApi/courseClient.test.ts
@@ -192,6 +192,39 @@ pactWith({ consumer: 'Accredited Programmes UI', provider: 'Accredited Programme
     })
   })
 
+  describe('findCoursesByOrganisation', () => {
+    const courses = [
+      courseFactory.build({ id: 'd3abc217-75ee-46e9-a010-368f30282367' }),
+      courseFactory.build({ id: '28e47d30-30bf-4dab-a8eb-9fda3f6400e8' }),
+      courseFactory.build({ id: '1811faa6-d568-4fc4-83ce-41118b90242e' }),
+    ]
+
+    beforeEach(() => {
+      provider.addInteraction({
+        state:
+          'Organisation BWN has courses d3abc217-75ee-46e9-a010-368f30282367, 28e47d30-30bf-4dab-a8eb-9fda3f6400e8, and 1811faa6-d568-4fc4-83ce-41118b90242e and no others',
+        uponReceiving: "A request for organisation BWN's courses",
+        willRespondWith: {
+          body: Matchers.like(courses),
+          status: 200,
+        },
+        withRequest: {
+          headers: {
+            authorization: `Bearer ${systemToken}`,
+          },
+          method: 'GET',
+          path: apiPaths.organisations.courses({ organisationId: 'BWN' }),
+        },
+      })
+    })
+
+    it("fetches the given organisation's courses", async () => {
+      const result = await courseClient.findCoursesByOrganisation('BWN')
+
+      expect(result).toEqual(courses)
+    })
+  })
+
   describe('findOfferings', () => {
     const courseOfferings = [
       courseOfferingFactory.build({

--- a/server/data/accreditedProgrammesApi/courseClient.ts
+++ b/server/data/accreditedProgrammesApi/courseClient.ts
@@ -54,6 +54,12 @@ export default class CourseClient {
     })) as Array<Course['name']>
   }
 
+  async findCoursesByOrganisation(organisationId: string): Promise<Array<Course>> {
+    return (await this.restClient.get({
+      path: apiPaths.organisations.courses({ organisationId }),
+    })) as Array<Course>
+  }
+
   async findOffering(courseOfferingId: CourseOffering['id']): Promise<CourseOffering> {
     return (await this.restClient.get({
       path: apiPaths.offerings.show({ courseOfferingId }),

--- a/server/data/accreditedProgrammesApi/referralClient.test.ts
+++ b/server/data/accreditedProgrammesApi/referralClient.test.ts
@@ -120,7 +120,13 @@ pactWith({ consumer: 'Accredited Programmes UI', provider: 'Accredited Programme
 
     describe('with query parameters', () => {
       const paginatedReferralSummaries: Paginated<ReferralSummary> = {
-        content: [referralSummaryFactory.build({ status: 'referral_submitted' })],
+        content: [
+          referralSummaryFactory.build({
+            audiences: ['General offence'],
+            courseName: 'Super Course',
+            status: 'referral_submitted',
+          }),
+        ],
         pageIsEmpty: false,
         pageNumber: 0,
         pageSize: 10,
@@ -131,9 +137,9 @@ pactWith({ consumer: 'Accredited Programmes UI', provider: 'Accredited Programme
       beforeEach(() => {
         provider.addInteraction({
           state:
-            'Referral(s) exist for organisation BWM with status REFERRAL_SUBMITTED to offerings for courses with audience General offence',
+            'Super Course referral(s) exist for organisation BWM with status REFERRAL_SUBMITTED to offerings for courses with audience General offence',
           uponReceiving:
-            "A request for organistion BWM's referral summaries with status REFERRAL_SUBMITTED to offerings for courses with audience General offence",
+            "A request for organistion BWM's Super Course referral summaries with status REFERRAL_SUBMITTED to offerings for courses with audience General offence",
           willRespondWith: {
             body: Matchers.like(paginatedReferralSummaries),
             status: 200,
@@ -146,6 +152,7 @@ pactWith({ consumer: 'Accredited Programmes UI', provider: 'Accredited Programme
             path: apiPaths.referrals.dashboard({ organisationId: 'BWM' }),
             query: {
               audience: 'General offence',
+              courseName: 'Super Course',
               size: '999',
               status: 'REFERRAL_SUBMITTED',
             },
@@ -156,6 +163,7 @@ pactWith({ consumer: 'Accredited Programmes UI', provider: 'Accredited Programme
       it("fetches the given organisation's referral summaries matching the given query parameters", async () => {
         const result = await referralClient.findReferralSummaries('BWM', {
           audience: 'General offence',
+          courseName: 'Super Course',
           status: 'REFERRAL_SUBMITTED',
         })
 

--- a/server/data/accreditedProgrammesApi/referralClient.ts
+++ b/server/data/accreditedProgrammesApi/referralClient.ts
@@ -3,6 +3,7 @@ import config from '../../config'
 import { apiPaths } from '../../paths'
 import RestClient from '../restClient'
 import type {
+  Course,
   CourseAudience,
   CreatedReferralResponse,
   Paginated,
@@ -39,13 +40,14 @@ export default class ReferralClient {
 
   async findReferralSummaries(
     organisationId: string,
-    query?: { audience?: CourseAudience['value']; status?: string },
+    query?: { audience?: CourseAudience['value']; courseName?: Course['name']; status?: string },
   ): Promise<Paginated<ReferralSummary>> {
     return (await this.restClient.get({
       path: apiPaths.referrals.dashboard({ organisationId }),
       query: {
-        ...(query?.status && { status: query.status }),
         ...(query?.audience && { audience: query.audience }),
+        ...(query?.courseName && { courseName: query.courseName }),
+        ...(query?.status && { status: query.status }),
         size: '999',
       },
     })) as Paginated<ReferralSummary>

--- a/server/paths/api.ts
+++ b/server/paths/api.ts
@@ -14,6 +14,9 @@ const updateStatusPath = referralPath.path('status')
 const submitPath = referralPath.path('submit')
 const dashboardPath = referralsPath.path('organisation/:organisationId/dashboard')
 
+const organisationsPath = path('/organisations')
+const coursesByOrganisationPath = organisationsPath.path(':organisationId/courses')
+
 const participationsByPersonPath = path('/people/:prisonNumber/course-participations')
 const participationsPath = path('/course-participations')
 const participationPath = participationsPath.path(':courseParticipationId')
@@ -28,6 +31,9 @@ export default {
   offerings: {
     course: courseByOfferingPath,
     show: offeringPath,
+  },
+  organisations: {
+    courses: coursesByOrganisationPath,
   },
   participations: {
     create: participationsPath,

--- a/server/paths/assess.ts
+++ b/server/paths/assess.ts
@@ -1,13 +1,15 @@
 import { path } from 'static-path'
 
 const assessPathBase = path('/assess')
-const caseListPath = assessPathBase.path('referrals/:courseName/case-list')
+const caseListIndex = assessPathBase.path('referrals/case-list')
+const courseCaseListPath = assessPathBase.path('referrals/:courseName/case-list')
 const referralShowPathBase = assessPathBase.path('referrals/:referralId')
 
 export default {
   caseList: {
-    filter: caseListPath,
-    show: caseListPath,
+    filter: courseCaseListPath,
+    index: caseListIndex,
+    show: courseCaseListPath,
   },
   show: {
     additionalInformation: referralShowPathBase.path('additional-information'),

--- a/server/paths/assess.ts
+++ b/server/paths/assess.ts
@@ -1,7 +1,7 @@
 import { path } from 'static-path'
 
 const assessPathBase = path('/assess')
-const caseListPath = assessPathBase.path('referrals/case-list')
+const caseListPath = assessPathBase.path('referrals/:courseName/case-list')
 const referralShowPathBase = assessPathBase.path('referrals/:referralId')
 
 export default {

--- a/server/routes/assess.ts
+++ b/server/routes/assess.ts
@@ -10,7 +10,7 @@ export default function routes(controllers: Controllers, router: Router): Router
 
   const { referralsController, caseListController } = controllers
 
-  get(assessPaths.caseList.index.pattern, caseListController.assessIndex())
+  get(assessPaths.caseList.index.pattern, caseListController.indexRedirect())
   get(assessPaths.caseList.show.pattern, caseListController.show())
   post(assessPaths.caseList.filter.pattern, caseListController.filter())
 

--- a/server/routes/assess.ts
+++ b/server/routes/assess.ts
@@ -10,6 +10,7 @@ export default function routes(controllers: Controllers, router: Router): Router
 
   const { referralsController, caseListController } = controllers
 
+  get(assessPaths.caseList.index.pattern, caseListController.assessIndex())
   get(assessPaths.caseList.show.pattern, caseListController.show())
   post(assessPaths.caseList.filter.pattern, caseListController.filter())
 

--- a/server/services/courseService.test.ts
+++ b/server/services/courseService.test.ts
@@ -215,6 +215,21 @@ describe('CourseService', () => {
     })
   })
 
+  describe('getCoursesByOrganisation', () => {
+    it('returns a list of courses for a given organisation', async () => {
+      const organisationId = faker.string.uuid()
+      const courses = courseFactory.buildList(3)
+      when(courseClient.findCoursesByOrganisation).calledWith(organisationId).mockResolvedValue(courses)
+
+      const result = await service.getCoursesByOrganisation(username, organisationId)
+
+      expect(result).toEqual(courses)
+
+      expect(courseClientBuilder).toHaveBeenCalledWith(systemToken)
+      expect(courseClient.findCoursesByOrganisation).toHaveBeenCalledWith(organisationId)
+    })
+  })
+
   describe('getOfferingsByCourse', () => {
     it('returns a list of offerings for a given course', async () => {
       const course = courseFactory.build()

--- a/server/services/courseService.ts
+++ b/server/services/courseService.ts
@@ -13,6 +13,7 @@ import type {
   Referral,
 } from '@accredited-programmes/models'
 import type { GovukFrontendSummaryListWithRowsWithKeysAndValues } from '@accredited-programmes/ui'
+import type { Prison } from '@prison-register-api'
 
 export default class CourseService {
   constructor(
@@ -95,6 +96,17 @@ export default class CourseService {
     const courseClient = this.courseClientBuilder(systemToken)
 
     return courseClient.all()
+  }
+
+  async getCoursesByOrganisation(
+    username: Express.User['username'],
+    organisationId: Prison['prisonId'],
+  ): Promise<Array<Course>> {
+    const hmppsAuthClient = this.hmppsAuthClientBuilder()
+    const systemToken = await hmppsAuthClient.getSystemClientToken(username)
+    const courseClient = this.courseClientBuilder(systemToken)
+
+    return courseClient.findCoursesByOrganisation(organisationId)
   }
 
   async getOffering(

--- a/server/services/referralService.test.ts
+++ b/server/services/referralService.test.ts
@@ -108,14 +108,14 @@ describe('ReferralService', () => {
       expect(referralClient.findReferralSummaries).toHaveBeenCalledWith(organisationId, undefined)
     })
 
-    describe('with filter values', () => {
+    describe('with query values', () => {
       it('makes the correct call to the referral client', async () => {
-        const filterValues = { audience: 'General offence', status: 'REFERRAL_SUBMITTED' }
+        const query = { audience: 'General offence', courseName: 'Lime Course', status: 'REFERRAL_SUBMITTED' }
 
-        await service.getReferralSummaries(username, organisationId, filterValues)
+        await service.getReferralSummaries(username, organisationId, query)
 
         expect(referralClientBuilder).toHaveBeenCalledWith(systemToken)
-        expect(referralClient.findReferralSummaries).toHaveBeenCalledWith(organisationId, filterValues)
+        expect(referralClient.findReferralSummaries).toHaveBeenCalledWith(organisationId, query)
       })
     })
   })

--- a/server/services/referralService.ts
+++ b/server/services/referralService.ts
@@ -1,5 +1,6 @@
 import type { HmppsAuthClient, ReferralClient, RestClientBuilder, RestClientBuilderWithoutToken } from '../data'
 import type {
+  Course,
   CourseAudience,
   CreatedReferralResponse,
   Organisation,
@@ -40,13 +41,13 @@ export default class ReferralService {
   async getReferralSummaries(
     username: Express.User['username'],
     organisationId: Organisation['id'],
-    filterValues?: { audience?: CourseAudience['value']; status?: string },
+    query?: { audience?: CourseAudience['value']; courseName?: Course['name']; status?: string },
   ): Promise<Paginated<ReferralSummary>> {
     const hmppsAuthClient = this.hmppsAuthClientBuilder()
     const systemToken = await hmppsAuthClient.getSystemClientToken(username)
     const referralClient = this.referralClientBuilder(systemToken)
 
-    return referralClient.findReferralSummaries(organisationId, filterValues)
+    return referralClient.findReferralSummaries(organisationId, query)
   }
 
   async submitReferral(username: Express.User['username'], referralId: Referral['id']): Promise<void> {

--- a/server/utils/courseUtils.test.ts
+++ b/server/utils/courseUtils.test.ts
@@ -2,6 +2,24 @@ import CourseUtils from './courseUtils'
 import { courseAudienceFactory, courseFactory, coursePrerequisiteFactory } from '../testutils/factories'
 
 describe('CourseUtils', () => {
+  describe('courseNameWithAlternateName', () => {
+    describe('when a course has an `alternateName`', () => {
+      it('returns the `name` and `alternateName` in brackets', () => {
+        const course = courseFactory.build({ alternateName: 'LC', name: 'Lime Course' })
+
+        expect(CourseUtils.courseNameWithAlternateName(course)).toEqual('Lime Course (LC)')
+      })
+    })
+
+    describe('when a course has no `alternateName`', () => {
+      it('just returns the `name`', () => {
+        const course = courseFactory.build({ alternateName: null, name: 'Lime Course' })
+
+        expect(CourseUtils.courseNameWithAlternateName(course)).toEqual('Lime Course')
+      })
+    })
+  })
+
   describe('courseRadioOptions', () => {
     it('returns a formatted array of courses to use with UI radios', () => {
       const courses = courseFactory.buildList(2)

--- a/server/utils/courseUtils.ts
+++ b/server/utils/courseUtils.ts
@@ -8,6 +8,10 @@ import type {
 } from '@accredited-programmes/ui'
 
 export default class CourseUtils {
+  static courseNameWithAlternateName(course: Course): string {
+    return course.alternateName ? `${course.name} (${course.alternateName})` : course.name
+  }
+
   static courseRadioOptions(courseNames: Array<Course['name']>): Array<GovukFrontendTagWithText> {
     return courseNames.map(courseName => {
       return {
@@ -18,12 +22,10 @@ export default class CourseUtils {
   }
 
   static presentCourse(course: Course): CoursePresenter {
-    const nameAndAlternateName = course.alternateName ? `${course.name} (${course.alternateName})` : course.name
-
     return {
       ...course,
       audienceTags: CourseUtils.audienceTags(course.audiences),
-      nameAndAlternateName,
+      nameAndAlternateName: this.courseNameWithAlternateName(course),
       prerequisiteSummaryListRows: CourseUtils.prerequisiteSummaryListRows(course.coursePrerequisites),
     }
   }

--- a/server/utils/referrals/caseListUtils.test.ts
+++ b/server/utils/referrals/caseListUtils.test.ts
@@ -1,5 +1,5 @@
 import CaseListUtils from './caseListUtils'
-import { referralSummaryFactory } from '../../testutils/factories'
+import { courseFactory, referralSummaryFactory } from '../../testutils/factories'
 import FormUtils from '../formUtils'
 import type { ReferralStatus } from '@accredited-programmes/models'
 
@@ -28,6 +28,36 @@ describe('CaseListUtils', () => {
 
         expect(FormUtils.getSelectItems).toHaveBeenCalledWith(expectedItems, 'general offence')
       })
+    })
+  })
+
+  describe('caseListPrimaryNavigationItems', () => {
+    it('returns primary navigation items, with no duplicate course names, sorted alphabetically by course name and sets the correct item as active', () => {
+      const courses = [
+        courseFactory.build({ name: 'Lime Course' }),
+        courseFactory.build({ name: 'Orange Course' }),
+        courseFactory.build({ name: 'Blue Course' }),
+      ]
+
+      expect(
+        CaseListUtils.caseListPrimaryNavigationItems('/assess/referrals/orange-course/case-list', courses),
+      ).toEqual([
+        {
+          active: false,
+          href: '/assess/referrals/blue-course/case-list',
+          text: 'Blue Course referrals',
+        },
+        {
+          active: false,
+          href: '/assess/referrals/lime-course/case-list',
+          text: 'Lime Course referrals',
+        },
+        {
+          active: true,
+          href: '/assess/referrals/orange-course/case-list',
+          text: 'Orange Course referrals',
+        },
+      ])
     })
   })
 

--- a/server/utils/referrals/caseListUtils.ts
+++ b/server/utils/referrals/caseListUtils.ts
@@ -1,9 +1,11 @@
+import type { Request } from 'express'
+
 import { assessPaths } from '../../paths'
 import DateUtils from '../dateUtils'
 import FormUtils from '../formUtils'
 import StringUtils from '../stringUtils'
-import type { ReferralStatus, ReferralSummary } from '@accredited-programmes/models'
-import type { TagColour } from '@accredited-programmes/ui'
+import type { Course, ReferralStatus, ReferralSummary } from '@accredited-programmes/models'
+import type { MojFrontendPrimaryNavigationItem, TagColour } from '@accredited-programmes/ui'
 import type { GovukFrontendSelectItem, GovukFrontendTableRow } from '@govuk-frontend'
 
 export default class CaseListUtils {
@@ -19,6 +21,26 @@ export default class CaseListUtils {
       ],
       selectedValue,
     )
+  }
+
+  static caseListPrimaryNavigationItems(
+    currentPath: Request['path'],
+    courses: Array<Course>,
+  ): Array<MojFrontendPrimaryNavigationItem> {
+    const coursesWithDuplicatesRemoved = courses.filter(
+      (course, index, self) => self.findIndex(c => c.name === course.name) === index,
+    )
+    const sortedCourses = coursesWithDuplicatesRemoved.sort((a, b) => a.name.localeCompare(b.name))
+
+    return sortedCourses.map(course => {
+      const path = assessPaths.caseList.show({ courseName: StringUtils.convertToUrlSlug(course.name) })
+
+      return {
+        active: currentPath === path,
+        href: path,
+        text: `${course.name} referrals`,
+      }
+    })
   }
 
   static caseListTableRows(referralSummary: Array<ReferralSummary>): Array<GovukFrontendTableRow> {

--- a/server/utils/stringUtils.test.ts
+++ b/server/utils/stringUtils.test.ts
@@ -1,6 +1,12 @@
 import StringUtils from './stringUtils'
 
 describe('utils', () => {
+  describe('convertFromUrlSlug', () => {
+    it('formats a lowercase, hyphenated string to capitalised words', () => {
+      expect(StringUtils.convertFromUrlSlug('a-url-slug')).toEqual('A Url Slug')
+    })
+  })
+
   describe('convertToTitleCase', () => {
     it.each([
       [null, null, ''],
@@ -14,6 +20,12 @@ describe('utils', () => {
       ['hyphenation', 'Robert-John SmiTH-jONes-WILSON', 'Robert-John Smith-Jones-Wilson'],
     ])('handles %s: %s -> %s', (_inputType: string | null, input: string | null, expectedOutput: string) => {
       expect(StringUtils.convertToTitleCase(input)).toEqual(expectedOutput)
+    })
+  })
+
+  describe('convertToUrlSlug', () => {
+    it('formats a string by making it lowercase and replacing the spaces with a hyphen', () => {
+      expect(StringUtils.convertToUrlSlug('The course name')).toEqual('the-course-name')
     })
   })
 

--- a/server/utils/stringUtils.ts
+++ b/server/utils/stringUtils.ts
@@ -1,8 +1,19 @@
 export default class StringUtils {
+  static convertFromUrlSlug(slug: string): string {
+    return slug
+      .split('-')
+      .map(word => this.properCase(word))
+      .join(' ')
+  }
+
   static convertToTitleCase(sentence: string | null): string {
     return sentence === null || StringUtils.isBlank(sentence)
       ? ''
       : sentence.split(' ').map(StringUtils.properCaseName).join(' ')
+  }
+
+  static convertToUrlSlug(string: string): string {
+    return string.toLowerCase().replace(/\s/g, '-')
   }
 
   static initialiseName(fullName?: string): string | null {

--- a/server/views/referrals/caseList/show.njk
+++ b/server/views/referrals/caseList/show.njk
@@ -1,10 +1,19 @@
 {% from "govuk/components/button/macro.njk" import govukButton %}
 {% from "govuk/components/select/macro.njk" import govukSelect %}
 {% from "govuk/components/table/macro.njk" import govukTable %}
+{% from "moj/components/primary-navigation/macro.njk" import mojPrimaryNavigation %}
 
 {% extends "../../partials/layout.njk" %}
 
+{% block primaryNavigation %}
+  {{ mojPrimaryNavigation({
+    label: 'Primary navigation',
+    items: primaryNavigationItems
+  }) }}
+{% endblock %}
+
 {% block content %}
+  <span class="govuk-caption-l">Referrals</span>
   <h1 class="govuk-heading-l">{{ pageHeading }}</h1>
 
   <div class="filters">


### PR DESCRIPTION
## Context

We need to show case lists for each course for an organisation.

## Changes in this PR
Adds a primary navigation to top of the case list page which contains links to a case list page for each course for an organisation. When visiting each course page, there will be a case list of referral summaries for that course.

## Screenshots of UI changes

![localhost_3000_assess_referrals_azure-course_case-list](https://github.com/ministryofjustice/hmpps-accredited-programmes-ui/assets/1067537/b8926fec-47a3-4ff0-8bff-3204cda6e6d0)


## Release checklist

[Release process documentation](../doc/how-to/perform-a-release.md)

As part of our continuous deployment strategy we must ensure that this work is
ready to be released once merged.

### Pre-merge

- [ ] There are changes required to the Accredited Programmes API for this change to work...
  - [ ] ... and they have been released to production already

### Post-merge

<!-- The outer checkboxes can be completed pre-merge -->

- [ ] This adds, extends or meaningfully modifies a feature...
  - [ ] ... and I have written or updated an end-to-end test for the happy path in the [Accredited Programmes E2E repo](https://github.com/ministryofjustice/hmpps-accredited-programmes-e2e)
- [ ] This makes new expectations of the API...
  - [ ] ... and I have notified the API developer(s) of changes to the contract tests (Pact), or the API is already compliant
- [ ] [Manually approve](../doc/how-to/perform-a-release.md#releasing-to-the-preprod-environment) release to preprod
- [ ] [Manually approve](../doc/how-to/perform-a-release.md#releasing-to-the-production-environment) release to prod

<!-- Should a release fail at any step, you as the author should now lead the work to
fix it as soon as possible. You can monitor deployment failures in CircleCI
itself and application errors are found in
[Sentry](https://ministryofjustice.sentry.io/projects/hmpps-accredited-programmes-ui/?project=4505330122686464&referrer=sidebar&statsPeriod=24h). -->
