### PR TITLE
(1198) Handle missing user loading

### DIFF
--- a/server/controllers/shared/referralsController.test.ts
+++ b/server/controllers/shared/referralsController.test.ts
@@ -82,7 +82,7 @@ describe('ReferralsController', () => {
     organisationService.getOrganisation.mockResolvedValue(organisation)
     personService.getPerson.mockResolvedValue(person)
     referralService.getReferral.mockResolvedValue(referral)
-    userService.getUserFromUsername.mockResolvedValue(referringUser)
+    userService.getFullNameFromUsername.mockResolvedValue(referringUser.name)
 
     controller = new SubmittedReferralsController(
       courseService,

--- a/server/controllers/shared/referralsController.ts
+++ b/server/controllers/shared/referralsController.ts
@@ -160,11 +160,11 @@ export default class ReferralsController {
     const { token: userToken, username } = req.user
 
     const referral = await this.referralService.getReferral(username, referralId)
-    const [course, courseOffering, person, referrerUser] = await Promise.all([
+    const [course, courseOffering, person, referrerUserFullName] = await Promise.all([
       this.courseService.getCourseByOffering(username, referral.offeringId),
       this.courseService.getOffering(username, referral.offeringId),
       this.personService.getPerson(username, referral.prisonNumber, res.locals.user.caseloads),
-      this.userService.getUserFromUsername(userToken, referral.referrerUsername),
+      this.userService.getFullNameFromUsername(userToken, referral.referrerUsername),
     ])
 
     const organisation = await this.organisationService.getOrganisation(userToken, courseOffering.organisationId)
@@ -180,7 +180,10 @@ export default class ReferralsController {
       pageHeading: `Referral to ${coursePresenter.nameAndAlternateName}`,
       person,
       referral,
-      submissionSummaryListRows: ShowReferralUtils.submissionSummaryListRows(referral.submittedOn, referrerUser.name),
+      submissionSummaryListRows: ShowReferralUtils.submissionSummaryListRows(
+        referral.submittedOn,
+        referrerUserFullName,
+      ),
     }
   }
 }

--- a/server/services/courseService.test.ts
+++ b/server/services/courseService.test.ts
@@ -113,7 +113,7 @@ describe('CourseService', () => {
         earliestCourseParticipation,
       ])
 
-      userService.getUserFromUsername.mockResolvedValue(addedByUser)
+      userService.getFullNameFromUsername.mockResolvedValue(addedByDisplayName)
     })
 
     describe('when no actions are passed', () => {
@@ -349,9 +349,9 @@ describe('CourseService', () => {
     const referralId = 'a-referral-id'
 
     it('fetches the creator, then formats the participation and creator in the appropriate for passing to a GOV.UK summary list Nunjucks macro', async () => {
-      when(userService.getUserFromUsername)
+      when(userService.getFullNameFromUsername)
         .calledWith(userToken, courseParticipation.addedBy)
-        .mockResolvedValue(addedByUser)
+        .mockResolvedValue(addedByDisplayName)
 
       when(CourseParticipationUtils.summaryListOptions as jest.Mock)
         .calledWith({ ...courseParticipation, addedByDisplayName }, referralId, {

--- a/server/services/courseService.ts
+++ b/server/services/courseService.ts
@@ -3,7 +3,7 @@ import type { ResponseError } from 'superagent'
 
 import type UserService from './userService'
 import type { CourseClient, HmppsAuthClient, RestClientBuilder, RestClientBuilderWithoutToken } from '../data'
-import { CourseParticipationUtils, StringUtils } from '../utils'
+import { CourseParticipationUtils } from '../utils'
 import type {
   Course,
   CourseOffering,
@@ -174,11 +174,11 @@ export default class CourseService {
     referralId: Referral['id'],
     withActions = { change: true, remove: true },
   ): Promise<GovukFrontendSummaryListWithRowsWithKeysAndValues> {
-    const addedByUser = await this.userService.getUserFromUsername(userToken, courseParticipation.addedBy)
+    const addedByDisplayName = await this.userService.getFullNameFromUsername(userToken, courseParticipation.addedBy)
 
     const courseParticipationPresenter = {
       ...courseParticipation,
-      addedByDisplayName: StringUtils.convertToTitleCase(addedByUser.name),
+      addedByDisplayName,
     }
 
     return CourseParticipationUtils.summaryListOptions(courseParticipationPresenter, referralId, withActions)

--- a/server/services/userService.ts
+++ b/server/services/userService.ts
@@ -27,6 +27,15 @@ export default class UserService {
     return { ...user, caseloads, displayName: StringUtils.convertToTitleCase(user.name) }
   }
 
+  /*
+   * A helper which presents a consistent language string across controllers
+   * And which factors in the user may no longer be an entity
+   */
+  async getFullNameFromUsername(userToken: Express.User['token'], username: User['username']): Promise<string> {
+    const user = await this.checkUserExistsFromUsername(userToken, username)
+    return user ? StringUtils.convertToTitleCase(user.name) : `User '${username}' not found`
+  }
+
   async getUserFromUsername(userToken: Express.User['token'], username: User['username']): Promise<User> {
     const hmppsManageUsersClient = this.hmppsManageUsersClientBuilder(userToken)
 
@@ -39,11 +48,36 @@ export default class UserService {
         throw createError(knownError.status, `User with username ${username} not found.`)
       }
 
-      const errorMessage =
-        knownError.message === 'Internal Server Error' ? `Error fetching user ${username}.` : knownError.message
-
-      throw createError(knownError.status || 500, errorMessage)
+      throw this.createUserLoadNon404Error(username, knownError)
     }
+  }
+
+  /*
+   * Rather than return a boolean this function returns a thruthy by way of the User object
+   * This likely saves on a subsequent call afterwards to fetch these details.
+   */
+  private async checkUserExistsFromUsername(
+    userToken: Express.User['token'],
+    username: User['username'],
+  ): Promise<User | null> {
+    const hmppsManageUsersClient = this.hmppsManageUsersClientBuilder(userToken)
+
+    try {
+      const result = await hmppsManageUsersClient.getUserFromUsername(username)
+      return result
+    } catch (error) {
+      const knownError = error as ResponseError
+      if (knownError.status === 404) {
+        return null
+      }
+      throw this.createUserLoadNon404Error(username, knownError)
+    }
+  }
+
+  private createUserLoadNon404Error(username: string, knownError: ResponseError) {
+    const errorMessage =
+      knownError.message === 'Internal Server Error' ? `Error fetching user ${username}.` : knownError.message
+    return createError(knownError.status || 500, errorMessage)
   }
 
   private async getCaseloads(systemToken: SystemToken): Promise<Array<Caseload>> {


### PR DESCRIPTION
When a user is not found a message is returned. The behaviour for two controllers was to throw if the user were missing.

Note the original function and its behaviour still exists as it may be used by other work in progress, and that behaviour may be preferred. If this is not the case a separate task could be actioned to remove it.

### Before

<img width="1137" alt="Screenshot 2023-12-19 at 11 53 08" src="https://github.com/ministryofjustice/hmpps-accredited-programmes-ui/assets/7350883/329692e4-b40c-49f2-b04c-80be2b47496b">

### After

<img width="924" alt="Screenshot 2023-12-19 at 11 50 38" src="https://github.com/ministryofjustice/hmpps-accredited-programmes-ui/assets/7350883/d4c77262-79bf-4cf0-9447-6a88ad6c1e30">

## Release checklist

[Release process documentation](../doc/how-to/perform-a-release.md)

As part of our continuous deployment strategy we must ensure that this work is
ready to be released once merged.

### Pre-merge

- [ ] There are changes required to the Accredited Programmes API for this change to work...
  - [ ] ... and they have been released to production already

### Post-merge

<!-- The outer checkboxes can be completed pre-merge -->

- [ ] This adds, extends or meaningfully modifies a feature...
  - [ ] ... and I have written or updated an end-to-end test for the happy path in the [Accredited Programmes E2E repo](https://github.com/ministryofjustice/hmpps-accredited-programmes-e2e)
- [ ] This makes new expectations of the API...
  - [ ] ... and I have notified the API developer(s) of changes to the contract tests (Pact), or the API is already compliant
- [ ] [Manually approve](../doc/how-to/perform-a-release.md#releasing-to-the-preprod-environment) release to preprod
- [ ] [Manually approve](../doc/how-to/perform-a-release.md#releasing-to-the-production-environment) release to prod

<!-- Should a release fail at any step, you as the author should now lead the work to
fix it as soon as possible. You can monitor deployment failures in CircleCI
itself and application errors are found in
[Sentry](https://ministryofjustice.sentry.io/projects/hmpps-accredited-programmes-ui/?project=4505330122686464&referrer=sidebar&statsPeriod=24h). -->
