### PR TITLE
Update case list to use `statusColour` and `statusDescription`

### DIFF
--- a/server/@types/models/Referral.ts
+++ b/server/@types/models/Referral.ts
@@ -6,6 +6,21 @@ import type { TagColour } from '@accredited-programmes/ui'
 import type { User } from '@manage-users-api'
 import type { Prisoner } from '@prisoner-search'
 
+const referralStatuses = [
+  'assessed_suitable',
+  'assessment_started',
+  'awaiting_assessment',
+  'deselected',
+  'not_suitable',
+  'on_hold_awaiting_assessment',
+  'on_programme',
+  'programme_complete',
+  'referral_started',
+  'referral_submitted',
+  'suitable_not_ready',
+  'withdrawn',
+] as const
+
 type Referral = {
   id: string // eslint-disable-next-line @typescript-eslint/member-ordering
   additionalInformation: string
@@ -30,7 +45,7 @@ type ReferralUpdate = {
   additionalInformation?: Referral['additionalInformation']
 }
 
-type ReferralStatus = 'assessment_started' | 'awaiting_assessment' | 'referral_started' | 'referral_submitted'
+type ReferralStatus = (typeof referralStatuses)[number]
 
 type ReferralView = {
   id: Referral['id'] // eslint-disable-next-line @typescript-eslint/member-ordering
@@ -55,4 +70,5 @@ type ReferralView = {
   tasksCompleted?: number
 }
 
+export { referralStatuses }
 export type { CreatedReferralResponse, Referral, ReferralStatus, ReferralUpdate, ReferralView }

--- a/server/testutils/factories/referral.ts
+++ b/server/testutils/factories/referral.ts
@@ -1,6 +1,7 @@
 import { faker } from '@faker-js/faker'
 import { Factory } from 'fishery'
 
+import { referralStatuses } from '../../@types/models/Referral'
 import type { Referral, ReferralStatus } from '@accredited-programmes/models'
 
 class ReferralFactory extends Factory<Referral> {
@@ -35,10 +36,39 @@ class ReferralFactory extends Factory<Referral> {
   }
 }
 
-export const randomStatus = (availableStatuses?: Array<ReferralStatus>) =>
-  faker.helpers.arrayElement(
-    availableStatuses || ['awaiting_assessment', 'assessment_started', 'referral_started', 'referral_submitted'],
-  ) as ReferralStatus
+const randomStatus = (availableStatuses?: Array<ReferralStatus>) =>
+  faker.helpers.arrayElement(availableStatuses || referralStatuses)
+
+const statusDescriptionAndColour = (status: ReferralStatus): Pick<Referral, 'statusColour' | 'statusDescription'> => {
+  switch (status) {
+    case 'awaiting_assessment':
+      return { statusColour: 'light-blue', statusDescription: 'Awaiting Assessment' }
+    case 'on_hold_awaiting_assessment':
+      return { statusColour: 'light-blue', statusDescription: 'On Hold - Awaiting Assessment' }
+    case 'assessment_started':
+      return { statusColour: 'blue', statusDescription: 'Assessment started' }
+    case 'referral_started':
+      return { statusColour: 'yellow', statusDescription: 'Referral started' }
+    case 'referral_submitted':
+      return { statusColour: 'green', statusDescription: 'Referral submitted' }
+    case 'on_programme':
+      return { statusColour: 'pink', statusDescription: 'On Programme' }
+    case 'withdrawn':
+      return { statusColour: 'grey', statusDescription: 'Withdrawn' }
+    case 'assessed_suitable':
+      return { statusColour: 'purple', statusDescription: 'Assessed as Suitable' }
+    case 'suitable_not_ready':
+      return { statusColour: 'yellow', statusDescription: 'Suitable but not ready' }
+    case 'programme_complete':
+      return { statusColour: 'grey', statusDescription: 'Programme complete' }
+    case 'deselected':
+      return { statusColour: 'grey', statusDescription: 'Deselected' }
+    case 'not_suitable':
+      return { statusColour: 'grey', statusDescription: 'Not suitable' }
+    default:
+      return { statusColour: undefined, statusDescription: undefined }
+  }
+}
 
 export default ReferralFactory.define(({ params }) => {
   const status = params.status || randomStatus()
@@ -53,5 +83,8 @@ export default ReferralFactory.define(({ params }) => {
     referrerUsername: faker.internet.userName(),
     status,
     submittedOn: status !== 'referral_started' ? faker.date.past().toISOString() : undefined,
+    ...statusDescriptionAndColour(status),
   }
 })
+
+export { randomStatus, statusDescriptionAndColour }

--- a/server/testutils/factories/referralView.ts
+++ b/server/testutils/factories/referralView.ts
@@ -3,7 +3,7 @@ import { Factory } from 'fishery'
 
 import courseAudienceFactory from './courseAudience'
 import FactoryHelpers from './factoryHelpers'
-import { randomStatus } from './referral'
+import { randomStatus, statusDescriptionAndColour } from './referral'
 import { StringUtils } from '../../utils'
 import type { ReferralStatus, ReferralView } from '@accredited-programmes/models'
 
@@ -20,6 +20,7 @@ class ReferralViewFactory extends Factory<ReferralView, ReferralViewTransientPar
 
 export default ReferralViewFactory.define(({ params, transientParams }) => {
   const { availableStatuses, requireOptionalFields } = transientParams
+  const status = params.status || randomStatus(availableStatuses)
 
   const referralViewWithAllFields: ReferralView = {
     id: faker.string.uuid(), // eslint-disable-next-line sort-keys
@@ -39,11 +40,12 @@ export default ReferralViewFactory.define(({ params, transientParams }) => {
     paroleEligibilityDate: FactoryHelpers.randomFutureDateString(),
     prisonNumber: faker.string.alphanumeric({ length: 7 }),
     referrerUsername: faker.internet.userName(),
-    status: randomStatus(availableStatuses),
+    status,
     submittedOn: faker.date.past().toISOString(),
     surname: faker.person.lastName(),
     tariffExpiryDate: FactoryHelpers.randomFutureDateString(),
     tasksCompleted: faker.number.int({ max: 4, min: 1 }),
+    ...statusDescriptionAndColour(status),
   }
 
   return {

--- a/server/utils/referrals/caseListUtils.test.ts
+++ b/server/utils/referrals/caseListUtils.test.ts
@@ -328,20 +328,19 @@ describe('CaseListUtils', () => {
   })
 
   describe('statusTagHtml', () => {
-    it.each([
-      ['assessment_started', 'yellow', 'Assessment started'],
-      ['awaiting_assessment', 'orange', 'Awaiting assessment'],
-      ['referral_submitted', 'red', 'Referral submitted'],
-      ['referral_started', 'grey', 'referral_started'],
-      [undefined, 'grey', 'Unknown'],
-    ])(
-      'should return the correct HTML for status "%s"',
-      (status: string | undefined, expectedColour: string, expectedText: string) => {
-        const result = CaseListUtils.statusTagHtml(status as ReferralStatus)
+    it('should return the correct HTML', () => {
+      expect(CaseListUtils.statusTagHtml('green', 'Referral submitted')).toBe(
+        '<strong class="govuk-tag govuk-tag--green">Referral submitted</strong>',
+      )
+    })
 
-        expect(result).toBe(`<strong class="govuk-tag govuk-tag--${expectedColour}">${expectedText}</strong>`)
-      },
-    )
+    describe('when the `statusDescription` is `undefined`', () => {
+      it('returns an empty string', () => {
+        expect(CaseListUtils.statusTagHtml('green', undefined)).toBe(
+          '<strong class="govuk-tag govuk-tag--green">Unknown status</strong>',
+        )
+      })
+    })
   })
 
   describe('subNavigationItems', () => {
@@ -552,7 +551,7 @@ describe('CaseListUtils', () => {
     describe('Referral status', () => {
       it('returns the status as a status tag HTML string', () => {
         expect(CaseListUtils.tableRowContent(referralView, 'Referral status')).toEqual(
-          CaseListUtils.statusTagHtml('referral_submitted'),
+          CaseListUtils.statusTagHtml('green', 'Referral submitted'),
         )
       })
     })

--- a/server/utils/referrals/caseListUtils.ts
+++ b/server/utils/referrals/caseListUtils.ts
@@ -4,8 +4,8 @@ import { assessPaths, referPaths } from '../../paths'
 import DateUtils from '../dateUtils'
 import FormUtils from '../formUtils'
 import StringUtils from '../stringUtils'
-import type { Course, ReferralStatus, ReferralView } from '@accredited-programmes/models'
-import type { CaseListColumnHeader, MojFrontendNavigationItem, QueryParam, TagColour } from '@accredited-programmes/ui'
+import type { Course, Referral, ReferralView } from '@accredited-programmes/models'
+import type { CaseListColumnHeader, MojFrontendNavigationItem, QueryParam } from '@accredited-programmes/ui'
 import type { GovukFrontendSelectItem, GovukFrontendTableHeadElement, GovukFrontendTableRow } from '@govuk-frontend'
 
 export default class CaseListUtils {
@@ -114,30 +114,11 @@ export default class CaseListUtils {
     return this.selectItems(['Assessment started', 'Awaiting assessment', 'Referral submitted'], selectedValue)
   }
 
-  static statusTagHtml(status?: ReferralStatus): string {
-    let colour: TagColour
-    let text: string
-
-    switch (status) {
-      case 'assessment_started':
-        colour = 'yellow'
-        text = 'Assessment started'
-        break
-      case 'awaiting_assessment':
-        colour = 'orange'
-        text = 'Awaiting assessment'
-        break
-      case 'referral_submitted':
-        colour = 'red'
-        text = 'Referral submitted'
-        break
-      default:
-        colour = 'grey'
-        text = status || 'Unknown'
-        break
-    }
-
-    return `<strong class="govuk-tag govuk-tag--${colour}">${text}</strong>`
+  static statusTagHtml(
+    statusColour?: Referral['statusColour'],
+    statusDescription?: Referral['statusDescription'],
+  ): string {
+    return `<strong class="govuk-tag govuk-tag--${statusColour}">${statusDescription || 'Unknown status'}</strong>`
   }
 
   static subNavigationItems(currentPath: Request['path']): Array<MojFrontendNavigationItem> {
@@ -187,7 +168,7 @@ export default class CaseListUtils {
       case 'Progress':
         return `${referralView.tasksCompleted || 0} out of 4 tasks complete`
       case 'Referral status':
-        return CaseListUtils.statusTagHtml(referralView.status)
+        return CaseListUtils.statusTagHtml(referralView.statusColour, referralView.statusDescription)
       case 'Release date type':
         return referralView.nonDtoReleaseDateType
           ? {


### PR DESCRIPTION
## Context

We no longer need to work out what colour a tag should be depending on the status as the api now returns this for us.

## Changes in this PR
- Update `ReferralStatus` types to include new statuses
- Update Referral related test utils to return `statusColour` and `statusDescription`
- Update `statusTagHtml` method which to take 2 params which will be the colour and description values from the api, rather than work them out on the front end.




## Release checklist

[Release process documentation](../doc/how-to/perform-a-release.md)

As part of our continuous deployment strategy we must ensure that this work is
ready to be released once merged.

### Pre-merge

- [ ] There are changes required to the Accredited Programmes API for this change to work...
  - [ ] ... and they have been released to production already

### Post-merge

<!-- The outer checkboxes can be completed pre-merge -->

- [ ] This adds, extends or meaningfully modifies a feature...
  - [ ] ... and I have written or updated an end-to-end test for the happy path in the [Accredited Programmes E2E repo](https://github.com/ministryofjustice/hmpps-accredited-programmes-e2e)
- [ ] This makes new expectations of the API...
  - [ ] ... and I have notified the API developer(s) of changes to the contract tests (Pact), or the API is already compliant
- [ ] [Manually approve](../doc/how-to/perform-a-release.md#releasing-to-the-preprod-environment) release to preprod
- [ ] [Manually approve](../doc/how-to/perform-a-release.md#releasing-to-the-production-environment) release to prod

<!-- Should a release fail at any step, you as the author should now lead the work to
fix it as soon as possible. You can monitor deployment failures in CircleCI
itself and application errors are found in
[Sentry](https://ministryofjustice.sentry.io/projects/hmpps-accredited-programmes-ui/?project=4505330122686464&referrer=sidebar&statsPeriod=24h). -->
