### PR TITLE
Use correct role for showing My referrals link

### DIFF
--- a/integration_tests/pages/page.ts
+++ b/integration_tests/pages/page.ts
@@ -204,7 +204,10 @@ export default abstract class Page {
   }
 
   shouldContainNavigation(currentPath: string): void {
-    const navigationItems = [{ href: '/programmes', text: 'List of programmes' }]
+    const navigationItems = [
+      { href: '/programmes', text: 'List of programmes' },
+      { href: '/refer/referrals/case-list', text: 'My referrals' },
+    ]
 
     cy.get('.moj-primary-navigation__item').each((navigationItemElement, navigationItemElementIndex) => {
       const { href, text } = navigationItems[navigationItemElementIndex]

--- a/server/views/partials/layout.njk
+++ b/server/views/partials/layout.njk
@@ -55,7 +55,7 @@
     ] %}
 
     {% for role in user.roles %}
-      {% if role === 'ROLE_POM' %}
+      {% if role === 'ROLE_ACP_REFERRER' %}
         {% set primaryNavigationItems = primaryNavigationItems.concat([
           {
             text: 'My referrals',


### PR DESCRIPTION
## Context

The **My referrals** link wasn't showing for users with `ROLE_ACP_REFERRER` as it was incorrectly using `ROLE_POM`.

## Changes in this PR
Switch to check if the user has `ROLE_ACP_REFERRER`.



## Release checklist

[Release process documentation](../doc/how-to/perform-a-release.md)

As part of our continuous deployment strategy we must ensure that this work is
ready to be released once merged.

### Pre-merge

- [ ] There are changes required to the Accredited Programmes API for this change to work...
  - [ ] ... and they have been released to production already

### Post-merge

<!-- The outer checkboxes can be completed pre-merge -->

- [ ] This adds, extends or meaningfully modifies a feature...
  - [ ] ... and I have written or updated an end-to-end test for the happy path in the [Accredited Programmes E2E repo](https://github.com/ministryofjustice/hmpps-accredited-programmes-e2e)
- [ ] This makes new expectations of the API...
  - [ ] ... and I have notified the API developer(s) of changes to the contract tests (Pact), or the API is already compliant
- [ ] [Manually approve](../doc/how-to/perform-a-release.md#releasing-to-the-preprod-environment) release to preprod
- [ ] [Manually approve](../doc/how-to/perform-a-release.md#releasing-to-the-production-environment) release to prod

<!-- Should a release fail at any step, you as the author should now lead the work to
fix it as soon as possible. You can monitor deployment failures in CircleCI
itself and application errors are found in
[Sentry](https://ministryofjustice.sentry.io/projects/hmpps-accredited-programmes-ui/?project=4505330122686464&referrer=sidebar&statsPeriod=24h). -->
