### PR TITLE
(1102) Move `Enter a different identifier` link inline with Continue button

### DIFF
--- a/server/views/referrals/new/people/show.njk
+++ b/server/views/referrals/new/people/show.njk
@@ -26,17 +26,23 @@
         iconFallbackText: "Warning"
       }) }}
 
-      <form action="{{ referPaths.new.create({}) }}" method="post">
+      <form id="newReferralForm" action="{{ referPaths.new.create({}) }}" method="post">
         <input type="hidden" name="_csrf" value="{{ csrfToken }}"/>
         <input type="hidden" name="courseOfferingId" value="{{ courseOfferingId }}"/>
         <input type="hidden" name="prisonNumber" value="{{ prisonNumber }}"/>
-
-        {{ govukButton({ text: "Continue" }) }}
       </form>
 
-      <a href="{{ referPaths.new.new({ courseOfferingId: courseOfferingId }) }}" class="govuk-link">
+      <div class="govuk-button-group">
+        {{ govukButton({ 
+          text: "Continue",
+          attributes: {
+            form: "newReferralForm"
+          }
+        }) }}
+        <a href="{{ referPaths.new.new({ courseOfferingId: courseOfferingId }) }}" class="govuk-link">
         Enter a different identifier
       </a>
+      </div>
     </div>
   </div>
 


### PR DESCRIPTION
Smaller screens accounted for by default too and link will go underneath the full width button.

## Context

https://trello.com/c/Fk5FrFIA/1102-move-enter-a-different-identifier-link-xs

## Changes in this PR
Put both actions inside `.govuk-button-group`.  This meant taking the **Continue** button out of the form but have added an `id` to the form itself and a `form` value to the button.


## Screenshots of UI changes

### Before
![image](https://github.com/ministryofjustice/hmpps-accredited-programmes-ui/assets/1067537/a3d9c18f-fd38-4e39-8523-135052d02935)

### After
![image](https://github.com/ministryofjustice/hmpps-accredited-programmes-ui/assets/1067537/9bb1e042-c54e-4e34-af6a-6b7d29b14d81)



## Release checklist

[Release process documentation](../doc/how-to/perform-a-release.md)

As part of our continuous deployment strategy we must ensure that this work is
ready to be released once merged.

### Pre-merge

- [ ] There are changes required to the Accredited Programmes API for this change to work...
  - [ ] ... and they have been released to production already

### Post-merge

<!-- The outer checkboxes can be completed pre-merge -->

- [ ] This adds, extends or meaningfully modifies a feature...
  - [ ] ... and I have written or updated an end-to-end test for the happy path in the [Accredited Programmes E2E repo](https://github.com/ministryofjustice/hmpps-accredited-programmes-e2e)
- [ ] This makes new expectations of the API...
  - [ ] ... and I have notified the API developer(s) of changes to the contract tests (Pact), or the API is already compliant
- [ ] [Manually approve](../doc/how-to/perform-a-release.md#releasing-to-the-preprod-environment) release to preprod
- [ ] [Manually approve](../doc/how-to/perform-a-release.md#releasing-to-the-production-environment) release to prod

<!-- Should a release fail at any step, you as the author should now lead the work to
fix it as soon as possible. You can monitor deployment failures in CircleCI
itself and application errors are found in
[Sentry](https://ministryofjustice.sentry.io/projects/hmpps-accredited-programmes-ui/?project=4505330122686464&referrer=sidebar&statsPeriod=24h). -->
