### PR TITLE
(1123) Add Referrer name to the top of view referral pages

### DIFF
--- a/integration_tests/pages/page.ts
+++ b/integration_tests/pages/page.ts
@@ -16,6 +16,7 @@ import type {
   HasTextString,
 } from '@accredited-programmes/ui'
 import type { GovukFrontendSummaryListCardTitle, GovukFrontendWarningText } from '@govuk-frontend'
+import type { User } from '@manage-users-api'
 
 export type PageElement = Cypress.Chainable<JQuery>
 
@@ -229,9 +230,15 @@ export default abstract class Page {
     })
   }
 
-  shouldContainSubmissionSummaryList(referral: Referral): void {
+  shouldContainSubmissionSummaryList(
+    referralSubmissionDate: Referral['submittedOn'],
+    referrerName: User['name'],
+  ): void {
     cy.get('[data-testid="submission-summary-list"]').then(summaryListElement => {
-      this.shouldContainSummaryListRows(ShowReferralUtils.submissionSummaryListRows(referral), summaryListElement)
+      this.shouldContainSummaryListRows(
+        ShowReferralUtils.submissionSummaryListRows(referralSubmissionDate, referrerName),
+        summaryListElement,
+      )
     })
   }
 

--- a/integration_tests/support/sharedTests.ts
+++ b/integration_tests/support/sharedTests.ts
@@ -27,6 +27,7 @@ import {
 } from '../pages/shared'
 import type { Person, Referral } from '@accredited-programmes/models'
 import type { CourseParticipationPresenter } from '@accredited-programmes/ui'
+import type { User } from '@manage-users-api'
 import type { Prisoner } from '@prisoner-search'
 
 type ApplicationRole = `${ApplicationRoles}`
@@ -67,6 +68,7 @@ const defaultPerson = personFactory.build({
   tariffDate: defaultPrisoner.tariffDate,
 })
 let referral: Referral
+let referringUser: User
 const organisation = OrganisationUtils.organisationFromPrison(prison)
 const user = userFactory.build()
 let courseParticipationPresenter1: CourseParticipationPresenter
@@ -89,6 +91,7 @@ const sharedTests = {
         prisonNumber: person.prisonNumber,
         ...(data?.referral || {}),
       })
+      referringUser = userFactory.build({ name: 'Referring User', username: referral.referrerUsername })
       courseParticipationPresenter1 = {
         ...courseParticipationFactory.build({
           addedBy: user.username,
@@ -117,6 +120,7 @@ const sharedTests = {
       cy.task('stubPrison', prison)
       cy.task('stubPrisoner', prisoner)
       cy.task('stubReferral', referral)
+      cy.task('stubUserDetails', referringUser)
     },
 
     showsAdditionalInformationPage: (role: ApplicationRole): void => {
@@ -133,7 +137,7 @@ const sharedTests = {
       additionalInformationPage.shouldContainNavigation(path)
       additionalInformationPage.shouldContainBackLink('#')
       additionalInformationPage.shouldContainCourseOfferingSummaryList(coursePresenter, organisation.name)
-      additionalInformationPage.shouldContainSubmissionSummaryList(referral)
+      additionalInformationPage.shouldContainSubmissionSummaryList(referral.submittedOn, referringUser.name)
       additionalInformationPage.shouldContainSubmittedReferralSideNavigation(path, referral.id)
       additionalInformationPage.shouldContainAdditionalInformationSummaryCard()
       additionalInformationPage.shouldContainSubmittedText()
@@ -160,7 +164,7 @@ const sharedTests = {
       offenceHistoryPage.shouldContainNavigation(path)
       offenceHistoryPage.shouldContainBackLink('#')
       offenceHistoryPage.shouldContainCourseOfferingSummaryList(coursePresenter, organisation.name)
-      offenceHistoryPage.shouldContainSubmissionSummaryList(referral)
+      offenceHistoryPage.shouldContainSubmissionSummaryList(referral.submittedOn, referringUser.name)
       offenceHistoryPage.shouldContainSubmittedReferralSideNavigation(path, referral.id)
       offenceHistoryPage.shouldContainImportedFromText()
       offenceHistoryPage.shouldContainNoOffenceHistoryMessage()
@@ -185,7 +189,7 @@ const sharedTests = {
       programmeHistoryPage.shouldContainNavigation(path)
       programmeHistoryPage.shouldContainBackLink('#')
       programmeHistoryPage.shouldContainCourseOfferingSummaryList(coursePresenter, organisation.name)
-      programmeHistoryPage.shouldContainSubmissionSummaryList(referral)
+      programmeHistoryPage.shouldContainSubmissionSummaryList(referral.submittedOn, referringUser.name)
       programmeHistoryPage.shouldContainSubmittedReferralSideNavigation(path, referral.id)
       programmeHistoryPage.shouldContainNoHistorySummaryCard()
     },
@@ -242,7 +246,7 @@ const sharedTests = {
       offenceHistoryPage.shouldContainNavigation(path)
       offenceHistoryPage.shouldContainBackLink('#')
       offenceHistoryPage.shouldContainCourseOfferingSummaryList(coursePresenter, organisation.name)
-      offenceHistoryPage.shouldContainSubmissionSummaryList(referral)
+      offenceHistoryPage.shouldContainSubmissionSummaryList(referral.submittedOn, referringUser.name)
       offenceHistoryPage.shouldContainSubmittedReferralSideNavigation(path, referral.id)
       offenceHistoryPage.shouldContainImportedFromText()
       offenceHistoryPage.shouldContainIndexOffenceSummaryCard()
@@ -263,7 +267,7 @@ const sharedTests = {
       personalDetailsPage.shouldContainNavigation(path)
       personalDetailsPage.shouldContainBackLink('#')
       personalDetailsPage.shouldContainCourseOfferingSummaryList(coursePresenter, organisation.name)
-      personalDetailsPage.shouldContainSubmissionSummaryList(referral)
+      personalDetailsPage.shouldContainSubmissionSummaryList(referral.submittedOn, referringUser.name)
       personalDetailsPage.shouldContainSubmittedReferralSideNavigation(path, referral.id)
       personalDetailsPage.shouldContainImportedFromText()
       personalDetailsPage.shouldContainPersonalDetailsSummaryCard()
@@ -294,7 +298,7 @@ const sharedTests = {
       programmeHistoryPage.shouldContainNavigation(path)
       programmeHistoryPage.shouldContainBackLink('#')
       programmeHistoryPage.shouldContainCourseOfferingSummaryList(coursePresenter, organisation.name)
-      programmeHistoryPage.shouldContainSubmissionSummaryList(referral)
+      programmeHistoryPage.shouldContainSubmissionSummaryList(referral.submittedOn, referringUser.name)
       programmeHistoryPage.shouldContainSubmittedReferralSideNavigation(path, referral.id)
       programmeHistoryPage.shouldContainHistorySummaryCards(courseParticipationsPresenter, referral.id, {
         change: false,
@@ -321,7 +325,7 @@ const sharedTests = {
       sentenceInformationPage.shouldContainNavigation(path)
       sentenceInformationPage.shouldContainBackLink('#')
       sentenceInformationPage.shouldContainCourseOfferingSummaryList(coursePresenter, organisation.name)
-      sentenceInformationPage.shouldContainSubmissionSummaryList(referral)
+      sentenceInformationPage.shouldContainSubmissionSummaryList(referral.submittedOn, referringUser.name)
       sentenceInformationPage.shouldContainSubmittedReferralSideNavigation(path, referral.id)
       sentenceInformationPage.shouldContainImportedFromText()
       sentenceInformationPage.shouldContainSentenceDetailsSummaryCard()
@@ -355,7 +359,7 @@ const sharedTests = {
       sentenceInformationPage.shouldContainNavigation(path)
       sentenceInformationPage.shouldContainBackLink('#')
       sentenceInformationPage.shouldContainCourseOfferingSummaryList(coursePresenter, organisation.name)
-      sentenceInformationPage.shouldContainSubmissionSummaryList(referral)
+      sentenceInformationPage.shouldContainSubmissionSummaryList(referral.submittedOn, referringUser.name)
       sentenceInformationPage.shouldContainSubmittedReferralSideNavigation(path, referral.id)
       sentenceInformationPage.shouldContainImportedFromText()
       sentenceInformationPage.shouldContainNoSentenceDetailsSummaryCard()

--- a/server/@types/models/Referral.ts
+++ b/server/@types/models/Referral.ts
@@ -11,6 +11,7 @@ type Referral = {
   offeringId: CourseOffering['id']
   prisonNumber: Person['prisonNumber']
   referrerId: Express.User['userId']
+  referrerUsername: Express.User['username']
   status: ReferralStatus
   submittedOn?: string
 }

--- a/server/controllers/shared/index.ts
+++ b/server/controllers/shared/index.ts
@@ -11,6 +11,7 @@ const controllers = (services: Services) => {
     services.organisationService,
     services.personService,
     services.referralService,
+    services.userService,
   )
 
   return {

--- a/server/testutils/factories/referral.ts
+++ b/server/testutils/factories/referral.ts
@@ -54,6 +54,7 @@ export default ReferralFactory.define(({ params }) => {
     offeringId: faker.string.uuid(),
     prisonNumber: faker.string.alphanumeric({ length: 7 }),
     referrerId: faker.string.numeric({ length: 6 }),
+    referrerUsername: faker.internet.userName(),
     status,
     submittedOn: status !== 'referral_started' ? faker.date.past().toISOString() : undefined,
   }

--- a/server/utils/referrals/showReferralUtils.test.ts
+++ b/server/utils/referrals/showReferralUtils.test.ts
@@ -51,6 +51,21 @@ describe('ShowReferralUtils', () => {
         },
       ])
     })
+
+    describe('when the referral has no submission date', () => {
+      it("returns submission details with 'Not known' for the 'Date referred' value", () => {
+        const referral = referralFactory.submitted().build({ submittedOn: undefined })
+
+        expect(ShowReferralUtils.submissionSummaryListRows(referral.submittedOn, 'Test User')).toEqual(
+          expect.arrayContaining([
+            {
+              key: { text: 'Date referred' },
+              value: { text: 'Not known' },
+            },
+          ]),
+        )
+      })
+    })
   })
 
   describe('viewReferralNavigationItems', () => {

--- a/server/utils/referrals/showReferralUtils.test.ts
+++ b/server/utils/referrals/showReferralUtils.test.ts
@@ -40,10 +40,14 @@ describe('ShowReferralUtils', () => {
     it('returns submission details relating to a referral in the appropriate format for passing to a GOV.UK summary list Nunjucks macro', () => {
       const referral = referralFactory.submitted().build({ submittedOn: '2023-10-31T00:00:00.000000' })
 
-      expect(ShowReferralUtils.submissionSummaryListRows(referral)).toEqual([
+      expect(ShowReferralUtils.submissionSummaryListRows(referral.submittedOn, 'Test User')).toEqual([
         {
           key: { text: 'Date referred' },
           value: { text: '31 October 2023' },
+        },
+        {
+          key: { text: 'Referrer name' },
+          value: { text: 'Test User' },
         },
       ])
     })

--- a/server/utils/referrals/showReferralUtils.ts
+++ b/server/utils/referrals/showReferralUtils.ts
@@ -8,6 +8,7 @@ import type {
   GovukFrontendSummaryListRowWithKeyAndValue,
   MojFrontendSideNavigationItem,
 } from '@accredited-programmes/ui'
+import type { User } from '@manage-users-api'
 
 export default class ShowReferralUtils {
   static courseOfferingSummaryListRows(
@@ -30,11 +31,20 @@ export default class ShowReferralUtils {
     ]
   }
 
-  static submissionSummaryListRows(referral: Referral): Array<GovukFrontendSummaryListRowWithKeyAndValue> {
+  static submissionSummaryListRows(
+    referralSubmissionDate: Referral['submittedOn'],
+    referrerName: User['name'],
+  ): Array<GovukFrontendSummaryListRowWithKeyAndValue> {
     return [
       {
         key: { text: 'Date referred' },
-        value: { text: DateUtils.govukFormattedFullDateString(referral.submittedOn) },
+        value: {
+          text: DateUtils.govukFormattedFullDateString(referralSubmissionDate),
+        },
+      },
+      {
+        key: { text: 'Referrer name' },
+        value: { text: referrerName },
       },
     ]
   }

--- a/server/utils/referrals/showReferralUtils.ts
+++ b/server/utils/referrals/showReferralUtils.ts
@@ -39,7 +39,7 @@ export default class ShowReferralUtils {
       {
         key: { text: 'Date referred' },
         value: {
-          text: DateUtils.govukFormattedFullDateString(referralSubmissionDate),
+          text: referralSubmissionDate ? DateUtils.govukFormattedFullDateString(referralSubmissionDate) : 'Not known',
         },
       },
       {


### PR DESCRIPTION
## Context

https://trello.com/c/FyFfGdPj/1123-use-referrerusername-field-to-display-name-of-person-who-created-a-referral-m

## Changes in this PR
Use the user `referrerUsername` value on a Referral and call manage users api to get the referring users name and display it on the view referral page and sub pages.


## Screenshots of UI changes

![image](https://github.com/ministryofjustice/hmpps-accredited-programmes-ui/assets/1067537/ec6fce09-b846-49f9-887e-3e257c0a6729)



## Release checklist

[Release process documentation](../doc/how-to/perform-a-release.md)

As part of our continuous deployment strategy we must ensure that this work is
ready to be released once merged.

### Pre-merge

- [ ] There are changes required to the Accredited Programmes API for this change to work...
  - [ ] ... and they have been released to production already

### Post-merge

<!-- The outer checkboxes can be completed pre-merge -->

- [ ] This adds, extends or meaningfully modifies a feature...
  - [ ] ... and I have written or updated an end-to-end test for the happy path in the [Accredited Programmes E2E repo](https://github.com/ministryofjustice/hmpps-accredited-programmes-e2e)
- [ ] This makes new expectations of the API...
  - [ ] ... and I have notified the API developer(s) of changes to the contract tests (Pact), or the API is already compliant
- [ ] [Manually approve](../doc/how-to/perform-a-release.md#releasing-to-the-preprod-environment) release to preprod
- [ ] [Manually approve](../doc/how-to/perform-a-release.md#releasing-to-the-production-environment) release to prod

<!-- Should a release fail at any step, you as the author should now lead the work to
fix it as soon as possible. You can monitor deployment failures in CircleCI
itself and application errors are found in
[Sentry](https://ministryofjustice.sentry.io/projects/hmpps-accredited-programmes-ui/?project=4505330122686464&referrer=sidebar&statsPeriod=24h). -->
