### PR TITLE
(1336 & 1337) Withdraw referral integration tests

### DIFF
--- a/cypress.config.ts
+++ b/cypress.config.ts
@@ -10,6 +10,7 @@ import oasys from './integration_tests/mockApis/oasys'
 import prisonApi from './integration_tests/mockApis/prison'
 import prisonRegisterApi from './integration_tests/mockApis/prisonRegister'
 import prisonerSearch from './integration_tests/mockApis/prisonerSearch'
+import referenceData from './integration_tests/mockApis/referenceData'
 import referrals from './integration_tests/mockApis/referrals'
 import tokenVerification from './integration_tests/mockApis/tokenVerification'
 import { resetStubs } from './wiremock'
@@ -43,6 +44,7 @@ export const defaultConfig: Cypress.ConfigOptions = {
         ...prisonApi,
         ...prisonRegisterApi,
         ...prisonerSearch,
+        ...referenceData,
         ...referrals,
         ...tokenVerification,
         log(message) {

--- a/integration_tests/e2e/refer/withdraw.cy.ts
+++ b/integration_tests/e2e/refer/withdraw.cy.ts
@@ -1,0 +1,160 @@
+import { ApplicationRoles } from '../../../server/middleware/roleBasedAccessMiddleware'
+import { referPaths } from '../../../server/paths'
+import {
+  referralFactory,
+  referralStatusCategoryFactory,
+  referralStatusHistoryFactory,
+  referralStatusReasonFactory,
+  userFactory,
+} from '../../../server/testutils/factories'
+import auth from '../../mockApis/auth'
+import Page from '../../pages/page'
+import { WithdrawCategoryPage, WithdrawReasonInformationPage, WithdrawReasonPage } from '../../pages/shared'
+import type { ReferralStatusHistoryPresenter } from '@accredited-programmes/ui'
+
+context('Withdraw referral', () => {
+  const anotherUser = userFactory.build({ name: 'Joshua Smith' })
+  const referral = referralFactory.submitted().build({ referrerUsername: auth.mockedUser.username })
+
+  const referralStatusCategories = referralStatusCategoryFactory.buildList(4, { referralStatusCode: 'WITHDRAWN' })
+  const referralStatusReasons = referralStatusReasonFactory.buildList(5)
+
+  const referralStatusHistory = [
+    referralStatusHistoryFactory.updated().build({ status: 'assessment_started', username: anotherUser.username }),
+    referralStatusHistoryFactory.submitted().build({ username: referral.referrerUsername }),
+  ]
+  const presentedStatusHistory: Array<ReferralStatusHistoryPresenter> = [
+    {
+      ...referralStatusHistory[0],
+      byLineText: anotherUser.name,
+    },
+    {
+      ...referralStatusHistory[1],
+      byLineText: 'You',
+    },
+  ]
+
+  const selectedCategory = referralStatusCategories[0].code
+  const selectedReason = referralStatusReasons[0].code
+  const reasonInformation = 'Some reason information'
+
+  beforeEach(() => {
+    cy.task('reset')
+    cy.task('stubSignIn', { authorities: [ApplicationRoles.ACP_REFERRER] })
+    cy.task('stubAuthUser')
+    cy.task('stubDefaultCaseloads')
+    cy.signIn()
+
+    cy.task('stubReferral', referral)
+    cy.task('stubUserDetails', anotherUser)
+    cy.task('stubStatusHistory', {
+      referralId: referral.id,
+      statusHistory: referralStatusHistory,
+    })
+    cy.task('stubReferalStatusCodeCategories', {
+      categories: referralStatusCategories,
+      referralStatus: 'WITHDRAWN',
+    })
+  })
+
+  describe('withdrawal category', () => {
+    const path = referPaths.withdraw.category({ referralId: referral.id })
+
+    it('shows the withdrawal category page', () => {
+      cy.visit(path)
+
+      const withdrawCategoryPage = Page.verifyOnPage(WithdrawCategoryPage)
+      withdrawCategoryPage.shouldContainCurrentStatusTimelineItem(presentedStatusHistory)
+      withdrawCategoryPage.shouldContainWithdrawalCategoryRadioItems(referralStatusCategories)
+    })
+
+    describe('when submitting without selecting a category', () => {
+      it('displays an error', () => {
+        cy.visit(path)
+
+        const withdrawCategoryPage = Page.verifyOnPage(WithdrawCategoryPage)
+        withdrawCategoryPage.shouldContainButton('Continue').click()
+        withdrawCategoryPage.shouldHaveErrors([
+          {
+            field: 'categoryCode',
+            message: 'Select a withdrawal category',
+          },
+        ])
+      })
+    })
+  })
+
+  describe('withdrawal reason', () => {
+    beforeEach(() => {
+      cy.visit(referPaths.withdraw.category({ referralId: referral.id }))
+
+      const withdrawCategoryPage = Page.verifyOnPage(WithdrawCategoryPage)
+      withdrawCategoryPage.selectWithdrawalCategoryAndSubmit(selectedCategory, referralStatusReasons)
+    })
+
+    it('shows the withdrawal reason page', () => {
+      const withdrawReasonPage = Page.verifyOnPage(WithdrawReasonPage)
+      withdrawReasonPage.shouldContainCurrentStatusTimelineItem(presentedStatusHistory)
+      withdrawReasonPage.shouldContainWithdrawalReasonRadioItems(referralStatusReasons)
+    })
+
+    describe('when submitting without selecting a reason', () => {
+      it('displays an error', () => {
+        const withdrawReasonPage = Page.verifyOnPage(WithdrawReasonPage)
+        withdrawReasonPage.shouldContainButton('Continue').click()
+        withdrawReasonPage.shouldHaveErrors([
+          {
+            field: 'reasonCode',
+            message: 'Select a withdrawal reason',
+          },
+        ])
+      })
+    })
+  })
+
+  describe('withdrawal reason information', () => {
+    beforeEach(() => {
+      cy.visit(referPaths.withdraw.category({ referralId: referral.id }))
+
+      const withdrawCategoryPage = Page.verifyOnPage(WithdrawCategoryPage)
+      withdrawCategoryPage.selectWithdrawalCategoryAndSubmit(selectedCategory, [])
+    })
+
+    it('shows the withdrawal reason information page', () => {
+      const withdrawReasonInformationPage = Page.verifyOnPage(WithdrawReasonInformationPage)
+      withdrawReasonInformationPage.shouldContainCurrentStatusTimelineItem(presentedStatusHistory)
+    })
+
+    describe('when submitting without entering reason information', () => {
+      it('displays an error', () => {
+        const withdrawReasonInformationPage = Page.verifyOnPage(WithdrawReasonInformationPage)
+        withdrawReasonInformationPage.shouldContainButton('Submit').click()
+        withdrawReasonInformationPage.shouldHaveErrors([
+          {
+            field: 'reasonInformation',
+            message: 'Enter withdrawal reason information',
+          },
+        ])
+      })
+    })
+  })
+
+  describe('when completing all the steps', () => {
+    it('navigates through each step and redirects to the status history page', () => {
+      cy.task('stubUpdateReferralStatus', referral.id)
+
+      cy.visit(referPaths.withdraw.category({ referralId: referral.id }))
+
+      const withdrawCategoryPage = Page.verifyOnPage(WithdrawCategoryPage)
+      withdrawCategoryPage.selectWithdrawalCategoryAndSubmit(selectedCategory, referralStatusReasons)
+
+      const withdrawReasonPage = Page.verifyOnPage(WithdrawReasonPage)
+      withdrawReasonPage.selectWithdrawalReasonAndSubmit(selectedReason)
+
+      const withdrawReasonInformationPage = Page.verifyOnPage(WithdrawReasonInformationPage)
+      withdrawReasonInformationPage.enterWithdrawalReasonInformationAndSubmit(reasonInformation)
+
+      cy.location('pathname').should('equal', referPaths.show.statusHistory({ referralId: referral.id }))
+    })
+  })
+})

--- a/integration_tests/mockApis/referenceData.ts
+++ b/integration_tests/mockApis/referenceData.ts
@@ -1,0 +1,47 @@
+import type { SuperAgentRequest } from 'superagent'
+
+import { apiPaths } from '../../server/paths'
+import { stubFor } from '../../wiremock'
+import type {
+  ReferralStatusCategory,
+  ReferralStatusReason,
+  ReferralStatusUppercase,
+} from '@accredited-programmes/models'
+
+export default {
+  stubReferalStatusCodeCategories: (args: {
+    categories: Array<ReferralStatusCategory>
+    referralStatus: ReferralStatusUppercase
+  }): SuperAgentRequest =>
+    stubFor({
+      request: {
+        method: 'GET',
+        url: apiPaths.referenceData.referralStatuses.statusCodeCategories({ referralStatusCode: args.referralStatus }),
+      },
+      response: {
+        headers: { 'Content-Type': 'application/json;charset=UTF-8' },
+        jsonBody: args.categories,
+        status: 200,
+      },
+    }),
+
+  stubReferralStatusCodeReasons: (args: {
+    reasons: Array<ReferralStatusReason>
+    referralStatus: ReferralStatusUppercase
+    referralStatusCategoryCode: ReferralStatusCategory['code']
+  }): SuperAgentRequest =>
+    stubFor({
+      request: {
+        method: 'GET',
+        url: apiPaths.referenceData.referralStatuses.statusCodeReasons({
+          categoryCode: args.referralStatusCategoryCode,
+          referralStatusCode: args.referralStatus,
+        }),
+      },
+      response: {
+        headers: { 'Content-Type': 'application/json;charset=UTF-8' },
+        jsonBody: args.reasons,
+        status: 200,
+      },
+    }),
+}

--- a/integration_tests/pages/page.ts
+++ b/integration_tests/pages/page.ts
@@ -20,6 +20,7 @@ import type {
   HasHtmlString,
   HasTextString,
   MojTimelineItem,
+  ReferralStatusHistoryPresenter,
 } from '@accredited-programmes/ui'
 import type {
   GovukFrontendRadiosItem,
@@ -121,6 +122,15 @@ export default abstract class Page {
       this.shouldContainSummaryListRows(
         ShowReferralUtils.courseOfferingSummaryListRows(course, organisationName),
         summaryListElement,
+      )
+    })
+  }
+
+  shouldContainCurrentStatusTimelineItem(statusHistoryPresenter: Array<ReferralStatusHistoryPresenter>) {
+    cy.get('[data-testid="status-history-timeline"]').then(timelineElement => {
+      this.shouldContainTimelineItems(
+        ShowReferralUtils.statusHistoryTimelineItems(statusHistoryPresenter).slice(0, 1),
+        timelineElement,
       )
     })
   }

--- a/integration_tests/pages/page.ts
+++ b/integration_tests/pages/page.ts
@@ -14,7 +14,6 @@ import type { Organisation, Person, Referral } from '@accredited-programmes/mode
 import type {
   CourseParticipationPresenter,
   CoursePresenter,
-  GovukFrontendRadiosItemWithLabel,
   GovukFrontendSummaryListCardActionsItemWithText,
   GovukFrontendSummaryListRowWithKeyAndValue,
   GovukFrontendTagWithText,
@@ -22,7 +21,11 @@ import type {
   HasTextString,
   MojTimelineItem,
 } from '@accredited-programmes/ui'
-import type { GovukFrontendSummaryListCardTitle, GovukFrontendWarningText } from '@govuk-frontend'
+import type {
+  GovukFrontendRadiosItem,
+  GovukFrontendSummaryListCardTitle,
+  GovukFrontendWarningText,
+} from '@govuk-frontend'
 import type { User } from '@manage-users-api'
 
 export type PageElement = Cypress.Chainable<JQuery>
@@ -275,13 +278,13 @@ export default abstract class Page {
     })
   }
 
-  shouldContainRadioItems(options: Array<GovukFrontendRadiosItemWithLabel>): void {
+  shouldContainRadioItems(options: Array<GovukFrontendRadiosItem>): void {
     options.forEach((option, optionIndex) => {
       cy.get('.govuk-radios__item')
         .eq(optionIndex)
         .within(() => {
           cy.get('.govuk-radios__label').then(radioButtonLabelElement => {
-            const { actual, expected } = Helpers.parseHtml(radioButtonLabelElement, option.label)
+            const { actual, expected } = Helpers.parseHtml(radioButtonLabelElement, option.text as string)
             expect(actual).to.equal(expected)
           })
           cy.get('.govuk-radios__input').should('have.attr', 'value', option.value)

--- a/integration_tests/pages/refer/new/programmeHistoryDetails.ts
+++ b/integration_tests/pages/refer/new/programmeHistoryDetails.ts
@@ -54,8 +54,8 @@ export default class NewReferralProgrammeHistoryDetailsPage extends Page {
   shouldContainOutcomeRadioItems() {
     cy.get('[data-testid="outcome-options"]').within(() => {
       this.shouldContainRadioItems([
-        { label: 'Complete', value: 'complete' },
-        { label: 'Incomplete', value: 'incomplete' },
+        { text: 'Complete', value: 'complete' },
+        { text: 'Incomplete', value: 'incomplete' },
       ])
     })
   }
@@ -63,8 +63,8 @@ export default class NewReferralProgrammeHistoryDetailsPage extends Page {
   shouldContainSettingRadioItems() {
     cy.get('[data-testid="setting-options"]').within(() => {
       this.shouldContainRadioItems([
-        { label: 'Community', value: 'community' },
-        { label: 'Custody', value: 'custody' },
+        { text: 'Community', value: 'community' },
+        { text: 'Custody', value: 'custody' },
       ])
     })
   }

--- a/integration_tests/pages/refer/new/selectProgramme.ts
+++ b/integration_tests/pages/refer/new/selectProgramme.ts
@@ -19,8 +19,8 @@ export default class NewReferralSelectProgrammePage extends Page {
 
   shouldContainCourseOptions() {
     this.shouldContainRadioItems([
-      ...this.courses.map(course => ({ label: course.name, value: course.name })),
-      { label: 'Other', value: 'Other' },
+      ...this.courses.map(course => ({ text: course.name, value: course.name })),
+      { text: 'Other', value: 'Other' },
     ])
   }
 

--- a/integration_tests/pages/shared/index.ts
+++ b/integration_tests/pages/shared/index.ts
@@ -15,6 +15,9 @@ import RoshAnalysisPage from './showReferral/risksAndNeeds/roshAnalysis'
 import ThinkingAndBehavingPage from './showReferral/risksAndNeeds/thinkingAndBehaving'
 import SentenceInformationPage from './showReferral/sentenceInformation'
 import StatusHistoryPage from './showReferral/statusHistory'
+import WithdrawCategoryPage from './withdraw/category'
+import WithdrawReasonPage from './withdraw/reason'
+import WithdrawReasonInformationPage from './withdraw/reasonInformation'
 
 export {
   AdditionalInformationPage,
@@ -34,4 +37,7 @@ export {
   SentenceInformationPage,
   StatusHistoryPage,
   ThinkingAndBehavingPage,
+  WithdrawCategoryPage,
+  WithdrawReasonInformationPage,
+  WithdrawReasonPage,
 }

--- a/integration_tests/pages/shared/withdraw/category.ts
+++ b/integration_tests/pages/shared/withdraw/category.ts
@@ -1,0 +1,25 @@
+import { ReferralUtils } from '../../../../server/utils'
+import Page from '../../page'
+import type { ReferralStatusCategory, ReferralStatusReason } from '@accredited-programmes/models'
+
+export default class WithdrawCategoryPage extends Page {
+  constructor() {
+    super('Withdrawal category')
+  }
+
+  selectWithdrawalCategoryAndSubmit(value: ReferralStatusCategory['code'], reasons: Array<ReferralStatusReason>) {
+    cy.task('stubReferralStatusCodeReasons', {
+      reasons,
+      referralStatus: 'WITHDRAWN',
+      referralStatusCategoryCode: value,
+    })
+    this.selectRadioButton('categoryCode', value)
+    this.shouldContainButton('Continue').click()
+  }
+
+  shouldContainWithdrawalCategoryRadioItems(referralStatusCategories: Array<ReferralStatusCategory>) {
+    cy.get('[data-testid="withdraw-category-options"]').within(() => {
+      this.shouldContainRadioItems(ReferralUtils.statusOptionsToRadioItems(referralStatusCategories))
+    })
+  }
+}

--- a/integration_tests/pages/shared/withdraw/reason.ts
+++ b/integration_tests/pages/shared/withdraw/reason.ts
@@ -1,0 +1,20 @@
+import { ReferralUtils } from '../../../../server/utils'
+import Page from '../../page'
+import type { ReferralStatusReason } from '@accredited-programmes/models'
+
+export default class WithdrawReasonPage extends Page {
+  constructor() {
+    super('Withdrawal reason')
+  }
+
+  selectWithdrawalReasonAndSubmit(value: ReferralStatusReason['code']) {
+    this.selectRadioButton('reasonCode', value)
+    this.shouldContainButton('Continue').click()
+  }
+
+  shouldContainWithdrawalReasonRadioItems(referralStatusReasons: Array<ReferralStatusReason>) {
+    cy.get('[data-testid="withdraw-reason-options"]').within(() => {
+      this.shouldContainRadioItems(ReferralUtils.statusOptionsToRadioItems(referralStatusReasons))
+    })
+  }
+}

--- a/integration_tests/pages/shared/withdraw/reasonInformation.ts
+++ b/integration_tests/pages/shared/withdraw/reasonInformation.ts
@@ -1,0 +1,12 @@
+import Page from '../../page'
+
+export default class WithdrawReasonInformationPage extends Page {
+  constructor() {
+    super('Withdraw referral')
+  }
+
+  enterWithdrawalReasonInformationAndSubmit(value: string) {
+    cy.get('textarea[id="reasonInformation"]').type(value)
+    this.shouldContainButton('Submit').click()
+  }
+}

--- a/server/@types/ui/index.d.ts
+++ b/server/@types/ui/index.d.ts
@@ -12,7 +12,6 @@ import type {
   GovukFrontendButton,
   GovukFrontendPagination,
   GovukFrontendPaginationItem,
-  GovukFrontendRadiosItem,
   GovukFrontendSummaryList,
   GovukFrontendSummaryListCardActions,
   GovukFrontendSummaryListCardActionsItem,
@@ -22,8 +21,6 @@ import type {
   GovukFrontendTag,
 } from '@govuk-frontend'
 import type { OffenceDto, OffenceHistoryDetail } from '@prison-api'
-
-type GovukFrontendRadiosItemWithLabel = GovukFrontendRadiosItem & { label: string }
 
 type GovukFrontendSummaryListCardActionsItemWithText = GovukFrontendSummaryListCardActionsItem & { text: string }
 
@@ -235,7 +232,6 @@ export type {
   CourseParticipationPresenter,
   CoursePresenter,
   GovukFrontendPaginationWithItems,
-  GovukFrontendRadiosItemWithLabel,
   GovukFrontendSummaryListCardActionsItemWithText,
   GovukFrontendSummaryListCardActionsWithItems,
   GovukFrontendSummaryListRowWithKeyAndValue,


### PR DESCRIPTION
## Context

Integration tests required for withdraw pages.


## Changes in this PR
- Added mock apis for reference-data endpoints
- Add pages and integration test for withdraw referral journey.




## Release checklist

[Release process documentation](../doc/how-to/perform-a-release.md)

As part of our continuous deployment strategy we must ensure that this work is
ready to be released once merged.

### Pre-merge

- [ ] There are changes required to the Accredited Programmes API for this change to work...
  - [ ] ... and they have been released to production already

### Post-merge

<!-- The outer checkboxes can be completed pre-merge -->

- [ ] This adds, extends or meaningfully modifies a feature...
  - [ ] ... and I have written or updated an end-to-end test for the happy path in the [Accredited Programmes E2E repo](https://github.com/ministryofjustice/hmpps-accredited-programmes-e2e)
- [ ] This makes new expectations of the API...
  - [ ] ... and I have notified the API developer(s) of changes to the contract tests (Pact), or the API is already compliant
- [ ] [Manually approve](../doc/how-to/perform-a-release.md#releasing-to-the-preprod-environment) release to preprod
- [ ] [Manually approve](../doc/how-to/perform-a-release.md#releasing-to-the-production-environment) release to prod

<!-- Should a release fail at any step, you as the author should now lead the work to
fix it as soon as possible. You can monitor deployment failures in CircleCI
itself and application errors are found in
[Sentry](https://ministryofjustice.sentry.io/projects/hmpps-accredited-programmes-ui/?project=4505330122686464&referrer=sidebar&statsPeriod=24h). -->
