### PR TITLE
(1139a) Add Draft referrals to My referrals

### DIFF
--- a/server/controllers/refer/caseListController.test.ts
+++ b/server/controllers/refer/caseListController.test.ts
@@ -103,6 +103,39 @@ describe('ReferCaseListController', () => {
       })
     })
 
+    describe('when the referral status group is "draft"', () => {
+      it('renders the show template with the correct response locals', async () => {
+        request.params = { referralStatusGroup: 'draft' }
+
+        const apiDraftStatusQuery = 'REFERRAL_STARTED'
+
+        ;(CaseListUtils.uiToApiStatusQueryParam as jest.Mock).mockReturnValue(apiDraftStatusQuery)
+
+        const requestHandler = controller.show()
+        await requestHandler(request, response, next)
+
+        expect(response.render).toHaveBeenCalledWith('referrals/caseList/refer/show', {
+          isMyReferralsPage: true,
+          pageHeading: 'My referrals',
+          pagination,
+          subNavigationItems: CaseListUtils.subNavigationItems(request.path),
+          tableRows: CaseListUtils.tableRows(paginatedReferralSummaries.content),
+        })
+        expect(CaseListUtils.uiToApiStatusQueryParam).toHaveBeenCalledWith(apiDraftStatusQuery.toLowerCase())
+        expect(referralService.getMyReferralSummaries).toHaveBeenCalledWith(username, {
+          status: apiDraftStatusQuery,
+        })
+        expect(PaginationUtils.pagination).toHaveBeenLastCalledWith(
+          request.path,
+          [],
+          paginatedReferralSummaries.pageNumber,
+          paginatedReferralSummaries.totalPages,
+        )
+        expect(CaseListUtils.subNavigationItems).toHaveBeenCalledWith(request.path)
+        expect(CaseListUtils.tableRows).toHaveBeenCalledWith(paginatedReferralSummaries.content)
+      })
+    })
+
     describe('when the referral status group is not valid', () => {
       it('throws a 404 error', async () => {
         request.params = { referralStatusGroup: 'invalid-group' }

--- a/server/utils/referrals/caseListUtils.test.ts
+++ b/server/utils/referrals/caseListUtils.test.ts
@@ -147,11 +147,11 @@ describe('CaseListUtils', () => {
         //   href: '/refer/referrals/case-list/closed',
         //   text: 'Closed referrals',
         // },
-        // {
-        //   active: false,
-        //   href: '/refer/referrals/case-list/draft',
-        //   text: 'Draft referrals',
-        // },
+        {
+          active: false,
+          href: '/refer/referrals/case-list/draft',
+          text: 'Draft referrals',
+        },
       ]
 
       expect(CaseListUtils.subNavigationItems(currentPath)).toEqual(expectedItems)

--- a/server/utils/referrals/caseListUtils.ts
+++ b/server/utils/referrals/caseListUtils.ts
@@ -91,7 +91,7 @@ export default class CaseListUtils {
     return [
       'open',
       // 'closed',
-      // 'draft'
+      'draft',
     ].map(referralStatusGroup => {
       const path = referPaths.caseList.show({ referralStatusGroup })
 


### PR DESCRIPTION
## Context

We need to show referrals with the `REFERRAL_STARTED` status on a separate Draft referrals page.

## Changes in this PR
Add new navigation item to new page and update associated tests. 

Table content including progress column to be done separately.

## Screenshots of UI changes
![image](https://github.com/ministryofjustice/hmpps-accredited-programmes-ui/assets/1067537/c9917a24-2b61-4c9b-80d1-a4a51d7d240e)



## Release checklist

[Release process documentation](../doc/how-to/perform-a-release.md)

As part of our continuous deployment strategy we must ensure that this work is
ready to be released once merged.

### Pre-merge

- [ ] There are changes required to the Accredited Programmes API for this change to work...
  - [ ] ... and they have been released to production already

### Post-merge

<!-- The outer checkboxes can be completed pre-merge -->

- [ ] This adds, extends or meaningfully modifies a feature...
  - [ ] ... and I have written or updated an end-to-end test for the happy path in the [Accredited Programmes E2E repo](https://github.com/ministryofjustice/hmpps-accredited-programmes-e2e)
- [ ] This makes new expectations of the API...
  - [ ] ... and I have notified the API developer(s) of changes to the contract tests (Pact), or the API is already compliant
- [ ] [Manually approve](../doc/how-to/perform-a-release.md#releasing-to-the-preprod-environment) release to preprod
- [ ] [Manually approve](../doc/how-to/perform-a-release.md#releasing-to-the-production-environment) release to prod

<!-- Should a release fail at any step, you as the author should now lead the work to
fix it as soon as possible. You can monitor deployment failures in CircleCI
itself and application errors are found in
[Sentry](https://ministryofjustice.sentry.io/projects/hmpps-accredited-programmes-ui/?project=4505330122686464&referrer=sidebar&statsPeriod=24h). -->
