### PR TITLE
(1104 & 1105) Update Programme History page content

### DIFF
--- a/integration_tests/e2e/refer/new/programmeHistory.cy.ts
+++ b/integration_tests/e2e/refer/new/programmeHistory.cy.ts
@@ -103,10 +103,11 @@ context('Programme history', () => {
         programmeHistoryPage.shouldContainNavigation(programmeHistoryPath)
         programmeHistoryPage.shouldContainBackLink(referPaths.new.show({ referralId: referral.id }))
         programmeHistoryPage.shouldNotContainSuccessMessage()
+        programmeHistoryPage.shouldContainPreHistoryText()
         programmeHistoryPage.shouldContainPreHistoryParagraph()
         programmeHistoryPage.shouldContainHistorySummaryCards(courseParticipationsPresenter, referral.id)
-        programmeHistoryPage.shouldContainButton('Continue')
-        programmeHistoryPage.shouldContainButtonLink('Add another', newParticipationPath)
+        programmeHistoryPage.shouldContainButtonLink('Add a programme', newParticipationPath)
+        programmeHistoryPage.shouldContainButton('Skip this section')
       })
 
       describe('and the programme history has been reviewed', () => {
@@ -159,10 +160,10 @@ context('Programme history', () => {
         programmeHistoryPage.shouldContainNavigation(programmeHistoryPath)
         programmeHistoryPage.shouldContainBackLink(referPaths.new.show({ referralId: referral.id }))
         programmeHistoryPage.shouldNotContainSuccessMessage()
-        programmeHistoryPage.shouldContainNoHistoryHeading()
-        programmeHistoryPage.shouldContainNoHistoryParagraph()
-        programmeHistoryPage.shouldContainButton('Continue')
+        programmeHistoryPage.shouldContainNoHistoryText()
+        programmeHistoryPage.shouldContainNoHistoryParagraphs()
         programmeHistoryPage.shouldContainButtonLink('Add a programme', newParticipationPath)
+        programmeHistoryPage.shouldContainButton('Skip this section')
       })
 
       describe('and the programme history has been reviewed', () => {

--- a/integration_tests/pages/refer/new/programmeHistory.ts
+++ b/integration_tests/pages/refer/new/programmeHistory.ts
@@ -22,32 +22,52 @@ export default class NewReferralProgrammeHistoryPage extends Page {
     this.referral = { ...this.referral, hasReviewedProgrammeHistory: true }
     // We're stubbing the referral here to make sure the updated referral is available on the task list page
     cy.task('stubReferral', this.referral)
-    this.shouldContainButton('Continue').click()
+    this.shouldContainButton('Skip this section').click()
   }
 
-  shouldContainNoHistoryHeading() {
-    cy.get('[data-testid="no-history-heading"]').should(
+  shouldContainNoHistoryParagraphs() {
+    cy.get('[data-testid="no-history-paragraph-1"]').should(
       'have.text',
-      `There is no Accredited Programme history for ${this.person.name}.`,
+      "The programme team may use information about a person's Accredited Programme history to assess whether they are suitable.",
+    )
+
+    cy.get('[data-testid="no-history-paragraph-2"]').should(
+      'have.text',
+      'You can continue by adding a programme history or skip this section of the referral if the history is not known.',
     )
   }
 
-  shouldContainNoHistoryParagraph() {
-    cy.get('[data-testid="no-history-paragraph"]').should(
-      'have.text',
-      `The programme team may use information about a person's Accredited Programme history to assess whether they are suitable. You can add a programme to this history or continue with the referral if the ${this.person.name}'s history is unknown.`,
+  shouldContainNoHistoryText() {
+    cy.get('[data-testid="history-text"]').should(
+      'contain.text',
+      `There is no record of Accredited Programmes for ${this.person.name}.`,
     )
   }
 
   shouldContainPreHistoryParagraph() {
     cy.get('[data-testid="pre-history-paragraph"]').should(
       'have.text',
-      `The history below shows ${this.person.name}'s history of Accredited Programmes. Add another programme if you know that they started or completed a programme which is not listed below.`,
+      'Add another programme if you know that they started or completed a programme which is not listed below or skip this section of the referral if the history is not known.',
+    )
+  }
+
+  shouldContainPreHistoryText() {
+    cy.get('[data-testid="history-text"]').should(
+      'contain.text',
+      `The history shows ${this.person.name} has previously started or completed an Accredited Programme.`,
     )
   }
 
   shouldContainSuccessMessage(message: string) {
     cy.get('[data-testid="success-banner"]').should('contain.text', message)
+  }
+
+  shouldNotContainNoHistoryParagraphs() {
+    cy.get('[data-testid="no-history-paragraph"]').should('not.exist')
+  }
+
+  shouldNotContainPreHistoryParagraph() {
+    cy.get('[data-testid="pre-history-paragraph"]').should('not.exist')
   }
 
   shouldNotContainSuccessMessage() {

--- a/server/controllers/refer/new/courseParticipationsController.test.ts
+++ b/server/controllers/refer/new/courseParticipationsController.test.ts
@@ -336,11 +336,38 @@ describe('NewReferralsCourseParticipationsController', () => {
 
       expect(response.render).toHaveBeenCalledWith('referrals/new/courseParticipations/index', {
         action: `${referPaths.new.programmeHistory.updateReviewedStatus({ referralId })}?_method=PUT`,
+        historyText: `The history shows ${person.name} has previously started or completed an Accredited Programme.`,
         pageHeading: 'Accredited Programme history',
         person,
         referralId,
         successMessage: undefined,
         summaryListsOptions: [summaryListOptions, summaryListOptions],
+      })
+    })
+
+    describe('when there is no programme history for a person', () => {
+      it('renders the index template with the correct response locals for `historyText` and `summaryListsOptions`', async () => {
+        referralService.getReferral.mockResolvedValue(draftReferral)
+        courseService.getAndPresentParticipationsByPerson.mockResolvedValue([])
+
+        const requestHandler = controller.index()
+        await requestHandler(request, response, next)
+
+        expect(referralService.getReferral).toHaveBeenCalledWith(username, referralId)
+        expect(courseService.getAndPresentParticipationsByPerson).toHaveBeenCalledWith(
+          username,
+          userToken,
+          person.prisonNumber,
+          referralId,
+        )
+
+        expect(response.render).toHaveBeenCalledWith(
+          'referrals/new/courseParticipations/index',
+          expect.objectContaining({
+            historyText: `There is no record of Accredited Programmes for ${person.name}.`,
+            summaryListsOptions: [],
+          }),
+        )
       })
     })
 

--- a/server/controllers/refer/new/courseParticipationsController.ts
+++ b/server/controllers/refer/new/courseParticipationsController.ts
@@ -176,8 +176,13 @@ export default class NewReferralsCourseParticipationsController {
 
       const successMessage = req.flash('successMessage')[0]
 
+      const historyText = summaryListsOptions.length
+        ? `The history shows ${person.name} has previously started or completed an Accredited Programme.`
+        : `There is no record of Accredited Programmes for ${person.name}.`
+
       return res.render('referrals/new/courseParticipations/index', {
         action: `${referPaths.new.programmeHistory.updateReviewedStatus({ referralId: referral.id })}?_method=PUT`,
+        historyText,
         pageHeading: 'Accredited Programme history',
         person,
         referralId,

--- a/server/views/referrals/new/courseParticipations/index.njk
+++ b/server/views/referrals/new/courseParticipations/index.njk
@@ -1,31 +1,10 @@
 {% from "govuk/components/back-link/macro.njk" import govukBackLink %}
 {% from "govuk/components/button/macro.njk" import govukButton %}
+{% from "govuk/components/inset-text/macro.njk" import govukInsetText %}
 {% from "govuk/components/summary-list/macro.njk" import govukSummaryList %}
 {% from "moj/components/banner/macro.njk" import mojBanner %}
 
 {% extends "../../../partials/layout.njk" %}
-
-{% macro actionForm(secondaryActionText) %}
-  <form action="{{ action }}" method="post">
-    <input type="hidden" name="_csrf" value="{{ csrfToken }}"/>
-    <input type="hidden" name="hasReviewedProgrammeHistory" value="true"/>
-
-    <div class="govuk-button-group">
-      {{ govukButton({
-        text: "Continue"
-      }) }}
-
-      {{ govukButton({
-        text: secondaryActionText,
-        classes: "govuk-button--secondary",
-        href: referPaths.new.programmeHistory.new({ referralId: referralId }),
-        attributes: {
-          "data-testid": "add-history-button"
-        }
-      }) }}
-    </div>
-  </form>
-{% endmacro %}
 
 {% block personBanner %}
   {% include "../../_personBanner.njk" %}
@@ -54,21 +33,45 @@
         }) }}
       {% endif %}
 
+      {{ govukInsetText({
+        classes: "govuk-!-margin-top-0",
+        text: historyText,
+        attributes: {
+          "data-testid": "history-text"
+        }
+      }) }}
+
       {% if summaryListsOptions.length %}
-        <p class="govuk-body" data-testid="pre-history-paragraph">The history below shows {{ person.name }}'s history of Accredited Programmes. Add another programme if you know that they started or completed a programme which is not listed below.</p>
-
-        {% for summaryListOptions in summaryListsOptions %}
-          {{ govukSummaryList(summaryListOptions) }}
-        {% endfor %}
-
-        {{ actionForm(secondaryActionText="Add another") }}
+        <p class="govuk-body" data-testid="pre-history-paragraph">Add another programme if you know that they started or completed a programme which is not listed below or skip this section of the referral if the history is not known.</p>
       {% else %}
-        <h2 class="govuk-heading-m" data-testid="no-history-heading">There is no Accredited Programme history for {{ person.name }}.</h2>
+        <p class="govuk-body" data-testid="no-history-paragraph-1">The programme team may use information about a person's Accredited Programme history to assess whether they are suitable.</p>
 
-        <p class="govuk-body" data-testid="no-history-paragraph">The programme team may use information about a person's Accredited Programme history to assess whether they are suitable. You can add a programme to this history or continue with the referral if the {{ person.name }}'s history is unknown.</p>
-
-        {{ actionForm(secondaryActionText="Add a programme") }}
+        <p class="govuk-body" data-testid="no-history-paragraph-2">You can continue by adding a programme history or skip this section of the referral if the history is not known.</p>
       {% endif %}
+
+      {% for summaryListOptions in summaryListsOptions %}
+        {{ govukSummaryList(summaryListOptions) }}
+      {% endfor %}
+
+      <form action="{{ action }}" method="post">
+        <input type="hidden" name="_csrf" value="{{ csrfToken }}"/>
+        <input type="hidden" name="hasReviewedProgrammeHistory" value="true"/>
+
+        <div class="govuk-button-group">
+          {{ govukButton({
+            text: "Add a programme",
+            href: referPaths.new.programmeHistory.new({ referralId: referralId }),
+            attributes: {
+              "data-testid": "add-history-button"
+            }
+          }) }}
+
+          {{ govukButton({
+            text: "Skip this section",
+            classes: "govuk-button--secondary"
+          }) }}
+        </div>
+      </form>
     </div>
   </div>
 {% endblock content %}


### PR DESCRIPTION
## Context

https://trello.com/c/uWDsgCor/1104-update-programme-history-page-without-history-state-s
https://trello.com/c/wdCsDyAW/1105-update-programme-history-page-with-history-state-s


## Changes in this PR
Content at the top of the page changed for both with history and without history states
Buttons switched and text changed


## Screenshots of UI changes

### Before
**Without history:**
![localhost_3000_refer_referrals_new_c11fab18-dc8d-420c-9c82-d0edd373732d_programme-history (1)](https://github.com/ministryofjustice/hmpps-accredited-programmes-ui/assets/1067537/35c9862b-3cfd-465e-9b39-2642a34f0f66)

**With history:**
![localhost_3000_refer_referrals_new_c11fab18-dc8d-420c-9c82-d0edd373732d_programme-history](https://github.com/ministryofjustice/hmpps-accredited-programmes-ui/assets/1067537/9cf7b80c-aa43-4b96-a45a-788896c30a7a)

### After
**Without history:**
![localhost_3000_refer_referrals_new_c11fab18-dc8d-420c-9c82-d0edd373732d_programme-history (2)](https://github.com/ministryofjustice/hmpps-accredited-programmes-ui/assets/1067537/2eb199df-a868-41c2-a9a3-d5cc39062c52)

**With history:**
![localhost_3000_refer_referrals_new_c11fab18-dc8d-420c-9c82-d0edd373732d_programme-history (4)](https://github.com/ministryofjustice/hmpps-accredited-programmes-ui/assets/1067537/03817cf2-7167-428c-ae3e-5d4923fa1994)

**With success message after adding:**
![localhost_3000_refer_referrals_new_c11fab18-dc8d-420c-9c82-d0edd373732d_programme-history (3)](https://github.com/ministryofjustice/hmpps-accredited-programmes-ui/assets/1067537/a83be7dd-e5c5-4b0d-bd88-7ff608b65bbd)



## Release checklist

[Release process documentation](../doc/how-to/perform-a-release.md)

As part of our continuous deployment strategy we must ensure that this work is
ready to be released once merged.

### Pre-merge

- [ ] There are changes required to the Accredited Programmes API for this change to work...
  - [ ] ... and they have been released to production already

### Post-merge

<!-- The outer checkboxes can be completed pre-merge -->

- [ ] This adds, extends or meaningfully modifies a feature...
  - [ ] ... and I have written or updated an end-to-end test for the happy path in the [Accredited Programmes E2E repo](https://github.com/ministryofjustice/hmpps-accredited-programmes-e2e)
- [ ] This makes new expectations of the API...
  - [ ] ... and I have notified the API developer(s) of changes to the contract tests (Pact), or the API is already compliant
- [ ] [Manually approve](../doc/how-to/perform-a-release.md#releasing-to-the-preprod-environment) release to preprod
- [ ] [Manually approve](../doc/how-to/perform-a-release.md#releasing-to-the-production-environment) release to prod

<!-- Should a release fail at any step, you as the author should now lead the work to
fix it as soon as possible. You can monitor deployment failures in CircleCI
itself and application errors are found in
[Sentry](https://ministryofjustice.sentry.io/projects/hmpps-accredited-programmes-ui/?project=4505330122686464&referrer=sidebar&statsPeriod=24h). -->
