### PR TITLE
(1197) Remove `referrerId` from Referral

### DIFF
--- a/script/utils/generateApiSeeds/tableDefinitions.ts
+++ b/script/utils/generateApiSeeds/tableDefinitions.ts
@@ -72,7 +72,6 @@ export default class TableDefinitions {
         { api: 'offering_id', ui: 'offeringId' },
         { api: 'prison_number', ui: 'prisonNumber' },
         { api: 'referrer_username', ui: 'referrerUsername' },
-        { api: 'referrer_id', ui: 'referrerId' },
         { api: 'additional_information', ui: 'additionalInformation' },
         { api: 'oasys_confirmed', ui: 'oasysConfirmed' },
         { api: 'has_reviewed_programme_history', ui: 'hasReviewedProgrammeHistory' },

--- a/script/utils/generateApiSeeds/tableRecords.ts
+++ b/script/utils/generateApiSeeds/tableRecords.ts
@@ -193,11 +193,10 @@ export default class TableRecords {
     const referral = referralFactory.build({
       offeringId,
       prisonNumber,
-      referrerId: referrer.id,
+      referrerUsername: referrer.username,
     })
     return {
       ...referral,
-      referrerUsername: referrer.username,
       status: referral.status.toUpperCase() as ReferralRecord['status'],
     }
   }

--- a/server/@types/models/Referral.ts
+++ b/server/@types/models/Referral.ts
@@ -10,7 +10,6 @@ type Referral = {
   oasysConfirmed: boolean
   offeringId: CourseOffering['id']
   prisonNumber: Person['prisonNumber']
-  referrerId: Express.User['userId']
   referrerUsername: Express.User['username']
   status: ReferralStatus
   submittedOn?: string

--- a/server/controllers/refer/new/referralsController.test.ts
+++ b/server/controllers/refer/new/referralsController.test.ts
@@ -121,7 +121,6 @@ describe('NewReferralsController', () => {
       courseService.getCourseByOffering.mockResolvedValue(referableCourse)
 
       TypeUtils.assertHasUser(request)
-      request.user.userId = draftReferral.referrerId
 
       referralService.createReferral.mockResolvedValue({ referralId })
 
@@ -134,7 +133,6 @@ describe('NewReferralsController', () => {
         username,
         draftReferral.offeringId,
         draftReferral.prisonNumber,
-        draftReferral.referrerId,
       )
     })
 
@@ -147,7 +145,6 @@ describe('NewReferralsController', () => {
         courseService.getCourseByOffering.mockResolvedValue(nonReferableCourse)
 
         TypeUtils.assertHasUser(request)
-        request.user.userId = draftReferral.referrerId
 
         const requestHandler = controller.create()
         const expectedError = createError(400, 'Course is not referable.')

--- a/server/controllers/refer/new/referralsController.ts
+++ b/server/controllers/refer/new/referralsController.ts
@@ -93,7 +93,7 @@ export default class NewReferralsController {
       TypeUtils.assertHasUser(req)
 
       const { courseOfferingId, prisonNumber } = req.body
-      const { username, userId } = req.user
+      const { username } = req.user
 
       const course = await this.courseService.getCourseByOffering(req.user.username, courseOfferingId)
       if (!course.referable) {
@@ -104,7 +104,6 @@ export default class NewReferralsController {
         username,
         courseOfferingId,
         prisonNumber,
-        userId,
       )
 
       res.redirect(referPaths.new.show({ referralId: createdReferralResponse.referralId }))

--- a/server/data/accreditedProgrammesApi/referralClient.test.ts
+++ b/server/data/accreditedProgrammesApi/referralClient.test.ts
@@ -21,7 +21,6 @@ pactWith({ consumer: 'Accredited Programmes UI', provider: 'Accredited Programme
   describe('create', () => {
     const createdReferralResponse: CreatedReferralResponse = { referralId: faker.string.uuid() }
     const prisonNumber = 'A1234AA'
-    const referrerId = faker.string.numeric({ length: 6 })
 
     beforeEach(() => {
       provider.addInteraction({
@@ -32,7 +31,7 @@ pactWith({ consumer: 'Accredited Programmes UI', provider: 'Accredited Programme
           status: 201,
         },
         withRequest: {
-          body: { offeringId: '7fffcc6a-11f8-4713-be35-cf5ff1aee517', prisonNumber, referrerId },
+          body: { offeringId: '7fffcc6a-11f8-4713-be35-cf5ff1aee517', prisonNumber },
           headers: {
             authorization: `Bearer ${userToken}`,
           },
@@ -43,7 +42,7 @@ pactWith({ consumer: 'Accredited Programmes UI', provider: 'Accredited Programme
     })
 
     it('creates a referral and returns a referral ID wrapper', async () => {
-      const result = await referralClient.create('7fffcc6a-11f8-4713-be35-cf5ff1aee517', prisonNumber, referrerId)
+      const result = await referralClient.create('7fffcc6a-11f8-4713-be35-cf5ff1aee517', prisonNumber)
 
       expect(result).toEqual(createdReferralResponse)
     })

--- a/server/data/accreditedProgrammesApi/referralClient.ts
+++ b/server/data/accreditedProgrammesApi/referralClient.ts
@@ -24,10 +24,9 @@ export default class ReferralClient {
   async create(
     courseOfferingId: Referral['offeringId'],
     prisonNumber: Referral['prisonNumber'],
-    referrerId: Referral['referrerId'],
   ): Promise<CreatedReferralResponse> {
     return (await this.restClient.post({
-      data: { offeringId: courseOfferingId, prisonNumber, referrerId },
+      data: { offeringId: courseOfferingId, prisonNumber },
       path: apiPaths.referrals.create({}),
     })) as CreatedReferralResponse
   }

--- a/server/services/referralService.test.ts
+++ b/server/services/referralService.test.ts
@@ -38,15 +38,10 @@ describe('ReferralService', () => {
       const createdReferralResponse: CreatedReferralResponse = { referralId: referral.id }
 
       when(referralClient.create)
-        .calledWith(referral.offeringId, referral.prisonNumber, referral.referrerId)
+        .calledWith(referral.offeringId, referral.prisonNumber)
         .mockResolvedValue(createdReferralResponse)
 
-      const result = await service.createReferral(
-        username,
-        referral.offeringId,
-        referral.prisonNumber,
-        referral.referrerId,
-      )
+      const result = await service.createReferral(username, referral.offeringId, referral.prisonNumber)
 
       expect(result).toEqual(createdReferralResponse)
 
@@ -54,11 +49,7 @@ describe('ReferralService', () => {
       expect(hmppsAuthClient.getSystemClientToken).toHaveBeenCalledWith(username)
 
       expect(referralClientBuilder).toHaveBeenCalledWith(systemToken)
-      expect(referralClient.create).toHaveBeenCalledWith(
-        referral.offeringId,
-        referral.prisonNumber,
-        referral.referrerId,
-      )
+      expect(referralClient.create).toHaveBeenCalledWith(referral.offeringId, referral.prisonNumber)
     })
   })
 

--- a/server/services/referralService.ts
+++ b/server/services/referralService.ts
@@ -21,13 +21,12 @@ export default class ReferralService {
     username: Express.User['username'],
     courseOfferingId: Referral['offeringId'],
     prisonNumber: Referral['prisonNumber'],
-    referrerId: Referral['referrerId'],
   ): Promise<CreatedReferralResponse> {
     const hmppsAuthClient = this.hmppsAuthClientBuilder()
     const systemToken = await hmppsAuthClient.getSystemClientToken(username)
     const referralClient = this.referralClientBuilder(systemToken)
 
-    return referralClient.create(courseOfferingId, prisonNumber, referrerId)
+    return referralClient.create(courseOfferingId, prisonNumber)
   }
 
   async getReferral(username: Express.User['username'], referralId: Referral['id']): Promise<Referral> {

--- a/server/testutils/factories/referral.ts
+++ b/server/testutils/factories/referral.ts
@@ -53,7 +53,6 @@ export default ReferralFactory.define(({ params }) => {
     oasysConfirmed: faker.datatype.boolean(),
     offeringId: faker.string.uuid(),
     prisonNumber: faker.string.alphanumeric({ length: 7 }),
-    referrerId: faker.string.numeric({ length: 6 }),
     referrerUsername: faker.internet.userName(),
     status,
     submittedOn: status !== 'referral_started' ? faker.date.past().toISOString() : undefined,

--- a/wiremock/stubs/referrals.json
+++ b/wiremock/stubs/referrals.json
@@ -2,9 +2,11 @@
   {
     "id": "4261ad11-279e-4698-b1bb-90241ec036b9",
     "additionalInformation": "",
+    "hasReviewedProgrammeHistory": false,
     "oasysConfirmed": false,
     "offeringId": "e78237cd-8244-4256-a1e8-8fb29b1f2f76",
     "prisonNumber": "DEF1234",
-    "referrerId": "5105a589-75b3-4ca0-9433-b96228c1c8f3"
+    "referrerUsername": "STUBBED_USER",
+    "status": "referral_started"
   }
 ]


### PR DESCRIPTION
## Context

Related to API change https://github.com/ministryofjustice/hmpps-accredited-programmes-api/pull/195 

## Release checklist

[Release process documentation](../doc/how-to/perform-a-release.md)

As part of our continuous deployment strategy we must ensure that this work is
ready to be released once merged.

### Pre-merge

- [ ] There are changes required to the Accredited Programmes API for this change to work...
  - [ ] ... and they have been released to production already

### Post-merge

<!-- The outer checkboxes can be completed pre-merge -->

- [ ] This adds, extends or meaningfully modifies a feature...
  - [ ] ... and I have written or updated an end-to-end test for the happy path in the [Accredited Programmes E2E repo](https://github.com/ministryofjustice/hmpps-accredited-programmes-e2e)
- [ ] This makes new expectations of the API...
  - [ ] ... and I have notified the API developer(s) of changes to the contract tests (Pact), or the API is already compliant
- [ ] [Manually approve](../doc/how-to/perform-a-release.md#releasing-to-the-preprod-environment) release to preprod
- [ ] [Manually approve](../doc/how-to/perform-a-release.md#releasing-to-the-production-environment) release to prod

<!-- Should a release fail at any step, you as the author should now lead the work to
fix it as soon as possible. You can monitor deployment failures in CircleCI
itself and application errors are found in
[Sentry](https://ministryofjustice.sentry.io/projects/hmpps-accredited-programmes-ui/?project=4505330122686464&referrer=sidebar&statsPeriod=24h). -->
