### PR TITLE
(1364b) Hint text on Select decision radio buttons

### DIFF
--- a/server/@types/models/Referral.ts
+++ b/server/@types/models/Referral.ts
@@ -88,7 +88,11 @@ type ReferralStatusRefData = {
   colour: TagColour
   description: string
   closed?: boolean
+  confirmationText?: string
   draft?: boolean
+  hasConfirmation?: boolean
+  hasNotes?: boolean
+  hintText?: string
 }
 
 type ReferralView = {

--- a/server/controllers/shared/updateStatusDecisionController.ts
+++ b/server/controllers/shared/updateStatusDecisionController.ts
@@ -22,13 +22,13 @@ export default class UpdateStatusDecisionController {
         delete req.session.referralStatusUpdateData
       }
 
-      const [statusHistory, statusTranisitions] = await Promise.all([
+      const [statusHistory, statusTransitions] = await Promise.all([
         this.referralService.getReferralStatusHistory(userToken, username, referralId),
         this.referralService.getStatusTransitions(username, referralId, { ptUser: isAssess }),
       ])
 
       const radioItems = ReferralUtils.statusOptionsToRadioItems(
-        statusTranisitions,
+        statusTransitions,
         req.session.referralStatusUpdateData?.status,
       )
 

--- a/server/testutils/factories/referralStatusRefData.ts
+++ b/server/testutils/factories/referralStatusRefData.ts
@@ -3,18 +3,29 @@ import { Factory } from 'fishery'
 
 import { statusDescriptionAndColour } from './referral'
 import { referralStatuses } from '../../@types/models/Referral'
-import type { ReferralStatusRefData, ReferralStatusUppercase } from '@accredited-programmes/models'
+import type { ReferralStatus, ReferralStatusRefData } from '@accredited-programmes/models'
 import type { TagColour } from '@accredited-programmes/ui'
 
-export default Factory.define<ReferralStatusRefData>(() => {
-  const code = faker.helpers.arrayElement(referralStatuses)
-  const { statusColour: colour, statusDescription: description } = statusDescriptionAndColour(code)
+export default Factory.define<ReferralStatusRefData>(({ params }) => {
+  const { hasConfirmation: hasConfirmationParam, hasNotes: hasNotesParam } = params
+
+  const code = faker.helpers.arrayElement(referralStatuses).toUpperCase() as ReferralStatus
+  const { statusColour, statusDescription } = statusDescriptionAndColour(code)
+  const colour = statusColour as TagColour
+  const description = statusDescription as string
+
+  const hasConfirmation = hasNotesParam ? false : hasConfirmationParam || faker.datatype.boolean()
+  const confirmationText = hasConfirmation ? faker.lorem.sentence() : undefined
+  const hasNotes = !hasConfirmation
 
   return {
     closed: faker.datatype.boolean(),
-    code: code.toUpperCase() as ReferralStatusUppercase,
-    colour: colour as TagColour,
-    description: description as string,
+    code,
+    colour,
+    confirmationText,
+    description,
     draft: faker.datatype.boolean(),
+    hasConfirmation,
+    hasNotes,
   }
 })

--- a/server/utils/referrals/referralUtils.test.ts
+++ b/server/utils/referrals/referralUtils.test.ts
@@ -1,4 +1,5 @@
 import ReferralUtils from './referralUtils'
+import { referralStatusRefDataFactory } from '../../testutils/factories'
 import type { ReferralStatusCategory } from '@accredited-programmes/models'
 
 describe('ReferralUtils', () => {
@@ -39,6 +40,26 @@ describe('ReferralUtils', () => {
           { checked: false, text: 'Category B', value: 'B' },
           { divider: 'or', value: '' },
           { checked: false, text: 'Other', value: 'OTHER' },
+        ])
+      })
+    })
+
+    describe('when the provided array includes an option with a `hintText`', () => {
+      it('should include a hint for the corresponding radio item', () => {
+        const hintText = 'Some hint text'
+        const referralStatusTransitions = [
+          referralStatusRefDataFactory.build(),
+          referralStatusRefDataFactory.build({ hintText }),
+        ]
+
+        expect(ReferralUtils.statusOptionsToRadioItems(referralStatusTransitions)).toEqual([
+          { checked: false, text: referralStatusTransitions[0].description, value: referralStatusTransitions[0].code },
+          {
+            checked: false,
+            hint: { text: hintText },
+            text: referralStatusTransitions[1].description,
+            value: referralStatusTransitions[1].code,
+          },
         ])
       })
     })

--- a/server/utils/referrals/referralUtils.ts
+++ b/server/utils/referrals/referralUtils.ts
@@ -1,7 +1,7 @@
 import type { GovukFrontendRadiosItem } from '@govuk-frontend'
 
 export default class ReferralUtils {
-  static statusOptionsToRadioItems<T extends { code: string; description: string }>(
+  static statusOptionsToRadioItems<T extends { code: string; description: string; hintText?: string }>(
     items: Array<T>,
     selectedItemCode?: string,
   ): Array<GovukFrontendRadiosItem> {
@@ -12,6 +12,13 @@ export default class ReferralUtils {
 
       acc.push({
         checked: selectedItemCode === item.code,
+        ...(item.hintText
+          ? {
+              hint: {
+                text: item.hintText,
+              },
+            }
+          : {}),
         text: item.description,
         value: item.code,
       })


### PR DESCRIPTION
## Context
We need to display hint text on the radio button items on the select decision page.


## Changes in this PR
- Update `ReferralStatusRefData` type and test factory
- Show hint text on radio buttons if provided.
- Fix variable name typo 


## Screenshots of UI changes

![image](https://github.com/ministryofjustice/hmpps-accredited-programmes-ui/assets/1067537/28f7f4f7-6d7e-4f57-bbc5-93618ac5956e)


## Release checklist

[Release process documentation](../doc/how-to/perform-a-release.md)

As part of our continuous deployment strategy we must ensure that this work is
ready to be released once merged.

### Pre-merge

- [ ] There are changes required to the Accredited Programmes API for this change to work...
  - [ ] ... and they have been released to production already

### Post-merge

<!-- The outer checkboxes can be completed pre-merge -->

- [ ] This adds, extends or meaningfully modifies a feature...
  - [ ] ... and I have written or updated an end-to-end test for the happy path in the [Accredited Programmes E2E repo](https://github.com/ministryofjustice/hmpps-accredited-programmes-e2e)
- [ ] This makes new expectations of the API...
  - [ ] ... and I have notified the API developer(s) of changes to the contract tests (Pact), or the API is already compliant
- [ ] [Manually approve](../doc/how-to/perform-a-release.md#releasing-to-the-preprod-environment) release to preprod
- [ ] [Manually approve](../doc/how-to/perform-a-release.md#releasing-to-the-production-environment) release to prod

<!-- Should a release fail at any step, you as the author should now lead the work to
fix it as soon as possible. You can monitor deployment failures in CircleCI
itself and application errors are found in
[Sentry](https://ministryofjustice.sentry.io/projects/hmpps-accredited-programmes-ui/?project=4505330122686464&referrer=sidebar&statsPeriod=24h). -->
