### PR TITLE
(1225) Oasys client and service

### DIFF
--- a/server/@types/models/OffenceDetail.ts
+++ b/server/@types/models/OffenceDetail.ts
@@ -1,0 +1,18 @@
+export interface OffenceDetail {
+  acceptsResponsibility: boolean
+  acceptsResponsibilityDetail: string
+  contactTargeting: boolean
+  domesticViolence: boolean
+  motivationAndTriggers: string
+  numberOfOthersInvolved: number
+  offenceDetails: string
+  othersInvolvedDetail: string
+  patternOffending: string
+  peerGroupInfluences: string
+  raciallyMotivated: boolean
+  recognisesImpact: boolean
+  repeatVictimisation: boolean
+  revenge: boolean
+  stalking: boolean
+  victimWasStranger: boolean
+}

--- a/server/@types/models/index.d.ts
+++ b/server/@types/models/index.d.ts
@@ -8,6 +8,7 @@ import type {
   CourseParticipationUpdate,
 } from './CourseParticipation'
 import type { CoursePrerequisite } from './CoursePrerequisite'
+import type { OffenceDetail } from './OffenceDetail'
 import type { Organisation } from './Organisation'
 import type { OrganisationAddress } from './OrganisationAddress'
 import type { Paginated } from './Paginated'
@@ -24,6 +25,7 @@ export type {
   CourseParticipationUpdate,
   CoursePrerequisite,
   CreatedReferralResponse,
+  OffenceDetail,
   Organisation,
   OrganisationAddress,
   Paginated,

--- a/server/data/accreditedProgrammesApi/oasysClient.ts
+++ b/server/data/accreditedProgrammesApi/oasysClient.ts
@@ -1,0 +1,20 @@
+/* istanbul ignore file */
+import config, { type ApiConfig } from '../../config'
+import { apiPaths } from '../../paths'
+import RestClient from '../restClient'
+import type { OffenceDetail, Referral } from '@accredited-programmes/models'
+import type { SystemToken } from '@hmpps-auth'
+
+export default class OasysClient {
+  restClient: RestClient
+
+  constructor(systemToken: SystemToken) {
+    this.restClient = new RestClient('oasysClient', config.apis.accreditedProgrammesApi as ApiConfig, systemToken)
+  }
+
+  async findOffenceDetails(prisonNumber: Referral['prisonNumber']): Promise<Array<OffenceDetail>> {
+    return (await this.restClient.get({
+      path: apiPaths.oasys.offenceDetails({ prisonNumber }),
+    })) as Array<OffenceDetail>
+  }
+}

--- a/server/data/index.ts
+++ b/server/data/index.ts
@@ -14,6 +14,7 @@ AppInsightsUtils.buildClient()
 /* eslint-enable import/order */
 
 import CourseClient from './accreditedProgrammesApi/courseClient'
+import OasysClient from './accreditedProgrammesApi/oasysClient'
 import ReferralClient from './accreditedProgrammesApi/referralClient'
 import { serviceCheckFactory } from './healthCheck'
 import HmppsAuthClient from './hmppsAuthClient'
@@ -36,6 +37,7 @@ const hmppsManageUsersClientBuilder: RestClientBuilder<HmppsManageUsersClient> =
   new HmppsManageUsersClient(userToken)
 const courseClientBuilder: RestClientBuilder<CourseClient> = (userToken: Express.User['token']) =>
   new CourseClient(userToken)
+const oasysClientBuilder: RestClientBuilder<OasysClient> = (systemToken: SystemToken) => new OasysClient(systemToken)
 const prisonRegisterApiClientBuilder: RestClientBuilder<PrisonRegisterApiClient> = (userToken: Express.User['token']) =>
   new PrisonRegisterApiClient(userToken)
 const prisonerSearchClientBuilder: RestClientBuilder<PrisonerSearchClient> = (systemToken: SystemToken) =>
@@ -49,6 +51,7 @@ export {
   CourseClient,
   HmppsAuthClient,
   HmppsManageUsersClient,
+  OasysClient,
   PrisonApiClient,
   PrisonRegisterApiClient,
   PrisonerSearchClient,
@@ -58,6 +61,7 @@ export {
   createRedisClient,
   hmppsAuthClientBuilder,
   hmppsManageUsersClientBuilder,
+  oasysClientBuilder,
   prisonApiClientBuilder,
   prisonRegisterApiClientBuilder,
   prisonerSearchClientBuilder,

--- a/server/paths/api.ts
+++ b/server/paths/api.ts
@@ -8,6 +8,9 @@ const offeringsByCoursePath = coursePath.path('offerings')
 const offeringPath = path('/offerings/:courseOfferingId')
 const courseByOfferingPath = offeringPath.path('course')
 
+const oasysBasePath = path('/oasys/:prisonNumber')
+const offenceDetailsPath = oasysBasePath.path('offence-details')
+
 const referralsPath = path('/referrals')
 const referralPath = referralsPath.path(':referralId')
 const updateStatusPath = referralPath.path('status')
@@ -28,6 +31,9 @@ export default {
     names: courseNamesPath,
     offerings: offeringsByCoursePath,
     show: coursePath,
+  },
+  oasys: {
+    offenceDetails: offenceDetailsPath,
   },
   offerings: {
     course: courseByOfferingPath,

--- a/server/services/oasysService.test.ts
+++ b/server/services/oasysService.test.ts
@@ -1,0 +1,53 @@
+import { createMock } from '@golevelup/ts-jest'
+import { when } from 'jest-when'
+
+import OasysService from './oasysService'
+import type { RedisClient } from '../data'
+import { HmppsAuthClient, OasysClient, TokenStore } from '../data'
+import { offenceDetailFactory, referralFactory } from '../testutils/factories'
+import type { OffenceDetail } from '@accredited-programmes/models'
+
+jest.mock('../data/accreditedProgrammesApi/oasysClient')
+jest.mock('../data/hmppsAuthClient')
+
+const redisClient = createMock<RedisClient>({})
+const tokenStore = new TokenStore(redisClient) as jest.Mocked<TokenStore>
+const systemToken = 'some system token'
+const username = 'USERNAME'
+
+describe('OasysService', () => {
+  const oasysClient = new OasysClient(systemToken) as jest.Mocked<OasysClient>
+  const oasysClientBuilder = jest.fn()
+
+  const hmppsAuthClient = new HmppsAuthClient(tokenStore) as jest.Mocked<HmppsAuthClient>
+  const hmppsAuthClientBuilder = jest.fn()
+
+  const service = new OasysService(hmppsAuthClientBuilder, oasysClientBuilder)
+
+  beforeEach(() => {
+    jest.resetAllMocks()
+
+    hmppsAuthClientBuilder.mockReturnValue(hmppsAuthClient)
+    oasysClientBuilder.mockReturnValue(oasysClient)
+    hmppsAuthClient.getSystemClientToken.mockResolvedValue(systemToken)
+  })
+
+  describe('getOffenceDetails', () => {
+    it('returns offence details for given prison number', async () => {
+      const referral = referralFactory.build()
+      const offenceDetails: Array<OffenceDetail> = offenceDetailFactory.buildList(3)
+
+      when(oasysClient.findOffenceDetails).calledWith(referral.prisonNumber).mockResolvedValue(offenceDetails)
+
+      const result = await service.getOffenceDetails(username, referral.prisonNumber)
+
+      expect(result).toEqual(offenceDetails)
+
+      expect(hmppsAuthClientBuilder).toHaveBeenCalled()
+      expect(hmppsAuthClient.getSystemClientToken).toHaveBeenCalledWith(username)
+
+      expect(oasysClientBuilder).toHaveBeenCalledWith(systemToken)
+      expect(oasysClient.findOffenceDetails).toHaveBeenCalledWith(referral.prisonNumber)
+    })
+  })
+})

--- a/server/services/oasysService.ts
+++ b/server/services/oasysService.ts
@@ -1,0 +1,20 @@
+import type { HmppsAuthClient, OasysClient, RestClientBuilder, RestClientBuilderWithoutToken } from '../data'
+import type { OffenceDetail, Referral } from '@accredited-programmes/models'
+
+export default class OasysService {
+  constructor(
+    private readonly hmppsAuthClientBuilder: RestClientBuilderWithoutToken<HmppsAuthClient>,
+    private readonly oasysClientBuilder: RestClientBuilder<OasysClient>,
+  ) {}
+
+  async getOffenceDetails(
+    username: Express.User['username'],
+    prisonNumber: Referral['prisonNumber'],
+  ): Promise<Array<OffenceDetail>> {
+    const hmppsAuthClient = this.hmppsAuthClientBuilder()
+    const systemToken = await hmppsAuthClient.getSystemClientToken(username)
+    const oasysClient = this.oasysClientBuilder(systemToken)
+
+    return oasysClient.findOffenceDetails(prisonNumber)
+  }
+}

--- a/server/testutils/factories/index.ts
+++ b/server/testutils/factories/index.ts
@@ -6,6 +6,7 @@ import courseParticipationFactory from './courseParticipation'
 import courseParticipationOutcomeFactory from './courseParticipationOutcome'
 import coursePrerequisiteFactory from './coursePrerequisite'
 import inmateDetailFactory from './inmateDetail'
+import offenceDetailFactory from './offenceDetail'
 import offenceDetailsFactory from './offenceDetails'
 import offenceDtoFactory from './offenceDto'
 import offenceHistoryDetailFactory from './offenceHistoryDetail'
@@ -29,6 +30,7 @@ export {
   courseParticipationOutcomeFactory,
   coursePrerequisiteFactory,
   inmateDetailFactory,
+  offenceDetailFactory,
   offenceDetailsFactory,
   offenceDtoFactory,
   offenceHistoryDetailFactory,

--- a/server/testutils/factories/offenceDetail.ts
+++ b/server/testutils/factories/offenceDetail.ts
@@ -1,0 +1,25 @@
+import { faker } from '@faker-js/faker'
+import { Factory } from 'fishery'
+
+import type { OffenceDetail } from '@accredited-programmes/models'
+
+export default Factory.define<OffenceDetail>(() => {
+  return {
+    acceptsResponsibility: faker.datatype.boolean(),
+    acceptsResponsibilityDetail: faker.lorem.sentence(),
+    contactTargeting: faker.datatype.boolean(),
+    domesticViolence: faker.datatype.boolean(),
+    motivationAndTriggers: faker.lorem.sentence(),
+    numberOfOthersInvolved: faker.number.int(),
+    offenceDetails: faker.lorem.sentence(),
+    othersInvolvedDetail: faker.lorem.sentence(),
+    patternOffending: faker.lorem.sentence(),
+    peerGroupInfluences: faker.lorem.sentence(),
+    raciallyMotivated: faker.datatype.boolean(),
+    recognisesImpact: faker.datatype.boolean(),
+    repeatVictimisation: faker.datatype.boolean(),
+    revenge: faker.datatype.boolean(),
+    stalking: faker.datatype.boolean(),
+    victimWasStranger: faker.datatype.boolean(),
+  }
+})


### PR DESCRIPTION
## Context

https://trello.com/c/Pdp4YHal/1225-add-client-service-classes-for-querying-our-oasys-endpoints-m



## Changes in this PR
- Added new client and service classes for oasys related endpoints from accredited programmes api
- Added offence detail related type, factory and related methods
  -  These may well likely change as the endpoints are developed



## Release checklist

[Release process documentation](../doc/how-to/perform-a-release.md)

As part of our continuous deployment strategy we must ensure that this work is
ready to be released once merged.

### Pre-merge

- [ ] There are changes required to the Accredited Programmes API for this change to work...
  - [ ] ... and they have been released to production already

### Post-merge

<!-- The outer checkboxes can be completed pre-merge -->

- [ ] This adds, extends or meaningfully modifies a feature...
  - [ ] ... and I have written or updated an end-to-end test for the happy path in the [Accredited Programmes E2E repo](https://github.com/ministryofjustice/hmpps-accredited-programmes-e2e)
- [ ] This makes new expectations of the API...
  - [ ] ... and I have notified the API developer(s) of changes to the contract tests (Pact), or the API is already compliant
- [ ] [Manually approve](../doc/how-to/perform-a-release.md#releasing-to-the-preprod-environment) release to preprod
- [ ] [Manually approve](../doc/how-to/perform-a-release.md#releasing-to-the-production-environment) release to prod

<!-- Should a release fail at any step, you as the author should now lead the work to
fix it as soon as possible. You can monitor deployment failures in CircleCI
itself and application errors are found in
[Sentry](https://ministryofjustice.sentry.io/projects/hmpps-accredited-programmes-ui/?project=4505330122686464&referrer=sidebar&statsPeriod=24h). -->
