### PR TITLE
Update govuk-frontend to minor version v5.1.0

### DIFF
--- a/integration_tests/pages/page.ts
+++ b/integration_tests/pages/page.ts
@@ -65,8 +65,12 @@ export default abstract class Page {
 
   manageDetails = (): PageElement => cy.get('[data-qa=manageDetails]')
 
+  selectCheckbox(name: string): void {
+    cy.get(`.govuk-checkboxes__input[name="${name}"]`).check({ force: true })
+  }
+
   selectRadioButton(name: string, value: string): void {
-    cy.get(`.govuk-radios__input[name="${name}"][value="${value}"]`).check()
+    cy.get(`.govuk-radios__input[name="${name}"][value="${value}"]`).check({ force: true })
   }
 
   selectSelectItem(testId: string, value: string): void {

--- a/integration_tests/pages/refer/new/checkAnswers.ts
+++ b/integration_tests/pages/refer/new/checkAnswers.ts
@@ -57,7 +57,7 @@ export default class NewReferralCheckAnswersPage extends Page {
       scenarioName: 'Submitting a referral',
     })
 
-    cy.get('[name="confirmation"]').check()
+    this.selectCheckbox('confirmation')
     this.shouldContainButton('Submit referral').click()
   }
 

--- a/integration_tests/pages/refer/new/confirmOasys.ts
+++ b/integration_tests/pages/refer/new/confirmOasys.ts
@@ -15,7 +15,7 @@ export default class NewReferralConfirmOasysPage extends Page {
   }
 
   confirmOasys() {
-    cy.get('[name="oasysConfirmed"]').check()
+    this.selectCheckbox('oasysConfirmed')
     this.referral = { ...this.referral, oasysConfirmed: true }
     // We're stubbing the referral here to make sure the updated referral is available on the task list page
     cy.task('stubReferral', this.referral)

--- a/integration_tests/pages/refer/new/programmeHistoryDetails.ts
+++ b/integration_tests/pages/refer/new/programmeHistoryDetails.ts
@@ -74,22 +74,22 @@ export default class NewReferralProgrammeHistoryDetailsPage extends Page {
   }
 
   shouldDisplayCommunityLocationInput() {
-    cy.get('[data-testid="community-setting-option"]').check()
+    this.selectRadioButton('setting[type]', 'community')
     cy.get('input[id="communityLocation"]').should('be.visible')
   }
 
   shouldDisplayCustodyLocationInput() {
-    cy.get('[data-testid="custody-setting-option"]').check()
+    this.selectRadioButton('setting[type]', 'custody')
     cy.get('input[id="custodyLocation"]').should('be.visible')
   }
 
   shouldDisplayYearCompletedInput() {
-    cy.get('[data-testid="complete-outcome-option"]').check()
+    this.selectRadioButton('outcome[status]', 'complete')
     cy.get('input[id="yearCompleted"]').should('be.visible')
   }
 
   shouldDisplayYearStartedInput() {
-    cy.get('[data-testid="incomplete-outcome-option"]').check()
+    this.selectRadioButton('outcome[status]', 'incomplete')
     cy.get('input[id="yearStarted"]').should('be.visible')
   }
 

--- a/integration_tests/pages/refer/new/selectProgramme.ts
+++ b/integration_tests/pages/refer/new/selectProgramme.ts
@@ -25,7 +25,7 @@ export default class NewReferralSelectProgrammePage extends Page {
   }
 
   shouldDisplayOtherCourseInput() {
-    cy.get('[data-testid="other-course-option"]').check()
+    this.selectRadioButton('courseName', 'Other')
     cy.get('input[name="otherCourseName"]').should('be.visible')
   }
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -25,7 +25,7 @@
         "express-prom-bundle": "^7.0.0",
         "express-session": "^1.17.3",
         "fishery": "^2.2.2",
-        "govuk-frontend": "^5.0.0",
+        "govuk-frontend": "^5.1.0",
         "helmet": "^7.0.0",
         "http-errors": "^2.0.0",
         "jquery": "^3.6.4",
@@ -7007,9 +7007,9 @@
       }
     },
     "node_modules/govuk-frontend": {
-      "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/govuk-frontend/-/govuk-frontend-5.0.0.tgz",
-      "integrity": "sha512-3WSfvQ+3kw/q/m8jrq/t8XnMUA8D2r0uhGyZaDbIh1gWTJBQzJBHbHiKYI9nc9ixIXdCFsc9RozkgEm57a795g==",
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/govuk-frontend/-/govuk-frontend-5.1.0.tgz",
+      "integrity": "sha512-Dc3J+uOI4i2VR3BVyfxbf6qVjTT4n4bBqbD0/Io6feP8pt/4IfKdP1vWimZf+BwMKKMXacw10hmdy5UcD6Cr8w==",
       "engines": {
         "node": ">= 4.2.0"
       }

--- a/package.json
+++ b/package.json
@@ -74,7 +74,7 @@
     "express-prom-bundle": "^7.0.0",
     "express-session": "^1.17.3",
     "fishery": "^2.2.2",
-    "govuk-frontend": "^5.0.0",
+    "govuk-frontend": "^5.1.0",
     "helmet": "^7.0.0",
     "http-errors": "^2.0.0",
     "jquery": "^3.6.4",


### PR DESCRIPTION
## Context
This was raised by the renovate bot to begin with but was causing the integration tests to fail with the error **"is being covered by another element"**, because it couldn't check radio and checkboxes.

Looking at what is in the 5.1.0 release, it includes [a change](https://github.com/alphagov/govuk-frontend/pull/4093) to radio and checkbox styling, which I believe is what is causing the issue. It looks like the removal of the `z-index` on `.govuk-radios__input` and `.govuk-checkboxes__input` has meant  they now have `z-index: auto` but the styled `label:before` and :`after` have `z-index: 1` which causes them to be higher in the `z-order` than the inputs, which causes the cypress error above.

## Changes in this PR
Updating `selectRadioButton()` and adding `selectCheckbox()` to `check()` with `force: true`, forces the click on the radio button even though it is covered by the labels pseudo elements.


## Release checklist

[Release process documentation](../doc/how-to/perform-a-release.md)

As part of our continuous deployment strategy we must ensure that this work is
ready to be released once merged.

### Pre-merge

- [ ] There are changes required to the Accredited Programmes API for this change to work...
  - [ ] ... and they have been released to production already

### Post-merge

<!-- The outer checkboxes can be completed pre-merge -->

- [ ] This adds, extends or meaningfully modifies a feature...
  - [ ] ... and I have written or updated an end-to-end test for the happy path in the [Accredited Programmes E2E repo](https://github.com/ministryofjustice/hmpps-accredited-programmes-e2e)
- [ ] This makes new expectations of the API...
  - [ ] ... and I have notified the API developer(s) of changes to the contract tests (Pact), or the API is already compliant
- [ ] [Manually approve](../doc/how-to/perform-a-release.md#releasing-to-the-preprod-environment) release to preprod
- [ ] [Manually approve](../doc/how-to/perform-a-release.md#releasing-to-the-production-environment) release to prod

<!-- Should a release fail at any step, you as the author should now lead the work to
fix it as soon as possible. You can monitor deployment failures in CircleCI
itself and application errors are found in
[Sentry](https://ministryofjustice.sentry.io/projects/hmpps-accredited-programmes-ui/?project=4505330122686464&referrer=sidebar&statsPeriod=24h). -->
