### PR TITLE
Provide non-optional fields in Pact contracts

### DIFF
--- a/server/data/accreditedProgrammesApi/courseClient.test.ts
+++ b/server/data/accreditedProgrammesApi/courseClient.test.ts
@@ -295,9 +295,9 @@ pactWith({ consumer: 'Accredited Programmes UI', provider: 'Accredited Programme
   })
 
   describe('findParticipation', () => {
-    const courseParticipation = courseParticipationFactory.build({
+    const courseParticipation = courseParticipationFactory.withAllOptionalFields().build({
       id: '0cff5da9-1e90-4ee2-a5cb-94dc49c4b004',
-      outcome: courseParticipationOutcomeFactory.incomplete().build(),
+      outcome: courseParticipationOutcomeFactory.incomplete(true).build(),
     })
 
     beforeEach(() => {
@@ -327,14 +327,14 @@ pactWith({ consumer: 'Accredited Programmes UI', provider: 'Accredited Programme
 
   describe('findParticipationsByPerson', () => {
     const courseParticipations = [
-      courseParticipationFactory.build({
+      courseParticipationFactory.withAllOptionalFields().build({
         id: '0cff5da9-1e90-4ee2-a5cb-94dc49c4b004',
-        outcome: courseParticipationOutcomeFactory.incomplete().build(),
+        outcome: courseParticipationOutcomeFactory.incomplete(true).build(),
         prisonNumber: 'A1234AA',
       }),
-      courseParticipationFactory.build({
+      courseParticipationFactory.withAllOptionalFields().build({
         id: 'eb357e5d-5416-43bf-a8d2-0dc8fd92162e',
-        outcome: courseParticipationOutcomeFactory.incomplete().build(),
+        outcome: courseParticipationOutcomeFactory.incomplete(true).build(),
         prisonNumber: 'A1234AA',
       }),
     ]

--- a/server/data/accreditedProgrammesApi/referralClient.test.ts
+++ b/server/data/accreditedProgrammesApi/referralClient.test.ts
@@ -125,7 +125,7 @@ pactWith({ consumer: 'Accredited Programmes UI', provider: 'Accredited Programme
         content: FactoryHelpers.buildListWith(
           referralSummaryFactory,
           { status: 'referral_submitted', tasksCompleted: undefined },
-          {},
+          { transient: { requireOptionalFields: true } },
           1,
         ),
         pageIsEmpty: false,
@@ -174,7 +174,7 @@ pactWith({ consumer: 'Accredited Programmes UI', provider: 'Accredited Programme
     describe('without query parameters', () => {
       const paginatedReferralSummaries: Paginated<ReferralSummary> = {
         content: [
-          referralSummaryFactory.build({
+          referralSummaryFactory.withAllOptionalFields().build({
             earliestReleaseDate: undefined,
             status: 'referral_submitted',
             tasksCompleted: undefined,
@@ -225,7 +225,7 @@ pactWith({ consumer: 'Accredited Programmes UI', provider: 'Accredited Programme
             status: 'referral_submitted',
             tasksCompleted: undefined,
           },
-          {},
+          { transient: { requireOptionalFields: true } },
           16,
         ),
         pageIsEmpty: false,

--- a/server/testutils/factories/courseParticipation.ts
+++ b/server/testutils/factories/courseParticipation.ts
@@ -16,6 +16,14 @@ class CourseParticipationFactory extends Factory<CourseParticipation> {
       source: undefined,
     })
   }
+
+  withAllOptionalFields() {
+    return this.params({
+      outcome: courseParticipationOutcomeFactory.withAllOptionalFields().build(),
+      setting: courseParticipationSettingFactory.withAllOptionalFields().build(),
+      source: faker.word.words(),
+    })
+  }
 }
 
 export default CourseParticipationFactory.define(() => ({

--- a/server/testutils/factories/courseParticipationOutcome.ts
+++ b/server/testutils/factories/courseParticipationOutcome.ts
@@ -10,35 +10,39 @@ const randomValidYear = (): number => {
 }
 
 const outcomeTypes = {
-  complete(): CourseParticipationOutcome {
+  complete(requireOptionalFields = false): CourseParticipationOutcome {
     return {
       status: 'complete',
-      yearCompleted: FactoryHelpers.optionalArrayElement(randomValidYear()),
+      yearCompleted: requireOptionalFields ? randomValidYear() : FactoryHelpers.optionalArrayElement(randomValidYear()),
       yearStarted: undefined,
     }
   },
 
-  incomplete(): CourseParticipationOutcome {
+  incomplete(requireOptionalFields = false): CourseParticipationOutcome {
     return {
       status: 'incomplete',
       yearCompleted: undefined,
-      yearStarted: FactoryHelpers.optionalArrayElement(randomValidYear()),
+      yearStarted: requireOptionalFields ? randomValidYear() : FactoryHelpers.optionalArrayElement(randomValidYear()),
     }
   },
 
-  random() {
+  random(requireOptionalFields = false) {
     const type = faker.helpers.arrayElement<'complete' | 'incomplete'>(['complete', 'incomplete'])
-    return this[type]()
+    return this[type](requireOptionalFields)
   },
 }
 
 class CourseParticipationOutcomeFactory extends Factory<CourseParticipationOutcome> {
-  complete() {
-    return this.params(outcomeTypes.complete())
+  complete(requireOptionalFields = false) {
+    return this.params(outcomeTypes.complete(requireOptionalFields))
   }
 
-  incomplete() {
-    return this.params(outcomeTypes.incomplete())
+  incomplete(requireOptionalFields = false) {
+    return this.params(outcomeTypes.incomplete(requireOptionalFields))
+  }
+
+  withAllOptionalFields() {
+    return this.params(outcomeTypes.random(true))
   }
 }
 

--- a/server/testutils/factories/courseParticipationSetting.ts
+++ b/server/testutils/factories/courseParticipationSetting.ts
@@ -4,7 +4,17 @@ import { Factory } from 'fishery'
 import FactoryHelpers from './factoryHelpers'
 import type { CourseParticipationSetting } from '@accredited-programmes/models'
 
-export default Factory.define<CourseParticipationSetting>(() => ({
-  location: FactoryHelpers.optionalArrayElement(faker.location.city()),
-  type: faker.helpers.arrayElement(['custody', 'community']),
-}))
+class CourseParticipationSettingFactory extends Factory<CourseParticipationSetting> {
+  withAllOptionalFields() {
+    return this.params({
+      location: faker.location.city(),
+    })
+  }
+}
+
+export default CourseParticipationSettingFactory.define(
+  (): CourseParticipationSetting => ({
+    location: FactoryHelpers.optionalArrayElement(faker.location.city()),
+    type: faker.helpers.arrayElement(['custody', 'community']),
+  }),
+)

--- a/server/testutils/factories/factoryHelpers.ts
+++ b/server/testutils/factories/factoryHelpers.ts
@@ -29,6 +29,10 @@ export default class FactoryHelpers {
   }
 
   static optionalRandomFutureDateString(): string | undefined {
-    return FactoryHelpers.optionalArrayElement(faker.date.future({ years: 20 }).toISOString().substring(0, 10))
+    return FactoryHelpers.optionalArrayElement(this.randomFutureDateString())
+  }
+
+  static randomFutureDateString(): string {
+    return faker.date.future({ years: 20 }).toISOString().substring(0, 10)
   }
 }


### PR DESCRIPTION
## Context

<!-- Is there a Trello ticket you can link to? -->
<!-- Do you need to add any environment variables? -->
<!-- Is an ADR required? An ADR should be added if this PR introduces a change to the architecture. -->

Randomly generating either a string or undefined value for fields in Pact tests is making it impossible for the Provider to supply them in its own Pact tests.

Closes #445

## Changes in this PR

An alternative approach to #445.

## Release checklist

[Release process documentation](../doc/how-to/perform-a-release.md)

As part of our continuous deployment strategy we must ensure that this work is
ready to be released once merged.

### Pre-merge

- [ ] There are changes required to the Accredited Programmes API for this change to work...
  - [ ] ... and they have been released to production already

### Post-merge

<!-- The outer checkboxes can be completed pre-merge -->

- [ ] This adds, extends or meaningfully modifies a feature...
  - [ ] ... and I have written or updated an end-to-end test for the happy path in the [Accredited Programmes E2E repo](https://github.com/ministryofjustice/hmpps-accredited-programmes-e2e)
- [ ] This makes new expectations of the API...
  - [ ] ... and I have notified the API developer(s) of changes to the contract tests (Pact), or the API is already compliant
- [ ] [Manually approve](../doc/how-to/perform-a-release.md#releasing-to-the-preprod-environment) release to preprod
- [ ] [Manually approve](../doc/how-to/perform-a-release.md#releasing-to-the-production-environment) release to prod

<!-- Should a release fail at any step, you as the author should now lead the work to
fix it as soon as possible. You can monitor deployment failures in CircleCI
itself and application errors are found in
[Sentry](https://ministryofjustice.sentry.io/projects/hmpps-accredited-programmes-ui/?project=4505330122686464&referrer=sidebar&statsPeriod=24h). -->
