### PR TITLE
(1307) Add `updatePerson` query param to case list referral links

### DIFF
--- a/server/controllers/shared/referralsController.test.ts
+++ b/server/controllers/shared/referralsController.test.ts
@@ -238,6 +238,18 @@ describe('ReferralsController', () => {
         expect(() => requestHandler(request, response, next)).rejects.toThrowError(expectedError)
       })
     })
+
+    describe('when the referral has been submitted with an `updatePerson` query', () => {
+      it('calls `referralService.getReferral` with the same value', async () => {
+        request.query.updatePerson = 'true'
+        request.path = referPaths.show.personalDetails({ referralId: referral.id })
+
+        const requestHandler = controller.personalDetails()
+        await requestHandler(request, response, next)
+
+        assertSharedDataServicesAreCalledWithExpectedArguments('true')
+      })
+    })
   })
 
   describe('programmeHistory', () => {
@@ -362,8 +374,10 @@ describe('ReferralsController', () => {
     })
   })
 
-  function assertSharedDataServicesAreCalledWithExpectedArguments() {
-    expect(referralService.getReferral).toHaveBeenCalledWith(username, referral.id)
+  function assertSharedDataServicesAreCalledWithExpectedArguments(updatePersonQueryValue?: string) {
+    expect(referralService.getReferral).toHaveBeenCalledWith(username, referral.id, {
+      updatePerson: updatePersonQueryValue,
+    })
     expect(courseService.getCourseByOffering).toHaveBeenCalledWith(username, referral.offeringId)
     expect(courseService.getOffering).toHaveBeenCalledWith(username, referral.offeringId)
     expect(personService.getPerson).toHaveBeenCalledWith(username, person.prisonNumber, response.locals.user.caseloads)

--- a/server/controllers/shared/referralsController.ts
+++ b/server/controllers/shared/referralsController.ts
@@ -158,8 +158,9 @@ export default class ReferralsController {
 
     const { referralId } = req.params
     const { token: userToken, username } = req.user
+    const { updatePerson } = req.query as Record<string, string>
 
-    const referral = await this.referralService.getReferral(username, referralId)
+    const referral = await this.referralService.getReferral(username, referralId, { updatePerson })
     const [course, courseOffering, person, referrerUserFullName] = await Promise.all([
       this.courseService.getCourseByOffering(username, referral.offeringId),
       this.courseService.getOffering(username, referral.offeringId),

--- a/server/data/accreditedProgrammesApi/referralClient.ts
+++ b/server/data/accreditedProgrammesApi/referralClient.ts
@@ -29,9 +29,17 @@ export default class ReferralClient {
     })) as CreatedReferralResponse
   }
 
-  async find(referralId: Referral['id']): Promise<Referral> {
+  async find(
+    referralId: Referral['id'],
+    query?: {
+      updatePerson?: string
+    },
+  ): Promise<Referral> {
     return (await this.restClient.get({
       path: apiPaths.referrals.show({ referralId }),
+      query: {
+        ...(query?.updatePerson && { updatePerson: query.updatePerson }),
+      },
     })) as Referral
   }
 

--- a/server/services/referralService.test.ts
+++ b/server/services/referralService.test.ts
@@ -94,19 +94,36 @@ describe('ReferralService', () => {
   })
 
   describe('getReferral', () => {
+    const referral = referralFactory.build()
+
     it('returns a given referral', async () => {
-      const referral = referralFactory.build()
-      when(referralClient.find).calledWith(referral.id).mockResolvedValue(referral)
+      when(referralClient.find).calledWith(referral.id, undefined).mockResolvedValue(referral)
 
       const result = await service.getReferral(username, referral.id)
-
+      expect(referralClient.find).toHaveBeenCalledWith(referral.id, undefined)
       expect(result).toEqual(referral)
 
       expect(hmppsAuthClientBuilder).toHaveBeenCalled()
       expect(hmppsAuthClient.getSystemClientToken).toHaveBeenCalledWith(username)
 
       expect(referralClientBuilder).toHaveBeenCalledWith(systemToken)
-      expect(referralClient.find).toHaveBeenCalledWith(referral.id)
+      expect(referralClient.find).toHaveBeenCalledWith(referral.id, undefined)
+    })
+
+    describe('with query values', () => {
+      it('makes the correct call to the referral client', async () => {
+        const query = {
+          updatePerson: 'true',
+        }
+
+        when(referralClient.find).calledWith(referral.id, query).mockResolvedValue(referral)
+
+        const result = await service.getReferral(username, referral.id, query)
+
+        expect(referralClientBuilder).toHaveBeenCalledWith(systemToken)
+        expect(referralClient.find).toHaveBeenCalledWith(referral.id, query)
+        expect(result).toEqual(referral)
+      })
     })
   })
 

--- a/server/services/referralService.ts
+++ b/server/services/referralService.ts
@@ -51,12 +51,16 @@ export default class ReferralService {
     return referralProgressIndicatorKeys.filter(item => referral[item]).length
   }
 
-  async getReferral(username: Express.User['username'], referralId: Referral['id']): Promise<Referral> {
+  async getReferral(
+    username: Express.User['username'],
+    referralId: Referral['id'],
+    query?: { updatePerson?: string },
+  ): Promise<Referral> {
     const hmppsAuthClient = this.hmppsAuthClientBuilder()
     const systemToken = await hmppsAuthClient.getSystemClientToken(username)
     const referralClient = this.referralClientBuilder(systemToken)
 
-    return referralClient.find(referralId)
+    return referralClient.find(referralId, query)
   }
 
   async getReferralViews(

--- a/server/utils/referrals/caseListUtils.test.ts
+++ b/server/utils/referrals/caseListUtils.test.ts
@@ -435,7 +435,7 @@ describe('CaseListUtils', () => {
     describe('Name / Prison number', () => {
       it('returns a HTML string with the prisoner name on the first line, which links to the referral, and their prison number on a new line', () => {
         expect(CaseListUtils.tableRowContent(referralView, 'Name / Prison number')).toEqual(
-          '<a class="govuk-link" href="/assess/referrals/referral-123/personal-details">Del Hatton</a><br>ABC1234',
+          '<a class="govuk-link" href="/assess/referrals/referral-123/personal-details?updatePerson=true">Del Hatton</a><br>ABC1234',
         )
       })
 
@@ -447,14 +447,16 @@ describe('CaseListUtils', () => {
               'Name / Prison number',
               assessPaths,
             ),
-          ).toEqual('<a class="govuk-link" href="/refer/referrals/new/referral-123">Del Hatton</a><br>ABC1234')
+          ).toEqual(
+            '<a class="govuk-link" href="/refer/referrals/new/referral-123?updatePerson=true">Del Hatton</a><br>ABC1234',
+          )
         })
       })
 
       describe('when referPaths is passed in as the paths argument', () => {
         it('links to a Refer show referral page', () => {
           expect(CaseListUtils.tableRowContent(referralView, 'Name / Prison number', referPaths)).toEqual(
-            '<a class="govuk-link" href="/refer/referrals/referral-123/personal-details">Del Hatton</a><br>ABC1234',
+            '<a class="govuk-link" href="/refer/referrals/referral-123/personal-details?updatePerson=true">Del Hatton</a><br>ABC1234',
           )
         })
       })
@@ -466,7 +468,9 @@ describe('CaseListUtils', () => {
               { ...referralView, forename: undefined, surname: undefined },
               'Name / Prison number',
             ),
-          ).toEqual('<a class="govuk-link" href="/assess/referrals/referral-123/personal-details">ABC1234</a>')
+          ).toEqual(
+            '<a class="govuk-link" href="/assess/referrals/referral-123/personal-details?updatePerson=true">ABC1234</a>',
+          )
         })
       })
     })

--- a/server/utils/referrals/caseListUtils.ts
+++ b/server/utils/referrals/caseListUtils.ts
@@ -300,7 +300,7 @@ export default class CaseListUtils {
         : paths.show.personalDetails({
             referralId: referralView.id,
           })
-    const nameAndPrisonNumberHtmlStart = `<a class="govuk-link" href="${path}">`
+    const nameAndPrisonNumberHtmlStart = `<a class="govuk-link" href="${path}?updatePerson=true">`
     const prisonerName = CaseListUtils.formattedPrisonerName(referralView?.forename, referralView?.surname)
     const nameAndPrisonNumberHtmlEnd = prisonerName
       ? `${prisonerName}</a><br>${referralView.prisonNumber}`


### PR DESCRIPTION
## Context

https://trello.com/c/LkEEasTc/1307-tell-api-when-request-for-referral-comes-after-clicking-on-a-case-list-record-s

When a user clicks on a referral from a case list, we want the API to do some background work to update the relevant person information for the case list (to aid sorting)

We therefore need to tell the API when a request for a referral has come through this journey as opposed to just clicking between show referral/risks and needs pages


## Changes in this PR
- Add `?updatePerson=true` to the links to a referral from the case lists
- Pass this query parameter through to `GET` `/referrals/:referralId?updatePerson=true` on the API.


## Release checklist

[Release process documentation](../doc/how-to/perform-a-release.md)

As part of our continuous deployment strategy we must ensure that this work is
ready to be released once merged.

### Pre-merge

- [ ] There are changes required to the Accredited Programmes API for this change to work...
  - [ ] ... and they have been released to production already

### Post-merge

<!-- The outer checkboxes can be completed pre-merge -->

- [ ] This adds, extends or meaningfully modifies a feature...
  - [ ] ... and I have written or updated an end-to-end test for the happy path in the [Accredited Programmes E2E repo](https://github.com/ministryofjustice/hmpps-accredited-programmes-e2e)
- [ ] This makes new expectations of the API...
  - [ ] ... and I have notified the API developer(s) of changes to the contract tests (Pact), or the API is already compliant
- [ ] [Manually approve](../doc/how-to/perform-a-release.md#releasing-to-the-preprod-environment) release to preprod
- [ ] [Manually approve](../doc/how-to/perform-a-release.md#releasing-to-the-production-environment) release to prod

<!-- Should a release fail at any step, you as the author should now lead the work to
fix it as soon as possible. You can monitor deployment failures in CircleCI
itself and application errors are found in
[Sentry](https://ministryofjustice.sentry.io/projects/hmpps-accredited-programmes-ui/?project=4505330122686464&referrer=sidebar&statsPeriod=24h). -->
