### PR TITLE
(1139b) Draft referral progress

### DIFF
--- a/server/services/referralService.test.ts
+++ b/server/services/referralService.test.ts
@@ -112,6 +112,35 @@ describe('ReferralService', () => {
     })
   })
 
+  describe('getNumberOfTasksCompleted', () => {
+    let referralService: ReferralService
+
+    beforeEach(() => {
+      referralService = createMock<ReferralService>(service)
+    })
+
+    it.each`
+      referralFormFields                                                                                          | expectedTasksCompleted
+      ${{ additionalInformation: '', hasReviewedProgrammeHistory: false, oasysConfirmed: false }}                 | ${1}
+      ${{ additionalInformation: 'Some information', hasReviewedProgrammeHistory: false, oasysConfirmed: false }} | ${2}
+      ${{ additionalInformation: 'Some information', hasReviewedProgrammeHistory: true, oasysConfirmed: false }}  | ${3}
+      ${{ additionalInformation: 'Some information', hasReviewedProgrammeHistory: true, oasysConfirmed: true }}   | ${4}
+    `(
+      'returns $expectedTasksCompleted when $referralFormFields',
+      async ({ referralFormFields, expectedTasksCompleted }) => {
+        const referral = referralFactory.started().build({
+          ...referralFormFields,
+        })
+
+        when(referralService.getReferral).calledWith(username, referral.id).mockResolvedValue(referral)
+
+        const result = await referralService.getNumberOfTasksCompleted(username, referral.id)
+
+        expect(result).toEqual(expectedTasksCompleted)
+      },
+    )
+  })
+
   describe('getReferralSummaries', () => {
     const organisationId = 'organisation-id'
 

--- a/server/services/referralService.ts
+++ b/server/services/referralService.ts
@@ -40,6 +40,19 @@ export default class ReferralService {
     return referralClient.findMyReferralSummaries(query)
   }
 
+  async getNumberOfTasksCompleted(username: Express.User['username'], referralId: Referral['id']): Promise<number> {
+    const referralProgressIndicatorKeys = [
+      'additionalInformation',
+      'hasReviewedProgrammeHistory',
+      'oasysConfirmed',
+      'prisonNumber',
+    ] as const
+
+    const referral = await this.getReferral(username, referralId)
+
+    return referralProgressIndicatorKeys.filter(item => referral[item]).length
+  }
+
   async getReferral(username: Express.User['username'], referralId: Referral['id']): Promise<Referral> {
     const hmppsAuthClient = this.hmppsAuthClientBuilder()
     const systemToken = await hmppsAuthClient.getSystemClientToken(username)


### PR DESCRIPTION
## Context

We need to display how many tasks have been completed for a draft referral in the draft referrals case list table.

## Changes in this PR

- Adds new method to `ReferralService` to calculate how many of the required fields on a referral have truthy values.
- Above method called in `ReferCaseListController.show` to return a `tasksCompleted` value that we can use in the table template.



## Release checklist

[Release process documentation](../doc/how-to/perform-a-release.md)

As part of our continuous deployment strategy we must ensure that this work is
ready to be released once merged.

### Pre-merge

- [ ] There are changes required to the Accredited Programmes API for this change to work...
  - [ ] ... and they have been released to production already

### Post-merge

<!-- The outer checkboxes can be completed pre-merge -->

- [ ] This adds, extends or meaningfully modifies a feature...
  - [ ] ... and I have written or updated an end-to-end test for the happy path in the [Accredited Programmes E2E repo](https://github.com/ministryofjustice/hmpps-accredited-programmes-e2e)
- [ ] This makes new expectations of the API...
  - [ ] ... and I have notified the API developer(s) of changes to the contract tests (Pact), or the API is already compliant
- [ ] [Manually approve](../doc/how-to/perform-a-release.md#releasing-to-the-preprod-environment) release to preprod
- [ ] [Manually approve](../doc/how-to/perform-a-release.md#releasing-to-the-production-environment) release to prod

<!-- Should a release fail at any step, you as the author should now lead the work to
fix it as soon as possible. You can monitor deployment failures in CircleCI
itself and application errors are found in
[Sentry](https://ministryofjustice.sentry.io/projects/hmpps-accredited-programmes-ui/?project=4505330122686464&referrer=sidebar&statsPeriod=24h). -->
