### PR TITLE
(1201b) Allow long audience tags

### DIFF
--- a/assets/scss/application.scss
+++ b/assets/scss/application.scss
@@ -7,6 +7,7 @@ $govuk-page-width: $moj-page-width;
 @import 'govuk/all';
 @import 'moj/all';
 
+@import './components/audience-tag';
 @import './components/dashboard';
 @import './components/header-bar';
 @import './components/navigation';

--- a/assets/scss/components/_audience-tag.scss
+++ b/assets/scss/components/_audience-tag.scss
@@ -1,0 +1,3 @@
+.audience-tag {
+  max-width: none;
+}

--- a/server/utils/courseUtils.test.ts
+++ b/server/utils/courseUtils.test.ts
@@ -50,7 +50,7 @@ describe('CourseUtils', () => {
         ...course,
         audienceTag: {
           attributes: { 'data-testid': 'audience-tag' },
-          classes: 'govuk-tag govuk-tag--green',
+          classes: 'govuk-tag govuk-tag--green audience-tag',
           text: 'Intimate partner violence offence',
         },
         nameAndAlternateName: 'Lime Course (LC)',

--- a/server/utils/courseUtils.ts
+++ b/server/utils/courseUtils.ts
@@ -44,7 +44,7 @@ export default class CourseUtils {
 
     return {
       attributes: { 'data-testid': 'audience-tag' },
-      classes: `govuk-tag govuk-tag--${colour}`,
+      classes: `govuk-tag govuk-tag--${colour} audience-tag`,
       text: audience,
     }
   }


### PR DESCRIPTION
## Context

<!-- Is there a Trello ticket you can link to? -->
<!-- Do you need to add any environment variables? -->
<!-- Is an ADR required? An ADR should be added if this PR introduces a change to the architecture. -->

Following the upgrade to `govuk-frontend@5`, the [`govuk-tag` class includes a max width][1]. In our prototype, longer tags are on two lines in the case list (for statuses), but audience tags are always on one line regardless of length

## Changes in this PR

- Add an `audience-tag` class to retain the single-line audience tags

## Screenshots of UI changes

### Before

<img width="778" alt="image" src="https://github.com/ministryofjustice/hmpps-accredited-programmes-ui/assets/40244233/5ade0d98-a800-436e-9ca8-e0bd18f3efc8">

### After

<img width="783" alt="image" src="https://github.com/ministryofjustice/hmpps-accredited-programmes-ui/assets/40244233/a4fff282-e708-4c15-b9d0-ec18e6a01e79">

## Release checklist

[Release process documentation](../doc/how-to/perform-a-release.md)

As part of our continuous deployment strategy we must ensure that this work is
ready to be released once merged.

### Pre-merge

- [ ] There are changes required to the Accredited Programmes API for this change to work...
  - [ ] ... and they have been released to production already

### Post-merge

<!-- The outer checkboxes can be completed pre-merge -->

- [ ] This adds, extends or meaningfully modifies a feature...
  - [ ] ... and I have written or updated an end-to-end test for the happy path in the [Accredited Programmes E2E repo](https://github.com/ministryofjustice/hmpps-accredited-programmes-e2e)
- [ ] This makes new expectations of the API...
  - [ ] ... and I have notified the API developer(s) of changes to the contract tests (Pact), or the API is already compliant
- [ ] [Manually approve](../doc/how-to/perform-a-release.md#releasing-to-the-preprod-environment) release to preprod
- [ ] [Manually approve](../doc/how-to/perform-a-release.md#releasing-to-the-production-environment) release to prod

<!-- Should a release fail at any step, you as the author should now lead the work to
fix it as soon as possible. You can monitor deployment failures in CircleCI
itself and application errors are found in
[Sentry](https://ministryofjustice.sentry.io/projects/hmpps-accredited-programmes-ui/?project=4505330122686464&referrer=sidebar&statsPeriod=24h). -->

[1]: https://github.com/alphagov/govuk-frontend/commit/f8ee9928e4d5410645e48b5575182dc2c1a9012d
