### PR TITLE
Temporarily skip Pact test

### DIFF
--- a/server/data/accreditedProgrammesApi/referralClient.test.ts
+++ b/server/data/accreditedProgrammesApi/referralClient.test.ts
@@ -80,7 +80,9 @@ pactWith({ consumer: 'Accredited Programmes UI', provider: 'Accredited Programme
   })
 
   describe('findMyReferralSummaries', () => {
-    describe('without query parameters', () => {
+    // TODO: enable this once Provider tests are refactored
+    // see https://github.com/ministryofjustice/hmpps-accredited-programmes-api/pull/223) for details
+    describe.skip('without query parameters', () => {
       const paginatedReferralSummaries: Paginated<ReferralSummary> = {
         content: [referralSummaryFactory.build({ status: 'referral_submitted' })],
         pageIsEmpty: false,


### PR DESCRIPTION
## Context

<!-- Is there a Trello ticket you can link to? -->
<!-- Do you need to add any environment variables? -->
<!-- Is an ADR required? An ADR should be added if this PR introduces a change to the architecture. -->

We recently added Pact contracts for fetching a logged-in user's Referrals.

This is proving very difficult to fulfil on the API side due to our poor test setup reusing data between tests. See https://github.com/ministryofjustice/hmpps-accredited-programmes-api/pull/223 for more information.

In the flow of these Pact tests, we update one Referral for the logged-in user to mark it as `submitted` (and thus give it a `submittedOn` date), and create a new in-progress Referral (with a `null` `submittedOn` date).

When we make this request for the logged-in user's Referrals, we get back a Referral with a `submittedOn` date and one without, which Pact [can't handle](https://github.com/pact-foundation/pact-js/issues/393) - to correctly verify the shape of the objects we're getting back, the `submittedOn` date needs to match for both Referrals.

## Changes in this PR

Temporarily skips this test, which will be re-enabled when we refactor the API tests to not re-use state between multiple tests. We're hoping to do that this week.

## Release checklist

[Release process documentation](../doc/how-to/perform-a-release.md)

As part of our continuous deployment strategy we must ensure that this work is
ready to be released once merged.

### Pre-merge

- [ ] There are changes required to the Accredited Programmes API for this change to work...
  - [ ] ... and they have been released to production already

### Post-merge

<!-- The outer checkboxes can be completed pre-merge -->

- [ ] This adds, extends or meaningfully modifies a feature...
  - [ ] ... and I have written or updated an end-to-end test for the happy path in the [Accredited Programmes E2E repo](https://github.com/ministryofjustice/hmpps-accredited-programmes-e2e)
- [ ] This makes new expectations of the API...
  - [ ] ... and I have notified the API developer(s) of changes to the contract tests (Pact), or the API is already compliant
- [ ] [Manually approve](../doc/how-to/perform-a-release.md#releasing-to-the-preprod-environment) release to preprod
- [ ] [Manually approve](../doc/how-to/perform-a-release.md#releasing-to-the-production-environment) release to prod

<!-- Should a release fail at any step, you as the author should now lead the work to
fix it as soon as possible. You can monitor deployment failures in CircleCI
itself and application errors are found in
[Sentry](https://ministryofjustice.sentry.io/projects/hmpps-accredited-programmes-ui/?project=4505330122686464&referrer=sidebar&statsPeriod=24h). -->
