### PR TITLE
An example on how to develop using docker-compose.

### DIFF
--- a/Dockerfile.dev
+++ b/Dockerfile.dev
@@ -1,0 +1,20 @@
+# Stage: base image
+FROM node:20.9-bullseye-slim as base
+
+ENV TZ=Europe/London
+RUN ln -snf "/usr/share/zoneinfo/$TZ" /etc/localtime && echo "$TZ" > /etc/timezone
+
+RUN addgroup --gid 2000 --system appgroup && \
+        adduser --uid 2000 --system appuser --gid 2000
+
+WORKDIR /usr/src/app
+
+COPY package.json ./
+COPY package-lock.json ./
+
+RUN npm i
+
+EXPOSE 3000 3001
+USER 2000
+
+CMD [ "npm", "run", "start:dev" ]

--- a/docker-compose-dev-live.yml
+++ b/docker-compose-dev-live.yml
@@ -1,0 +1,35 @@
+version: '3.1'
+
+networks:
+  hmpps: null
+  
+services:
+
+  redis:
+    environment:
+      - ALLOW_EMPTY_PASSWORD=yes
+    image: redis:6.2
+    networks:
+      - hmpps
+    ports:
+      - '6379:6379'
+
+  app:
+    build: 
+      context: .
+      dockerfile: ./Dockerfile.dev
+    volumes:
+      - .:/usr/src/app
+    environment:
+      - REDIS_HOST=redis
+    env_file:
+      - .env
+      - .env.dev.live
+    networks:
+      - hmpps
+    depends_on:
+      - redis
+    ports:
+      - '3000:3000'
+      - '3001:3001'
+    restart: always


### PR DESCRIPTION
This example is for dev'ing against the cloud dev services.

**Benefits**

Uses same node as prod.
Easier env management.
Starts only the services that are required.
Don't need separate util scripts with switching params.

**Drawbacks**

`npm i` is run inside the container (as it should be as some npm package binaries can be node version specific).  When changing package.json the container should be rebuilt (add --build onto the up command).

**Usage**

Stick the dev env params into a file named .env.dev.live

Then run this once (will take a bit of time)...

`docker compose -f docker-compose-dev-live.yml build`

And then this...

`docker compose -f docker-compose-dev-live.yml up`

**Future**

Services and env can be built up from multiple files. Something like this

`docker compose -f docker-compose-dev-live.yml -f docker-compose-api-mock.yml up`

Here the docker-compose-api-mock.yml would only contain the wiremock service details and the env key (no need for another env file). `docker compose` would end up with three services and the app will be point to the api mock service url.

