### PR TITLE
(1337a) Add session object for handling status update journeys

### DIFF
--- a/server/@types/express/index.d.ts
+++ b/server/@types/express/index.d.ts
@@ -2,12 +2,14 @@
 // @ts-expect-error to fix later: https://github.com/microsoft/TypeScript/issues/16472
 import type { Request as ConnectFlashRequest } from '@types/connect-flash'
 
+import type { ReferralStatus, ReferralStatusUppercase } from '@accredited-programmes/models'
 import type { UserDetails } from '@accredited-programmes/users'
 
 declare module 'express-session' {
   // Declare that the session will potentially contain these additional fields
   interface SessionData {
     nowInMinutes: number
+    referralStatusUpdateData: ReferralStatusUpdateSessionData
     returnTo: string
     user: UserDetails
   }
@@ -40,10 +42,17 @@ declare global {
 
 type RequestWithUser = Express.RequestWithUser
 
+interface ReferralStatusUpdateSessionData {
+  referralId: string
+  status: ReferralStatus | ReferralStatusUppercase
+  statusCategoryCode?: Uppercase<string>
+  statusReasonCode?: Uppercase<string>
+}
+
 // @ts-expect-error to fix later
 export { global }
 
-export type { RequestWithUser }
+export type { ReferralStatusUpdateSessionData, RequestWithUser }
 
 // @ts-expect-error to fix later
 export default {}

--- a/server/utils/referrals/referralUtils.test.ts
+++ b/server/utils/referrals/referralUtils.test.ts
@@ -9,9 +9,22 @@ describe('ReferralUtils', () => {
         { code: 'B', description: 'Category B', referralStatusCode: 'WITHDRAWN' },
       ]
       expect(ReferralUtils.statusCategoriesToRadioItems(statusCategories)).toEqual([
-        { text: 'Category A', value: 'A' },
-        { text: 'Category B', value: 'B' },
+        { checked: false, text: 'Category A', value: 'A' },
+        { checked: false, text: 'Category B', value: 'B' },
       ])
+    })
+
+    describe('when a selected status category is provided', () => {
+      it('should mark the corresponding radio item as checked', () => {
+        const statusCategories: Array<ReferralStatusCategory> = [
+          { code: 'A', description: 'Category A', referralStatusCode: 'WITHDRAWN' },
+          { code: 'B', description: 'Category B', referralStatusCode: 'WITHDRAWN' },
+        ]
+        expect(ReferralUtils.statusCategoriesToRadioItems(statusCategories, 'B')).toEqual([
+          { checked: false, text: 'Category A', value: 'A' },
+          { checked: true, text: 'Category B', value: 'B' },
+        ])
+      })
     })
 
     describe('when the categories include a description with the value "Other"', () => {
@@ -22,10 +35,10 @@ describe('ReferralUtils', () => {
           { code: 'OTHER', description: 'Other', referralStatusCode: 'WITHDRAWN' },
         ]
         expect(ReferralUtils.statusCategoriesToRadioItems(statusCategories)).toEqual([
-          { text: 'Category A', value: 'A' },
-          { text: 'Category B', value: 'B' },
+          { checked: false, text: 'Category A', value: 'A' },
+          { checked: false, text: 'Category B', value: 'B' },
           { divider: 'or', value: '' },
-          { text: 'Other', value: 'OTHER' },
+          { checked: false, text: 'Other', value: 'OTHER' },
         ])
       })
     })

--- a/server/utils/referrals/referralUtils.ts
+++ b/server/utils/referrals/referralUtils.ts
@@ -2,13 +2,17 @@ import type { ReferralStatusCategory } from '@accredited-programmes/models'
 import type { GovukFrontendRadiosItem } from '@govuk-frontend'
 
 export default class ReferralUtils {
-  static statusCategoriesToRadioItems(statusCategories: Array<ReferralStatusCategory>): Array<GovukFrontendRadiosItem> {
+  static statusCategoriesToRadioItems(
+    statusCategories: Array<ReferralStatusCategory>,
+    selectedStatusCategory?: ReferralStatusCategory['code'],
+  ): Array<GovukFrontendRadiosItem> {
     return statusCategories.reduce<Array<GovukFrontendRadiosItem>>((acc, statusCategory) => {
       if (statusCategory.description === 'Other') {
         acc.push({ divider: 'or', value: '' })
       }
 
       acc.push({
+        checked: selectedStatusCategory === statusCategory.code,
         text: statusCategory.description,
         value: statusCategory.code,
       })


### PR DESCRIPTION
## Context

We need to share form selections made on previous pages across multiple steps.


## Changes in this PR
- Add `referralStatusUpdateData` to `req.session`
- Update `WithdrawCategoryController` so:
  -  It clears any session data at the start of a new withdrawal, if it's for an unrelated referral or a status other than `WITHDRAWN`
  -  If the session data is for the current referral and `WITHDRAWN`, then use the data to pre check the previously selected radio item. So when navigating back, selections will be maintained.
  - When submitting, set `referralStatusUpdateData` and clear `statusReasonCode` for the next step, incase an un-matching `categoryCode` has been selected.


## Release checklist

[Release process documentation](../doc/how-to/perform-a-release.md)

As part of our continuous deployment strategy we must ensure that this work is
ready to be released once merged.

### Pre-merge

- [ ] There are changes required to the Accredited Programmes API for this change to work...
  - [ ] ... and they have been released to production already

### Post-merge

<!-- The outer checkboxes can be completed pre-merge -->

- [ ] This adds, extends or meaningfully modifies a feature...
  - [ ] ... and I have written or updated an end-to-end test for the happy path in the [Accredited Programmes E2E repo](https://github.com/ministryofjustice/hmpps-accredited-programmes-e2e)
- [ ] This makes new expectations of the API...
  - [ ] ... and I have notified the API developer(s) of changes to the contract tests (Pact), or the API is already compliant
- [ ] [Manually approve](../doc/how-to/perform-a-release.md#releasing-to-the-preprod-environment) release to preprod
- [ ] [Manually approve](../doc/how-to/perform-a-release.md#releasing-to-the-production-environment) release to prod

<!-- Should a release fail at any step, you as the author should now lead the work to
fix it as soon as possible. You can monitor deployment failures in CircleCI
itself and application errors are found in
[Sentry](https://ministryofjustice.sentry.io/projects/hmpps-accredited-programmes-ui/?project=4505330122686464&referrer=sidebar&statsPeriod=24h). -->
