### PR TITLE
(813) Restrict draft referrals to referrer user only

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,7 +38,9 @@ As the Prisoner Search is a complex API with multiple dependencies, we've opted 
 
 ### With a mocked API
 
-**Warning:** the mocked API currently only covers the Find journey and searching for a person before creating a referral. The rest of the Refer journey will not work with a mocked API at present.
+**Warning:** only some parts of the journey are available with the mocked API.
+
+Mocked referral summaries and referrals are mocked to have been referred by `ACP_POM_USER`. To view these referrals with the `status` set to `referral_started`, you must be logged in as `ACP_POM_USER`.
 
 To run the application as above but with a mocked Accredited Programmes API (port 9099), run:
 

--- a/integration_tests/e2e/refer.cy.ts
+++ b/integration_tests/e2e/refer.cy.ts
@@ -40,4 +40,20 @@ context('General Refer functionality', () => {
       Page.verifyOnPage(NewReferralCompletePage)
     })
   })
+
+  describe('When a user attempts to view a draft referral and they are not the referrer user', () => {
+    it('redirects to the auth error page', () => {
+      cy.task('stubSignIn', { authorities: [ApplicationRoles.ACP_REFERRER] })
+      cy.signIn()
+
+      const draftReferral = referralFactory.started().build()
+      cy.task('stubReferral', draftReferral)
+
+      const path = referPaths.new.show({ referralId: draftReferral.id })
+      cy.visit(path, { failOnStatusCode: false })
+
+      const authErrorPage = Page.verifyOnPage(AuthErrorPage)
+      authErrorPage.shouldContainAuthErrorMessage()
+    })
+  })
 })

--- a/integration_tests/e2e/refer.cy.ts
+++ b/integration_tests/e2e/refer.cy.ts
@@ -1,6 +1,7 @@
 import { ApplicationRoles } from '../../server/middleware/roleBasedAccessMiddleware'
 import { referPaths } from '../../server/paths'
 import { referralFactory } from '../../server/testutils/factories'
+import auth from '../mockApis/auth'
 import AuthErrorPage from '../pages/authError'
 import Page from '../pages/page'
 import { NewReferralCompletePage } from '../pages/refer'
@@ -30,7 +31,7 @@ context('General Refer functionality', () => {
       cy.task('stubSignIn', { authorities: [ApplicationRoles.ACP_REFERRER] })
       cy.signIn()
 
-      const referral = referralFactory.submitted().build({})
+      const referral = referralFactory.submitted().build({ referrerUsername: auth.mockedUser.username })
       cy.task('stubReferral', referral)
 
       const path = referPaths.new.programmeHistory.index({ referralId: referral.id })

--- a/integration_tests/e2e/refer/new/additionalInformation.cy.ts
+++ b/integration_tests/e2e/refer/new/additionalInformation.cy.ts
@@ -9,6 +9,7 @@ import {
   referralFactory,
 } from '../../../../server/testutils/factories'
 import { OrganisationUtils } from '../../../../server/utils'
+import auth from '../../../mockApis/auth'
 import Page from '../../../pages/page'
 import { NewReferralAdditionalInformationPage, NewReferralTaskListPage } from '../../../pages/refer'
 
@@ -23,7 +24,11 @@ context('Additional information', () => {
     name: 'Del Hatton',
     prisonNumber: prisoner.prisonerNumber,
   })
-  const referral = referralFactory.started().build({ offeringId: courseOffering.id, prisonNumber: person.prisonNumber })
+  const referral = referralFactory.started().build({
+    offeringId: courseOffering.id,
+    prisonNumber: person.prisonNumber,
+    referrerUsername: auth.mockedUser.username,
+  })
 
   beforeEach(() => {
     cy.task('reset')

--- a/integration_tests/e2e/refer/new/confirmOasys.cy.ts
+++ b/integration_tests/e2e/refer/new/confirmOasys.cy.ts
@@ -9,6 +9,7 @@ import {
   referralFactory,
 } from '../../../../server/testutils/factories'
 import { OrganisationUtils } from '../../../../server/utils'
+import auth from '../../../mockApis/auth'
 import Page from '../../../pages/page'
 import { NewReferralConfirmOasysPage, NewReferralTaskListPage } from '../../../pages/refer'
 
@@ -23,7 +24,11 @@ context('OASys confirmation', () => {
     name: 'Del Hatton',
     prisonNumber: prisoner.prisonerNumber,
   })
-  const referral = referralFactory.started().build({ offeringId: courseOffering.id, prisonNumber: person.prisonNumber })
+  const referral = referralFactory.started().build({
+    offeringId: courseOffering.id,
+    prisonNumber: person.prisonNumber,
+    referrerUsername: auth.mockedUser.username,
+  })
 
   beforeEach(() => {
     cy.task('reset')

--- a/integration_tests/e2e/refer/new/create.cy.ts
+++ b/integration_tests/e2e/refer/new/create.cy.ts
@@ -9,6 +9,7 @@ import {
   referralFactory,
 } from '../../../../server/testutils/factories'
 import { OrganisationUtils } from '../../../../server/utils'
+import auth from '../../../mockApis/auth'
 import Page from '../../../pages/page'
 import {
   NewReferralConfirmPersonPage,
@@ -119,9 +120,11 @@ context('Searching for a person and creating a referral', () => {
     cy.task('stubPrison', prison)
     cy.task('stubPrisoner', prisoner)
 
-    const referral = referralFactory
-      .started()
-      .build({ offeringId: courseOffering.id, prisonNumber: person.prisonNumber })
+    const referral = referralFactory.started().build({
+      offeringId: courseOffering.id,
+      prisonNumber: person.prisonNumber,
+      referrerUsername: auth.mockedUser.username,
+    })
     cy.task('stubCreateReferral', referral)
     cy.task('stubReferral', referral)
 

--- a/integration_tests/e2e/refer/new/programmeHistory.cy.ts
+++ b/integration_tests/e2e/refer/new/programmeHistory.cy.ts
@@ -11,6 +11,7 @@ import {
   userFactory,
 } from '../../../../server/testutils/factories'
 import { type CourseParticipationDetailsBody, OrganisationUtils, StringUtils } from '../../../../server/utils'
+import auth from '../../../mockApis/auth'
 import Page from '../../../pages/page'
 import {
   NewReferralDeleteProgrammeHistoryPage,
@@ -34,7 +35,7 @@ context('Programme history', () => {
   })
   const courses = courseFactory.buildList(4)
   const courseNames = courses.map(course => course.name)
-  const addedByUser1 = userFactory.build()
+  const addedByUser1 = userFactory.build({ username: auth.mockedUser.username })
   const addedByUser2 = userFactory.build()
   const courseParticipationWithKnownCourseName = courseParticipationFactory.build({
     addedBy: addedByUser1.username,
@@ -55,7 +56,11 @@ context('Programme history', () => {
     addedByDisplayName: StringUtils.convertToTitleCase(addedByUser2.name),
   }
   const courseOffering = courseOfferingFactory.build()
-  const referral = referralFactory.started().build({ offeringId: courseOffering.id, prisonNumber: person.prisonNumber })
+  const referral = referralFactory.started().build({
+    offeringId: courseOffering.id,
+    prisonNumber: person.prisonNumber,
+    referrerUsername: addedByUser1.username,
+  })
   const programmeHistoryPath = referPaths.new.programmeHistory.index({ referralId: referral.id })
   const newParticipationPath = referPaths.new.programmeHistory.new({ referralId: referral.id })
 

--- a/integration_tests/e2e/refer/new/show.cy.ts
+++ b/integration_tests/e2e/refer/new/show.cy.ts
@@ -9,6 +9,7 @@ import {
   referralFactory,
 } from '../../../../server/testutils/factories'
 import { OrganisationUtils } from '../../../../server/utils'
+import auth from '../../../mockApis/auth'
 import Page from '../../../pages/page'
 import { NewReferralShowPersonPage, NewReferralTaskListPage } from '../../../pages/refer'
 
@@ -29,7 +30,11 @@ context('Showing the referral task list and person page', () => {
     religionOrBelief: prisoner.religion,
     setting: 'Custody',
   })
-  const referral = referralFactory.started().build({ offeringId: courseOffering.id, prisonNumber: person.prisonNumber })
+  const referral = referralFactory.started().build({
+    offeringId: courseOffering.id,
+    prisonNumber: person.prisonNumber,
+    referrerUsername: auth.mockedUser.username,
+  })
 
   beforeEach(() => {
     cy.task('reset')

--- a/integration_tests/e2e/refer/new/submit.cy.ts
+++ b/integration_tests/e2e/refer/new/submit.cy.ts
@@ -11,6 +11,7 @@ import {
   userFactory,
 } from '../../../../server/testutils/factories'
 import { OrganisationUtils, StringUtils } from '../../../../server/utils'
+import auth from '../../../mockApis/auth'
 import Page from '../../../pages/page'
 import { NewReferralCheckAnswersPage, NewReferralCompletePage, NewReferralTaskListPage } from '../../../pages/refer'
 import type { CourseParticipationPresenter } from '@accredited-programmes/ui'
@@ -35,7 +36,7 @@ context('Submitting a referral', () => {
   })
   const prison = prisonFactory.build({ prisonId: courseOffering.organisationId })
   const organisation = OrganisationUtils.organisationFromPrison(prison)
-  const addedByUser1 = userFactory.build({ name: 'Bobby Brown' })
+  const addedByUser1 = userFactory.build({ name: 'Bobby Brown', username: auth.mockedUser.username })
   const addedByUser2 = userFactory.build()
   const courseParticipationWithKnownCourseName = courseParticipationFactory.build({
     addedBy: addedByUser1.username,
@@ -218,7 +219,7 @@ context('Submitting a referral', () => {
   })
 
   it('Shows the complete page for a completed referral', () => {
-    const submittedReferral = referralFactory.submitted().build()
+    const submittedReferral = referralFactory.submitted().build({ referrerUsername: auth.mockedUser.username })
     cy.task('stubReferral', submittedReferral)
 
     const path = referPaths.new.complete({ referralId: submittedReferral.id })

--- a/server/controllers/refer/new/additionalInformationController.ts
+++ b/server/controllers/refer/new/additionalInformationController.ts
@@ -1,6 +1,6 @@
 import type { Request, Response, TypedRequestHandler } from 'express'
 
-import { referPaths } from '../../../paths'
+import { authPaths, referPaths } from '../../../paths'
 import type { PersonService, ReferralService } from '../../../services'
 import { FormUtils, TypeUtils } from '../../../utils'
 import type { ReferralUpdate } from '@accredited-programmes/models'
@@ -21,6 +21,10 @@ export default class NewReferralsAdditionalInformationController {
 
       if (referral.status !== 'referral_started') {
         return res.redirect(referPaths.new.complete({ referralId }))
+      }
+
+      if (referral.referrerUsername !== req.user.username) {
+        return res.redirect(authPaths.error({}))
       }
 
       const person = await this.personService.getPerson(
@@ -49,6 +53,10 @@ export default class NewReferralsAdditionalInformationController {
 
       if (referral.status !== 'referral_started') {
         return res.redirect(referPaths.new.complete({ referralId }))
+      }
+
+      if (referral.referrerUsername !== req.user.username) {
+        return res.redirect(authPaths.error({}))
       }
 
       const formattedAdditionalInformation = req.body.additionalInformation?.trim()

--- a/server/controllers/refer/new/oasysConfirmationController.test.ts
+++ b/server/controllers/refer/new/oasysConfirmationController.test.ts
@@ -3,16 +3,17 @@ import { createMock } from '@golevelup/ts-jest'
 import type { NextFunction, Request, Response } from 'express'
 
 import NewReferralsOasysConfirmationController from './oasysConfirmationController'
-import { referPaths } from '../../../paths'
+import { authPaths, referPaths } from '../../../paths'
 import type { PersonService, ReferralService } from '../../../services'
 import { courseOfferingFactory, personFactory, referralFactory } from '../../../testutils/factories'
 import Helpers from '../../../testutils/helpers'
-import { FormUtils } from '../../../utils'
+import { FormUtils, TypeUtils } from '../../../utils'
 
 jest.mock('../../../utils/formUtils')
 
 describe('NewReferralsOasysConfirmationController', () => {
   const username = 'SOME_USERNAME'
+  const otherUsername = 'SOME_OTHER_USERNAME'
   let request: DeepMocked<Request>
   let response: DeepMocked<Response>
   const next: DeepMocked<NextFunction> = createMock<NextFunction>({})
@@ -23,12 +24,20 @@ describe('NewReferralsOasysConfirmationController', () => {
   const courseOffering = courseOfferingFactory.build()
   const person = personFactory.build()
   const referralId = 'A-REFERRAL-ID'
-  const draftReferral = referralFactory
-    .started()
-    .build({ id: referralId, oasysConfirmed: false, offeringId: courseOffering.id, prisonNumber: person.prisonNumber })
-  const submittedReferral = referralFactory
-    .submitted()
-    .build({ id: referralId, oasysConfirmed: false, offeringId: courseOffering.id, prisonNumber: person.prisonNumber })
+  const draftReferral = referralFactory.started().build({
+    id: referralId,
+    oasysConfirmed: false,
+    offeringId: courseOffering.id,
+    prisonNumber: person.prisonNumber,
+    referrerUsername: username,
+  })
+  const submittedReferral = referralFactory.submitted().build({
+    id: referralId,
+    oasysConfirmed: false,
+    offeringId: courseOffering.id,
+    prisonNumber: person.prisonNumber,
+    referrerUsername: username,
+  })
 
   let controller: NewReferralsOasysConfirmationController
 
@@ -75,6 +84,22 @@ describe('NewReferralsOasysConfirmationController', () => {
         expect(response.redirect).toHaveBeenCalledWith(referPaths.new.complete({ referralId }))
       })
     })
+
+    describe('when the logged in user is not the referrer', () => {
+      it('redirects to the auth error page', async () => {
+        TypeUtils.assertHasUser(request)
+
+        request.user.username = otherUsername
+
+        referralService.getReferral.mockResolvedValue(draftReferral)
+
+        const requestHandler = controller.show()
+        await requestHandler(request, response, next)
+
+        expect(referralService.getReferral).toHaveBeenCalledWith(otherUsername, referralId)
+        expect(response.redirect).toHaveBeenCalledWith(authPaths.error({}))
+      })
+    })
   })
 
   describe('update', () => {
@@ -116,6 +141,22 @@ describe('NewReferralsOasysConfirmationController', () => {
 
         expect(referralService.getReferral).toHaveBeenCalledWith(username, referralId)
         expect(response.redirect).toHaveBeenCalledWith(referPaths.new.complete({ referralId }))
+      })
+    })
+
+    describe('when the logged in user is not the referrer', () => {
+      it('redirects to the auth error page', async () => {
+        TypeUtils.assertHasUser(request)
+
+        request.user.username = otherUsername
+
+        referralService.getReferral.mockResolvedValue(draftReferral)
+
+        const requestHandler = controller.update()
+        await requestHandler(request, response, next)
+
+        expect(referralService.getReferral).toHaveBeenCalledWith(otherUsername, referralId)
+        expect(response.redirect).toHaveBeenCalledWith(authPaths.error({}))
       })
     })
   })

--- a/server/controllers/refer/new/oasysConfirmationController.ts
+++ b/server/controllers/refer/new/oasysConfirmationController.ts
@@ -1,6 +1,6 @@
 import type { Request, Response, TypedRequestHandler } from 'express'
 
-import { referPaths } from '../../../paths'
+import { authPaths, referPaths } from '../../../paths'
 import type { PersonService, ReferralService } from '../../../services'
 import { FormUtils, TypeUtils } from '../../../utils'
 import type { ReferralUpdate } from '@accredited-programmes/models'
@@ -21,6 +21,10 @@ export default class NewReferralsOasysConfirmationController {
 
       if (referral.status !== 'referral_started') {
         return res.redirect(referPaths.new.complete({ referralId }))
+      }
+
+      if (referral.referrerUsername !== req.user.username) {
+        return res.redirect(authPaths.error({}))
       }
 
       const person = await this.personService.getPerson(
@@ -49,6 +53,10 @@ export default class NewReferralsOasysConfirmationController {
 
       if (referral.status !== 'referral_started') {
         return res.redirect(referPaths.new.complete({ referralId }))
+      }
+
+      if (referral.referrerUsername !== req.user.username) {
+        return res.redirect(authPaths.error({}))
       }
 
       const { oasysConfirmed } = req.body

--- a/server/controllers/refer/new/referralsController.ts
+++ b/server/controllers/refer/new/referralsController.ts
@@ -1,7 +1,7 @@
 import type { Request, Response, TypedRequestHandler } from 'express'
 import createError from 'http-errors'
 
-import { referPaths } from '../../../paths'
+import { authPaths, referPaths } from '../../../paths'
 import type { CourseService, OrganisationService, PersonService, ReferralService, UserService } from '../../../services'
 import { CourseUtils, FormUtils, NewReferralUtils, PersonUtils, TypeUtils } from '../../../utils'
 import type { CreatedReferralResponse } from '@accredited-programmes/models'
@@ -25,6 +25,10 @@ export default class NewReferralsController {
 
       if (referral.status !== 'referral_started') {
         return res.redirect(referPaths.new.complete({ referralId }))
+      }
+
+      if (referral.referrerUsername !== req.user.username) {
+        return res.redirect(authPaths.error({}))
       }
 
       if (!NewReferralUtils.isReadyForSubmission(referral)) {
@@ -83,7 +87,11 @@ export default class NewReferralsController {
         throw createError(400, 'Referral has not been submitted.')
       }
 
-      res.render('referrals/new/complete', {
+      if (referral.referrerUsername !== req.user.username) {
+        return res.redirect(authPaths.error({}))
+      }
+
+      return res.render('referrals/new/complete', {
         pageHeading: 'Referral complete',
       })
     }
@@ -139,6 +147,10 @@ export default class NewReferralsController {
         return res.redirect(referPaths.new.complete({ referralId }))
       }
 
+      if (referral.referrerUsername !== req.user.username) {
+        return res.redirect(authPaths.error({}))
+      }
+
       const course = await this.courseService.getCourseByOffering(req.user.token, referral.offeringId)
       const courseOffering = await this.courseService.getOffering(req.user.token, referral.offeringId)
       const organisation = await this.organisationService.getOrganisation(req.user.token, courseOffering.organisationId)
@@ -169,6 +181,10 @@ export default class NewReferralsController {
 
       if (referral.status !== 'referral_started') {
         return res.redirect(referPaths.new.complete({ referralId }))
+      }
+
+      if (referral.referrerUsername !== req.user.username) {
+        return res.redirect(authPaths.error({}))
       }
 
       const person = await this.personService.getPerson(
@@ -223,6 +239,10 @@ export default class NewReferralsController {
 
       if (referral.status !== 'referral_started') {
         return res.redirect(referPaths.new.complete({ referralId }))
+      }
+
+      if (referral.referrerUsername !== req.user.username) {
+        return res.redirect(authPaths.error({}))
       }
 
       if (!NewReferralUtils.isReadyForSubmission(referral)) {

--- a/server/paths/auth.ts
+++ b/server/paths/auth.ts
@@ -1,0 +1,5 @@
+import { path } from 'static-path'
+
+export default {
+  error: path('/authError'),
+}

--- a/server/paths/index.ts
+++ b/server/paths/index.ts
@@ -1,5 +1,6 @@
 import apiPaths from './api'
 import assessPaths, { assessPathBase } from './assess'
+import authPaths from './auth'
 import findPaths from './find'
 import prisonApiPaths from './prisonApi'
 import prisonRegisterApiPaths from './prisonRegisterApi'
@@ -10,6 +11,7 @@ export {
   apiPaths,
   assessPathBase,
   assessPaths,
+  authPaths,
   findPaths,
   prisonApiPaths,
   prisonRegisterApiPaths,

--- a/wiremock/stubs/referralSummaries.json
+++ b/wiremock/stubs/referralSummaries.json
@@ -8,7 +8,7 @@
     "prisonerName": { "firstName": "Savannah", "lastName": "Fritsch" },
     "prisonName": "County Tyrone (HMP)",
     "prisonNumber": "Y7RLN5A",
-    "referrerUsername": "STUBBED_USER",
+    "referrerUsername": "ACP_POM_USER",
     "sentence": {
       "conditionalReleaseDate": "2025-10-12",
       "indeterminateSentence": false,
@@ -28,7 +28,7 @@
     "prisonerName": { "firstName": "Savannah", "lastName": "Fritsch" },
     "prisonName": "County Tyrone (HMP)",
     "prisonNumber": "Y7RLN5A",
-    "referrerUsername": "STUBBED_USER",
+    "referrerUsername": "ACP_POM_USER",
     "sentence": {
       "conditionalReleaseDate": "2025-10-12",
       "indeterminateSentence": false,

--- a/wiremock/stubs/referrals.json
+++ b/wiremock/stubs/referrals.json
@@ -6,7 +6,7 @@
     "oasysConfirmed": false,
     "offeringId": "e78237cd-8244-4256-a1e8-8fb29b1f2f76",
     "prisonNumber": "Y7RLN5A",
-    "referrerUsername": "STUBBED_USER",
+    "referrerUsername": "ACP_POM_USER",
     "status": "referral_started"
   },
   {
@@ -16,7 +16,7 @@
     "oasysConfirmed": true,
     "offeringId": "e78237cd-8244-4256-a1e8-8fb29b1f2f76",
     "prisonNumber": "Y7RLN5A",
-    "referrerUsername": "STUBBED_USER",
+    "referrerUsername": "ACP_POM_USER",
     "status": "referral_submitted"
   }
 ]


### PR DESCRIPTION
## Context

https://trello.com/c/RuS9U9nL/813-ensure-referrers-cant-view-or-edit-draft-referrals-if-theyre-not-the-one-who-created-them-s


## Changes in this PR
Check if logged in `username` is same as `referral.referrerUsername` for a **draft** referral when trying to view or update information related to the referral.


## Release checklist

[Release process documentation](../doc/how-to/perform-a-release.md)

As part of our continuous deployment strategy we must ensure that this work is
ready to be released once merged.

### Pre-merge

- [ ] There are changes required to the Accredited Programmes API for this change to work...
  - [ ] ... and they have been released to production already

### Post-merge

<!-- The outer checkboxes can be completed pre-merge -->

- [ ] This adds, extends or meaningfully modifies a feature...
  - [ ] ... and I have written or updated an end-to-end test for the happy path in the [Accredited Programmes E2E repo](https://github.com/ministryofjustice/hmpps-accredited-programmes-e2e)
- [ ] This makes new expectations of the API...
  - [ ] ... and I have notified the API developer(s) of changes to the contract tests (Pact), or the API is already compliant
- [ ] [Manually approve](../doc/how-to/perform-a-release.md#releasing-to-the-preprod-environment) release to preprod
- [ ] [Manually approve](../doc/how-to/perform-a-release.md#releasing-to-the-production-environment) release to prod

<!-- Should a release fail at any step, you as the author should now lead the work to
fix it as soon as possible. You can monitor deployment failures in CircleCI
itself and application errors are found in
[Sentry](https://ministryofjustice.sentry.io/projects/hmpps-accredited-programmes-ui/?project=4505330122686464&referrer=sidebar&statsPeriod=24h). -->
