### PR TITLE
(1136a) Add new `ReferralView` type and factory

### DIFF
--- a/server/@types/models/Referral.ts
+++ b/server/@types/models/Referral.ts
@@ -55,4 +55,25 @@ type ReferralSummary = {
   tasksCompleted?: number
 }
 
-export type { CreatedReferralResponse, Referral, ReferralStatus, ReferralSummary, ReferralUpdate }
+type ReferralView = {
+  id: Referral['id'] // eslint-disable-next-line @typescript-eslint/member-ordering
+  audience?: string
+  conditionalReleaseDate?: Person['conditionalReleaseDate']
+  courseName?: Course['name']
+  earliestReleaseDate?: Person['conditionalReleaseDate'] | Person['paroleEligibilityDate'] | Person['tariffDate']
+  earliestReleaseDateType?: string
+  forename?: string
+  nonDtoReleaseDateType?: Prisoner['nonDtoReleaseDateType']
+  organisationId?: Organisation['id']
+  organisationName?: Organisation['name']
+  paroleEligibilityDate?: Person['paroleEligibilityDate']
+  prisonNumber?: Person['prisonNumber']
+  referrerUsername?: User['username']
+  status?: ReferralStatus
+  submittedOn?: Referral['submittedOn']
+  surname?: string
+  tariffExpiryDate?: Person['tariffDate']
+  tasksCompleted?: number
+}
+
+export type { CreatedReferralResponse, Referral, ReferralStatus, ReferralSummary, ReferralUpdate, ReferralView }

--- a/server/@types/models/index.d.ts
+++ b/server/@types/models/index.d.ts
@@ -19,7 +19,14 @@ import type { OrganisationAddress } from './OrganisationAddress'
 import type { Paginated } from './Paginated'
 import type { Person } from './Person'
 import type { Psychiatric } from './Psychiatric'
-import type { CreatedReferralResponse, Referral, ReferralStatus, ReferralSummary, ReferralUpdate } from './Referral'
+import type {
+  CreatedReferralResponse,
+  Referral,
+  ReferralStatus,
+  ReferralSummary,
+  ReferralUpdate,
+  ReferralView,
+} from './Referral'
 import type { Relationships } from './Relationships'
 import type { RiskLevel, RisksAndAlerts } from './RisksAndAlerts'
 import type { RoshAnalysis } from './RoshAnalysis'
@@ -49,6 +56,7 @@ export type {
   ReferralStatus,
   ReferralSummary,
   ReferralUpdate,
+  ReferralView,
   Relationships,
   RiskLevel,
   RisksAndAlerts,

--- a/server/@types/ui/index.d.ts
+++ b/server/@types/ui/index.d.ts
@@ -186,6 +186,19 @@ type RiskBox = {
 
 type RiskLevelOrUnknown = RiskLevel | 'UNKNOWN'
 
+type SortableCaseListColumnKey =
+  | 'audience'
+  | 'conditionalReleaseDate'
+  | 'courseName'
+  | 'earliestReleaseDate'
+  | 'nonDtoReleaseDateType'
+  | 'organisationName'
+  | 'paroleEligibilityDate'
+  | 'status'
+  | 'submittedOn'
+  | 'surname'
+  | 'tariffExpiryDate'
+
 export type {
   CaseListColumnHeader,
   CourseParticipationPresenter,
@@ -215,5 +228,6 @@ export type {
   RiskBox,
   RiskLevelOrUnknown,
   RisksAndNeedsSharedPageData,
+  SortableCaseListColumnKey,
   TagColour,
 }

--- a/server/testutils/factories/index.ts
+++ b/server/testutils/factories/index.ts
@@ -25,6 +25,7 @@ import prisonerFactory from './prisoner'
 import psychiatricFactory from './psychiatric'
 import referralFactory from './referral'
 import referralSummaryFactory from './referralSummary'
+import referralViewFactory from './referralView'
 import relationshipsFactory from './relationships'
 import risksAndAlertsFactory from './risksAndAlerts'
 import roshAnalysisFactory from './roshAnalysis'
@@ -58,6 +59,7 @@ export {
   psychiatricFactory,
   referralFactory,
   referralSummaryFactory,
+  referralViewFactory,
   relationshipsFactory,
   risksAndAlertsFactory,
   roshAnalysisFactory,

--- a/server/testutils/factories/referralView.ts
+++ b/server/testutils/factories/referralView.ts
@@ -1,0 +1,69 @@
+import { faker } from '@faker-js/faker'
+import { Factory } from 'fishery'
+
+import courseAudienceFactory from './courseAudience'
+import FactoryHelpers from './factoryHelpers'
+import { randomStatus } from './referral'
+import { StringUtils } from '../../utils'
+import type { ReferralStatus, ReferralView } from '@accredited-programmes/models'
+
+interface ReferralViewTransientParams {
+  availableStatuses: Array<ReferralStatus>
+  requireOptionalFields?: boolean
+}
+
+class ReferralViewFactory extends Factory<ReferralView, ReferralViewTransientParams> {
+  withAllOptionalFields() {
+    return this.transient({ requireOptionalFields: true })
+  }
+}
+
+export default ReferralViewFactory.define(({ params, transientParams }) => {
+  const { availableStatuses, requireOptionalFields } = transientParams
+
+  const referralViewWithAllFields: ReferralView = {
+    id: faker.string.uuid(), // eslint-disable-next-line sort-keys
+    audience: courseAudienceFactory.build(),
+    conditionalReleaseDate: FactoryHelpers.randomFutureDateString(),
+    courseName: `${StringUtils.convertToTitleCase(faker.color.human())} Course`,
+    earliestReleaseDate: FactoryHelpers.randomFutureDateString(),
+    earliestReleaseDateType: faker.helpers.arrayElement([
+      'Tariff Date',
+      'Parole Eligibility Date',
+      'Conditional Release Date',
+    ]),
+    forename: faker.person.firstName(),
+    nonDtoReleaseDateType: faker.helpers.arrayElement(['ARD', 'CRD', 'NPD', 'PRRD']),
+    organisationId: faker.string.alpha({ casing: 'upper', length: 3 }),
+    organisationName: `${faker.location.county()} (HMP)`,
+    paroleEligibilityDate: FactoryHelpers.randomFutureDateString(),
+    prisonNumber: faker.string.alphanumeric({ length: 7 }),
+    referrerUsername: faker.internet.userName(),
+    status: randomStatus(availableStatuses),
+    submittedOn: faker.date.past().toISOString(),
+    surname: faker.person.lastName(),
+    tariffExpiryDate: FactoryHelpers.randomFutureDateString(),
+    tasksCompleted: faker.number.int({ max: 4, min: 1 }),
+  }
+
+  return {
+    ...referralViewWithAllFields,
+    audience: FactoryHelpers.optionalArrayElement(referralViewWithAllFields.audience),
+    conditionalReleaseDate: FactoryHelpers.optionalArrayElement(referralViewWithAllFields.conditionalReleaseDate),
+    courseName: FactoryHelpers.optionalArrayElement(referralViewWithAllFields.courseName),
+    earliestReleaseDate: FactoryHelpers.optionalArrayElement(referralViewWithAllFields.earliestReleaseDate),
+    earliestReleaseDateType: FactoryHelpers.optionalArrayElement(referralViewWithAllFields.earliestReleaseDateType),
+    forename: FactoryHelpers.optionalArrayElement(referralViewWithAllFields.forename),
+    nonDtoReleaseDateType: FactoryHelpers.optionalArrayElement(referralViewWithAllFields.nonDtoReleaseDateType),
+    organisationId: FactoryHelpers.optionalArrayElement(referralViewWithAllFields.organisationId),
+    organisationName: FactoryHelpers.optionalArrayElement(referralViewWithAllFields.organisationName),
+    paroleEligibilityDate: FactoryHelpers.optionalArrayElement(referralViewWithAllFields.paroleEligibilityDate),
+    prisonNumber: FactoryHelpers.optionalArrayElement(referralViewWithAllFields.prisonNumber),
+    referrerUsername: FactoryHelpers.optionalArrayElement(referralViewWithAllFields.referrerUsername),
+    surname: FactoryHelpers.optionalArrayElement(referralViewWithAllFields.surname),
+    tariffExpiryDate: FactoryHelpers.optionalArrayElement(referralViewWithAllFields.tariffExpiryDate),
+    tasksCompleted: FactoryHelpers.optionalArrayElement(referralViewWithAllFields.tasksCompleted),
+    ...(requireOptionalFields ? referralViewWithAllFields : {}),
+    ...params,
+  }
+})


### PR DESCRIPTION
## Context

We need to sort results across multiple pages rather than on the client. We will be using a new dashboard endpoint which has a new `ReferralView` schema, which is essentially a flatter version of the existing `ReferralSummary` type.

## Changes in this PR
- Added `ReferralView` type as we will no longer be using `ReferralSummary`
- Add `SortableCaseListColumnKey` type which should match to the names of the columns we want to sort.


## Release checklist

[Release process documentation](../doc/how-to/perform-a-release.md)

As part of our continuous deployment strategy we must ensure that this work is
ready to be released once merged.

### Pre-merge

- [ ] There are changes required to the Accredited Programmes API for this change to work...
  - [ ] ... and they have been released to production already

### Post-merge

<!-- The outer checkboxes can be completed pre-merge -->

- [ ] This adds, extends or meaningfully modifies a feature...
  - [ ] ... and I have written or updated an end-to-end test for the happy path in the [Accredited Programmes E2E repo](https://github.com/ministryofjustice/hmpps-accredited-programmes-e2e)
- [ ] This makes new expectations of the API...
  - [ ] ... and I have notified the API developer(s) of changes to the contract tests (Pact), or the API is already compliant
- [ ] [Manually approve](../doc/how-to/perform-a-release.md#releasing-to-the-preprod-environment) release to preprod
- [ ] [Manually approve](../doc/how-to/perform-a-release.md#releasing-to-the-production-environment) release to prod

<!-- Should a release fail at any step, you as the author should now lead the work to
fix it as soon as possible. You can monitor deployment failures in CircleCI
itself and application errors are found in
[Sentry](https://ministryofjustice.sentry.io/projects/hmpps-accredited-programmes-ui/?project=4505330122686464&referrer=sidebar&statsPeriod=24h). -->
