### PR TITLE
(1170) Tweak filter URLs

### DIFF
--- a/integration_tests/e2e/assess/caseList.cy.ts
+++ b/integration_tests/e2e/assess/caseList.cy.ts
@@ -3,7 +3,7 @@ import { assessPaths } from '../../../server/paths'
 import { referralSummaryFactory } from '../../../server/testutils/factories'
 import Page from '../../pages/page'
 import { CaseListPage } from '../../pages/shared'
-import type { ReferralStatus, ReferralSummary } from '@accredited-programmes/models'
+import type { ReferralSummary } from '@accredited-programmes/models'
 
 context('Referral case lists', () => {
   const referralSummaries: Array<ReferralSummary> = [
@@ -46,13 +46,13 @@ context('Referral case lists', () => {
       })
       caseListPage.shouldContainTableOfReferralSummaries()
 
-      const programmeStrandSelectedValue = 'General offence'
-      const referralStatusSelectedValue = 'ASSESSMENT_STARTED'
+      const programmeStrandSelectedValue = 'general offence'
+      const referralStatusSelectedValue = 'assessment started'
       const filteredReferralSummaries = [
         referralSummaryFactory.build({
-          audiences: [programmeStrandSelectedValue],
+          audiences: ['General offence'],
           prisonNumber: 'ABC123',
-          status: referralStatusSelectedValue.toLowerCase() as ReferralStatus,
+          status: 'assessment_started',
         }),
       ]
 

--- a/integration_tests/pages/shared/caseList.ts
+++ b/integration_tests/pages/shared/caseList.ts
@@ -46,8 +46,8 @@ export default class CaseListPage extends Page {
     cy.task('stubFindReferralSummaries', {
       organisationId: 'MRI',
       queryParameters: {
-        audience: { equalTo: programmeStrandSelectedValue },
-        status: { equalTo: referralStatusSelectedValue },
+        audience: { equalTo: ReferralUtils.uiToApiAudienceQueryParam(programmeStrandSelectedValue) },
+        status: { equalTo: ReferralUtils.uiToApiStatusQueryParam(referralStatusSelectedValue) },
       },
       referralSummaries: filteredReferralSummaries,
     })

--- a/server/@types/ui/index.d.ts
+++ b/server/@types/ui/index.d.ts
@@ -131,6 +131,11 @@ type MojFrontendSideNavigationItem = {
   text: string
 }
 
+type QueryParam = {
+  key: string
+  value: string
+}
+
 export type {
   CourseParticipationPresenter,
   CoursePresenter,
@@ -147,6 +152,7 @@ export type {
   OffenceHistory,
   OrganisationWithOfferingEmailsPresenter,
   OrganisationWithOfferingId,
+  QueryParam,
   ReferralSharedPageData,
   ReferralTaskListItem,
   ReferralTaskListSection,

--- a/server/controllers/shared/caseListController.test.ts
+++ b/server/controllers/shared/caseListController.test.ts
@@ -58,7 +58,7 @@ describe('CaseListController', () => {
     })
 
     describe('when `req.body.audience` and `req.body.status` are provided', () => {
-      it('asks PathUtils to generate a path with both as query params and redirects to the result', async () => {
+      it('asks PathUtils to generate a path with both as query params - audience renamed "strand" - and redirects to the result', async () => {
         request.body.audience = audience
         request.body.status = status
 
@@ -66,7 +66,7 @@ describe('CaseListController', () => {
         await requestHandler(request, response, next)
 
         expect(PathUtils.pathWithQuery).toHaveBeenLastCalledWith(redirectPathBase, [
-          { key: 'audience', value: audience },
+          { key: 'strand', value: audience },
           { key: 'status', value: status },
         ])
         expect(response.redirect).toHaveBeenCalledWith(pathWithQuery)
@@ -87,16 +87,14 @@ describe('CaseListController', () => {
     })
 
     describe('when `req.body.status` is undefined', () => {
-      it('asks PathUtils to generate a path with audience as a query param and redirects to the result', async () => {
+      it('asks PathUtils to generate a path with audience as a query param - renamed "strand" - and redirects to the result', async () => {
         request.body.audience = audience
         request.body.status = undefined
 
         const requestHandler = controller.filter()
         await requestHandler(request, response, next)
 
-        expect(PathUtils.pathWithQuery).toHaveBeenLastCalledWith(redirectPathBase, [
-          { key: 'audience', value: audience },
-        ])
+        expect(PathUtils.pathWithQuery).toHaveBeenLastCalledWith(redirectPathBase, [{ key: 'strand', value: audience }])
         expect(response.redirect).toHaveBeenCalledWith(pathWithQuery)
       })
     })
@@ -140,8 +138,8 @@ describe('CaseListController', () => {
       it('renders the show template with the correct response locals', async () => {
         request.path = assessPaths.caseList.show({})
         request.query = {
-          audience: 'General offence',
           status: 'REFERRAL_SUBMITTED',
+          strand: 'General offence',
         }
 
         const requestHandler = controller.show()

--- a/server/controllers/shared/caseListController.test.ts
+++ b/server/controllers/shared/caseListController.test.ts
@@ -6,8 +6,10 @@ import CaseListController from './caseListController'
 import { assessPaths } from '../../paths'
 import type { ReferralService } from '../../services'
 import { referralSummaryFactory } from '../../testutils/factories'
-import { ReferralUtils } from '../../utils'
+import { PathUtils, ReferralUtils } from '../../utils'
 import type { Paginated, ReferralSummary } from '@accredited-programmes/models'
+
+jest.mock('../../utils/pathUtils')
 
 describe('CaseListController', () => {
   const username = 'USERNAME'
@@ -45,6 +47,74 @@ describe('CaseListController', () => {
     jest.resetAllMocks()
   })
 
+  describe('filter', () => {
+    const redirectPathBase = assessPaths.caseList.show({})
+    const pathWithQuery = 'path-with-query'
+    const audience = 'General violence offence'
+    const status = 'ASSESSMENT_STARTED'
+
+    beforeEach(() => {
+      ;(PathUtils.pathWithQuery as jest.Mock).mockReturnValue(pathWithQuery)
+    })
+
+    describe('when `req.body.audience` and `req.body.status` are provided', () => {
+      it('asks PathUtils to generate a path with both as query params and redirects to the result', async () => {
+        request.body.audience = audience
+        request.body.status = status
+
+        const requestHandler = controller.filter()
+        await requestHandler(request, response, next)
+
+        expect(PathUtils.pathWithQuery).toHaveBeenLastCalledWith(redirectPathBase, [
+          { key: 'audience', value: audience },
+          { key: 'status', value: status },
+        ])
+        expect(response.redirect).toHaveBeenCalledWith(pathWithQuery)
+      })
+    })
+
+    describe('when `req.body.audience` is undefined', () => {
+      it('asks PathUtils to generate a path with status as a query param and redirects to the result', async () => {
+        request.body.audience = undefined
+        request.body.status = status
+
+        const requestHandler = controller.filter()
+        await requestHandler(request, response, next)
+
+        expect(PathUtils.pathWithQuery).toHaveBeenLastCalledWith(redirectPathBase, [{ key: 'status', value: status }])
+        expect(response.redirect).toHaveBeenCalledWith(pathWithQuery)
+      })
+    })
+
+    describe('when `req.body.status` is undefined', () => {
+      it('asks PathUtils to generate a path with audience as a query param and redirects to the result', async () => {
+        request.body.audience = audience
+        request.body.status = undefined
+
+        const requestHandler = controller.filter()
+        await requestHandler(request, response, next)
+
+        expect(PathUtils.pathWithQuery).toHaveBeenLastCalledWith(redirectPathBase, [
+          { key: 'audience', value: audience },
+        ])
+        expect(response.redirect).toHaveBeenCalledWith(pathWithQuery)
+      })
+    })
+
+    describe('when `req.body.audience` and `req.body.status` are both `undefined`', () => {
+      it('asks PathUtils to generate a path without any query params and redirects to the result', async () => {
+        request.body.audience = undefined
+        request.body.status = undefined
+
+        const requestHandler = controller.filter()
+        await requestHandler(request, response, next)
+
+        expect(PathUtils.pathWithQuery).toHaveBeenLastCalledWith(redirectPathBase, [])
+        expect(response.redirect).toHaveBeenCalledWith(pathWithQuery)
+      })
+    })
+  })
+
   describe('show', () => {
     it('renders the show template with the correct response locals', async () => {
       request.path = assessPaths.caseList.show({})
@@ -53,6 +123,7 @@ describe('CaseListController', () => {
       await requestHandler(request, response, next)
 
       expect(response.render).toHaveBeenCalledWith('referrals/caseList/show', {
+        action: assessPaths.caseList.filter({}),
         audienceSelectItems: ReferralUtils.audienceSelectItems(),
         pageHeading: 'My referrals',
         referralStatusSelectItems: ReferralUtils.statusSelectItems(),
@@ -77,6 +148,7 @@ describe('CaseListController', () => {
         await requestHandler(request, response, next)
 
         expect(response.render).toHaveBeenCalledWith('referrals/caseList/show', {
+          action: assessPaths.caseList.filter({}),
           audienceSelectItems: ReferralUtils.audienceSelectItems('General offence'),
           pageHeading: 'My referrals',
           referralStatusSelectItems: ReferralUtils.statusSelectItems('REFERRAL_SUBMITTED'),

--- a/server/controllers/shared/caseListController.test.ts
+++ b/server/controllers/shared/caseListController.test.ts
@@ -138,8 +138,8 @@ describe('CaseListController', () => {
       it('renders the show template with the correct response locals', async () => {
         request.path = assessPaths.caseList.show({})
         request.query = {
-          status: 'REFERRAL_SUBMITTED',
-          strand: 'General offence',
+          status: 'referral submitted',
+          strand: 'general offence',
         }
 
         const requestHandler = controller.show()
@@ -147,9 +147,9 @@ describe('CaseListController', () => {
 
         expect(response.render).toHaveBeenCalledWith('referrals/caseList/show', {
           action: assessPaths.caseList.filter({}),
-          audienceSelectItems: ReferralUtils.audienceSelectItems('General offence'),
+          audienceSelectItems: ReferralUtils.audienceSelectItems('general offence'),
           pageHeading: 'My referrals',
-          referralStatusSelectItems: ReferralUtils.statusSelectItems('REFERRAL_SUBMITTED'),
+          referralStatusSelectItems: ReferralUtils.statusSelectItems('referral submitted'),
           tableRows: ReferralUtils.caseListTableRows(paginatedReferralSummaries.content),
         })
 

--- a/server/controllers/shared/caseListController.ts
+++ b/server/controllers/shared/caseListController.ts
@@ -35,8 +35,8 @@ export default class CaseListController {
       const { activeCaseLoadId, username } = res.locals.user
 
       const paginatedReferralSummaries = await this.referralService.getReferralSummaries(username, activeCaseLoadId, {
-        audience,
-        status,
+        audience: ReferralUtils.uiToApiAudienceQueryParam(audience),
+        status: ReferralUtils.uiToApiStatusQueryParam(status),
       })
 
       return res.render('referrals/caseList/show', {

--- a/server/controllers/shared/caseListController.ts
+++ b/server/controllers/shared/caseListController.ts
@@ -15,7 +15,7 @@ export default class CaseListController {
       const queryParams: Array<QueryParam> = []
 
       if (req.body.audience) {
-        queryParams.push({ key: 'audience', value: req.body.audience })
+        queryParams.push({ key: 'strand', value: req.body.audience })
       }
 
       if (req.body.status) {
@@ -30,7 +30,7 @@ export default class CaseListController {
     return async (req: Request, res: Response) => {
       TypeUtils.assertHasUser(req)
 
-      const { audience, status } = req.query as Record<string, string>
+      const { status, strand: audience } = req.query as Record<string, string>
 
       const { activeCaseLoadId, username } = res.locals.user
 

--- a/server/controllers/shared/caseListController.ts
+++ b/server/controllers/shared/caseListController.ts
@@ -1,10 +1,30 @@
 import type { Request, Response, TypedRequestHandler } from 'express'
 
+import { assessPaths } from '../../paths'
 import type { ReferralService } from '../../services'
-import { ReferralUtils, TypeUtils } from '../../utils'
+import { PathUtils, ReferralUtils, TypeUtils } from '../../utils'
+import type { QueryParam } from '@accredited-programmes/ui'
 
 export default class CaseListController {
   constructor(private readonly referralService: ReferralService) {}
+
+  filter(): TypedRequestHandler<Request, Response> {
+    return async (req: Request, res: Response) => {
+      TypeUtils.assertHasUser(req)
+
+      const queryParams: Array<QueryParam> = []
+
+      if (req.body.audience) {
+        queryParams.push({ key: 'audience', value: req.body.audience })
+      }
+
+      if (req.body.status) {
+        queryParams.push({ key: 'status', value: req.body.status })
+      }
+
+      return res.redirect(PathUtils.pathWithQuery(assessPaths.caseList.show({}), queryParams))
+    }
+  }
 
   show(): TypedRequestHandler<Request, Response> {
     return async (req: Request, res: Response) => {
@@ -20,6 +40,7 @@ export default class CaseListController {
       })
 
       return res.render('referrals/caseList/show', {
+        action: assessPaths.caseList.filter({}),
         audienceSelectItems: ReferralUtils.audienceSelectItems(audience),
         pageHeading: 'My referrals',
         referralStatusSelectItems: ReferralUtils.statusSelectItems(status),

--- a/server/paths/assess.ts
+++ b/server/paths/assess.ts
@@ -6,6 +6,7 @@ const referralShowPathBase = assessPathBase.path('referrals/:referralId')
 
 export default {
   caseList: {
+    filter: caseListPath,
     show: caseListPath,
   },
   show: {

--- a/server/routes/assess.ts
+++ b/server/routes/assess.ts
@@ -6,11 +6,12 @@ import { assessPaths } from '../paths'
 import { RouteUtils } from '../utils'
 
 export default function routes(controllers: Controllers, router: Router): Router {
-  const { get } = RouteUtils.actions(router, { allowedRoles: [ApplicationRoles.ACP_PROGRAMME_TEAM] })
+  const { get, post } = RouteUtils.actions(router, { allowedRoles: [ApplicationRoles.ACP_PROGRAMME_TEAM] })
 
   const { referralsController, caseListController } = controllers
 
   get(assessPaths.caseList.show.pattern, caseListController.show())
+  post(assessPaths.caseList.filter.pattern, caseListController.filter())
 
   get(assessPaths.show.additionalInformation.pattern, referralsController.additionalInformation())
   get(assessPaths.show.offenceHistory.pattern, referralsController.offenceHistory())

--- a/server/utils/index.ts
+++ b/server/utils/index.ts
@@ -9,6 +9,7 @@ import FormUtils from './formUtils'
 import nunjucksSetup from './nunjucksSetup'
 import OffenceUtils from './offenceUtils'
 import OrganisationUtils from './organisationUtils'
+import PathUtils from './pathUtils'
 import PersonUtils from './personUtils'
 import ReferralUtils from './referralUtils'
 import RouteUtils from './routeUtils'
@@ -24,6 +25,7 @@ export {
   FormUtils,
   OffenceUtils,
   OrganisationUtils,
+  PathUtils,
   PersonUtils,
   ReferralUtils,
   RouteUtils,

--- a/server/utils/pathUtils.test.ts
+++ b/server/utils/pathUtils.test.ts
@@ -1,0 +1,24 @@
+import PathUtils from './pathUtils'
+
+describe('PathUtils', () => {
+  describe('pathWithQuery', () => {
+    const path = 'a-path'
+
+    describe('when there are no query params', () => {
+      it('returns the path', () => {
+        expect(PathUtils.pathWithQuery(path, [])).toEqual(path)
+      })
+    })
+
+    describe('when there are query params', () => {
+      it('returns the path with the query params in a URL-friendly format', () => {
+        expect(
+          PathUtils.pathWithQuery(path, [
+            { key: 'sector', value: 'Information technology' },
+            { key: 'region', value: 'South America' },
+          ]),
+        ).toEqual(`${path}?sector=Information+technology&region=South+America`)
+      })
+    })
+  })
+})

--- a/server/utils/pathUtils.ts
+++ b/server/utils/pathUtils.ts
@@ -1,0 +1,17 @@
+import type { QueryParam } from '@accredited-programmes/ui'
+
+export default class PathUtils {
+  static pathWithQuery(path: string, queryParams: Array<QueryParam>): string {
+    if (!queryParams.length) {
+      return path
+    }
+
+    const queryString = queryParams
+      .map(({ key, value }) => {
+        return `${key}=${value.replace(/\s/g, '+')}`
+      })
+      .join('&')
+
+    return `${path}?${queryString}`
+  }
+}

--- a/server/utils/referralUtils.test.ts
+++ b/server/utils/referralUtils.test.ts
@@ -67,12 +67,12 @@ describe('ReferralUtils', () => {
 
   describe('audienceSelectItems', () => {
     const expectedItems = {
-      'Extremism offence': 'Extremism offence',
-      'Gang offence': 'Gang offence',
-      'General offence': 'General offence',
-      'General violence offence': 'General violence offence',
-      'Intimate partner violence offence': 'Intimate partner violence offence',
-      'Sexual offence': 'Sexual offence',
+      'extremism offence': 'Extremism offence',
+      'gang offence': 'Gang offence',
+      'general offence': 'General offence',
+      'general violence offence': 'General violence offence',
+      'intimate partner violence offence': 'Intimate partner violence offence',
+      'sexual offence': 'Sexual offence',
     }
 
     it('makes a call to the `FormUtils.getSelectItems` method with an `undefined` `selectedValue` parameter', () => {
@@ -83,9 +83,9 @@ describe('ReferralUtils', () => {
 
     describe('when a selected value is provided', () => {
       it('makes a call to the `FormUtils.getSelectItems` method with the correct `selectedValue` parameter', () => {
-        ReferralUtils.audienceSelectItems('General offence')
+        ReferralUtils.audienceSelectItems('general offence')
 
-        expect(FormUtils.getSelectItems).toHaveBeenCalledWith(expectedItems, 'General offence')
+        expect(FormUtils.getSelectItems).toHaveBeenCalledWith(expectedItems, 'general offence')
       })
     })
   })
@@ -218,10 +218,10 @@ describe('ReferralUtils', () => {
 
   describe('statusSelectItems', () => {
     const expectedItems = {
-      ASSESSMENT_STARTED: 'Assessment started',
-      AWAITING_ASSESSMENT: 'Awaiting assessment',
-      REFERRAL_STARTED: 'Referral started',
-      REFERRAL_SUBMITTED: 'Referral submitted',
+      'assessment started': 'Assessment started',
+      'awaiting assessment': 'Awaiting assessment',
+      'referral started': 'Referral started',
+      'referral submitted': 'Referral submitted',
     }
 
     it('makes a call to the `FormUtils.getSelectItems` method with an `undefined` `selectedValue` parameter', () => {
@@ -232,9 +232,9 @@ describe('ReferralUtils', () => {
 
     describe('when a selected value is provided', () => {
       it('makes a call to the `FormUtils.getSelectItems` method with the correct `selectedValue` parameter', () => {
-        ReferralUtils.statusSelectItems('REFERRAL_SUBMITTED')
+        ReferralUtils.statusSelectItems('referral submitted')
 
-        expect(FormUtils.getSelectItems).toHaveBeenCalledWith(expectedItems, 'REFERRAL_SUBMITTED')
+        expect(FormUtils.getSelectItems).toHaveBeenCalledWith(expectedItems, 'referral submitted')
       })
     })
   })
@@ -374,6 +374,30 @@ describe('ReferralUtils', () => {
 
       expect(checkAnswersTask.url).toEqual(`/refer/referrals/new/${referralWithOasysConfirmed.id}/check-answers`)
       expect(checkAnswersTask.statusTag.text).toEqual('not started')
+    })
+  })
+
+  describe('uiToApiAudienceQueryParam', () => {
+    it('returns the UI query param formatted to match the API data', () => {
+      expect(ReferralUtils.uiToApiAudienceQueryParam('general violence offence')).toEqual('General violence offence')
+    })
+
+    describe('when the param is falsey', () => {
+      it('returns `undefined`', () => {
+        expect(ReferralUtils.uiToApiAudienceQueryParam(undefined)).toEqual(undefined)
+      })
+    })
+  })
+
+  describe('uiToApiStatusQueryParam', () => {
+    it('returns the UI query param formatted to match the API data', () => {
+      expect(ReferralUtils.uiToApiStatusQueryParam('referral submitted')).toEqual('REFERRAL_SUBMITTED')
+    })
+
+    describe('when the param is falsey', () => {
+      it('returns `undefined`', () => {
+        expect(ReferralUtils.uiToApiStatusQueryParam(undefined)).toEqual(undefined)
+      })
     })
   })
 

--- a/server/utils/referralUtils.ts
+++ b/server/utils/referralUtils.ts
@@ -2,6 +2,7 @@ import type { Request } from 'express'
 
 import DateUtils from './dateUtils'
 import FormUtils from './formUtils'
+import StringUtils from './stringUtils'
 import { assessPaths, referPaths } from '../paths'
 import { assessPathBase } from '../paths/assess'
 import type {
@@ -60,17 +61,15 @@ export default class ReferralUtils {
   }
 
   static audienceSelectItems(selectedValue?: string): Array<GovukFrontendSelectItem> {
-    const audienceValues = [
-      'Extremism offence',
-      'Gang offence',
-      'General offence',
-      'General violence offence',
-      'Intimate partner violence offence',
-      'Sexual offence',
-    ]
-
-    return FormUtils.getSelectItems(
-      Object.fromEntries(audienceValues.map(audience => [audience, audience])),
+    return this.caseListSelectItems(
+      [
+        'Extremism offence',
+        'Gang offence',
+        'General offence',
+        'General violence offence',
+        'Intimate partner violence offence',
+        'Sexual offence',
+      ],
       selectedValue,
     )
   }
@@ -131,13 +130,8 @@ export default class ReferralUtils {
   }
 
   static statusSelectItems(selectedValue?: string): Array<GovukFrontendSelectItem> {
-    return FormUtils.getSelectItems(
-      {
-        ASSESSMENT_STARTED: 'Assessment started',
-        AWAITING_ASSESSMENT: 'Awaiting assessment',
-        REFERRAL_STARTED: 'Referral started',
-        REFERRAL_SUBMITTED: 'Referral submitted',
-      },
+    return this.caseListSelectItems(
+      ['Assessment started', 'Awaiting assessment', 'Referral started', 'Referral submitted'],
       selectedValue,
     )
   }
@@ -238,6 +232,14 @@ export default class ReferralUtils {
     ]
   }
 
+  static uiToApiAudienceQueryParam(uiAudienceQueryParam: string | undefined): string | undefined {
+    return uiAudienceQueryParam ? StringUtils.properCase(uiAudienceQueryParam) : undefined
+  }
+
+  static uiToApiStatusQueryParam(uiStatusQueryParam: string | undefined): string | undefined {
+    return uiStatusQueryParam ? uiStatusQueryParam.toUpperCase().replace(/\s/g, '_') : undefined
+  }
+
   static viewReferralNavigationItems(
     currentPath: Request['path'],
     referralId: Referral['id'],
@@ -271,6 +273,13 @@ export default class ReferralUtils {
       ...item,
       active: currentPath === item.href,
     }))
+  }
+
+  private static caseListSelectItems(values: Array<string>, selectedValue?: string): Array<GovukFrontendSelectItem> {
+    return FormUtils.getSelectItems(
+      Object.fromEntries(values.map(value => [value.toLowerCase(), value])),
+      selectedValue,
+    )
   }
 
   private static taskListStatusTag(text: ReferralTaskListStatusText, dataTestId?: string): ReferralTaskListStatusTag {

--- a/server/views/referrals/caseList/show.njk
+++ b/server/views/referrals/caseList/show.njk
@@ -9,7 +9,9 @@
 
   <div class="filters">
     <h2 class="govuk-heading-m">Filters</h2>
-    <form class="form-controls">
+    <form class="form-controls" action="{{ action }}" method="post">
+      <input type="hidden" name="_csrf" value="{{ csrfToken }}"/>
+
       {{ govukSelect({
         id: "audience",
         name: "audience",
@@ -17,7 +19,7 @@
           text: "Programme strand"
         },
         items: audienceSelectItems,
-         attributes: {
+          attributes: {
           "data-testid": "programme-strand-select"
         }
       }) }}


### PR DESCRIPTION
## Context

<!-- Is there a Trello ticket you can link to? -->
<!-- Do you need to add any environment variables? -->
<!-- Is an ADR required? An ADR should be added if this PR introduces a change to the architecture. -->

We identified a few things that would clean up the URLs used when filtering the case list

## Changes in this PR

- Omit unused filter fields from query params
- Use 'strand' as audience query param
- Use lower case for query params

## UI changes

### Before

Both params: `/assess/referrals/case-list?audience=General+violence+offence&status=REFERRAL_SUBMITTED`
One param: `/assess/referrals/case-list?audience=General+violence+offence&status=`

### After

Both params: `/assess/referrals/case-list?strand=general+violence+offence&status=referral+submitted`
One param: `/assess/referrals/case-list?strand=general+violence+offence`

## Release checklist

[Release process documentation](../doc/how-to/perform-a-release.md)

As part of our continuous deployment strategy we must ensure that this work is
ready to be released once merged.

### Pre-merge

- [ ] There are changes required to the Accredited Programmes API for this change to work...
  - [ ] ... and they have been released to production already

### Post-merge

<!-- The outer checkboxes can be completed pre-merge -->

- [ ] This adds, extends or meaningfully modifies a feature...
  - [ ] ... and I have written or updated an end-to-end test for the happy path in the [Accredited Programmes E2E repo](https://github.com/ministryofjustice/hmpps-accredited-programmes-e2e)
- [ ] This makes new expectations of the API...
  - [ ] ... and I have notified the API developer(s) of changes to the contract tests (Pact), or the API is already compliant
- [ ] [Manually approve](../doc/how-to/perform-a-release.md#releasing-to-the-preprod-environment) release to preprod
- [ ] [Manually approve](../doc/how-to/perform-a-release.md#releasing-to-the-production-environment) release to prod

<!-- Should a release fail at any step, you as the author should now lead the work to
fix it as soon as possible. You can monitor deployment failures in CircleCI
itself and application errors are found in
[Sentry](https://ministryofjustice.sentry.io/projects/hmpps-accredited-programmes-ui/?project=4505330122686464&referrer=sidebar&statsPeriod=24h). -->
