### PR TITLE
Run integration tests in parallel

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -91,10 +91,12 @@ jobs:
               -u $PACT_BROKER_USERNAME -p $PACT_BROKER_PASSWORD
 
   integration_test:
+    parallelism: 4
     executor:
       name: hmpps/node_redis
       node_tag: << pipeline.parameters.node-version >>
       redis_tag: '6.2'
+      resource_class: medium+
     steps:
       - checkout
       - attach_workspace:
@@ -120,10 +122,16 @@ jobs:
           background: true
       - run:
           name: Wait for node app to start
-          command: sleep 5
+          command: |
+            until curl http://localhost:3007/health > /dev/null 2>&1; do
+              printf '.'
+              sleep 1
+            done
       - run:
           name: integration tests
-          command: npm run test:integration:cli:run
+          command: |
+            TESTS=$(circleci tests glob "integration_tests/e2e/**/*.cy.ts" | circleci tests split --split-by=timings | paste -sd ',')
+            npm run test:integration:cli:run -- --spec $TESTS
       - store_test_results:
           path: test_results/integration
       - store_artifacts:

--- a/integration_tests/e2e/assess.cy.ts
+++ b/integration_tests/e2e/assess.cy.ts
@@ -4,6 +4,12 @@ import AuthErrorPage from '../pages/authError'
 import Page from '../pages/page'
 
 context('General Assess functionality', () => {
+  beforeEach(() => {
+    cy.task('reset')
+    cy.task('stubAuthUser')
+    cy.task('stubDefaultCaseloads')
+  })
+
   describe('When the user does not have the `ROLE_ACP_PROGRAMME_TEAM` role', () => {
     it('shows the auth error page', () => {
       cy.task('stubSignIn', { authorities: [ApplicationRoles.ACP_REFERRER] })


### PR DESCRIPTION
## Context

<!-- Is there a Trello ticket you can link to? -->
<!-- Do you need to add any environment variables? -->
<!-- Is an ADR required? An ADR should be added if this PR introduces a change to the architecture. -->

This is largely taken from [the approach taken on Approved Premises](https://github.com/ministryofjustice/hmpps-approved-premises-ui/pull/818). Our main integration test suite takes roughly 5.5-7.5 minutes to run on CI, while parallel jobs take a maximum of around 2.5 minutes. This can lead to devs waiting a long time whenever a change is made before they can confirm everything is passing on CI, and to move onto preprod and prod deployment where appropriate, interrupting the flow of a task

The refer-disabled integration tests aren't as comprehensive at this point, but in any case, they aren't causing anywhere near the slow down as the main suite, and it won't be long before they become redundant (when Refer launches), so there's no need to tamper with them at present

## Changes in this PR

- Run integration tests in parallel on CI
- Update a test suite to remove an accidental cross-suite dependency

With this change, the suite currently completes in around 2.5-3 minutes (down from 5.5-7.5), bringing it roughly in line with parallel jobs

## Release checklist

[Release process documentation](../doc/how-to/perform-a-release.md)

As part of our continuous deployment strategy we must ensure that this work is
ready to be released once merged.

### Pre-merge

- [ ] There are changes required to the Accredited Programmes API for this change to work...
  - [ ] ... and they have been released to production already

### Post-merge

<!-- The outer checkboxes can be completed pre-merge -->

- [ ] This adds, extends or meaningfully modifies a feature...
  - [ ] ... and I have written or updated an end-to-end test for the happy path in the [Accredited Programmes E2E repo](https://github.com/ministryofjustice/hmpps-accredited-programmes-e2e)
- [ ] This makes new expectations of the API...
  - [ ] ... and I have notified the API developer(s) of changes to the contract tests (Pact), or the API is already compliant
- [ ] [Manually approve](../doc/how-to/perform-a-release.md#releasing-to-the-preprod-environment) release to preprod
- [ ] [Manually approve](../doc/how-to/perform-a-release.md#releasing-to-the-production-environment) release to prod

<!-- Should a release fail at any step, you as the author should now lead the work to
fix it as soon as possible. You can monitor deployment failures in CircleCI
itself and application errors are found in
[Sentry](https://ministryofjustice.sentry.io/projects/hmpps-accredited-programmes-ui/?project=4505330122686464&referrer=sidebar&statsPeriod=24h). -->