### PR TITLE
(1335a) Status history page

### DIFF
--- a/server/controllers/shared/index.ts
+++ b/server/controllers/shared/index.ts
@@ -2,6 +2,7 @@
 
 import ReferralsController from './referralsController'
 import RisksAndNeedsController from './risksAndNeedsController'
+import StatusHistoryController from './statusHistoryController'
 import type { Services } from '../../services'
 
 const controllers = (services: Services) => {
@@ -19,9 +20,16 @@ const controllers = (services: Services) => {
     services.referralService,
   )
 
+  const statusHistoryController = new StatusHistoryController(
+    services.courseService,
+    services.personService,
+    services.referralService,
+  )
+
   return {
     referralsController,
     risksAndNeedsController,
+    statusHistoryController,
   }
 }
 

--- a/server/controllers/shared/statusHistoryController.test.ts
+++ b/server/controllers/shared/statusHistoryController.test.ts
@@ -1,0 +1,92 @@
+import type { DeepMocked } from '@golevelup/ts-jest'
+import { createMock } from '@golevelup/ts-jest'
+import type { NextFunction, Request, Response } from 'express'
+
+import StatusHistoryController from './statusHistoryController'
+import { referPaths } from '../../paths'
+import type { CourseService, PersonService, ReferralService } from '../../services'
+import {
+  courseFactory,
+  courseOfferingFactory,
+  organisationFactory,
+  personFactory,
+  referralFactory,
+} from '../../testutils/factories'
+import Helpers from '../../testutils/helpers'
+import { CourseUtils, ShowReferralUtils } from '../../utils'
+import type { Person, Referral } from '@accredited-programmes/models'
+
+jest.mock('../../utils/referrals/showReferralUtils')
+
+const mockShowReferralUtils = ShowReferralUtils as jest.Mocked<typeof ShowReferralUtils>
+
+describe('StatusHistoryController', () => {
+  const userToken = 'SOME_TOKEN'
+  const username = 'USERNAME'
+
+  let request: DeepMocked<Request>
+  let response: DeepMocked<Response>
+  const next: DeepMocked<NextFunction> = createMock<NextFunction>({})
+
+  const courseService = createMock<CourseService>({})
+  const personService = createMock<PersonService>({})
+  const referralService = createMock<ReferralService>({})
+
+  const course = courseFactory.build()
+  const coursePresenter = CourseUtils.presentCourse(course)
+  const organisation = organisationFactory.build()
+  const courseOffering = courseOfferingFactory.build({ organisationId: organisation.id })
+  const subNavigationItems = [{ active: true, href: 'sub-nav-href', text: 'Sub Nav Item' }]
+  let person: Person
+  let referral: Referral
+
+  let controller: StatusHistoryController
+
+  beforeEach(() => {
+    person = personFactory.build()
+    referral = referralFactory.submitted().build({ offeringId: courseOffering.id, prisonNumber: person.prisonNumber })
+    mockShowReferralUtils.subNavigationItems.mockReturnValue(subNavigationItems)
+
+    courseService.getCourseByOffering.mockResolvedValue(course)
+    courseService.getOffering.mockResolvedValue(courseOffering)
+    personService.getPerson.mockResolvedValue(person)
+    referralService.getReferral.mockResolvedValue(referral)
+
+    controller = new StatusHistoryController(courseService, personService, referralService)
+
+    request = createMock<Request>({
+      params: { referralId: referral.id },
+      path: referPaths.show.statusHistory({ referralId: referral.id }),
+      user: { token: userToken, username },
+    })
+    response = Helpers.createMockResponseWithCaseloads()
+  })
+
+  describe('show', () => {
+    it('should render the show template with the correct response locals', async () => {
+      const requestHandler = controller.show()
+      await requestHandler(request, response, next)
+
+      expect(response.render).toHaveBeenCalledWith('referrals/show/statusHistory/show', {
+        pageHeading: `Referral to ${coursePresenter.nameAndAlternateName}`,
+        pageSubHeading: 'Status history',
+        person,
+        referral,
+        subNavigationItems,
+      })
+
+      expect(referralService.getReferral).toHaveBeenCalledWith(username, referral.id)
+      expect(courseService.getCourseByOffering).toHaveBeenCalledWith(username, referral.offeringId)
+      expect(personService.getPerson).toHaveBeenCalledWith(
+        username,
+        referral.prisonNumber,
+        response.locals.user.caseloads,
+      )
+      expect(mockShowReferralUtils.subNavigationItems).toHaveBeenCalledWith(
+        `/refer/referrals/${referral.id}/status-history`,
+        'statusHistory',
+        referral.id,
+      )
+    })
+  })
+})

--- a/server/controllers/shared/statusHistoryController.ts
+++ b/server/controllers/shared/statusHistoryController.ts
@@ -1,0 +1,38 @@
+import type { Request, Response, TypedRequestHandler } from 'express'
+
+import type { CourseService, PersonService, ReferralService } from '../../services'
+import { CourseUtils, ShowReferralUtils, TypeUtils } from '../../utils'
+
+export default class StatusHistoryController {
+  constructor(
+    private readonly courseService: CourseService,
+    private readonly personService: PersonService,
+    private readonly referralService: ReferralService,
+  ) {}
+
+  show(): TypedRequestHandler<Request, Response> {
+    return async (req: Request, res: Response) => {
+      TypeUtils.assertHasUser(req)
+
+      const { referralId } = req.params
+      const { username } = req.user
+
+      const referral = await this.referralService.getReferral(username, referralId)
+
+      const [course, person] = await Promise.all([
+        this.courseService.getCourseByOffering(username, referral.offeringId),
+        this.personService.getPerson(username, referral.prisonNumber, res.locals.user.caseloads),
+      ])
+
+      const coursePresenter = CourseUtils.presentCourse(course)
+
+      return res.render('referrals/show/statusHistory/show', {
+        pageHeading: `Referral to ${coursePresenter.nameAndAlternateName}`,
+        pageSubHeading: 'Status history',
+        person,
+        referral,
+        subNavigationItems: ShowReferralUtils.subNavigationItems(req.path, 'statusHistory', referral.id),
+      })
+    }
+  }
+}

--- a/server/paths/assess.ts
+++ b/server/paths/assess.ts
@@ -31,6 +31,7 @@ export default {
       thinkingAndBehaving: risksAndNeedsPathBase.path('thinking-and-behaving'),
     },
     sentenceInformation: referralShowPathBase.path('sentence-information'),
+    statusHistory: referralShowPathBase.path('status-history'),
   },
 }
 

--- a/server/paths/refer.ts
+++ b/server/paths/refer.ts
@@ -83,6 +83,7 @@ export default {
       thinkingAndBehaving: risksAndNeedsPathBase.path('thinking-and-behaving'),
     },
     sentenceInformation: referralShowPathBase.path('sentence-information'),
+    statusHistory: referralShowPathBase.path('status-history'),
   },
 }
 

--- a/server/routes/refer.ts
+++ b/server/routes/refer.ts
@@ -22,6 +22,7 @@ export default function routes(controllers: Controllers, router: Router): Router
     newReferralsOasysConfirmationController,
     referralsController,
     risksAndNeedsController,
+    statusHistoryController,
   } = controllers
 
   get(referPaths.caseList.index.pattern, referCaseListController.indexRedirect())
@@ -64,6 +65,8 @@ export default function routes(controllers: Controllers, router: Router): Router
   get(referPaths.new.checkAnswers.pattern, newReferralsController.checkAnswers())
   get(referPaths.new.complete.pattern, newReferralsController.complete())
   post(referPaths.new.submit.pattern, newReferralsController.submit())
+
+  get(referPaths.show.statusHistory.pattern, statusHistoryController.show())
 
   get(referPaths.show.additionalInformation.pattern, referralsController.additionalInformation())
   get(referPaths.show.offenceHistory.pattern, referralsController.offenceHistory())

--- a/server/utils/referrals/showReferralUtils.test.ts
+++ b/server/utils/referrals/showReferralUtils.test.ts
@@ -67,10 +67,37 @@ describe('ShowReferralUtils', () => {
     const mockReferralId = 'mock-referral-id'
 
     describe('when on the refer journey', () => {
+      it('returns navigation items for the referral pages with the refer paths and sets the Status history link as active', () => {
+        const currentRequestPath = referPaths.show.statusHistory({ referralId: mockReferralId })
+
+        expect(ShowReferralUtils.subNavigationItems(currentRequestPath, 'statusHistory', mockReferralId)).toEqual([
+          {
+            active: true,
+            href: '/refer/referrals/mock-referral-id/status-history',
+            text: 'Status history',
+          },
+          {
+            active: false,
+            href: '/refer/referrals/mock-referral-id/personal-details',
+            text: 'Referral details',
+          },
+          {
+            active: false,
+            href: '/refer/referrals/mock-referral-id/risks-and-needs/risks-and-alerts',
+            text: 'Risks and needs',
+          },
+        ])
+      })
+
       it('returns navigation items for the referral pages with the refer paths and sets the Referral details link as active', () => {
         const currentRequestPath = referPaths.show.personalDetails({ referralId: mockReferralId })
 
         expect(ShowReferralUtils.subNavigationItems(currentRequestPath, 'referral', mockReferralId)).toEqual([
+          {
+            active: false,
+            href: '/refer/referrals/mock-referral-id/status-history',
+            text: 'Status history',
+          },
           {
             active: true,
             href: '/refer/referrals/mock-referral-id/personal-details',
@@ -90,6 +117,11 @@ describe('ShowReferralUtils', () => {
         expect(ShowReferralUtils.subNavigationItems(currentRequestPath, 'risksAndNeeds', mockReferralId)).toEqual([
           {
             active: false,
+            href: '/refer/referrals/mock-referral-id/status-history',
+            text: 'Status history',
+          },
+          {
+            active: false,
             href: '/refer/referrals/mock-referral-id/personal-details',
             text: 'Referral details',
           },
@@ -103,10 +135,37 @@ describe('ShowReferralUtils', () => {
     })
 
     describe('when on the assess journey', () => {
+      it('returns navigation items for the referral pages with the refer paths and sets the Status history link as active', () => {
+        const currentRequestPath = assessPaths.show.statusHistory({ referralId: mockReferralId })
+
+        expect(ShowReferralUtils.subNavigationItems(currentRequestPath, 'statusHistory', mockReferralId)).toEqual([
+          {
+            active: true,
+            href: '/assess/referrals/mock-referral-id/status-history',
+            text: 'Status history',
+          },
+          {
+            active: false,
+            href: '/assess/referrals/mock-referral-id/personal-details',
+            text: 'Referral details',
+          },
+          {
+            active: false,
+            href: '/assess/referrals/mock-referral-id/risks-and-needs/risks-and-alerts',
+            text: 'Risks and needs',
+          },
+        ])
+      })
+
       it('returns navigation items for the referral pages with the assess paths and sets the Referral details link as active', () => {
         const currentRequestPath = assessPaths.show.personalDetails({ referralId: mockReferralId })
 
         expect(ShowReferralUtils.subNavigationItems(currentRequestPath, 'referral', mockReferralId)).toEqual([
+          {
+            active: false,
+            href: '/assess/referrals/mock-referral-id/status-history',
+            text: 'Status history',
+          },
           {
             active: true,
             href: '/assess/referrals/mock-referral-id/personal-details',
@@ -124,6 +183,11 @@ describe('ShowReferralUtils', () => {
         const currentRequestPath = assessPaths.show.risksAndNeeds.offenceAnalysis({ referralId: mockReferralId })
 
         expect(ShowReferralUtils.subNavigationItems(currentRequestPath, 'risksAndNeeds', mockReferralId)).toEqual([
+          {
+            active: false,
+            href: '/assess/referrals/mock-referral-id/status-history',
+            text: 'Status history',
+          },
           {
             active: false,
             href: '/assess/referrals/mock-referral-id/personal-details',

--- a/server/utils/referrals/showReferralUtils.ts
+++ b/server/utils/referrals/showReferralUtils.ts
@@ -51,12 +51,17 @@ export default class ShowReferralUtils {
 
   static subNavigationItems(
     currentPath: Request['path'],
-    currentSection: 'referral' | 'risksAndNeeds',
+    currentSection: 'referral' | 'risksAndNeeds' | 'statusHistory',
     referralId: Referral['id'],
   ): Array<MojFrontendNavigationItem> {
     const paths = currentPath.startsWith(assessPathBase.pattern) ? assessPaths : referPaths
 
     return [
+      {
+        active: currentSection === 'statusHistory',
+        href: paths.show.statusHistory({ referralId }),
+        text: 'Status history',
+      },
       {
         active: currentSection === 'referral',
         href: paths.show.personalDetails({ referralId }),

--- a/server/views/referrals/show/partials/referralLayout.njk
+++ b/server/views/referrals/show/partials/referralLayout.njk
@@ -1,6 +1,6 @@
 {% from "govuk/components/summary-list/macro.njk" import govukSummaryList %}
 
-{% extends "./rootLayout.njk" %}
+{% extends "./withNavigationLayout.njk" %}
 
 {% block supportingContent %}
   {{ govukSummaryList({

--- a/server/views/referrals/show/partials/risksAndNeedsLayout.njk
+++ b/server/views/referrals/show/partials/risksAndNeedsLayout.njk
@@ -1,9 +1,9 @@
 {% from "govuk/components/inset-text/macro.njk" import govukInsetText %}
 
-{% extends "./rootLayout.njk" %}
+{% extends "./withNavigationLayout.njk" %}
 
 {% block supportingContent %}
-  <p data-testid="risks-and-needs-oasys-message">Relevant sections from OASys to support the referral. The full Layer 3 assessment is available in OASys. Information is accurate at the time of the referral being submitted.</p>
+  <p class="govuk-!-margin-bottom-0" data-testid="risks-and-needs-oasys-message">Relevant sections from OASys to support the referral. The full Layer 3 assessment is available in OASys. Information is accurate at the time of the referral being submitted.</p>
 {% endblock supportingContent %}
 
 {% block primaryContent %}

--- a/server/views/referrals/show/partials/rootLayout.njk
+++ b/server/views/referrals/show/partials/rootLayout.njk
@@ -34,19 +34,4 @@
       {% block supportingContent %}{% endblock supportingContent %}
     </div>
   </div>
-
-  <hr class="govuk-section-break govuk-section-break--l govuk-section-break--visible">
-
-  <div class="govuk-grid-row">
-    <div class="govuk-grid-column-one-quarter">
-      {{ mojSideNavigation({
-        label: 'Side navigation',
-        items: navigationItems
-      }) }}
-    </div>
-
-    <div class="govuk-grid-column-three-quarters govuk-!-margin-top-4">
-      {% block primaryContent %}{% endblock primaryContent %}
-    </div>
-  </div>
 {% endblock content %}

--- a/server/views/referrals/show/partials/withNavigationLayout.njk
+++ b/server/views/referrals/show/partials/withNavigationLayout.njk
@@ -1,0 +1,25 @@
+{% extends "./rootLayout.njk" %}
+
+{% block content %}
+  {{ super() }}
+
+  <hr class="govuk-section-break govuk-section-break--xl govuk-section-break--visible">
+
+  <div class="govuk-grid-row">
+    {% if navigationItems | length %}
+      <div class="govuk-grid-column-one-quarter">
+        {{ mojSideNavigation({
+          label: 'Side navigation',
+          items: navigationItems,
+          classes: 'govuk-!-padding-top-0'
+        }) }}
+      </div>
+    {% endif %}
+
+    <div class="govuk-grid-column-three-quarters">
+      {% block primaryContent %}{% endblock primaryContent %}
+    </div>
+  </div>
+{% endblock %}
+```
+

--- a/server/views/referrals/show/statusHistory/show.njk
+++ b/server/views/referrals/show/statusHistory/show.njk
@@ -1,0 +1,5 @@
+{% extends "../partials/rootLayout.njk" %}
+
+{% block supportingContent %}
+  <p>Timeline here</p>
+{% endblock supportingContent %}


### PR DESCRIPTION
## Context

We need a Status history page to view the timeline of a referral.

## Changes in this PR
This adds the `StatusHistoryController`, associated template, paths and links to the new page.

There is placeholder text where the timeline will be. 


## Screenshots of UI changes

![image](https://github.com/ministryofjustice/hmpps-accredited-programmes-ui/assets/1067537/eb2d0101-fe13-489b-bfe5-411e274b8c5c)



## Release checklist

[Release process documentation](../doc/how-to/perform-a-release.md)

As part of our continuous deployment strategy we must ensure that this work is
ready to be released once merged.

### Pre-merge

- [ ] There are changes required to the Accredited Programmes API for this change to work...
  - [ ] ... and they have been released to production already

### Post-merge

<!-- The outer checkboxes can be completed pre-merge -->

- [ ] This adds, extends or meaningfully modifies a feature...
  - [ ] ... and I have written or updated an end-to-end test for the happy path in the [Accredited Programmes E2E repo](https://github.com/ministryofjustice/hmpps-accredited-programmes-e2e)
- [ ] This makes new expectations of the API...
  - [ ] ... and I have notified the API developer(s) of changes to the contract tests (Pact), or the API is already compliant
- [ ] [Manually approve](../doc/how-to/perform-a-release.md#releasing-to-the-preprod-environment) release to preprod
- [ ] [Manually approve](../doc/how-to/perform-a-release.md#releasing-to-the-production-environment) release to prod

<!-- Should a release fail at any step, you as the author should now lead the work to
fix it as soon as possible. You can monitor deployment failures in CircleCI
itself and application errors are found in
[Sentry](https://ministryofjustice.sentry.io/projects/hmpps-accredited-programmes-ui/?project=4505330122686464&referrer=sidebar&statsPeriod=24h). -->
