### PR TITLE
Add `previousPath` to Referral update status journey session data

### DIFF
--- a/integration_tests/e2e/refer/withdraw.cy.ts
+++ b/integration_tests/e2e/refer/withdraw.cy.ts
@@ -64,6 +64,7 @@ context('Withdraw referral', () => {
       cy.visit(path)
 
       const withdrawCategoryPage = Page.verifyOnPage(WithdrawCategoryPage)
+      withdrawCategoryPage.shouldContainBackLink(referPaths.show.statusHistory({ referralId: referral.id }))
       withdrawCategoryPage.shouldContainCurrentStatusTimelineItem(presentedStatusHistory)
       withdrawCategoryPage.shouldContainWithdrawalCategoryRadioItems(referralStatusCategories)
     })
@@ -94,6 +95,7 @@ context('Withdraw referral', () => {
 
     it('shows the withdrawal reason page', () => {
       const withdrawReasonPage = Page.verifyOnPage(WithdrawReasonPage)
+      withdrawReasonPage.shouldContainBackLink(referPaths.withdraw.category({ referralId: referral.id }))
       withdrawReasonPage.shouldContainCurrentStatusTimelineItem(presentedStatusHistory)
       withdrawReasonPage.shouldContainWithdrawalReasonRadioItems(referralStatusReasons)
     })
@@ -122,6 +124,7 @@ context('Withdraw referral', () => {
 
     it('shows the withdrawal reason information page', () => {
       const withdrawReasonInformationPage = Page.verifyOnPage(WithdrawReasonInformationPage)
+      withdrawReasonInformationPage.shouldContainBackLink(referPaths.withdraw.category({ referralId: referral.id }))
       withdrawReasonInformationPage.shouldContainCurrentStatusTimelineItem(presentedStatusHistory)
     })
 
@@ -146,12 +149,15 @@ context('Withdraw referral', () => {
       cy.visit(referPaths.withdraw.category({ referralId: referral.id }))
 
       const withdrawCategoryPage = Page.verifyOnPage(WithdrawCategoryPage)
+      withdrawCategoryPage.shouldContainBackLink(referPaths.show.statusHistory({ referralId: referral.id }))
       withdrawCategoryPage.selectWithdrawalCategoryAndSubmit(selectedCategory, referralStatusReasons)
 
       const withdrawReasonPage = Page.verifyOnPage(WithdrawReasonPage)
+      withdrawReasonPage.shouldContainBackLink(referPaths.withdraw.category({ referralId: referral.id }))
       withdrawReasonPage.selectWithdrawalReasonAndSubmit(selectedReason)
 
       const withdrawReasonInformationPage = Page.verifyOnPage(WithdrawReasonInformationPage)
+      withdrawReasonInformationPage.shouldContainBackLink(referPaths.withdraw.reason({ referralId: referral.id }))
       withdrawReasonInformationPage.enterWithdrawalReasonInformationAndSubmit(reasonInformation)
 
       cy.location('pathname').should('equal', referPaths.show.statusHistory({ referralId: referral.id }))

--- a/server/@types/express/index.d.ts
+++ b/server/@types/express/index.d.ts
@@ -45,6 +45,7 @@ type RequestWithUser = Express.RequestWithUser
 interface ReferralStatusUpdateSessionData {
   referralId: string
   status: ReferralStatus | ReferralStatusUppercase
+  previousPath?: string
   statusCategoryCode?: Uppercase<string>
   statusReasonCode?: Uppercase<string>
 }

--- a/server/controllers/shared/updateStatusDecisionController.test.ts
+++ b/server/controllers/shared/updateStatusDecisionController.test.ts
@@ -155,6 +155,7 @@ describe('UpdateStatusDecisionController', () => {
       await requestHandler(request, response, next)
 
       expect(request.session.referralStatusUpdateData).toEqual({
+        previousPath: request.path,
         referralId: referral.id,
         status: 'NOT_SUITABLE',
       })
@@ -169,6 +170,7 @@ describe('UpdateStatusDecisionController', () => {
         await requestHandler(request, response, next)
 
         expect(request.session.referralStatusUpdateData).toEqual({
+          previousPath: request.path,
           referralId: referral.id,
           status: 'NOT_SUITABLE',
         })
@@ -196,6 +198,7 @@ describe('UpdateStatusDecisionController', () => {
         await requestHandler(request, response, next)
 
         expect(request.session.referralStatusUpdateData).toEqual({
+          previousPath: request.path,
           referralId: referral.id,
           status: 'WITHDRAWN',
         })

--- a/server/controllers/shared/updateStatusDecisionController.ts
+++ b/server/controllers/shared/updateStatusDecisionController.ts
@@ -57,6 +57,7 @@ export default class UpdateStatusDecisionController {
       }
 
       req.session.referralStatusUpdateData = {
+        previousPath: req.path,
         referralId,
         status: statusDecision,
       }

--- a/server/controllers/shared/withdrawCategoryController.test.ts
+++ b/server/controllers/shared/withdrawCategoryController.test.ts
@@ -112,6 +112,26 @@ describe('WithdrawCategoryController', () => {
       })
     })
 
+    describe('when `referralStatusUpdateData` has `previousPath`', () => {
+      it('should render the show template with the correct `backLinkHref` value', async () => {
+        request.session.referralStatusUpdateData = {
+          previousPath: '/previous-path',
+          referralId: referral.id,
+          status: 'WITHDRAWN',
+        }
+
+        const requestHandler = controller.show()
+        await requestHandler(request, response, next)
+
+        expect(response.render).toHaveBeenCalledWith(
+          'referrals/withdraw/category/show',
+          expect.objectContaining({
+            backLinkHref: '/previous-path',
+          }),
+        )
+      })
+    })
+
     describe('when `referralStatusUpdateData` is for the same referral', () => {
       it('should keep `referralStatusUpdateData` in the session and make the call to check the correct radio item', async () => {
         const session: ReferralStatusUpdateSessionData = {
@@ -176,6 +196,7 @@ describe('WithdrawCategoryController', () => {
       await requestHandler(request, response, next)
 
       expect(request.session.referralStatusUpdateData).toEqual({
+        previousPath: request.path,
         referralId: referral.id,
         status: 'WITHDRAWN',
         statusCategoryCode: 'STATUS-CAT-A',
@@ -192,6 +213,7 @@ describe('WithdrawCategoryController', () => {
         await requestHandler(request, response, next)
 
         expect(request.session.referralStatusUpdateData).toEqual({
+          previousPath: request.path,
           referralId: referral.id,
           status: 'WITHDRAWN',
           statusCategoryCode: 'STATUS-CAT-A',

--- a/server/controllers/shared/withdrawCategoryController.ts
+++ b/server/controllers/shared/withdrawCategoryController.ts
@@ -38,7 +38,7 @@ export default class WithdrawCategoryController {
       FormUtils.setFieldErrors(req, res, ['categoryCode'])
 
       return res.render('referrals/withdraw/category/show', {
-        backLinkHref: paths.show.statusHistory({ referralId }),
+        backLinkHref: referralStatusUpdateData?.previousPath || paths.show.statusHistory({ referralId }),
         pageHeading: 'Withdrawal category',
         radioItems,
         timelineItems: ShowReferralUtils.statusHistoryTimelineItems(statusHistory).slice(0, 1),
@@ -60,6 +60,7 @@ export default class WithdrawCategoryController {
       }
 
       req.session.referralStatusUpdateData = {
+        previousPath: req.path,
         referralId,
         status: withdrawnStatus,
         statusCategoryCode: categoryCode,

--- a/server/controllers/shared/withdrawReasonController.test.ts
+++ b/server/controllers/shared/withdrawReasonController.test.ts
@@ -3,6 +3,7 @@ import { createMock } from '@golevelup/ts-jest'
 import type { NextFunction, Request, Response } from 'express'
 
 import WithdrawReasonController from './withdrawReasonController'
+import type { ReferralStatusUpdateSessionData } from '../../@types/express'
 import { assessPaths, referPaths } from '../../paths'
 import type { ReferenceDataService, ReferralService } from '../../services'
 import { referralFactory, referralStatusHistoryFactory, referralStatusReasonFactory } from '../../testutils/factories'
@@ -202,7 +203,15 @@ describe('WithdrawReasonController', () => {
   })
 
   describe('submit', () => {
+    let referralStatusUpdateSessionData: ReferralStatusUpdateSessionData
+
     beforeEach(() => {
+      referralStatusUpdateSessionData = {
+        referralId: referral.id,
+        status: 'WITHDRAWN',
+        statusCategoryCode: 'STATUS-CAT-A',
+        statusReasonCode: undefined,
+      }
       request.body = { reasonCode: 'STATUS-REASON-A' }
       request.session.referralStatusUpdateData = {
         referralId: referral.id,
@@ -217,7 +226,8 @@ describe('WithdrawReasonController', () => {
       await requestHandler(request, response, next)
 
       expect(request.session.referralStatusUpdateData).toEqual({
-        ...request.session.referralStatusUpdateData,
+        ...referralStatusUpdateSessionData,
+        previousPath: request.path,
         statusReasonCode: 'STATUS-REASON-A',
       })
       expect(response.redirect).toHaveBeenCalledWith(referPaths.withdraw.reasonInformation({ referralId: referral.id }))
@@ -231,7 +241,8 @@ describe('WithdrawReasonController', () => {
         await requestHandler(request, response, next)
 
         expect(request.session.referralStatusUpdateData).toEqual({
-          ...request.session.referralStatusUpdateData,
+          ...referralStatusUpdateSessionData,
+          previousPath: request.path,
           statusReasonCode: 'STATUS-REASON-A',
         })
         expect(response.redirect).toHaveBeenCalledWith(

--- a/server/controllers/shared/withdrawReasonController.ts
+++ b/server/controllers/shared/withdrawReasonController.ts
@@ -77,7 +77,11 @@ export default class WithdrawReasonController {
         return res.redirect(paths.withdraw.reason({ referralId }))
       }
 
-      referralStatusUpdateData.statusReasonCode = reasonCode
+      req.session.referralStatusUpdateData = {
+        ...referralStatusUpdateData,
+        previousPath: req.path,
+        statusReasonCode: reasonCode,
+      }
 
       return res.redirect(paths.withdraw.reasonInformation({ referralId }))
     }

--- a/server/controllers/shared/withdrawReasonInformationController.test.ts
+++ b/server/controllers/shared/withdrawReasonInformationController.test.ts
@@ -60,6 +60,7 @@ describe('WithdrawReasonInformationController', () => {
       path: referPaths.withdraw.reasonInformation({ referralId: referral.id }),
       session: {
         referralStatusUpdateData: {
+          previousPath: '/previous-path',
           referralId: referral.id,
           status: 'WITHDRAWN',
           statusCategoryCode: 'STATUS-CAT-A',
@@ -77,7 +78,7 @@ describe('WithdrawReasonInformationController', () => {
       await requestHandler(request, response, next)
 
       expect(response.render).toHaveBeenCalledWith('referrals/withdraw/reason-information/show', {
-        backLinkHref: referPaths.withdraw.reason({ referralId: referral.id }),
+        backLinkHref: '/previous-path',
         cancelLink: referPaths.show.statusHistory({ referralId: referral.id }),
         maxLength: 100,
         pageHeading: 'Withdraw referral',
@@ -100,7 +101,7 @@ describe('WithdrawReasonInformationController', () => {
         expect(response.render).toHaveBeenCalledWith(
           'referrals/withdraw/reason-information/show',
           expect.objectContaining({
-            backLinkHref: assessPaths.withdraw.reason({ referralId: referral.id }),
+            backLinkHref: '/previous-path',
             cancelLink: assessPaths.show.statusHistory({ referralId: referral.id }),
           }),
         )

--- a/server/controllers/shared/withdrawReasonInformationController.ts
+++ b/server/controllers/shared/withdrawReasonInformationController.ts
@@ -34,7 +34,7 @@ export default class WithdrawReasonInformationController {
       FormUtils.setFormValues(req, res)
 
       return res.render('referrals/withdraw/reason-information/show', {
-        backLinkHref: paths.withdraw.reason({ referralId }),
+        backLinkHref: referralStatusUpdateData.previousPath,
         cancelLink: paths.show.statusHistory({ referralId }),
         maxLength,
         pageHeading: 'Withdraw referral',


### PR DESCRIPTION
## Context

The withdraw journey can be started from both the status history page and the update status journey, so the withdraw category page needs to know where to go Back to.
    
The reason information page also needs to have a flexible back link as it can be redirected to from both the category and reason steps, depending on your initial category selection.

## Changes in this PR
- Add `previousPath` to session object so we can update the value when submitting forms and then use it where we need it.



## Release checklist

[Release process documentation](../doc/how-to/perform-a-release.md)

As part of our continuous deployment strategy we must ensure that this work is
ready to be released once merged.

### Pre-merge

- [ ] There are changes required to the Accredited Programmes API for this change to work...
  - [ ] ... and they have been released to production already

### Post-merge

<!-- The outer checkboxes can be completed pre-merge -->

- [ ] This adds, extends or meaningfully modifies a feature...
  - [ ] ... and I have written or updated an end-to-end test for the happy path in the [Accredited Programmes E2E repo](https://github.com/ministryofjustice/hmpps-accredited-programmes-e2e)
- [ ] This makes new expectations of the API...
  - [ ] ... and I have notified the API developer(s) of changes to the contract tests (Pact), or the API is already compliant
- [ ] [Manually approve](../doc/how-to/perform-a-release.md#releasing-to-the-preprod-environment) release to preprod
- [ ] [Manually approve](../doc/how-to/perform-a-release.md#releasing-to-the-production-environment) release to prod

<!-- Should a release fail at any step, you as the author should now lead the work to
fix it as soon as possible. You can monitor deployment failures in CircleCI
itself and application errors are found in
[Sentry](https://ministryofjustice.sentry.io/projects/hmpps-accredited-programmes-ui/?project=4505330122686464&referrer=sidebar&statsPeriod=24h). -->
