### PR TITLE
(1214c) Offence analysis page content

### DIFF
--- a/server/@types/models/OffenceDetail.ts
+++ b/server/@types/models/OffenceDetail.ts
@@ -1,18 +1,18 @@
 export interface OffenceDetail {
-  acceptsResponsibility: boolean
-  acceptsResponsibilityDetail: string
-  contactTargeting: boolean
-  domesticViolence: boolean
-  motivationAndTriggers: string
-  numberOfOthersInvolved: number
-  offenceDetails: string
-  othersInvolvedDetail: string
-  patternOffending: string
-  peerGroupInfluences: string
-  raciallyMotivated: boolean
-  recognisesImpact: boolean
-  repeatVictimisation: boolean
-  revenge: boolean
-  stalking: boolean
-  victimWasStranger: boolean
+  acceptsResponsibility?: boolean
+  acceptsResponsibilityDetail?: string
+  contactTargeting?: boolean
+  domesticViolence?: boolean
+  motivationAndTriggers?: string
+  numberOfOthersInvolved?: number
+  offenceDetails?: string
+  othersInvolvedDetail?: string
+  patternOffending?: string
+  peerGroupInfluences?: string
+  raciallyMotivated?: boolean
+  recognisesImpact?: boolean
+  repeatVictimisation?: boolean
+  revenge?: boolean
+  stalking?: boolean
+  victimWasStranger?: boolean
 }

--- a/server/controllers/shared/index.ts
+++ b/server/controllers/shared/index.ts
@@ -14,6 +14,7 @@ const controllers = (services: Services) => {
   )
   const risksAndNeedsController = new RisksAndNeedsController(
     services.courseService,
+    services.oasysService,
     services.personService,
     services.referralService,
   )

--- a/server/data/accreditedProgrammesApi/oasysClient.ts
+++ b/server/data/accreditedProgrammesApi/oasysClient.ts
@@ -12,9 +12,9 @@ export default class OasysClient {
     this.restClient = new RestClient('oasysClient', config.apis.accreditedProgrammesApi as ApiConfig, systemToken)
   }
 
-  async findOffenceDetails(prisonNumber: Referral['prisonNumber']): Promise<Array<OffenceDetail>> {
+  async findOffenceDetails(prisonNumber: Referral['prisonNumber']): Promise<OffenceDetail> {
     return (await this.restClient.get({
       path: apiPaths.oasys.offenceDetails({ prisonNumber }),
-    })) as Array<OffenceDetail>
+    })) as OffenceDetail
   }
 }

--- a/server/services/index.ts
+++ b/server/services/index.ts
@@ -2,6 +2,7 @@
 
 import CourseService from './courseService'
 import healthCheck from './healthCheck'
+import OasysService from './oasysService'
 import OrganisationService from './organisationService'
 import PersonService from './personService'
 import ReferralService from './referralService'
@@ -10,6 +11,7 @@ import {
   courseClientBuilder,
   hmppsAuthClientBuilder,
   hmppsManageUsersClientBuilder,
+  oasysClientBuilder,
   prisonApiClientBuilder,
   prisonRegisterApiClientBuilder,
   prisonerSearchClientBuilder,
@@ -17,6 +19,7 @@ import {
 } from '../data'
 
 const services = () => {
+  const oasysService = new OasysService(hmppsAuthClientBuilder, oasysClientBuilder)
   const organisationService = new OrganisationService(prisonRegisterApiClientBuilder)
   const personService = new PersonService(hmppsAuthClientBuilder, prisonApiClientBuilder, prisonerSearchClientBuilder)
   const referralService = new ReferralService(hmppsAuthClientBuilder, referralClientBuilder)
@@ -25,6 +28,7 @@ const services = () => {
 
   return {
     courseService,
+    oasysService,
     organisationService,
     personService,
     referralService,
@@ -34,6 +38,15 @@ const services = () => {
 
 type Services = ReturnType<typeof services>
 
-export { CourseService, OrganisationService, PersonService, ReferralService, UserService, healthCheck, services }
+export {
+  CourseService,
+  OasysService,
+  OrganisationService,
+  PersonService,
+  ReferralService,
+  UserService,
+  healthCheck,
+  services,
+}
 
 export type { Services }

--- a/server/services/oasysService.test.ts
+++ b/server/services/oasysService.test.ts
@@ -5,7 +5,6 @@ import OasysService from './oasysService'
 import type { RedisClient } from '../data'
 import { HmppsAuthClient, OasysClient, TokenStore } from '../data'
 import { offenceDetailFactory, referralFactory } from '../testutils/factories'
-import type { OffenceDetail } from '@accredited-programmes/models'
 
 jest.mock('../data/accreditedProgrammesApi/oasysClient')
 jest.mock('../data/hmppsAuthClient')
@@ -35,7 +34,7 @@ describe('OasysService', () => {
   describe('getOffenceDetails', () => {
     it('returns offence details for given prison number', async () => {
       const referral = referralFactory.build()
-      const offenceDetails: Array<OffenceDetail> = offenceDetailFactory.buildList(3)
+      const offenceDetails = offenceDetailFactory.build()
 
       when(oasysClient.findOffenceDetails).calledWith(referral.prisonNumber).mockResolvedValue(offenceDetails)
 

--- a/server/services/oasysService.ts
+++ b/server/services/oasysService.ts
@@ -10,7 +10,7 @@ export default class OasysService {
   async getOffenceDetails(
     username: Express.User['username'],
     prisonNumber: Referral['prisonNumber'],
-  ): Promise<Array<OffenceDetail>> {
+  ): Promise<OffenceDetail> {
     const hmppsAuthClient = this.hmppsAuthClientBuilder()
     const systemToken = await hmppsAuthClient.getSystemClientToken(username)
     const oasysClient = this.oasysClientBuilder(systemToken)

--- a/server/utils/index.ts
+++ b/server/utils/index.ts
@@ -16,6 +16,7 @@ import CaseListUtils from './referrals/caseListUtils'
 import NewReferralUtils from './referrals/newReferralUtils'
 import ShowReferralUtils from './referrals/showReferralUtils'
 import ShowRisksAndNeedsUtils from './referrals/showRisksAndNeedsUtils'
+import OffenceAnalysisUtils from './risksAndNeeds/offenceAnalysisUtils'
 import RouteUtils from './routeUtils'
 import SentenceInformationUtils from './sentenceInformationUtils'
 import StringUtils from './stringUtils'
@@ -29,6 +30,7 @@ export {
   DateUtils,
   FormUtils,
   NewReferralUtils,
+  OffenceAnalysisUtils,
   OffenceUtils,
   OrganisationUtils,
   PaginationUtils,

--- a/server/utils/risksAndNeeds/offenceAnalysisUtils.test.ts
+++ b/server/utils/risksAndNeeds/offenceAnalysisUtils.test.ts
@@ -1,0 +1,197 @@
+import OffenceAnalysisUtils from './offenceAnalysisUtils'
+import { offenceDetailFactory } from '../../testutils/factories'
+
+describe('OffenceAnalysisUtils', () => {
+  const offenceDetail = offenceDetailFactory.build({
+    acceptsResponsibility: true,
+    acceptsResponsibilityDetail: 'Detail about the persons acceptance',
+    contactTargeting: false,
+    domesticViolence: true,
+    motivationAndTriggers: 'Detail about motivation and triggers',
+    numberOfOthersInvolved: 2,
+    offenceDetails: 'Details about the offence',
+    othersInvolvedDetail: 'Detail about the others involved',
+    patternOffending: 'Detail about the pattern of offending',
+    peerGroupInfluences: 'Detail about influences',
+    raciallyMotivated: false,
+    recognisesImpact: true,
+    repeatVictimisation: false,
+    revenge: true,
+    stalking: false,
+    victimWasStranger: true,
+  })
+
+  describe('impactAndConsequencesSummaryListRows', () => {
+    it('formats the impact and consequences offence details in the appropriate format for passing to a GOV.UK summary list Nunjucks macro', () => {
+      expect(OffenceAnalysisUtils.impactAndConsequencesSummaryListRows(offenceDetail)).toEqual([
+        {
+          key: {
+            text: 'Does the offender recognise the impact and consequences of offending on victim / community / wider society?',
+          },
+          value: {
+            text: 'Yes',
+          },
+        },
+      ])
+    })
+  })
+
+  describe('otherOffendersAndInfluencesSummaryListRows', () => {
+    it('formats the other offenders and influences offence details in the appropriate format for passing to a GOV.UK summary list Nunjucks macro', () => {
+      expect(OffenceAnalysisUtils.otherOffendersAndInfluencesSummaryListRows(offenceDetail)).toEqual([
+        {
+          key: { text: 'Were there other offenders involved?' },
+          value: {
+            text: 'Yes',
+          },
+        },
+        {
+          key: { text: 'Number of others involved' },
+          value: {
+            text: '2',
+          },
+        },
+        {
+          key: { text: 'Was the offender the leader?' },
+          value: {
+            text: 'Detail about the others involved',
+          },
+        },
+        {
+          key: { text: 'Peer group influences (e.g. offender easily led, gang member)' },
+          value: {
+            text: 'Detail about influences',
+          },
+        },
+      ])
+    })
+
+    describe('when there were no other offenders involved', () => {
+      it('returns "No" for the "Were there other offenders involved?" key', () => {
+        expect(
+          OffenceAnalysisUtils.otherOffendersAndInfluencesSummaryListRows(
+            offenceDetailFactory.build({ numberOfOthersInvolved: 0 }),
+          ),
+        ).toEqual(
+          expect.arrayContaining([
+            {
+              key: { text: 'Were there other offenders involved?' },
+              value: {
+                text: 'No',
+              },
+            },
+          ]),
+        )
+      })
+    })
+
+    describe('when `numberOfOthersInvolved` is undefined', () => {
+      it('returns "No" for the "Were there other offenders involved?" key', () => {
+        expect(
+          OffenceAnalysisUtils.otherOffendersAndInfluencesSummaryListRows(
+            offenceDetailFactory.build({ numberOfOthersInvolved: undefined }),
+          ),
+        ).toEqual(
+          expect.arrayContaining([
+            {
+              key: { text: 'Were there other offenders involved?' },
+              value: {
+                text: 'No',
+              },
+            },
+          ]),
+        )
+      })
+    })
+  })
+
+  describe('responsibilitySummaryListRows', () => {
+    it('formats the responsibilty related offence details in the appropriate format for passing to a GOV.UK summary list Nunjucks macro', () => {
+      expect(OffenceAnalysisUtils.responsibilitySummaryListRows(offenceDetail)).toEqual([
+        {
+          key: { text: 'Does the offender accept responsibility for the current offence(s)?' },
+          value: {
+            text: 'Yes',
+          },
+        },
+        {
+          key: {
+            text: 'How much responsibility does s/he acknowledge for the offence(s). Does s/he blame others, minimise the extent of his/her offending?',
+          },
+          value: {
+            text: 'Detail about the persons acceptance',
+          },
+        },
+      ])
+    })
+  })
+
+  describe('textValue', () => {
+    it('returns the text value', () => {
+      expect(OffenceAnalysisUtils.textValue('Some text')).toEqual('Some text')
+    })
+
+    describe('when the text value is undefined', () => {
+      it('returns the "No information available" message', () => {
+        expect(OffenceAnalysisUtils.textValue(undefined)).toEqual('No information available')
+      })
+    })
+
+    describe('when the text value is an empty string', () => {
+      it('returns the "No information available" message', () => {
+        expect(OffenceAnalysisUtils.textValue('')).toEqual('No information available')
+      })
+    })
+  })
+
+  describe('victimsAndPartnersSummaryListRows', () => {
+    it('formats the victims and partners related offence details in the appropriate format for passing to a GOV.UK summary list Nunjucks macro', () => {
+      expect(OffenceAnalysisUtils.victimsAndPartnersSummaryListRows(offenceDetail)).toEqual([
+        {
+          key: { text: 'Were there any direct victim(s) e.g. contact targeting?' },
+          value: {
+            text: 'No',
+          },
+        },
+        {
+          key: {
+            text: 'Were any of the victim(s) targeted because of racial motivation or hatred of other identifiable group?',
+          },
+          value: {
+            text: 'No',
+          },
+        },
+        {
+          key: { text: 'Response to a specific victim (e.g. revenge, settling grudges)' },
+          value: {
+            text: 'Yes',
+          },
+        },
+        {
+          key: { text: 'Physical violence towards partner' },
+          value: {
+            text: 'Yes',
+          },
+        },
+        {
+          key: { text: 'Repeat victimisation of the same person' },
+          value: {
+            text: 'No',
+          },
+        },
+        {
+          key: { text: 'Were the victim(s) stranger(s) to the offender?' },
+          value: {
+            text: 'Yes',
+          },
+        },
+        {
+          key: { text: 'Stalking' },
+          value: {
+            text: 'No',
+          },
+        },
+      ])
+    })
+  })
+})

--- a/server/utils/risksAndNeeds/offenceAnalysisUtils.ts
+++ b/server/utils/risksAndNeeds/offenceAnalysisUtils.ts
@@ -1,0 +1,128 @@
+import type { OffenceDetail } from '@accredited-programmes/models'
+import type { GovukFrontendSummaryListRowWithKeyAndValue } from '@accredited-programmes/ui'
+
+export default class OffenceAnalysisUtils {
+  static impactAndConsequencesSummaryListRows(
+    offenceDetail: OffenceDetail,
+  ): Array<GovukFrontendSummaryListRowWithKeyAndValue> {
+    return [
+      {
+        key: {
+          text: 'Does the offender recognise the impact and consequences of offending on victim / community / wider society?',
+        },
+        value: {
+          text: this.yesOrNo(offenceDetail.recognisesImpact),
+        },
+      },
+    ]
+  }
+
+  static otherOffendersAndInfluencesSummaryListRows(
+    offenceDetail: OffenceDetail,
+  ): Array<GovukFrontendSummaryListRowWithKeyAndValue> {
+    return [
+      {
+        key: { text: 'Were there other offenders involved?' },
+        value: {
+          text: this.yesOrNo(!!offenceDetail.numberOfOthersInvolved && offenceDetail.numberOfOthersInvolved > 0),
+        },
+      },
+      {
+        key: { text: 'Number of others involved' },
+        value: {
+          text: this.textValue(offenceDetail.numberOfOthersInvolved?.toString()),
+        },
+      },
+      {
+        key: { text: 'Was the offender the leader?' },
+        value: {
+          text: this.textValue(offenceDetail.othersInvolvedDetail),
+        },
+      },
+      {
+        key: { text: 'Peer group influences (e.g. offender easily led, gang member)' },
+        value: {
+          text: this.textValue(offenceDetail.peerGroupInfluences),
+        },
+      },
+    ]
+  }
+
+  static responsibilitySummaryListRows(
+    offenceDetail: OffenceDetail,
+  ): Array<GovukFrontendSummaryListRowWithKeyAndValue> {
+    return [
+      {
+        key: { text: 'Does the offender accept responsibility for the current offence(s)?' },
+        value: {
+          text: this.yesOrNo(offenceDetail.acceptsResponsibility),
+        },
+      },
+      {
+        key: {
+          text: 'How much responsibility does s/he acknowledge for the offence(s). Does s/he blame others, minimise the extent of his/her offending?',
+        },
+        value: {
+          text: this.textValue(offenceDetail.acceptsResponsibilityDetail),
+        },
+      },
+    ]
+  }
+
+  static textValue(value?: string): string {
+    return value || 'No information available'
+  }
+
+  static victimsAndPartnersSummaryListRows(
+    offenceDetail: OffenceDetail,
+  ): Array<GovukFrontendSummaryListRowWithKeyAndValue> {
+    return [
+      {
+        key: { text: 'Were there any direct victim(s) e.g. contact targeting?' },
+        value: {
+          text: this.yesOrNo(offenceDetail.contactTargeting),
+        },
+      },
+      {
+        key: {
+          text: 'Were any of the victim(s) targeted because of racial motivation or hatred of other identifiable group?',
+        },
+        value: { text: this.yesOrNo(offenceDetail.raciallyMotivated) },
+      },
+      {
+        key: { text: 'Response to a specific victim (e.g. revenge, settling grudges)' },
+        value: {
+          text: this.yesOrNo(offenceDetail.revenge),
+        },
+      },
+      {
+        key: { text: 'Physical violence towards partner' },
+        value: {
+          text: this.yesOrNo(offenceDetail.domesticViolence),
+        },
+      },
+      {
+        key: { text: 'Repeat victimisation of the same person' },
+        value: {
+          text: this.yesOrNo(offenceDetail.repeatVictimisation),
+        },
+      },
+      {
+        key: { text: 'Were the victim(s) stranger(s) to the offender?' },
+        value: {
+          text: this.yesOrNo(offenceDetail.victimWasStranger),
+        },
+      },
+      {
+        key: { text: 'Stalking' },
+        value: {
+          text: this.yesOrNo(offenceDetail.stalking),
+        },
+      },
+    ]
+  }
+
+  private static yesOrNo(value?: boolean): 'No' | 'Yes' {
+    return value ? 'Yes' : 'No'
+  }
+}

--- a/server/views/referrals/show/risksAndNeeds/offenceAnalysis.njk
+++ b/server/views/referrals/show/risksAndNeeds/offenceAnalysis.njk
@@ -1,7 +1,63 @@
+{% from "govuk/components/summary-list/macro.njk" import govukSummaryList %}
+
+{% from "../../../partials/keylessSummaryCard.njk" import keylessSummaryCard %}
+
 {% extends "../partials/risksAndNeedsLayout.njk" %}
 
 {% block primaryContent %}
   {{ super() }}
 
-  <p>Offence analysis content</p>
+  {{ keylessSummaryCard("Section 2.1 - Brief offence details", bodyText=offenceDetailsText, testId="brief-offence-details-summary-card") }}
+
+  {{ govukSummaryList({
+    card: {
+      title: {
+        text: "Section 2.3 - Victims and partners"
+      },
+      attributes: {
+        "data-testid": "victims-and-partners-summary-list"
+      }
+    },
+    rows: victimsAndPartnersSummaryListRows
+  }) }}
+
+  {{ govukSummaryList({
+    card: {
+      title: {
+        text: "Section 2.6 - Impact and consequences"
+      },
+      attributes: {
+        "data-testid": "impact-and-consequences-summary-list"
+      }
+    },
+    rows: impactAndConsequencesSummaryListRows
+  }) }}
+
+  {{ govukSummaryList({
+    card: {
+      title: {
+        text: "Section 2.7 - Other offenders and influences"
+      },
+      attributes: {
+        "data-testid": "other-offenders-and-influences-summary-list"
+      }
+    },
+    rows: otherOffendersAndInfluencesSummaryListRows
+  }) }}
+
+  {{ keylessSummaryCard("Section 2.8 - Motivation and triggers", bodyText=motivationAndTriggersText, testId="motivation-and-triggers-summary-card") }}
+
+  {{ govukSummaryList({
+    card: {
+      title: {
+        text: "Section 2.11 - Responsibility"
+      },
+      attributes: {
+        "data-testid": "responsibility-summary-list"
+      }
+    },
+    rows: responsibilitySummaryListRows
+  }) }}
+
+  {{ keylessSummaryCard("Section 2.12 - Pattern of offending", bodyText=patternOffendingText, testId="pattern-offending-summary-card") }}
 {% endblock primaryContent %}

--- a/wiremock/scripts/stubAccreditedProgrammesApi.ts
+++ b/wiremock/scripts/stubAccreditedProgrammesApi.ts
@@ -8,6 +8,7 @@ import {
   courseOfferings,
   courseParticipations,
   courses,
+  oasysOffenceDetail,
   prisoners,
   referralSummaries,
   referrals,
@@ -226,6 +227,24 @@ stubs.push(() =>
     },
   }),
 )
+
+prisoners.forEach(prisoner => {
+  stubs.push(() =>
+    stubFor({
+      request: {
+        method: 'GET',
+        url: apiPaths.oasys.offenceDetails({ prisonNumber: prisoner.prisonerNumber }),
+      },
+      response: {
+        headers: {
+          'Content-Type': 'application/json;charset=UTF-8',
+        },
+        jsonBody: oasysOffenceDetail,
+        status: 200,
+      },
+    }),
+  )
+})
 
 console.log('Stubbing Accredited Programmes API')
 processStubs(stubs)

--- a/wiremock/stubs/index.ts
+++ b/wiremock/stubs/index.ts
@@ -2,6 +2,7 @@ import caseloads from './caseloads.json'
 import courseOfferings from './courseOfferings.json'
 import courseParticipations from './courseParticipations.json'
 import courses from './courses.json'
+import oasysOffenceDetail from './oasysOffenceDetail.json'
 import offenceCodes from './offenceCodes.json'
 import offenderBookings from './offenderBookings.json'
 import offenderSentenceAndOffences from './offenderSentenceAndOffences.json'
@@ -14,6 +15,7 @@ export {
   courseOfferings,
   courseParticipations,
   courses,
+  oasysOffenceDetail,
   offenceCodes,
   offenderBookings,
   offenderSentenceAndOffences,

--- a/wiremock/stubs/oasysOffenceDetail.json
+++ b/wiremock/stubs/oasysOffenceDetail.json
@@ -1,0 +1,18 @@
+{
+  "offenceDetails": "Details about the offence",
+  "contactTargeting": false,
+  "raciallyMotivated": false,
+  "revenge": false,
+  "domesticViolence": false,
+  "repeatVictimisation": false,
+  "victimWasStranger": false,
+  "stalking": false,
+  "recognisesImpact": false,
+  "numberOfOthersInvolved": 2,
+  "othersInvolvedDetail": "Detail about the others involved",
+  "peerGroupInfluences": "Detail about influences",
+  "motivationAndTriggers": "Detail about motivation and triggers",
+  "acceptsResponsibility": false,
+  "acceptsResponsibilityDetail": "Detail about the persons acceptance",
+  "patternOffending": "Detail about the pattern of offending"
+}


### PR DESCRIPTION
## Context

<!-- Is there a Trello ticket you can link to? -->
<!-- Do you need to add any environment variables? -->
<!-- Is an ADR required? An ADR should be added if this PR introduces a change to the architecture. -->



## Changes in this PR



## Screenshots of UI changes
![localhost_3000_assess_referrals_4261ad11-279e-4698-b1bb-90241ec036b9_risks-and-needs_offence-analysis](https://github.com/ministryofjustice/hmpps-accredited-programmes-ui/assets/1067537/7406a479-a04b-4783-83c7-967aeb17761d)




## Release checklist

[Release process documentation](../doc/how-to/perform-a-release.md)

As part of our continuous deployment strategy we must ensure that this work is
ready to be released once merged.

### Pre-merge

- [ ] There are changes required to the Accredited Programmes API for this change to work...
  - [ ] ... and they have been released to production already

### Post-merge

<!-- The outer checkboxes can be completed pre-merge -->

- [ ] This adds, extends or meaningfully modifies a feature...
  - [ ] ... and I have written or updated an end-to-end test for the happy path in the [Accredited Programmes E2E repo](https://github.com/ministryofjustice/hmpps-accredited-programmes-e2e)
- [ ] This makes new expectations of the API...
  - [ ] ... and I have notified the API developer(s) of changes to the contract tests (Pact), or the API is already compliant
- [ ] [Manually approve](../doc/how-to/perform-a-release.md#releasing-to-the-preprod-environment) release to preprod
- [ ] [Manually approve](../doc/how-to/perform-a-release.md#releasing-to-the-production-environment) release to prod

<!-- Should a release fail at any step, you as the author should now lead the work to
fix it as soon as possible. You can monitor deployment failures in CircleCI
itself and application errors are found in
[Sentry](https://ministryofjustice.sentry.io/projects/hmpps-accredited-programmes-ui/?project=4505330122686464&referrer=sidebar&statsPeriod=24h). -->
