### PR TITLE
(1384b) Move update status select decision controller to be for assess journey only

### DIFF
--- a/server/controllers/assess/index.ts
+++ b/server/controllers/assess/index.ts
@@ -1,13 +1,17 @@
 /* istanbul ignore file */
 
 import AssessCaseListController from './caseListController'
+import UpdateStatusDecisionController from './updateStatusDecisionController'
 import type { Services } from '../../services'
 
 const controllers = (services: Services) => {
   const assessCaseListController = new AssessCaseListController(services.courseService, services.referralService)
 
+  const updateStatusDecisionController = new UpdateStatusDecisionController(services.referralService)
+
   return {
     assessCaseListController,
+    updateStatusDecisionController,
   }
 }
 

--- a/server/controllers/shared/index.ts
+++ b/server/controllers/shared/index.ts
@@ -3,7 +3,6 @@
 import ReferralsController from './referralsController'
 import RisksAndNeedsController from './risksAndNeedsController'
 import StatusHistoryController from './statusHistoryController'
-import UpdateStatusDecisionController from './updateStatusDecisionController'
 import WithdrawCategoryController from './withdrawCategoryController'
 import WithdrawReasonController from './withdrawReasonController'
 import WithdrawReasonInformationController from './withdrawReasonInformationController'
@@ -30,8 +29,6 @@ const controllers = (services: Services) => {
     services.referralService,
   )
 
-  const updateStatusDecisionController = new UpdateStatusDecisionController(services.referralService)
-
   const withdrawCategoryController = new WithdrawCategoryController(
     services.referenceDataService,
     services.referralService,
@@ -45,7 +42,6 @@ const controllers = (services: Services) => {
     referralsController,
     risksAndNeedsController,
     statusHistoryController,
-    updateStatusDecisionController,
     withdrawCategoryController,
     withdrawReasonController,
     withdrawReasonInformationController,

--- a/server/paths/assess.ts
+++ b/server/paths/assess.ts
@@ -10,6 +10,7 @@ const risksAndNeedsPathBase = referralShowPathBase.path('risks-and-needs')
 const withdrawBasePath = referralShowPathBase.path('withdraw')
 
 const updateStatusPathBase = referralShowPathBase.path('update-status')
+const updateStatusSelectionShowPath = updateStatusPathBase.path('selection')
 
 export default {
   caseList: {
@@ -38,8 +39,19 @@ export default {
     statusHistory: referralShowPathBase.path('status-history'),
   },
   updateStatus: {
-    confirm: updateStatusPathBase.path('confirm'),
-    decision: updateStatusPathBase,
+    decision: {
+      show: updateStatusPathBase,
+      submit: updateStatusPathBase,
+    },
+    selection: {
+      confirmation: {
+        submit: updateStatusSelectionShowPath.path('confirmation'),
+      },
+      reason: {
+        submit: updateStatusSelectionShowPath.path('reason'),
+      },
+      show: updateStatusSelectionShowPath,
+    },
   },
   withdraw: {
     category: withdrawBasePath,

--- a/server/paths/refer.ts
+++ b/server/paths/refer.ts
@@ -25,8 +25,6 @@ const risksAndNeedsPathBase = referralShowPathBase.path('risks-and-needs')
 
 const withdrawBasePath = referralShowPathBase.path('withdraw')
 
-const updateStatusPathBase = referralShowPathBase.path('update-status')
-
 export default {
   caseList: {
     index: caseListPath,
@@ -88,10 +86,6 @@ export default {
     },
     sentenceInformation: referralShowPathBase.path('sentence-information'),
     statusHistory: referralShowPathBase.path('status-history'),
-  },
-  updateStatus: {
-    confirm: updateStatusPathBase.path('confirm'),
-    decision: updateStatusPathBase,
   },
   withdraw: {
     category: withdrawBasePath,

--- a/server/routes/assess.ts
+++ b/server/routes/assess.ts
@@ -42,8 +42,8 @@ export default function routes(controllers: Controllers, router: Router): Router
   get(assessPaths.show.risksAndNeeds.roshAnalysis.pattern, risksAndNeedsController.roshAnalysis())
   get(assessPaths.show.risksAndNeeds.thinkingAndBehaving.pattern, risksAndNeedsController.thinkingAndBehaving())
 
-  get(assessPaths.updateStatus.decision.pattern, updateStatusDecisionController.show())
-  post(assessPaths.updateStatus.decision.pattern, updateStatusDecisionController.submit())
+  get(assessPaths.updateStatus.decision.show.pattern, updateStatusDecisionController.show())
+  post(assessPaths.updateStatus.decision.submit.pattern, updateStatusDecisionController.submit())
 
   get(assessPaths.withdraw.category.pattern, withdrawCategoryController.show())
   post(assessPaths.withdraw.category.pattern, withdrawCategoryController.submit())

--- a/server/utils/referrals/showReferralUtils.ts
+++ b/server/utils/referrals/showReferralUtils.ts
@@ -31,7 +31,7 @@ export default class ShowReferralUtils {
       buttons.push({
         classes: 'govuk-button--secondary',
         disabled: closed,
-        href: closed ? undefined : assessPaths.updateStatus.decision({ referralId: referral.id }),
+        href: closed ? undefined : assessPaths.updateStatus.decision.show({ referralId: referral.id }),
         text: 'Update status',
       })
     } else {


### PR DESCRIPTION
## Context

The select decision step of the update status journey is only for users on the assess journey. Subsequent steps will be linked to directly from the refer journey.

## Changes in this PR
- Move `UpdateStatusDecisionController` to be used by assess journey only, not shared with refer.
- Update `assess` related paths for update status and add some more in ready for the next step.



## Release checklist

[Release process documentation](../doc/how-to/perform-a-release.md)

As part of our continuous deployment strategy we must ensure that this work is
ready to be released once merged.

### Pre-merge

- [ ] There are changes required to the Accredited Programmes API for this change to work...
  - [ ] ... and they have been released to production already

### Post-merge

<!-- The outer checkboxes can be completed pre-merge -->

- [ ] This adds, extends or meaningfully modifies a feature...
  - [ ] ... and I have written or updated an end-to-end test for the happy path in the [Accredited Programmes E2E repo](https://github.com/ministryofjustice/hmpps-accredited-programmes-e2e)
- [ ] This makes new expectations of the API...
  - [ ] ... and I have notified the API developer(s) of changes to the contract tests (Pact), or the API is already compliant
- [ ] [Manually approve](../doc/how-to/perform-a-release.md#releasing-to-the-preprod-environment) release to preprod
- [ ] [Manually approve](../doc/how-to/perform-a-release.md#releasing-to-the-production-environment) release to prod

<!-- Should a release fail at any step, you as the author should now lead the work to
fix it as soon as possible. You can monitor deployment failures in CircleCI
itself and application errors are found in
[Sentry](https://ministryofjustice.sentry.io/projects/hmpps-accredited-programmes-ui/?project=4505330122686464&referrer=sidebar&statsPeriod=24h). -->
