### PR TITLE
(1126b) Use Refer paths in Refer case lists

### DIFF
--- a/server/controllers/refer/caseListController.test.ts
+++ b/server/controllers/refer/caseListController.test.ts
@@ -114,7 +114,11 @@ describe('ReferCaseListController', () => {
           paginatedReferralSummaries.totalPages,
         )
         expect(CaseListUtils.subNavigationItems).toHaveBeenCalledWith(request.path)
-        expect(CaseListUtils.tableRows).toHaveBeenCalledWith(paginatedReferralSummaries.content, columnsToInclude)
+        expect(CaseListUtils.tableRows).toHaveBeenCalledWith(
+          paginatedReferralSummaries.content,
+          columnsToInclude,
+          referPaths,
+        )
         expect(referralService.getNumberOfTasksCompleted).not.toHaveBeenCalled()
       })
     })
@@ -177,6 +181,7 @@ describe('ReferCaseListController', () => {
         expect(CaseListUtils.tableRows).toHaveBeenCalledWith(
           expectedPaginatedReferralSummariesContent,
           columnsToInclude,
+          referPaths,
         )
         expect(referralService.getNumberOfTasksCompleted).toHaveBeenCalledTimes(
           paginatedReferralSummaries.content.length,

--- a/server/controllers/refer/caseListController.ts
+++ b/server/controllers/refer/caseListController.ts
@@ -71,15 +71,19 @@ export default class ReferCaseListController {
         pageHeading: 'My referrals',
         pagination,
         subNavigationItems: CaseListUtils.subNavigationItems(req.path),
-        tableRows: CaseListUtils.tableRows(paginatedReferralSummariesContent, [
-          'Name / Prison number',
-          'Date referred',
-          'Earliest release date',
-          'Release date type',
-          'Programme location',
-          'Programme name',
-          finalColumnHeader,
-        ]),
+        tableRows: CaseListUtils.tableRows(
+          paginatedReferralSummariesContent,
+          [
+            'Name / Prison number',
+            'Date referred',
+            'Earliest release date',
+            'Release date type',
+            'Programme location',
+            'Programme name',
+            finalColumnHeader,
+          ],
+          referPaths,
+        ),
       })
     }
   }

--- a/server/utils/referrals/caseListUtils.test.ts
+++ b/server/utils/referrals/caseListUtils.test.ts
@@ -1,4 +1,5 @@
 import CaseListUtils from './caseListUtils'
+import { referPaths } from '../../paths'
 import { courseFactory, referralSummaryFactory } from '../../testutils/factories'
 import FormUtils from '../formUtils'
 import type { ReferralStatus } from '@accredited-programmes/models'
@@ -240,6 +241,14 @@ describe('CaseListUtils', () => {
         expect(CaseListUtils.tableRowContent(referralSummary, 'Name / Prison number')).toEqual(
           '<a class="govuk-link" href="/assess/referrals/referral-123/personal-details">Del Hatton</a><br>ABC1234',
         )
+      })
+
+      describe('when referPaths is passed in as the paths argument', () => {
+        it('links to a Refer show referral page', () => {
+          expect(CaseListUtils.tableRowContent(referralSummary, 'Name / Prison number', referPaths)).toEqual(
+            '<a class="govuk-link" href="/refer/referrals/referral-123/personal-details">Del Hatton</a><br>ABC1234',
+          )
+        })
       })
 
       describe('when `prisonerName` is `undefined`', () => {
@@ -562,6 +571,35 @@ describe('CaseListUtils', () => {
           },
         ],
       ])
+    })
+
+    describe('when referPaths is passed in as the paths argument', () => {
+      it('passes the paths to `tableRowContent` for that row', () => {
+        expect(
+          CaseListUtils.tableRows(referralSummaries, ['Name / Prison number', 'Date referred'], referPaths),
+        ).toEqual([
+          [
+            {
+              attributes: { 'data-sort-value': 'Del Hatton' },
+              html: CaseListUtils.tableRowContent(referralSummaries[0], 'Name / Prison number', referPaths),
+            },
+            {
+              attributes: { 'data-sort-value': undefined },
+              text: CaseListUtils.tableRowContent(referralSummaries[0], 'Date referred'),
+            },
+          ],
+          [
+            {
+              attributes: { 'data-sort-value': '' },
+              html: CaseListUtils.tableRowContent(referralSummaries[1], 'Name / Prison number', referPaths),
+            },
+            {
+              attributes: { 'data-sort-value': '2021-01-01T00:00:00.000Z' },
+              text: CaseListUtils.tableRowContent(referralSummaries[1], 'Date referred'),
+            },
+          ],
+        ])
+      })
     })
   })
 

--- a/server/utils/referrals/caseListUtils.test.ts
+++ b/server/utils/referrals/caseListUtils.test.ts
@@ -1,5 +1,5 @@
 import CaseListUtils from './caseListUtils'
-import { referPaths } from '../../paths'
+import { assessPaths, referPaths } from '../../paths'
 import { courseFactory, referralSummaryFactory } from '../../testutils/factories'
 import FormUtils from '../formUtils'
 import type { ReferralStatus } from '@accredited-programmes/models'
@@ -241,6 +241,18 @@ describe('CaseListUtils', () => {
         expect(CaseListUtils.tableRowContent(referralSummary, 'Name / Prison number')).toEqual(
           '<a class="govuk-link" href="/assess/referrals/referral-123/personal-details">Del Hatton</a><br>ABC1234',
         )
+      })
+
+      describe('with an unsubmitted referral', () => {
+        it('links to the Refer new referral show page', () => {
+          expect(
+            CaseListUtils.tableRowContent(
+              { ...referralSummary, status: 'referral_started', submittedOn: undefined },
+              'Name / Prison number',
+              assessPaths,
+            ),
+          ).toEqual('<a class="govuk-link" href="/refer/referrals/new/referral-123">Del Hatton</a><br>ABC1234')
+        })
       })
 
       describe('when referPaths is passed in as the paths argument', () => {

--- a/server/utils/referrals/caseListUtils.ts
+++ b/server/utils/referrals/caseListUtils.ts
@@ -103,7 +103,11 @@ export default class CaseListUtils {
     })
   }
 
-  static tableRowContent(referralSummary: ReferralSummary, column: CaseListColumnHeader): string {
+  static tableRowContent(
+    referralSummary: ReferralSummary,
+    column: CaseListColumnHeader,
+    paths: typeof assessPaths | typeof referPaths = assessPaths,
+  ): string {
     switch (column) {
       case 'Conditional release date':
         return referralSummary.sentence?.conditionalReleaseDate
@@ -116,7 +120,7 @@ export default class CaseListUtils {
           ? DateUtils.govukFormattedFullDateString(referralSummary.earliestReleaseDate)
           : 'N/A'
       case 'Name / Prison number':
-        return CaseListUtils.nameAndPrisonNumberHtml(referralSummary)
+        return CaseListUtils.nameAndPrisonNumberHtml(referralSummary, paths)
       case 'Parole eligibility date':
         return referralSummary.sentence?.paroleEligibilityDate
           ? DateUtils.govukFormattedFullDateString(referralSummary.sentence.paroleEligibilityDate)
@@ -152,6 +156,7 @@ export default class CaseListUtils {
   static tableRows(
     referralSummaries: Array<ReferralSummary>,
     columnsToInclude: Array<CaseListColumnHeader>,
+    paths: typeof assessPaths | typeof referPaths = assessPaths,
   ): Array<GovukFrontendTableRow> {
     return referralSummaries.map(summary => {
       const row: GovukFrontendTableRow = []
@@ -179,7 +184,7 @@ export default class CaseListUtils {
           case 'Name / Prison number':
             row.push({
               attributes: { 'data-sort-value': CaseListUtils.formattedPrisonerName(summary.prisonerName) },
-              html: CaseListUtils.tableRowContent(summary, 'Name / Prison number'),
+              html: CaseListUtils.tableRowContent(summary, 'Name / Prison number', paths),
             })
             break
           case 'Parole eligibility date':
@@ -243,8 +248,11 @@ export default class CaseListUtils {
     )
   }
 
-  private static nameAndPrisonNumberHtml(referralSummary: ReferralSummary): string {
-    const nameAndPrisonNumberHtmlStart = `<a class="govuk-link" href="${assessPaths.show.personalDetails({
+  private static nameAndPrisonNumberHtml(
+    referralSummary: ReferralSummary,
+    paths: typeof assessPaths | typeof referPaths,
+  ): string {
+    const nameAndPrisonNumberHtmlStart = `<a class="govuk-link" href="${paths.show.personalDetails({
       referralId: referralSummary.id,
     })}">`
     const prisonerName = CaseListUtils.formattedPrisonerName(referralSummary.prisonerName)

--- a/server/utils/referrals/caseListUtils.ts
+++ b/server/utils/referrals/caseListUtils.ts
@@ -252,9 +252,13 @@ export default class CaseListUtils {
     referralSummary: ReferralSummary,
     paths: typeof assessPaths | typeof referPaths,
   ): string {
-    const nameAndPrisonNumberHtmlStart = `<a class="govuk-link" href="${paths.show.personalDetails({
-      referralId: referralSummary.id,
-    })}">`
+    const path =
+      referralSummary.status === 'referral_started'
+        ? referPaths.new.show({ referralId: referralSummary.id })
+        : paths.show.personalDetails({
+            referralId: referralSummary.id,
+          })
+    const nameAndPrisonNumberHtmlStart = `<a class="govuk-link" href="${path}">`
     const prisonerName = CaseListUtils.formattedPrisonerName(referralSummary.prisonerName)
     const nameAndPrisonNumberHtmlEnd = prisonerName
       ? `${prisonerName}</a><br>${referralSummary.prisonNumber}`


### PR DESCRIPTION
## Context

Previously we were using the Assess paths everywhere for the link to view an individual referral

## Changes in this PR

- Allow Refer paths to be used for links to referrals in the Refer case lists

## Release checklist

[Release process documentation](../doc/how-to/perform-a-release.md)

As part of our continuous deployment strategy we must ensure that this work is
ready to be released once merged.

### Pre-merge

- [ ] There are changes required to the Accredited Programmes API for this change to work...
  - [ ] ... and they have been released to production already

### Post-merge

<!-- The outer checkboxes can be completed pre-merge -->

- [ ] This adds, extends or meaningfully modifies a feature...
  - [ ] ... and I have written or updated an end-to-end test for the happy path in the [Accredited Programmes E2E repo](https://github.com/ministryofjustice/hmpps-accredited-programmes-e2e)
- [ ] This makes new expectations of the API...
  - [ ] ... and I have notified the API developer(s) of changes to the contract tests (Pact), or the API is already compliant
- [ ] [Manually approve](../doc/how-to/perform-a-release.md#releasing-to-the-preprod-environment) release to preprod
- [ ] [Manually approve](../doc/how-to/perform-a-release.md#releasing-to-the-production-environment) release to prod

<!-- Should a release fail at any step, you as the author should now lead the work to
fix it as soon as possible. You can monitor deployment failures in CircleCI
itself and application errors are found in
[Sentry](https://ministryofjustice.sentry.io/projects/hmpps-accredited-programmes-ui/?project=4505330122686464&referrer=sidebar&statsPeriod=24h). -->
