### PR TITLE
(1337e) Withdraw layout partial

### DIFF
--- a/server/views/referrals/withdraw/category/show.njk
+++ b/server/views/referrals/withdraw/category/show.njk
@@ -1,43 +1,13 @@
-{% from "govuk/components/back-link/macro.njk" import govukBackLink %}
 {% from "govuk/components/button/macro.njk" import govukButton %}
-{% from "govuk/components/error-summary/macro.njk" import govukErrorSummary %}
 {% from "govuk/components/radios/macro.njk" import govukRadios %}
-{% from "moj/components/timeline/macro.njk" import mojTimeline %}
 
-{% extends "../../../partials/layout.njk" %}
-
-{% block backLink %}
-  {{ govukBackLink({
-    text: "Back",
-    href: backLinkHref
-  }) }}
-{% endblock backLink %}
+{% extends "../partials/layout.njk" %}
 
 {% block content %}
+  {{ super() }}
+
   <div class="govuk-grid-row">
     <div class="govuk-grid-column-two-thirds">
-      {% if errors.list | length %}
-        {{ govukErrorSummary({
-          titleText: "There is a problem",
-          errorList: errors.list
-        }) }}
-      {% endif %}
-
-      <h1 class="govuk-heading-l">{{ pageHeading }}</h1>
-
-      <p>If you withdraw the referral, it will be closed.</p>
-
-      <h2 class="govuk-heading-m">Current status</h2>
-
-      {{ mojTimeline({
-        items: timelineItems,
-        attributes: {
-          "data-testid": "status-history-timeline"
-        }
-      }) }}
-
-      <hr class="govuk-section-break govuk-section-break--xl govuk-section-break--visible">
-
       <form method="post">
         <input type="hidden" name="_csrf" value="{{ csrfToken }}"/>
 

--- a/server/views/referrals/withdraw/partials/layout.njk
+++ b/server/views/referrals/withdraw/partials/layout.njk
@@ -1,0 +1,42 @@
+{% from "govuk/components/back-link/macro.njk" import govukBackLink %}
+{% from "govuk/components/button/macro.njk" import govukButton %}
+{% from "govuk/components/error-summary/macro.njk" import govukErrorSummary %}
+{% from "moj/components/timeline/macro.njk" import mojTimeline %}
+
+{% extends "../../../partials/layout.njk" %}
+
+{% block backLink %}
+  {{ govukBackLink({
+    text: "Back",
+    href: backLinkHref
+  }) }}
+{% endblock backLink %}
+
+{% block content %}
+  <div class="govuk-grid-row">
+    <div class="govuk-grid-column-two-thirds">
+      {% if errors.list | length %}
+        {{ govukErrorSummary({
+          titleText: "There is a problem",
+          errorList: errors.list
+        }) }}
+      {% endif %}
+
+      <h1 class="govuk-heading-l">{{ pageHeading }}</h1>
+
+      <p>If you withdraw the referral, it will be closed.</p>
+
+      <h2 class="govuk-heading-m">Current status</h2>
+
+      {{ mojTimeline({
+        items: timelineItems,
+        attributes: {
+          "data-testid": "status-history-timeline"
+        },
+        classes: "govuk-!-margin-bottom-0"
+      }) }}
+    </div>
+  </div>
+
+  <hr class="govuk-section-break govuk-section-break--xl govuk-section-break--visible">
+{% endblock content %}

--- a/server/views/referrals/withdraw/reason-information/show.njk
+++ b/server/views/referrals/withdraw/reason-information/show.njk
@@ -1,48 +1,14 @@
-{% from "govuk/components/back-link/macro.njk" import govukBackLink %}
 {% from "govuk/components/button/macro.njk" import govukButton %}
 {% from "govuk/components/character-count/macro.njk" import govukCharacterCount %}
-{% from "govuk/components/error-summary/macro.njk" import govukErrorSummary %}
 {% from "govuk/components/warning-text/macro.njk" import govukWarningText %}
-{% from "moj/components/timeline/macro.njk" import mojTimeline %}
 
-{% extends "../../../partials/layout.njk" %}
-
-{% block backLink %}
-  {{ govukBackLink({
-    text: "Back",
-    href: backLinkHref
-  }) }}
-{% endblock backLink %}
+{% extends "../partials/layout.njk" %}
 
 {% block content %}
+  {{ super() }}
+
   <div class="govuk-grid-row">
     <div class="govuk-grid-column-two-thirds">
-      {% if errors.list | length %}
-        {{ govukErrorSummary({
-          titleText: "There is a problem",
-          errorList: errors.list
-        }) }}
-      {% endif %}
-
-      <h1 class="govuk-heading-l">{{ pageHeading }}</h1>
-
-      <p>If you withdraw the referral, it will be closed.</p>
-
-      <h2 class="govuk-heading-m">Current status</h2>
-
-      {{ mojTimeline({
-        items: timelineItems,
-        attributes: {
-          "data-testid": "status-history-timeline"
-        }
-      }) }}
-
-      <hr class="govuk-section-break govuk-section-break--xl govuk-section-break--visible">
-
-      <h2 class="govuk-heading-m">Give a reason</h2>
-
-      <p>Provide more information about the reason for withdrawing this referral.</p>
-
       <form method="post">
         <input type="hidden" name="_csrf" value="{{ csrfToken }}"/>
 
@@ -68,7 +34,7 @@
             text: "Submit"
           }) }}
 
-          <a class="govuk-link" href={{ cancelLink }}>Cancel</a>
+          <a href={{ cancelLink }}>Cancel</a>
         </div>
       </form>
     </div>

--- a/server/views/referrals/withdraw/reason/show.njk
+++ b/server/views/referrals/withdraw/reason/show.njk
@@ -1,43 +1,13 @@
-{% from "govuk/components/back-link/macro.njk" import govukBackLink %}
 {% from "govuk/components/button/macro.njk" import govukButton %}
-{% from "govuk/components/error-summary/macro.njk" import govukErrorSummary %}
 {% from "govuk/components/radios/macro.njk" import govukRadios %}
-{% from "moj/components/timeline/macro.njk" import mojTimeline %}
 
-{% extends "../../../partials/layout.njk" %}
-
-{% block backLink %}
-  {{ govukBackLink({
-    text: "Back",
-    href: backLinkHref
-  }) }}
-{% endblock backLink %}
+{% extends "../partials/layout.njk" %}
 
 {% block content %}
+  {{ super() }}
+
   <div class="govuk-grid-row">
     <div class="govuk-grid-column-two-thirds">
-      {% if errors.list | length %}
-        {{ govukErrorSummary({
-          titleText: "There is a problem",
-          errorList: errors.list
-        }) }}
-      {% endif %}
-
-      <h1 class="govuk-heading-l">{{ pageHeading }}</h1>
-
-      <p>If you withdraw the referral, it will be closed.</p>
-
-      <h2 class="govuk-heading-m">Current status</h2>
-
-      {{ mojTimeline({
-        items: timelineItems,
-        attributes: {
-          "data-testid": "status-history-timeline"
-        }
-      }) }}
-
-      <hr class="govuk-section-break govuk-section-break--xl govuk-section-break--visible">
-
       <form method="post">
         <input type="hidden" name="_csrf" value="{{ csrfToken }}"/>
 
@@ -61,7 +31,7 @@
             text: "Continue"
           }) }}
 
-          <a class="govuk-link" href={{ cancelLink }}>Cancel</a>
+          <a href={{ cancelLink }}>Cancel</a>
         </div>
       </form>
     </div>


### PR DESCRIPTION
## Context

The 3 withdrawal related pages share a similar layout and content.


## Changes in this PR
- Created a layout for the withdraw pages which contains the back link, page heading, time line and divider.
- Apply the layout to the category, reason and reason information form pages.

This may further be extended/changed/removed in future as we add more status update journeys.


## Release checklist

[Release process documentation](../doc/how-to/perform-a-release.md)

As part of our continuous deployment strategy we must ensure that this work is
ready to be released once merged.

### Pre-merge

- [ ] There are changes required to the Accredited Programmes API for this change to work...
  - [ ] ... and they have been released to production already

### Post-merge

<!-- The outer checkboxes can be completed pre-merge -->

- [ ] This adds, extends or meaningfully modifies a feature...
  - [ ] ... and I have written or updated an end-to-end test for the happy path in the [Accredited Programmes E2E repo](https://github.com/ministryofjustice/hmpps-accredited-programmes-e2e)
- [ ] This makes new expectations of the API...
  - [ ] ... and I have notified the API developer(s) of changes to the contract tests (Pact), or the API is already compliant
- [ ] [Manually approve](../doc/how-to/perform-a-release.md#releasing-to-the-preprod-environment) release to preprod
- [ ] [Manually approve](../doc/how-to/perform-a-release.md#releasing-to-the-production-environment) release to prod

<!-- Should a release fail at any step, you as the author should now lead the work to
fix it as soon as possible. You can monitor deployment failures in CircleCI
itself and application errors are found in
[Sentry](https://ministryofjustice.sentry.io/projects/hmpps-accredited-programmes-ui/?project=4505330122686464&referrer=sidebar&statsPeriod=24h). -->
