### PR TITLE
Remove random nulls from factories

### DIFF
--- a/server/testutils/factories/courseParticipation.ts
+++ b/server/testutils/factories/courseParticipation.ts
@@ -3,7 +3,6 @@ import { Factory } from 'fishery'
 
 import courseParticipationOutcomeFactory from './courseParticipationOutcome'
 import courseParticipationSettingFactory from './courseParticipationSetting'
-import FactoryHelpers from './factoryHelpers'
 import { StringUtils } from '../../utils'
 import type { CourseParticipation } from '@accredited-programmes/models'
 
@@ -24,8 +23,8 @@ export default CourseParticipationFactory.define(() => ({
   courseName: `${StringUtils.convertToTitleCase(faker.color.human())} Course`,
   createdAt: `${faker.date.between({ from: '2023-09-20T00:00:00.000Z', to: new Date() })}`,
   detail: faker.lorem.paragraph({ max: 5, min: 0 }),
-  outcome: FactoryHelpers.optionalArrayElement([courseParticipationOutcomeFactory.build()]),
+  outcome: courseParticipationOutcomeFactory.build(),
   prisonNumber: faker.string.alphanumeric({ length: 7 }),
-  setting: FactoryHelpers.optionalArrayElement([courseParticipationSettingFactory.build()]),
-  source: FactoryHelpers.optionalArrayElement(faker.word.words()),
+  setting: courseParticipationSettingFactory.build(),
+  source: faker.word.words(),
 }))

--- a/server/testutils/factories/courseParticipationOutcome.ts
+++ b/server/testutils/factories/courseParticipationOutcome.ts
@@ -1,7 +1,6 @@
 import { faker } from '@faker-js/faker/locale/en_GB'
 import { Factory } from 'fishery'
 
-import FactoryHelpers from './factoryHelpers'
 import type { CourseParticipationOutcome } from '@accredited-programmes/models'
 
 const randomValidYear = (): number => {
@@ -13,7 +12,7 @@ const outcomeTypes = {
   complete(): CourseParticipationOutcome {
     return {
       status: 'complete',
-      yearCompleted: FactoryHelpers.optionalArrayElement(randomValidYear()),
+      yearCompleted: randomValidYear(),
       yearStarted: undefined,
     }
   },
@@ -22,7 +21,7 @@ const outcomeTypes = {
     return {
       status: 'incomplete',
       yearCompleted: undefined,
-      yearStarted: FactoryHelpers.optionalArrayElement(randomValidYear()),
+      yearStarted: randomValidYear(),
     }
   },
 

--- a/server/testutils/factories/courseParticipationSetting.ts
+++ b/server/testutils/factories/courseParticipationSetting.ts
@@ -1,10 +1,9 @@
 import { faker } from '@faker-js/faker/locale/en_GB'
 import { Factory } from 'fishery'
 
-import FactoryHelpers from './factoryHelpers'
 import type { CourseParticipationSetting } from '@accredited-programmes/models'
 
 export default Factory.define<CourseParticipationSetting>(() => ({
-  location: FactoryHelpers.optionalArrayElement(faker.location.city()),
+  location: faker.location.city(),
   type: faker.helpers.arrayElement(['custody', 'community']),
 }))

--- a/server/testutils/factories/factoryHelpers.ts
+++ b/server/testutils/factories/factoryHelpers.ts
@@ -28,7 +28,7 @@ export default class FactoryHelpers {
     return faker.helpers.arrayElement(fullOptions.concat(options))
   }
 
-  static optionalRandomFutureDateString(): string | undefined {
-    return FactoryHelpers.optionalArrayElement(faker.date.future({ years: 20 }).toISOString().substring(0, 10))
+  static randomFutureDateString(): string | undefined {
+    return faker.date.future({ years: 20 }).toISOString().substring(0, 10)
   }
 }

--- a/server/testutils/factories/factoryHelpers.ts
+++ b/server/testutils/factories/factoryHelpers.ts
@@ -23,11 +23,6 @@ export default class FactoryHelpers {
     return built
   }
 
-  static optionalArrayElement<T>(options: Array<T> | T): T | undefined {
-    const fullOptions: Array<T | undefined> = [undefined]
-    return faker.helpers.arrayElement(fullOptions.concat(options))
-  }
-
   static randomFutureDateString(): string | undefined {
     return faker.date.future({ years: 20 }).toISOString().substring(0, 10)
   }

--- a/server/testutils/factories/inmateDetail.ts
+++ b/server/testutils/factories/inmateDetail.ts
@@ -1,7 +1,6 @@
 import { faker } from '@faker-js/faker/locale/en_GB'
 import { Factory } from 'fishery'
 
-import FactoryHelpers from './factoryHelpers'
 import offenceHistoryDetail from './offenceHistoryDetail'
 import type { InmateDetail } from '@prison-api'
 
@@ -9,7 +8,7 @@ export default Factory.define<Partial<InmateDetail>>(() => {
   const offenceHistory = [offenceHistoryDetail.build({ mostSerious: true }), offenceHistoryDetail.build()]
 
   return {
-    offenceHistory: FactoryHelpers.optionalArrayElement([offenceHistory]),
-    offenderNo: FactoryHelpers.optionalArrayElement(faker.string.alphanumeric({ casing: 'upper', length: 7 })),
+    offenceHistory,
+    offenderNo: faker.string.alphanumeric({ casing: 'upper', length: 7 }),
   }
 })

--- a/server/testutils/factories/offenceDetails.ts
+++ b/server/testutils/factories/offenceDetails.ts
@@ -1,13 +1,12 @@
 import { faker } from '@faker-js/faker/locale/en_GB'
 import { Factory } from 'fishery'
 
-import FactoryHelpers from './factoryHelpers'
 import type { OffenceDetails } from '@accredited-programmes/ui'
 
 export default Factory.define<OffenceDetails>(() => ({
-  code: FactoryHelpers.optionalArrayElement(faker.string.alphanumeric({ casing: 'upper', length: 6 })),
-  date: FactoryHelpers.optionalArrayElement(faker.date.past({ years: 10 }).toISOString().substring(0, 10)),
-  description: FactoryHelpers.optionalArrayElement(faker.lorem.sentence()),
-  mostSerious: FactoryHelpers.optionalArrayElement(faker.datatype.boolean()),
-  statuteCodeDescription: FactoryHelpers.optionalArrayElement(faker.lorem.sentence()),
+  code: faker.string.alphanumeric({ casing: 'upper', length: 6 }),
+  date: faker.date.past({ years: 10 }).toISOString().substring(0, 10),
+  description: faker.lorem.sentence(),
+  mostSerious: faker.datatype.boolean(),
+  statuteCodeDescription: faker.lorem.sentence(),
 }))

--- a/server/testutils/factories/offenceHistoryDetail.ts
+++ b/server/testutils/factories/offenceHistoryDetail.ts
@@ -1,11 +1,10 @@
 import { faker } from '@faker-js/faker/locale/en_GB'
 import { Factory } from 'fishery'
 
-import FactoryHelpers from './factoryHelpers'
 import type { OffenceHistoryDetail } from '@prison-api'
 
 export default Factory.define<Partial<OffenceHistoryDetail>>(() => ({
   mostSerious: faker.datatype.boolean(),
-  offenceCode: FactoryHelpers.optionalArrayElement(faker.string.alphanumeric({ casing: 'upper', length: 6 })),
-  offenceDate: FactoryHelpers.optionalArrayElement(faker.date.past({ years: 1 }).toISOString().substring(0, 10)),
+  offenceCode: faker.string.alphanumeric({ casing: 'upper', length: 6 }),
+  offenceDate: faker.date.past({ years: 1 }).toISOString().substring(0, 10),
 }))

--- a/server/testutils/factories/offenderSentenceAndOffences.ts
+++ b/server/testutils/factories/offenderSentenceAndOffences.ts
@@ -1,9 +1,8 @@
 import { faker } from '@faker-js/faker/locale/en_GB'
 import { Factory } from 'fishery'
 
-import FactoryHelpers from './factoryHelpers'
 import type { OffenderSentenceAndOffences } from '@prison-api'
 
 export default Factory.define<OffenderSentenceAndOffences>(() => ({
-  sentenceTypeDescription: FactoryHelpers.optionalArrayElement(faker.word.words({ count: { max: 5, min: 1 } })),
+  sentenceTypeDescription: faker.word.words({ count: { max: 5, min: 1 } }),
 }))

--- a/server/testutils/factories/person.ts
+++ b/server/testutils/factories/person.ts
@@ -27,7 +27,7 @@ export default Factory.define<Person>(({ params }) => {
     prisonNumber: faker.string.alphanumeric({ length: 7 }),
     religionOrBelief: faker.lorem.word(),
     sentenceExpiryDate: FactoryHelpers.optionalRandomFutureDateString(),
-    sentenceStartDate: FactoryHelpers.optionalArrayElement([`${faker.date.past({ years: 20 })}`.substring(0, 10)]),
+    sentenceStartDate: `${faker.date.past({ years: 20 })}`.substring(0, 10),
     setting: 'Custody',
     tariffDate,
   }

--- a/server/testutils/factories/person.ts
+++ b/server/testutils/factories/person.ts
@@ -8,10 +8,10 @@ export default Factory.define<Person>(({ params }) => {
   const county = faker.location.county()
   const currentPrison = params.currentPrison || `${county} (HMP)`
   const conditionalReleaseDate =
-    'conditionalReleaseDate' in params ? params.conditionalReleaseDate : FactoryHelpers.optionalRandomFutureDateString()
+    'conditionalReleaseDate' in params ? params.conditionalReleaseDate : FactoryHelpers.randomFutureDateString()
   const paroleEligibilityDate =
-    'paroleEligibilityDate' in params ? params.conditionalReleaseDate : FactoryHelpers.optionalRandomFutureDateString()
-  const tariffDate = 'tariffDate' in params ? params.tariffDate : FactoryHelpers.optionalRandomFutureDateString()
+    'paroleEligibilityDate' in params ? params.conditionalReleaseDate : FactoryHelpers.randomFutureDateString()
+  const tariffDate = 'tariffDate' in params ? params.tariffDate : FactoryHelpers.randomFutureDateString()
 
   return {
     bookingId: faker.string.numeric({ length: 10 }),
@@ -20,13 +20,13 @@ export default Factory.define<Person>(({ params }) => {
     dateOfBirth: faker.date.birthdate().toDateString(),
     ethnicity: faker.lorem.word(),
     gender: faker.person.gender(),
-    homeDetentionCurfewEligibilityDate: FactoryHelpers.optionalRandomFutureDateString(),
+    homeDetentionCurfewEligibilityDate: FactoryHelpers.randomFutureDateString(),
     indeterminateSentence: faker.datatype.boolean(),
     name: `${faker.person.firstName()} ${faker.person.lastName()}`,
     paroleEligibilityDate,
     prisonNumber: faker.string.alphanumeric({ length: 7 }),
     religionOrBelief: faker.lorem.word(),
-    sentenceExpiryDate: FactoryHelpers.optionalRandomFutureDateString(),
+    sentenceExpiryDate: FactoryHelpers.randomFutureDateString(),
     sentenceStartDate: `${faker.date.past({ years: 20 })}`.substring(0, 10),
     setting: 'Custody',
     tariffDate,

--- a/server/testutils/factories/prisoner.ts
+++ b/server/testutils/factories/prisoner.ts
@@ -27,20 +27,20 @@ export default PrisonerFactory.define(({ params }) => {
 
   return {
     bookingId: generateBookingId(),
-    conditionalReleaseDate: FactoryHelpers.optionalRandomFutureDateString(),
+    conditionalReleaseDate: FactoryHelpers.randomFutureDateString(),
     dateOfBirth: [year, month, day].join('-'),
     ethnicity: StringUtils.properCase(faker.lorem.word()),
     firstName: faker.person.firstName(),
     gender: faker.person.gender(),
-    homeDetentionCurfewEligibilityDate: FactoryHelpers.optionalRandomFutureDateString(),
+    homeDetentionCurfewEligibilityDate: FactoryHelpers.randomFutureDateString(),
     indeterminateSentence: faker.datatype.boolean(),
     lastName: faker.person.lastName(),
-    paroleEligibilityDate: FactoryHelpers.optionalRandomFutureDateString(),
+    paroleEligibilityDate: FactoryHelpers.randomFutureDateString(),
     prisonName,
     prisonerNumber: faker.string.alphanumeric({ casing: 'upper', length: 7 }),
     religion: StringUtils.properCase(faker.lorem.word()),
-    sentenceExpiryDate: FactoryHelpers.optionalRandomFutureDateString(),
+    sentenceExpiryDate: FactoryHelpers.randomFutureDateString(),
     sentenceStartDate: `${faker.date.past({ years: 20 })}`.substring(0, 10),
-    tariffDate: FactoryHelpers.optionalRandomFutureDateString(),
+    tariffDate: FactoryHelpers.randomFutureDateString(),
   }
 })

--- a/server/testutils/factories/prisoner.ts
+++ b/server/testutils/factories/prisoner.ts
@@ -26,21 +26,21 @@ export default PrisonerFactory.define(({ params }) => {
   const day = dateOfBirth.getDate()
 
   return {
-    bookingId: FactoryHelpers.optionalArrayElement(generateBookingId()),
+    bookingId: generateBookingId(),
     conditionalReleaseDate: FactoryHelpers.optionalRandomFutureDateString(),
     dateOfBirth: [year, month, day].join('-'),
     ethnicity: StringUtils.properCase(faker.lorem.word()),
     firstName: faker.person.firstName(),
     gender: faker.person.gender(),
     homeDetentionCurfewEligibilityDate: FactoryHelpers.optionalRandomFutureDateString(),
-    indeterminateSentence: FactoryHelpers.optionalArrayElement([faker.datatype.boolean()]),
+    indeterminateSentence: faker.datatype.boolean(),
     lastName: faker.person.lastName(),
     paroleEligibilityDate: FactoryHelpers.optionalRandomFutureDateString(),
     prisonName,
     prisonerNumber: faker.string.alphanumeric({ casing: 'upper', length: 7 }),
     religion: StringUtils.properCase(faker.lorem.word()),
     sentenceExpiryDate: FactoryHelpers.optionalRandomFutureDateString(),
-    sentenceStartDate: FactoryHelpers.optionalArrayElement([`${faker.date.past({ years: 20 })}`.substring(0, 10)]),
+    sentenceStartDate: `${faker.date.past({ years: 20 })}`.substring(0, 10),
     tariffDate: FactoryHelpers.optionalRandomFutureDateString(),
   }
 })

--- a/server/testutils/factories/referralSummary.ts
+++ b/server/testutils/factories/referralSummary.ts
@@ -12,9 +12,9 @@ interface ReferralSummaryTransientParams {
 }
 
 export default Factory.define<ReferralSummary, ReferralSummaryTransientParams>(({ params, transientParams }) => {
-  const conditionalReleaseDate = FactoryHelpers.optionalRandomFutureDateString()
-  const paroleEligibilityDate = FactoryHelpers.optionalRandomFutureDateString()
-  const tariffExpiryDate = FactoryHelpers.optionalRandomFutureDateString()
+  const conditionalReleaseDate = FactoryHelpers.randomFutureDateString()
+  const paroleEligibilityDate = FactoryHelpers.randomFutureDateString()
+  const tariffExpiryDate = FactoryHelpers.randomFutureDateString()
   const indeterminateSentence = faker.datatype.boolean()
 
   const sentence: ReferralSummary['sentence'] = Object.prototype.hasOwnProperty.call(params, 'sentence')

--- a/server/testutils/factories/referralSummary.ts
+++ b/server/testutils/factories/referralSummary.ts
@@ -15,17 +15,17 @@ export default Factory.define<ReferralSummary, ReferralSummaryTransientParams>((
   const conditionalReleaseDate = FactoryHelpers.optionalRandomFutureDateString()
   const paroleEligibilityDate = FactoryHelpers.optionalRandomFutureDateString()
   const tariffExpiryDate = FactoryHelpers.optionalRandomFutureDateString()
-  const indeterminateSentence = FactoryHelpers.optionalArrayElement(faker.datatype.boolean())
+  const indeterminateSentence = faker.datatype.boolean()
 
   const sentence: ReferralSummary['sentence'] = Object.prototype.hasOwnProperty.call(params, 'sentence')
     ? params.sentence
-    : FactoryHelpers.optionalArrayElement({
+    : {
         conditionalReleaseDate,
         indeterminateSentence,
-        nonDtoReleaseDateType: FactoryHelpers.optionalArrayElement(['ARD', 'CRD', 'NPD', 'PRRD']),
+        nonDtoReleaseDateType: faker.helpers.arrayElement(['ARD', 'CRD', 'NPD', 'PRRD']),
         paroleEligibilityDate,
         tariffExpiryDate,
-      })
+      }
 
   let earliestReleaseDate: ReferralSummary['earliestReleaseDate']
   if (sentence) {
@@ -59,6 +59,6 @@ export default Factory.define<ReferralSummary, ReferralSummaryTransientParams>((
     submittedOn: status !== 'referral_started' ? faker.date.past().toISOString() : undefined,
     tasksCompleted: Object.prototype.hasOwnProperty.call(params, 'tasksCompleted')
       ? params.tasksCompleted
-      : FactoryHelpers.optionalArrayElement(faker.number.int({ max: 4, min: 1 })),
+      : faker.number.int({ max: 4, min: 1 }),
   }
 })


### PR DESCRIPTION
## Context

<!-- Is there a Trello ticket you can link to? -->
<!-- Do you need to add any environment variables? -->
<!-- Is an ADR required? An ADR should be added if this PR introduces a change to the architecture. -->

Our Pact contracts are being generated every time we deploy a branch to dev. Because we allow for randomly `null` values in our Factory-generated objects, it makes it impossible for the API code to reliably provide these.

## Changes in this PR

Removes random `null` setting of fields in our factories. We originally added this functionality to make our generated objects more realistic in relation to what would come back from the various APIs, but we're already manually passing in these `null` values in tests that check for them.

## Release checklist

[Release process documentation](../doc/how-to/perform-a-release.md)

As part of our continuous deployment strategy we must ensure that this work is
ready to be released once merged.

### Pre-merge

- [ ] There are changes required to the Accredited Programmes API for this change to work...
  - [ ] ... and they have been released to production already

### Post-merge

<!-- The outer checkboxes can be completed pre-merge -->

- [ ] This adds, extends or meaningfully modifies a feature...
  - [ ] ... and I have written or updated an end-to-end test for the happy path in the [Accredited Programmes E2E repo](https://github.com/ministryofjustice/hmpps-accredited-programmes-e2e)
- [ ] This makes new expectations of the API...
  - [ ] ... and I have notified the API developer(s) of changes to the contract tests (Pact), or the API is already compliant
- [ ] [Manually approve](../doc/how-to/perform-a-release.md#releasing-to-the-preprod-environment) release to preprod
- [ ] [Manually approve](../doc/how-to/perform-a-release.md#releasing-to-the-production-environment) release to prod

<!-- Should a release fail at any step, you as the author should now lead the work to
fix it as soon as possible. You can monitor deployment failures in CircleCI
itself and application errors are found in
[Sentry](https://ministryofjustice.sentry.io/projects/hmpps-accredited-programmes-ui/?project=4505330122686464&referrer=sidebar&statsPeriod=24h). -->
