### PR TITLE
(1384a) Add client and service methods for getting referral status data

### DIFF
--- a/server/data/accreditedProgrammesApi/referenceDataClient.ts
+++ b/server/data/accreditedProgrammesApi/referenceDataClient.ts
@@ -3,8 +3,10 @@ import config, { type ApiConfig } from '../../config'
 import { apiPaths } from '../../paths'
 import RestClient from '../restClient'
 import type {
+  ReferralStatus,
   ReferralStatusCategory,
   ReferralStatusReason,
+  ReferralStatusRefData,
   ReferralStatusUppercase,
 } from '@accredited-programmes/models'
 import type { SystemToken } from '@hmpps-auth'
@@ -22,6 +24,14 @@ export default class ReferenceDataClient {
     return (await this.restClient.get({
       path: apiPaths.referenceData.referralStatuses.statusCodeCategories({ referralStatusCode }),
     })) as Array<ReferralStatusCategory>
+  }
+
+  async findReferralStatusCodeData(
+    referralStatusCode: ReferralStatus | ReferralStatusUppercase,
+  ): Promise<ReferralStatusRefData> {
+    return (await this.restClient.get({
+      path: apiPaths.referenceData.referralStatuses.codeData({ referralStatusCode }),
+    })) as ReferralStatusRefData
   }
 
   async findReferralStatusCodeReasons(

--- a/server/paths/api.ts
+++ b/server/paths/api.ts
@@ -29,6 +29,7 @@ const participationPath = participationsPath.path(':courseParticipationId')
 const referenceDataPath = path('/reference-data')
 const referralStatusesPath = referenceDataPath.path('referral-statuses')
 
+const referralStatusesCodeDataPath = referralStatusesPath.path(':referralStatusCode')
 const referralStatusCodeCategoriesPath = referralStatusesPath.path(':referralStatusCode/categories')
 const referralStatusCodeReasonsPath = referralStatusCodeCategoriesPath.path(':categoryCode/reasons')
 
@@ -69,6 +70,7 @@ export default {
   },
   referenceData: {
     referralStatuses: {
+      codeData: referralStatusesCodeDataPath,
       statusCodeCategories: referralStatusCodeCategoriesPath,
       statusCodeReasons: referralStatusCodeReasonsPath,
     },

--- a/server/services/referenceDataService.test.ts
+++ b/server/services/referenceDataService.test.ts
@@ -4,7 +4,11 @@ import { when } from 'jest-when'
 import ReferenceDataService from './referenceDataService'
 import type { RedisClient } from '../data'
 import { HmppsAuthClient, ReferenceDataClient, TokenStore } from '../data'
-import { referralStatusCategoryFactory, referralStatusReasonFactory } from '../testutils/factories'
+import {
+  referralStatusCategoryFactory,
+  referralStatusReasonFactory,
+  referralStatusRefDataFactory,
+} from '../testutils/factories'
 import type { ReferralStatusUppercase } from '@accredited-programmes/models'
 
 jest.mock('../data/accreditedProgrammesApi/referenceDataClient')
@@ -14,6 +18,7 @@ const redisClient = createMock<RedisClient>({})
 const tokenStore = new TokenStore(redisClient) as jest.Mocked<TokenStore>
 const systemToken = 'some system token'
 const username = 'USERNAME'
+const referralStatusCode: ReferralStatusUppercase = 'WITHDRAWN'
 
 describe('ReferenceDataService', () => {
   const referenceDataClient = new ReferenceDataClient(systemToken) as jest.Mocked<ReferenceDataClient>
@@ -34,7 +39,6 @@ describe('ReferenceDataService', () => {
 
   describe('getReferralStatusCodeCategories', () => {
     it('should return referral status code categories', async () => {
-      const referralStatusCode: ReferralStatusUppercase = 'WITHDRAWN'
       const categories = referralStatusCategoryFactory.buildList(2, { referralStatusCode })
 
       when(referenceDataClient.findReferralStatusCodeCategories)
@@ -47,9 +51,22 @@ describe('ReferenceDataService', () => {
     })
   })
 
+  describe('getReferralStatusCodeData', () => {
+    it('should return reference data for the referral status code', async () => {
+      const referralStatusRefData = referralStatusRefDataFactory.build()
+
+      when(referenceDataClient.findReferralStatusCodeData)
+        .calledWith(referralStatusCode)
+        .mockResolvedValue(referralStatusRefData)
+
+      const result = await service.getReferralStatusCodeData(username, referralStatusCode)
+
+      expect(result).toEqual(referralStatusRefData)
+    })
+  })
+
   describe('getReferralStatusCodeReasons', () => {
     it('should return referral status code reasons', async () => {
-      const referralStatusCode: ReferralStatusUppercase = 'WITHDRAWN'
       const categoryCode = 'A'
       const reasons = referralStatusReasonFactory.buildList(2, { referralCategoryCode: categoryCode })
 

--- a/server/services/referenceDataService.ts
+++ b/server/services/referenceDataService.ts
@@ -1,7 +1,9 @@
 import type { HmppsAuthClient, ReferenceDataClient, RestClientBuilder, RestClientBuilderWithoutToken } from '../data'
 import type {
+  ReferralStatus,
   ReferralStatusCategory,
   ReferralStatusReason,
+  ReferralStatusRefData,
   ReferralStatusUppercase,
 } from '@accredited-programmes/models'
 
@@ -20,6 +22,17 @@ export default class ReferenceDataService {
     const referenceDataClient = this.referenceDataClient(systemToken)
 
     return referenceDataClient.findReferralStatusCodeCategories(referralStatusCode)
+  }
+
+  async getReferralStatusCodeData(
+    username: Express.User['username'],
+    referralStatusCode: ReferralStatus | ReferralStatusUppercase,
+  ): Promise<ReferralStatusRefData> {
+    const hmppsAuthClient = this.hmppsAuthClientBuilder()
+    const systemToken = await hmppsAuthClient.getSystemClientToken(username)
+    const referenceDataClient = this.referenceDataClient(systemToken)
+
+    return referenceDataClient.findReferralStatusCodeData(referralStatusCode)
   }
 
   async getReferralStatusCodeReasons(


### PR DESCRIPTION
## Context

We need the reference data for a referral status code.

## Changes in this PR
- Add api path for `reference-data/referral-statuses/:referralStatusCode`
- Add method to `ReferenceDataClient`
- Add method to `ReferenceDataService` 


## Release checklist

[Release process documentation](../doc/how-to/perform-a-release.md)

As part of our continuous deployment strategy we must ensure that this work is
ready to be released once merged.

### Pre-merge

- [ ] There are changes required to the Accredited Programmes API for this change to work...
  - [ ] ... and they have been released to production already

### Post-merge

<!-- The outer checkboxes can be completed pre-merge -->

- [ ] This adds, extends or meaningfully modifies a feature...
  - [ ] ... and I have written or updated an end-to-end test for the happy path in the [Accredited Programmes E2E repo](https://github.com/ministryofjustice/hmpps-accredited-programmes-e2e)
- [ ] This makes new expectations of the API...
  - [ ] ... and I have notified the API developer(s) of changes to the contract tests (Pact), or the API is already compliant
- [ ] [Manually approve](../doc/how-to/perform-a-release.md#releasing-to-the-preprod-environment) release to preprod
- [ ] [Manually approve](../doc/how-to/perform-a-release.md#releasing-to-the-production-environment) release to prod

<!-- Should a release fail at any step, you as the author should now lead the work to
fix it as soon as possible. You can monitor deployment failures in CircleCI
itself and application errors are found in
[Sentry](https://ministryofjustice.sentry.io/projects/hmpps-accredited-programmes-ui/?project=4505330122686464&referrer=sidebar&statsPeriod=24h). -->
