### PR TITLE
(1335b) Status history timeline

### DIFF
--- a/server/@types/models/Referral.ts
+++ b/server/@types/models/Referral.ts
@@ -47,6 +47,20 @@ type ReferralUpdate = {
 
 type ReferralStatus = (typeof referralStatuses)[number]
 
+type ReferralStatusHistory = {
+  id?: string
+  notes?: string
+  previousStatus?: Referral['status']
+  previousStatusColour?: Referral['statusColour']
+  previousStatusDescription?: Referral['statusDescription']
+  referralId?: Referral['id']
+  status?: Referral['status']
+  statusColour?: Referral['statusColour']
+  statusDescription?: Referral['statusDescription']
+  statusStartDate?: string
+  username?: User['username']
+}
+
 type ReferralView = {
   id: Referral['id'] // eslint-disable-next-line @typescript-eslint/member-ordering
   audience?: string
@@ -71,4 +85,4 @@ type ReferralView = {
 }
 
 export { referralStatuses }
-export type { CreatedReferralResponse, Referral, ReferralStatus, ReferralUpdate, ReferralView }
+export type { CreatedReferralResponse, Referral, ReferralStatus, ReferralStatusHistory, ReferralUpdate, ReferralView }

--- a/server/@types/models/index.d.ts
+++ b/server/@types/models/index.d.ts
@@ -19,7 +19,14 @@ import type { OrganisationAddress } from './OrganisationAddress'
 import type { Paginated } from './Paginated'
 import type { Person } from './Person'
 import type { Psychiatric } from './Psychiatric'
-import type { CreatedReferralResponse, Referral, ReferralStatus, ReferralUpdate, ReferralView } from './Referral'
+import type {
+  CreatedReferralResponse,
+  Referral,
+  ReferralStatus,
+  ReferralStatusHistory,
+  ReferralUpdate,
+  ReferralView,
+} from './Referral'
 import type { Relationships } from './Relationships'
 import type { RiskLevel, RisksAndAlerts } from './RisksAndAlerts'
 import type { RoshAnalysis } from './RoshAnalysis'
@@ -47,6 +54,7 @@ export type {
   Psychiatric,
   Referral,
   ReferralStatus,
+  ReferralStatusHistory,
   ReferralUpdate,
   ReferralView,
   Relationships,

--- a/server/@types/ui/index.d.ts
+++ b/server/@types/ui/index.d.ts
@@ -5,6 +5,7 @@ import type {
   Organisation,
   Person,
   Referral,
+  ReferralStatusHistory,
   RiskLevel,
 } from '@accredited-programmes/models'
 import type {
@@ -209,6 +210,23 @@ type SortableCaseListColumnKey =
   | 'surname'
   | 'tariffExpiryDate'
 
+type HtmlOrText = { html: string } | { text: string }
+
+type MojTimelineItem = HtmlOrText & {
+  byline: {
+    text: string
+  }
+  datetime: {
+    timestamp: string
+    type?: 'date' | 'datetime' | 'shortdate' | 'shortdatetime' | 'time'
+  }
+  label: HtmlOrText
+}
+
+type ReferralStatusHistoryPresenter = ReferralStatusHistory & {
+  byLineText: MojTimelineItem['byline']['text']
+}
+
 export type {
   CaseListColumnHeader,
   CourseParticipationPresenter,
@@ -223,6 +241,7 @@ export type {
   HasHtmlString,
   HasTextString,
   MojFrontendNavigationItem,
+  MojTimelineItem,
   OffenceDetails,
   OffenceHistory,
   OrganisationWithOfferingEmailsPresenter,
@@ -231,6 +250,7 @@ export type {
   QueryParam,
   ReferralSharedPageData,
   ReferralStatusGroup,
+  ReferralStatusHistoryPresenter,
   ReferralTaskListItem,
   ReferralTaskListSection,
   ReferralTaskListStatusTag,

--- a/server/controllers/shared/statusHistoryController.ts
+++ b/server/controllers/shared/statusHistoryController.ts
@@ -15,12 +15,13 @@ export default class StatusHistoryController {
       TypeUtils.assertHasUser(req)
 
       const { referralId } = req.params
-      const { username } = req.user
+      const { token: userToken, username } = req.user
 
       const referral = await this.referralService.getReferral(username, referralId)
 
-      const [course, person] = await Promise.all([
+      const [course, statusHistory, person] = await Promise.all([
         this.courseService.getCourseByOffering(username, referral.offeringId),
+        this.referralService.getReferralStatusHistory(userToken, username, referralId),
         this.personService.getPerson(username, referral.prisonNumber, res.locals.user.caseloads),
       ])
 
@@ -32,6 +33,7 @@ export default class StatusHistoryController {
         person,
         referral,
         subNavigationItems: ShowReferralUtils.subNavigationItems(req.path, 'statusHistory', referral.id),
+        timelineItems: ShowReferralUtils.statusHistoryTimelineItems(statusHistory),
       })
     }
   }

--- a/server/data/accreditedProgrammesApi/referralClient.ts
+++ b/server/data/accreditedProgrammesApi/referralClient.ts
@@ -1,3 +1,5 @@
+/* istanbul ignore file */
+
 import type { ApiConfig } from '../../config'
 import config from '../../config'
 import { apiPaths } from '../../paths'
@@ -7,6 +9,7 @@ import type {
   Paginated,
   Referral,
   ReferralStatus,
+  ReferralStatusHistory,
   ReferralUpdate,
   ReferralView,
 } from '@accredited-programmes/models'
@@ -59,6 +62,12 @@ export default class ReferralClient {
         size: '15',
       },
     })) as Paginated<ReferralView>
+  }
+
+  async findReferralStatusHistory(referralId: Referral['id']): Promise<Array<ReferralStatusHistory>> {
+    return (await this.restClient.get({
+      path: apiPaths.referrals.statusHistory({ referralId }),
+    })) as Array<ReferralStatusHistory>
   }
 
   async findReferralViews(

--- a/server/paths/api.ts
+++ b/server/paths/api.ts
@@ -16,6 +16,7 @@ const updateStatusPath = referralPath.path('status')
 const submitPath = referralPath.path('submit')
 const dashboardPath = referralsPath.path('view/organisation/:organisationId/dashboard')
 const myDashboardPath = referralsPath.path('view/me/dashboard')
+const statusHistoryPath = referralPath.path('status-history')
 
 const organisationsPath = path('/organisations')
 const coursesByOrganisationPath = organisationsPath.path(':organisationId/courses')
@@ -64,6 +65,7 @@ export default {
     dashboard: dashboardPath,
     myDashboard: myDashboardPath,
     show: referralPath,
+    statusHistory: statusHistoryPath,
     submit: submitPath,
     update: referralPath,
     updateStatus: updateStatusPath,

--- a/server/routes/assess.ts
+++ b/server/routes/assess.ts
@@ -8,11 +8,14 @@ import { RouteUtils } from '../utils'
 export default function routes(controllers: Controllers, router: Router): Router {
   const { get, post } = RouteUtils.actions(router, { allowedRoles: [ApplicationRoles.ACP_PROGRAMME_TEAM] })
 
-  const { assessCaseListController, referralsController, risksAndNeedsController } = controllers
+  const { assessCaseListController, referralsController, risksAndNeedsController, statusHistoryController } =
+    controllers
 
   get(assessPaths.caseList.index.pattern, assessCaseListController.indexRedirect())
   get(assessPaths.caseList.show.pattern, assessCaseListController.show())
   post(assessPaths.caseList.filter.pattern, assessCaseListController.filter())
+
+  get(assessPaths.show.statusHistory.pattern, statusHistoryController.show())
 
   get(assessPaths.show.additionalInformation.pattern, referralsController.additionalInformation())
   get(assessPaths.show.offenceHistory.pattern, referralsController.offenceHistory())

--- a/server/services/index.ts
+++ b/server/services/index.ts
@@ -22,8 +22,8 @@ const services = () => {
   const oasysService = new OasysService(hmppsAuthClientBuilder, oasysClientBuilder)
   const organisationService = new OrganisationService(prisonRegisterApiClientBuilder)
   const personService = new PersonService(hmppsAuthClientBuilder, prisonApiClientBuilder, prisonerSearchClientBuilder)
-  const referralService = new ReferralService(hmppsAuthClientBuilder, referralClientBuilder)
   const userService = new UserService(hmppsManageUsersClientBuilder, prisonApiClientBuilder)
+  const referralService = new ReferralService(hmppsAuthClientBuilder, referralClientBuilder, userService)
   const courseService = new CourseService(courseClientBuilder, hmppsAuthClientBuilder, userService)
 
   return {

--- a/server/testutils/factories/index.ts
+++ b/server/testutils/factories/index.ts
@@ -24,6 +24,7 @@ import prisonAddressFactory from './prisonAddress'
 import prisonerFactory from './prisoner'
 import psychiatricFactory from './psychiatric'
 import referralFactory from './referral'
+import referralStatusHistoryFactory from './referralStatusHistory'
 import referralViewFactory from './referralView'
 import relationshipsFactory from './relationships'
 import risksAndAlertsFactory from './risksAndAlerts'
@@ -57,6 +58,7 @@ export {
   prisonerFactory,
   psychiatricFactory,
   referralFactory,
+  referralStatusHistoryFactory,
   referralViewFactory,
   relationshipsFactory,
   risksAndAlertsFactory,

--- a/server/testutils/factories/referral.ts
+++ b/server/testutils/factories/referral.ts
@@ -39,7 +39,7 @@ class ReferralFactory extends Factory<Referral> {
 const randomStatus = (availableStatuses?: Array<ReferralStatus>) =>
   faker.helpers.arrayElement(availableStatuses || referralStatuses)
 
-const statusDescriptionAndColour = (status: ReferralStatus): Pick<Referral, 'statusColour' | 'statusDescription'> => {
+const statusDescriptionAndColour = (status?: ReferralStatus): Pick<Referral, 'statusColour' | 'statusDescription'> => {
   switch (status) {
     case 'awaiting_assessment':
       return { statusColour: 'light-blue', statusDescription: 'Awaiting Assessment' }

--- a/server/testutils/factories/referralStatusHistory.ts
+++ b/server/testutils/factories/referralStatusHistory.ts
@@ -1,0 +1,52 @@
+import { faker } from '@faker-js/faker'
+import { Factory } from 'fishery'
+
+import { randomStatus, statusDescriptionAndColour } from './referral'
+import { referralStatuses } from '../../@types/models/Referral'
+import type { ReferralStatusHistory } from '@accredited-programmes/models'
+
+class ReferralStatusHistoryFactory extends Factory<ReferralStatusHistory> {
+  started() {
+    return this.params({ notes: undefined, previousStatus: undefined, status: 'referral_started' })
+  }
+
+  submitted() {
+    return this.params({ notes: undefined, previousStatus: 'referral_started', status: 'referral_submitted' })
+  }
+
+  updated() {
+    return this.params({
+      notes: 'Some notes',
+      previousStatus: 'referral_submitted',
+      status: randomStatus(
+        referralStatuses.filter(status => !['referral_started', 'referral_submitted'].includes(status)),
+      ),
+    })
+  }
+}
+
+export default ReferralStatusHistoryFactory.define(({ params }) => {
+  const previousStatus = Object.prototype.hasOwnProperty.call(params, 'previousStatus')
+    ? params.previousStatus
+    : randomStatus()
+  const previousStatusColourAndDescription = statusDescriptionAndColour(previousStatus)
+
+  const availableStatusesExcludingPreviousStatus = referralStatuses.filter(status => status !== previousStatus)
+
+  const currentStatus = params.status || randomStatus(availableStatusesExcludingPreviousStatus)
+  const currentStatusDescriptionAndColour = statusDescriptionAndColour(currentStatus)
+
+  return {
+    id: faker.string.uuid(), // eslint-disable-next-line sort-keys
+    notes: faker.lorem.paragraph({ max: 5, min: 0 }),
+    previousStatus,
+    previousStatusColour: previousStatusColourAndDescription.statusColour,
+    previousStatusDescription: previousStatusColourAndDescription.statusDescription,
+    referralId: faker.internet.userName(),
+    status: currentStatus,
+    statusColour: currentStatusDescriptionAndColour.statusColour,
+    statusDescription: currentStatusDescriptionAndColour.statusDescription,
+    statusStartDate: faker.date.past().toISOString(),
+    username: faker.internet.userName(),
+  }
+})

--- a/server/utils/nunjucksSetup.ts
+++ b/server/utils/nunjucksSetup.ts
@@ -54,4 +54,11 @@ export default function nunjucksSetup(app: express.Express, path: pathModule.Pla
 
   njkEnv.addGlobal('findPaths', findPaths)
   njkEnv.addGlobal('referPaths', referPaths)
+
+  // eslint-disable-next-line global-require, @typescript-eslint/no-var-requires
+  const mojFilters = require('@ministryofjustice/frontend/moj/filters/all')()
+
+  Object.keys(mojFilters).forEach(filterName => {
+    njkEnv.addFilter(filterName, mojFilters[filterName])
+  })
 }

--- a/server/utils/referrals/showReferralUtils.ts
+++ b/server/utils/referrals/showReferralUtils.ts
@@ -1,5 +1,6 @@
 import type { Request } from 'express'
 
+import CaseListUtils from './caseListUtils'
 import { assessPathBase, assessPaths, referPaths } from '../../paths'
 import DateUtils from '../dateUtils'
 import type { Organisation, Referral } from '@accredited-programmes/models'
@@ -7,6 +8,8 @@ import type {
   CoursePresenter,
   GovukFrontendSummaryListRowWithKeyAndValue,
   MojFrontendNavigationItem,
+  MojTimelineItem,
+  ReferralStatusHistoryPresenter,
 } from '@accredited-programmes/ui'
 import type { User } from '@manage-users-api'
 
@@ -29,6 +32,32 @@ export default class ShowReferralUtils {
         value: { text: organisationName },
       },
     ]
+  }
+
+  static statusHistoryTimelineItems(
+    statusHistoryPresenter: Array<ReferralStatusHistoryPresenter>,
+  ): Array<MojTimelineItem> {
+    return statusHistoryPresenter.map(status => {
+      const html = CaseListUtils.statusTagHtml(status.statusColour, status.statusDescription)
+
+      return {
+        byline: {
+          text: status.byLineText,
+        },
+        datetime: {
+          timestamp: status.statusStartDate as string,
+          type: 'datetime',
+        },
+        html: status.notes
+          ? html.concat(
+              `<p class="govuk-!-margin-top-4 govuk-!-margin-bottom-0"><strong>Status details: </strong>${status.notes}</p>`,
+            )
+          : html,
+        label: {
+          text: status.status?.toLowerCase() === 'referral_submitted' ? 'Referral submitted' : 'Status update',
+        },
+      }
+    })
   }
 
   static submissionSummaryListRows(

--- a/server/views/referrals/show/statusHistory/show.njk
+++ b/server/views/referrals/show/statusHistory/show.njk
@@ -1,5 +1,9 @@
+{% from "moj/components/timeline/macro.njk" import mojTimeline %}
+
 {% extends "../partials/rootLayout.njk" %}
 
 {% block supportingContent %}
-  <p>Timeline here</p>
+  {{ mojTimeline({
+    items: timelineItems
+  }) }}
 {% endblock supportingContent %}


### PR DESCRIPTION
## Context

We need to display the timeline of a referral and all the statuses it has been in on the status history page.

## Changes in this PR
- New client method for `/referrals/:id/status-history`
- Add MoJ frontend nunjucks filters so we can use the timeline component as it formats the passed in date
- New referral util for turning a status history record into something that can be used in the timeline macro
- Add missing route for status history page for assess
- New ReferralService method for getting status history from client and getting the full name from the username

Integration tests to follow.


## Screenshots of UI changes

![image](https://github.com/ministryofjustice/hmpps-accredited-programmes-ui/assets/1067537/3df75751-1143-4029-8780-a70e83e679b3)



## Release checklist

[Release process documentation](../doc/how-to/perform-a-release.md)

As part of our continuous deployment strategy we must ensure that this work is
ready to be released once merged.

### Pre-merge

- [ ] There are changes required to the Accredited Programmes API for this change to work...
  - [ ] ... and they have been released to production already

### Post-merge

<!-- The outer checkboxes can be completed pre-merge -->

- [ ] This adds, extends or meaningfully modifies a feature...
  - [ ] ... and I have written or updated an end-to-end test for the happy path in the [Accredited Programmes E2E repo](https://github.com/ministryofjustice/hmpps-accredited-programmes-e2e)
- [ ] This makes new expectations of the API...
  - [ ] ... and I have notified the API developer(s) of changes to the contract tests (Pact), or the API is already compliant
- [ ] [Manually approve](../doc/how-to/perform-a-release.md#releasing-to-the-preprod-environment) release to preprod
- [ ] [Manually approve](../doc/how-to/perform-a-release.md#releasing-to-the-production-environment) release to prod

<!-- Should a release fail at any step, you as the author should now lead the work to
fix it as soon as possible. You can monitor deployment failures in CircleCI
itself and application errors are found in
[Sentry](https://ministryofjustice.sentry.io/projects/hmpps-accredited-programmes-ui/?project=4505330122686464&referrer=sidebar&statsPeriod=24h). -->
