### PR TITLE
(1183) Filter out draft referrals from assess case list

### DIFF
--- a/integration_tests/e2e/assess/caseList.cy.ts
+++ b/integration_tests/e2e/assess/caseList.cy.ts
@@ -13,11 +13,13 @@ context('Referral case lists', () => {
   const limeCourseReferralSummaries = FactoryHelpers.buildListWith(
     referralSummaryFactory,
     { courseName: limeCourse.name },
+    {},
     15,
   )
   const orangeCourseReferralSummaries = FactoryHelpers.buildListWith(
     referralSummaryFactory,
     { courseName: orangeCourse.name },
+    {},
     15,
   )
 

--- a/integration_tests/e2e/assess/caseList.cy.ts
+++ b/integration_tests/e2e/assess/caseList.cy.ts
@@ -10,16 +10,17 @@ context('Referral case lists', () => {
   const limeCourse = courseFactory.build({ name: 'Lime Course' })
   const orangeCourse = courseFactory.build({ name: 'Blue Course' })
   const courses = [limeCourse, orangeCourse]
+  const availableStatuses = ['assessment_started', 'awaiting_assessment', 'referral_submitted']
   const limeCourseReferralSummaries = FactoryHelpers.buildListWith(
     referralSummaryFactory,
     { courseName: limeCourse.name },
-    {},
+    { transient: { availableStatuses } },
     15,
   )
   const orangeCourseReferralSummaries = FactoryHelpers.buildListWith(
     referralSummaryFactory,
     { courseName: orangeCourse.name },
-    {},
+    { transient: { availableStatuses } },
     15,
   )
 

--- a/server/controllers/assess/caseListController.test.ts
+++ b/server/controllers/assess/caseListController.test.ts
@@ -126,8 +126,10 @@ describe('AssessCaseListController', () => {
     })
 
     it('renders the show template with the correct response locals', async () => {
+      const apiStatusQuery = 'ASSESSMENT_STARTED,AWAITING_ASSESSMENT,REFERRAL_SUBMITTED'
+
       ;(CaseListUtils.uiToApiAudienceQueryParam as jest.Mock).mockReturnValue(undefined)
-      ;(CaseListUtils.uiToApiStatusQueryParam as jest.Mock).mockReturnValue(undefined)
+      ;(CaseListUtils.uiToApiStatusQueryParam as jest.Mock).mockReturnValue(apiStatusQuery)
 
       const requestHandler = controller.show()
       await requestHandler(request, response, next)
@@ -142,11 +144,11 @@ describe('AssessCaseListController', () => {
         tableRows,
       })
       expect(CaseListUtils.uiToApiAudienceQueryParam).toHaveBeenCalledWith(undefined)
-      expect(CaseListUtils.uiToApiStatusQueryParam).toHaveBeenCalledWith(undefined)
+      expect(CaseListUtils.uiToApiStatusQueryParam).toHaveBeenCalledWith(apiStatusQuery.toLowerCase())
       expect(referralService.getReferralSummaries).toHaveBeenCalledWith(username, activeCaseLoadId, {
         audience: undefined,
         courseName: 'Lime Course',
-        status: undefined,
+        status: apiStatusQuery,
       })
       expect(CaseListUtils.queryParamsExcludingPage).toHaveBeenLastCalledWith(undefined, undefined)
       expect(PaginationUtils.pagination).toHaveBeenLastCalledWith(

--- a/server/controllers/assess/caseListController.ts
+++ b/server/controllers/assess/caseListController.ts
@@ -63,11 +63,13 @@ export default class AssessCaseListController {
         throw createError(404, `${formattedCourseName} not found.`)
       }
 
+      const statusQuery = status || ['assessment_started', 'awaiting_assessment', 'referral_submitted'].join(',')
+
       const paginatedReferralSummaries = await this.referralService.getReferralSummaries(username, activeCaseLoadId, {
         audience: CaseListUtils.uiToApiAudienceQueryParam(audience),
         courseName: selectedCourse.name,
         page: page ? (Number(page) - 1).toString() : undefined,
-        status: CaseListUtils.uiToApiStatusQueryParam(status),
+        status: CaseListUtils.uiToApiStatusQueryParam(statusQuery),
       })
 
       const pagination = PaginationUtils.pagination(

--- a/server/data/accreditedProgrammesApi/referralClient.test.ts
+++ b/server/data/accreditedProgrammesApi/referralClient.test.ts
@@ -123,6 +123,7 @@ pactWith({ consumer: 'Accredited Programmes UI', provider: 'Accredited Programme
         content: FactoryHelpers.buildListWith(
           referralSummaryFactory,
           { audiences: ['General offence'], courseName: 'Super Course', status: 'referral_submitted' },
+          {},
           16,
         ),
         pageIsEmpty: false,

--- a/server/testutils/factories/factoryHelpers.ts
+++ b/server/testutils/factories/factoryHelpers.ts
@@ -1,5 +1,5 @@
 import { faker } from '@faker-js/faker/locale/en_GB'
-import type { DeepPartial, Factory } from 'fishery'
+import type { BuildOptions, DeepPartial, Factory } from 'fishery'
 
 export default class FactoryHelpers {
   static buildListBetween<T>(factory: Factory<T>, options: { max: number; min?: number }): Array<T> {
@@ -8,11 +8,16 @@ export default class FactoryHelpers {
     return factory.buildList(quantity)
   }
 
-  static buildListWith<T>(factory: Factory<T>, properties: DeepPartial<T>, count: number): Array<T> {
+  static buildListWith<T>(
+    factory: Factory<T>,
+    properties: DeepPartial<T>,
+    options: BuildOptions<T, unknown>,
+    count: number,
+  ): Array<T> {
     const built: Array<T> = []
 
     while (built.length < count) {
-      built.push(factory.build(properties))
+      built.push(factory.build(properties, options))
     }
 
     return built

--- a/server/testutils/factories/referral.ts
+++ b/server/testutils/factories/referral.ts
@@ -35,13 +35,10 @@ class ReferralFactory extends Factory<Referral> {
   }
 }
 
-export const randomStatus = () =>
-  faker.helpers.arrayElement([
-    'awaiting_assessment',
-    'assessment_started',
-    'referral_started',
-    'referral_submitted',
-  ]) as ReferralStatus
+export const randomStatus = (availableStatuses?: Array<ReferralStatus>) =>
+  faker.helpers.arrayElement(
+    availableStatuses || ['awaiting_assessment', 'assessment_started', 'referral_started', 'referral_submitted'],
+  ) as ReferralStatus
 
 export default ReferralFactory.define(({ params }) => {
   const status = params.status || randomStatus()

--- a/server/testutils/factories/referralSummary.ts
+++ b/server/testutils/factories/referralSummary.ts
@@ -5,10 +5,15 @@ import courseAudienceFactory from './courseAudience'
 import FactoryHelpers from './factoryHelpers'
 import { randomStatus } from './referral'
 import { StringUtils } from '../../utils'
-import type { ReferralSummary } from '@accredited-programmes/models'
+import type { ReferralStatus, ReferralSummary } from '@accredited-programmes/models'
 
-export default Factory.define<ReferralSummary>(({ params }) => {
-  const status = params.status || randomStatus()
+interface ReferralSummaryTransientParams {
+  availableStatuses: Array<ReferralStatus>
+}
+
+export default Factory.define<ReferralSummary, ReferralSummaryTransientParams>(({ params, transientParams }) => {
+  const { availableStatuses } = transientParams
+  const status = params.status || randomStatus(availableStatuses)
 
   return {
     id: faker.string.uuid(), // eslint-disable-next-line sort-keys

--- a/server/utils/referrals/caseListUtils.test.ts
+++ b/server/utils/referrals/caseListUtils.test.ts
@@ -99,7 +99,6 @@ describe('CaseListUtils', () => {
     const expectedItems = {
       'assessment started': 'Assessment started',
       'awaiting assessment': 'Awaiting assessment',
-      'referral started': 'Referral started',
       'referral submitted': 'Referral submitted',
     }
 

--- a/server/utils/referrals/caseListUtils.ts
+++ b/server/utils/referrals/caseListUtils.ts
@@ -58,10 +58,7 @@ export default class CaseListUtils {
   }
 
   static statusSelectItems(selectedValue?: string): Array<GovukFrontendSelectItem> {
-    return this.selectItems(
-      ['Assessment started', 'Awaiting assessment', 'Referral started', 'Referral submitted'],
-      selectedValue,
-    )
+    return this.selectItems(['Assessment started', 'Awaiting assessment', 'Referral submitted'], selectedValue)
   }
 
   static statusTagHtml(status: ReferralStatus): string {


### PR DESCRIPTION
## Context

On the assess case list view, we need to filter out any referrals with the REFERRAL_STARTED status.

## Changes in this PR
The dashboard endpoint now allows us to pass a list of statuses so we can filter by only the statuses we need.  The controller makes the request for all statuses except `referral_started` but will still use the selected filter value.

## Screenshots of UI changes

![image](https://github.com/ministryofjustice/hmpps-accredited-programmes-ui/assets/1067537/1a234c89-a411-4e70-a042-aa15018a15b5)


## Release checklist

[Release process documentation](../doc/how-to/perform-a-release.md)

As part of our continuous deployment strategy we must ensure that this work is
ready to be released once merged.

### Pre-merge

- [ ] There are changes required to the Accredited Programmes API for this change to work...
  - [ ] ... and they have been released to production already

### Post-merge

<!-- The outer checkboxes can be completed pre-merge -->

- [ ] This adds, extends or meaningfully modifies a feature...
  - [ ] ... and I have written or updated an end-to-end test for the happy path in the [Accredited Programmes E2E repo](https://github.com/ministryofjustice/hmpps-accredited-programmes-e2e)
- [ ] This makes new expectations of the API...
  - [ ] ... and I have notified the API developer(s) of changes to the contract tests (Pact), or the API is already compliant
- [ ] [Manually approve](../doc/how-to/perform-a-release.md#releasing-to-the-preprod-environment) release to preprod
- [ ] [Manually approve](../doc/how-to/perform-a-release.md#releasing-to-the-production-environment) release to prod

<!-- Should a release fail at any step, you as the author should now lead the work to
fix it as soon as possible. You can monitor deployment failures in CircleCI
itself and application errors are found in
[Sentry](https://ministryofjustice.sentry.io/projects/hmpps-accredited-programmes-ui/?project=4505330122686464&referrer=sidebar&statsPeriod=24h). -->
