### PR TITLE
Update types related to Referral status tag colours

### DIFF
--- a/server/@types/models/Referral.ts
+++ b/server/@types/models/Referral.ts
@@ -2,6 +2,7 @@ import type { Course } from './Course'
 import type { CourseOffering } from './CourseOffering'
 import type { Organisation } from './Organisation'
 import type { Person } from './Person'
+import type { TagColour } from '@accredited-programmes/ui'
 import type { User } from '@manage-users-api'
 import type { Prisoner } from '@prisoner-search'
 
@@ -14,6 +15,8 @@ type Referral = {
   prisonNumber: Person['prisonNumber']
   referrerUsername: Express.User['username']
   status: ReferralStatus
+  statusColour?: TagColour
+  statusDescription?: string
   submittedOn?: string
 }
 
@@ -44,6 +47,8 @@ type ReferralView = {
   prisonNumber?: Person['prisonNumber']
   referrerUsername?: User['username']
   status?: ReferralStatus
+  statusColour?: Referral['statusColour']
+  statusDescription?: Referral['statusDescription']
   submittedOn?: Referral['submittedOn']
   surname?: string
   tariffExpiryDate?: Person['tariffDate']

--- a/server/@types/ui/index.d.ts
+++ b/server/@types/ui/index.d.ts
@@ -50,7 +50,17 @@ type HasHtmlString = {
   html: string
 }
 
-type TagColour = 'blue' | 'green' | 'grey' | 'orange' | 'pink' | 'purple' | 'red' | 'turquoise' | 'yellow'
+type TagColour =
+  | 'blue'
+  | 'green'
+  | 'grey'
+  | 'light-blue'
+  | 'orange'
+  | 'pink'
+  | 'purple'
+  | 'red'
+  | 'turquoise'
+  | 'yellow'
 
 type CaseListColumnHeader =
   | 'Conditional release date'


### PR DESCRIPTION
## Context

The API now returns `statusColour` and `statusDescription` keys so the front end no longer has to match a status with a coloured tag.


## Changes in this PR

- Update `Referral` and `ReferralView` types to include new keys.
- Update `TagColour` type

Work in progress to use these new values.


## Release checklist

[Release process documentation](../doc/how-to/perform-a-release.md)

As part of our continuous deployment strategy we must ensure that this work is
ready to be released once merged.

### Pre-merge

- [ ] There are changes required to the Accredited Programmes API for this change to work...
  - [ ] ... and they have been released to production already

### Post-merge

<!-- The outer checkboxes can be completed pre-merge -->

- [ ] This adds, extends or meaningfully modifies a feature...
  - [ ] ... and I have written or updated an end-to-end test for the happy path in the [Accredited Programmes E2E repo](https://github.com/ministryofjustice/hmpps-accredited-programmes-e2e)
- [ ] This makes new expectations of the API...
  - [ ] ... and I have notified the API developer(s) of changes to the contract tests (Pact), or the API is already compliant
- [ ] [Manually approve](../doc/how-to/perform-a-release.md#releasing-to-the-preprod-environment) release to preprod
- [ ] [Manually approve](../doc/how-to/perform-a-release.md#releasing-to-the-production-environment) release to prod

<!-- Should a release fail at any step, you as the author should now lead the work to
fix it as soon as possible. You can monitor deployment failures in CircleCI
itself and application errors are found in
[Sentry](https://ministryofjustice.sentry.io/projects/hmpps-accredited-programmes-ui/?project=4505330122686464&referrer=sidebar&statsPeriod=24h). -->
