### PR TITLE
(1384c) Update status selection

### DIFF
--- a/server/controllers/shared/index.ts
+++ b/server/controllers/shared/index.ts
@@ -3,6 +3,7 @@
 import ReferralsController from './referralsController'
 import RisksAndNeedsController from './risksAndNeedsController'
 import StatusHistoryController from './statusHistoryController'
+import UpdateStatusSelectionController from './updateStatusSelectionController'
 import WithdrawCategoryController from './withdrawCategoryController'
 import WithdrawReasonController from './withdrawReasonController'
 import WithdrawReasonInformationController from './withdrawReasonInformationController'
@@ -29,6 +30,11 @@ const controllers = (services: Services) => {
     services.referralService,
   )
 
+  const updateStatusSelectionController = new UpdateStatusSelectionController(
+    services.referenceDataService,
+    services.referralService,
+  )
+
   const withdrawCategoryController = new WithdrawCategoryController(
     services.referenceDataService,
     services.referralService,
@@ -42,6 +48,7 @@ const controllers = (services: Services) => {
     referralsController,
     risksAndNeedsController,
     statusHistoryController,
+    updateStatusSelectionController,
     withdrawCategoryController,
     withdrawReasonController,
     withdrawReasonInformationController,

--- a/server/controllers/shared/updateStatusSelectionController.test.ts
+++ b/server/controllers/shared/updateStatusSelectionController.test.ts
@@ -1,0 +1,278 @@
+import type { DeepMocked } from '@golevelup/ts-jest'
+import { createMock } from '@golevelup/ts-jest'
+import type { NextFunction, Request, Response } from 'express'
+
+import UpdateStatusSelectionController from './updateStatusSelectionController'
+import { assessPaths, referPaths } from '../../paths'
+import type { ReferenceDataService, ReferralService } from '../../services'
+import { referralFactory, referralStatusHistoryFactory, referralStatusRefDataFactory } from '../../testutils/factories'
+import Helpers from '../../testutils/helpers'
+import { FormUtils, ShowReferralUtils } from '../../utils'
+import type { Referral, ReferralStatusRefData } from '@accredited-programmes/models'
+import type { MojTimelineItem, ReferralStatusHistoryPresenter } from '@accredited-programmes/ui'
+
+jest.mock('../../utils/formUtils')
+jest.mock('../../utils/referrals/showReferralUtils')
+
+const mockShowReferralUtils = ShowReferralUtils as jest.Mocked<typeof ShowReferralUtils>
+
+describe('UpdateStatusSelectionController', () => {
+  const userToken = 'SOME_TOKEN'
+  const username = 'USERNAME'
+
+  let request: DeepMocked<Request>
+  let response: DeepMocked<Response>
+  const next: DeepMocked<NextFunction> = createMock<NextFunction>({})
+
+  const referralService = createMock<ReferralService>({})
+  const referenceDataService = createMock<ReferenceDataService>({})
+
+  const timelineItems: Array<MojTimelineItem> = [
+    {
+      byline: { text: 'Test User' },
+      datetime: { timestamp: new Date().toISOString(), type: 'datetime' },
+      html: 'html',
+      label: { text: 'Referral submitted' },
+    },
+    {
+      byline: { text: 'Test User' },
+      datetime: { timestamp: new Date().toISOString(), type: 'datetime' },
+      html: 'html',
+      label: { text: 'Referral started' },
+    },
+  ]
+  let referral: Referral
+  let referralStatusHistory: Array<ReferralStatusHistoryPresenter>
+  let referralStatusRefData: ReferralStatusRefData
+
+  let controller: UpdateStatusSelectionController
+
+  beforeEach(() => {
+    referral = referralFactory.submitted().build()
+    referralStatusHistory = [{ ...referralStatusHistoryFactory.submitted().build(), byLineText: 'You' }]
+    referralStatusRefData = referralStatusRefDataFactory.build({ description: 'On Programme', hasConfirmation: true })
+    mockShowReferralUtils.statusHistoryTimelineItems.mockReturnValue(timelineItems)
+
+    referralService.getReferralStatusHistory.mockResolvedValue(referralStatusHistory)
+    referenceDataService.getReferralStatusCodeData.mockResolvedValue(referralStatusRefData)
+
+    controller = new UpdateStatusSelectionController(referenceDataService, referralService)
+
+    request = createMock<Request>({
+      params: { referralId: referral.id },
+      path: assessPaths.updateStatus.selection.show({ referralId: referral.id }),
+      session: { referralStatusUpdateData: { referralId: referral.id, status: 'ON_PROGRAMME' } },
+      user: { token: userToken, username },
+    })
+    response = Helpers.createMockResponseWithCaseloads()
+  })
+
+  afterEach(() => {
+    jest.resetAllMocks()
+  })
+
+  describe('show', () => {
+    it('should render the show template with the correct response locals', async () => {
+      const requestHandler = controller.show()
+      await requestHandler(request, response, next)
+
+      expect(response.render).toHaveBeenCalledWith('referrals/updateStatus/selection/show', {
+        action: assessPaths.updateStatus.selection.confirmation.submit({ referralId: referral.id }),
+        backLinkHref: '#',
+        maxLength: 100,
+        pageHeading: 'Move referral to on programme',
+        referralStatusRefData,
+        timelineItems: timelineItems.slice(0, 1),
+      })
+
+      expect(referralService.getReferralStatusHistory).toHaveBeenCalledWith(userToken, username, referral.id)
+      expect(referenceDataService.getReferralStatusCodeData).toHaveBeenCalledWith(username, 'ON_PROGRAMME')
+      expect(FormUtils.setFieldErrors).toHaveBeenCalledWith(request, response, ['confirmation'])
+    })
+
+    describe('when `referralStatusUpdateData` is not present', () => {
+      it('should redirect to the status history route', async () => {
+        request.session.referralStatusUpdateData = undefined
+
+        const requestHandler = controller.show()
+        await requestHandler(request, response, next)
+
+        expect(response.redirect).toHaveBeenCalledWith(assessPaths.show.statusHistory({ referralId: referral.id }))
+      })
+    })
+
+    describe('when `referralStatusUpdateData` is for a different referral', () => {
+      it('should redirect to the status history route', async () => {
+        request.session.referralStatusUpdateData = {
+          referralId: 'DIFFERENT_REFERRAL_ID',
+          status: 'WITHDRAWN',
+        }
+
+        const requestHandler = controller.show()
+        await requestHandler(request, response, next)
+
+        expect(response.redirect).toHaveBeenCalledWith(assessPaths.show.statusHistory({ referralId: referral.id }))
+      })
+    })
+
+    describe('when the reference data requires notes instead of confirmation', () => {
+      it('should render the template with the correct form action and call the relevant `FormUtils` methods', async () => {
+        referralStatusRefData = referralStatusRefDataFactory.build({ description: 'On Programme', hasNotes: true })
+        referenceDataService.getReferralStatusCodeData.mockResolvedValue(referralStatusRefData)
+
+        const requestHandler = controller.show()
+        await requestHandler(request, response, next)
+
+        expect(response.render).toHaveBeenCalledWith(
+          'referrals/updateStatus/selection/show',
+          expect.objectContaining({
+            action: assessPaths.updateStatus.selection.reason.submit({ referralId: referral.id }),
+          }),
+        )
+
+        expect(FormUtils.setFieldErrors).toHaveBeenCalledWith(request, response, ['reason'])
+        expect(FormUtils.setFormValues).toHaveBeenCalledWith(request, response)
+      })
+    })
+  })
+
+  describe('submitConfirmation', () => {
+    beforeEach(() => {
+      request.body = { confirmation: 'true' }
+    })
+
+    it('should update the referral status, delete `referralStatusUpdateData` and redirect back to the status history page of the referral', async () => {
+      const requestHandler = controller.submitConfirmation()
+      await requestHandler(request, response, next)
+
+      expect(referralService.updateReferralStatus).toHaveBeenCalledWith(username, referral.id, {
+        ptUser: true,
+        status: 'ON_PROGRAMME',
+      })
+      expect(request.session.referralStatusUpdateData).toBeUndefined()
+      expect(response.redirect).toHaveBeenCalledWith(assessPaths.show.statusHistory({ referralId: referral.id }))
+    })
+
+    describe('when there is no `referralStatusUpdateData`', () => {
+      it('should redirect to the status history route', async () => {
+        request.session.referralStatusUpdateData = undefined
+
+        const requestHandler = controller.submitConfirmation()
+        await requestHandler(request, response, next)
+
+        expect(response.redirect).toHaveBeenCalledWith(assessPaths.show.statusHistory({ referralId: referral.id }))
+      })
+    })
+
+    describe('when submitting the form on the refer journey', () => {
+      it('should update the referral status, delete `referralStatusUpdateData` and redirect back to the refer status history page of the referral', async () => {
+        request.path = referPaths.updateStatus.selection.show({ referralId: referral.id })
+
+        const requestHandler = controller.submitConfirmation()
+        await requestHandler(request, response, next)
+
+        expect(referralService.updateReferralStatus).toHaveBeenCalledWith(username, referral.id, {
+          ptUser: false,
+          status: 'ON_PROGRAMME',
+        })
+        expect(request.session.referralStatusUpdateData).toBeUndefined()
+        expect(response.redirect).toHaveBeenCalledWith(referPaths.show.statusHistory({ referralId: referral.id }))
+      })
+    })
+
+    describe('when `confirmation` is not present', () => {
+      it('should redirect to the update status selection show page', async () => {
+        request.body = {}
+
+        const requestHandler = controller.submitConfirmation()
+        await requestHandler(request, response, next)
+
+        expect(request.flash).toHaveBeenCalledWith('confirmationError', 'Select confirmation')
+        expect(response.redirect).toHaveBeenCalledWith(
+          assessPaths.updateStatus.selection.show({ referralId: referral.id }),
+        )
+      })
+    })
+  })
+
+  describe('submitReason', () => {
+    const reason = 'This person is not suitable for the programme.'
+
+    beforeEach(() => {
+      request.body = { reason }
+      request.session.referralStatusUpdateData = { referralId: referral.id, status: 'NOT_SUITABLE' }
+    })
+
+    it('should update the referral status, delete `referralStatusUpdateData` and redirect back to the status history page of the referral', async () => {
+      const requestHandler = controller.submitReason()
+      await requestHandler(request, response, next)
+
+      expect(referralService.updateReferralStatus).toHaveBeenCalledWith(username, referral.id, {
+        notes: reason,
+        ptUser: true,
+        status: 'NOT_SUITABLE',
+      })
+      expect(request.session.referralStatusUpdateData).toBeUndefined()
+      expect(response.redirect).toHaveBeenCalledWith(assessPaths.show.statusHistory({ referralId: referral.id }))
+    })
+
+    describe('when there is no `referralStatusUpdateData`', () => {
+      it('should redirect to the status history route', async () => {
+        request.session.referralStatusUpdateData = undefined
+
+        const requestHandler = controller.submitReason()
+        await requestHandler(request, response, next)
+
+        expect(response.redirect).toHaveBeenCalledWith(assessPaths.show.statusHistory({ referralId: referral.id }))
+      })
+    })
+
+    describe('when submitting the form on the refer journey', () => {
+      it('should update the referral status, delete `referralStatusUpdateData` and redirect back to the refer status history page of the referral', async () => {
+        request.path = referPaths.updateStatus.selection.show({ referralId: referral.id })
+
+        const requestHandler = controller.submitReason()
+        await requestHandler(request, response, next)
+
+        expect(referralService.updateReferralStatus).toHaveBeenCalledWith(username, referral.id, {
+          notes: reason,
+          ptUser: false,
+          status: 'NOT_SUITABLE',
+        })
+        expect(request.session.referralStatusUpdateData).toBeUndefined()
+        expect(response.redirect).toHaveBeenCalledWith(referPaths.show.statusHistory({ referralId: referral.id }))
+      })
+    })
+
+    describe('when `reason` is not present', () => {
+      it('should redirect to the update status selection show page with a flash message', async () => {
+        request.body = {}
+
+        const requestHandler = controller.submitReason()
+        await requestHandler(request, response, next)
+
+        expect(request.flash).toHaveBeenCalledWith('reasonError', 'Enter a reason')
+        expect(response.redirect).toHaveBeenCalledWith(
+          assessPaths.updateStatus.selection.show({ referralId: referral.id }),
+        )
+      })
+    })
+
+    describe('when `reason` is too long', () => {
+      it('should redirect to the update status selection show page with a flash message', async () => {
+        const longReason = 'a'.repeat(101)
+
+        request.body = { reason: longReason }
+
+        const requestHandler = controller.submitReason()
+        await requestHandler(request, response, next)
+
+        expect(request.flash).toHaveBeenCalledWith('reasonError', 'Reason must be 100 characters or less')
+        expect(request.flash).toHaveBeenCalledWith('formValues', [JSON.stringify({ reason: longReason })])
+        expect(response.redirect).toHaveBeenCalledWith(
+          assessPaths.updateStatus.selection.show({ referralId: referral.id }),
+        )
+      })
+    })
+  })
+})

--- a/server/controllers/shared/updateStatusSelectionController.ts
+++ b/server/controllers/shared/updateStatusSelectionController.ts
@@ -1,0 +1,139 @@
+import type { Request, Response, TypedRequestHandler } from 'express'
+
+import { assessPathBase, assessPaths, referPaths } from '../../paths'
+import type { ReferenceDataService, ReferralService } from '../../services'
+import { FormUtils, ShowReferralUtils, TypeUtils } from '../../utils'
+import type { ReferralStatus, ReferralStatusUppercase } from '@accredited-programmes/models'
+
+const maxLength = 100
+
+export default class UpdateStatusSelectionController {
+  constructor(
+    private readonly referenceDataService: ReferenceDataService,
+    private readonly referralService: ReferralService,
+  ) {}
+
+  show(): TypedRequestHandler<Request, Response> {
+    return async (req: Request, res: Response) => {
+      TypeUtils.assertHasUser(req)
+
+      const paths = this.getPaths(req)
+
+      const { referralId } = req.params
+      const { token: userToken, username } = req.user
+      const { referralStatusUpdateData } = req.session
+
+      if (!referralStatusUpdateData?.status || referralStatusUpdateData.referralId !== referralId) {
+        return res.redirect(paths.show.statusHistory({ referralId }))
+      }
+
+      const [statusHistory, referralStatusRefData] = await Promise.all([
+        this.referralService.getReferralStatusHistory(userToken, username, referralId),
+        this.referenceDataService.getReferralStatusCodeData(username, referralStatusUpdateData.status),
+      ])
+
+      const { description, hasConfirmation } = referralStatusRefData
+
+      if (hasConfirmation) {
+        FormUtils.setFieldErrors(req, res, ['confirmation'])
+      } else {
+        FormUtils.setFieldErrors(req, res, ['reason'])
+        FormUtils.setFormValues(req, res)
+      }
+
+      return res.render('referrals/updateStatus/selection/show', {
+        action: hasConfirmation
+          ? paths.updateStatus.selection.confirmation.submit({ referralId })
+          : paths.updateStatus.selection.reason.submit({ referralId }),
+        backLinkHref: '#',
+        maxLength,
+        pageHeading: `Move referral to ${description.toLowerCase()}`,
+        referralStatusRefData,
+        timelineItems: ShowReferralUtils.statusHistoryTimelineItems(statusHistory).slice(0, 1),
+      })
+    }
+  }
+
+  submitConfirmation(): TypedRequestHandler<Request, Response> {
+    return async (req: Request, res: Response) => {
+      const paths = this.getPaths(req)
+
+      const { referralId } = req.params
+      const { confirmation } = req.body
+      const { referralStatusUpdateData } = req.session
+
+      if (!referralStatusUpdateData?.status) {
+        return res.redirect(paths.show.statusHistory({ referralId }))
+      }
+
+      if (!confirmation) {
+        req.flash('confirmationError', 'Select confirmation')
+
+        return res.redirect(paths.updateStatus.selection.show({ referralId }))
+      }
+
+      return this.updateReferralStatus(req, res, referralStatusUpdateData.status)
+    }
+  }
+
+  submitReason(): TypedRequestHandler<Request, Response> {
+    return async (req: Request, res: Response) => {
+      let hasErrors = false
+      const paths = this.getPaths(req)
+
+      const { referralId } = req.params
+      const { referralStatusUpdateData } = req.session
+      const reason = req.body.reason?.trim()
+
+      if (!referralStatusUpdateData?.status) {
+        return res.redirect(paths.show.statusHistory({ referralId }))
+      }
+
+      if (!reason) {
+        req.flash('reasonError', 'Enter a reason')
+        hasErrors = true
+      }
+
+      if (reason?.length > maxLength) {
+        req.flash('reasonError', `Reason must be ${maxLength} characters or less`)
+        req.flash('formValues', [JSON.stringify({ reason })])
+        hasErrors = true
+      }
+
+      if (hasErrors) {
+        return res.redirect(paths.updateStatus.selection.show({ referralId }))
+      }
+
+      return this.updateReferralStatus(req, res, referralStatusUpdateData.status, reason)
+    }
+  }
+
+  private getPaths(req: Request) {
+    return req.path.startsWith(assessPathBase.pattern) ? assessPaths : referPaths
+  }
+
+  private async updateReferralStatus(
+    req: Request,
+    res: Response,
+    status: ReferralStatus | ReferralStatusUppercase,
+    notes?: string,
+  ) {
+    TypeUtils.assertHasUser(req)
+
+    const isAssess = req.path.startsWith(assessPathBase.pattern)
+    const paths = isAssess ? assessPaths : referPaths
+
+    const { username } = req.user
+    const { referralId } = req.params
+
+    await this.referralService.updateReferralStatus(username, referralId, {
+      notes,
+      ptUser: isAssess,
+      status,
+    })
+
+    delete req.session.referralStatusUpdateData
+
+    return res.redirect(paths.show.statusHistory({ referralId }))
+  }
+}

--- a/server/paths/refer.ts
+++ b/server/paths/refer.ts
@@ -25,6 +25,9 @@ const risksAndNeedsPathBase = referralShowPathBase.path('risks-and-needs')
 
 const withdrawBasePath = referralShowPathBase.path('withdraw')
 
+const updateStatusPathBase = referralShowPathBase.path('update-status')
+const updateStatusSelectionShowPath = updateStatusPathBase.path('selection')
+
 export default {
   caseList: {
     index: caseListPath,
@@ -86,6 +89,17 @@ export default {
     },
     sentenceInformation: referralShowPathBase.path('sentence-information'),
     statusHistory: referralShowPathBase.path('status-history'),
+  },
+  updateStatus: {
+    selection: {
+      confirmation: {
+        submit: updateStatusSelectionShowPath.path('confirmation'),
+      },
+      reason: {
+        submit: updateStatusSelectionShowPath.path('reason'),
+      },
+      show: updateStatusSelectionShowPath,
+    },
   },
   withdraw: {
     category: withdrawBasePath,

--- a/server/routes/assess.ts
+++ b/server/routes/assess.ts
@@ -14,6 +14,7 @@ export default function routes(controllers: Controllers, router: Router): Router
     risksAndNeedsController,
     statusHistoryController,
     updateStatusDecisionController,
+    updateStatusSelectionController,
     withdrawCategoryController,
     withdrawReasonController,
     withdrawReasonInformationController,
@@ -44,6 +45,13 @@ export default function routes(controllers: Controllers, router: Router): Router
 
   get(assessPaths.updateStatus.decision.show.pattern, updateStatusDecisionController.show())
   post(assessPaths.updateStatus.decision.submit.pattern, updateStatusDecisionController.submit())
+
+  get(assessPaths.updateStatus.selection.show.pattern, updateStatusSelectionController.show())
+  post(
+    assessPaths.updateStatus.selection.confirmation.submit.pattern,
+    updateStatusSelectionController.submitConfirmation(),
+  )
+  post(assessPaths.updateStatus.selection.reason.submit.pattern, updateStatusSelectionController.submitReason())
 
   get(assessPaths.withdraw.category.pattern, withdrawCategoryController.show())
   post(assessPaths.withdraw.category.pattern, withdrawCategoryController.submit())

--- a/server/views/referrals/updateStatus/selection/show.njk
+++ b/server/views/referrals/updateStatus/selection/show.njk
@@ -1,0 +1,89 @@
+{% from "govuk/components/back-link/macro.njk" import govukBackLink %}
+{% from "govuk/components/button/macro.njk" import govukButton %}
+{% from "govuk/components/character-count/macro.njk" import govukCharacterCount %}
+{% from "govuk/components/checkboxes/macro.njk" import govukCheckboxes %}
+{% from "govuk/components/error-summary/macro.njk" import govukErrorSummary %}
+{% from "moj/components/timeline/macro.njk" import mojTimeline %}
+
+{% extends "../../../partials/layout.njk" %}
+
+{% set formattedDescription = referralStatusRefData.description | lower %}
+
+{% block backLink %}
+  {{ govukBackLink({
+    text: "Back",
+    href: backLinkHref
+  }) }}
+{% endblock backLink %}
+
+{% block content %}
+  <div class="govuk-grid-row">
+    <div class="govuk-grid-column-two-thirds">
+      {% if errors.list | length %}
+        {{ govukErrorSummary({
+          titleText: "There is a problem",
+          errorList: errors.list
+        }) }}
+      {% endif %}
+
+      <h1 class="govuk-heading-l">{{ pageHeading }}</h1>
+
+      <p>Submitting this will change the status to {{ formattedDescription }}.</p>
+
+      <h2 class="govuk-heading-m">Current status</h2>
+
+      {{ mojTimeline({
+        items: timelineItems,
+        attributes: {
+          "data-testid": "status-history-timeline"
+        },
+        classes: "govuk-!-margin-bottom-0"
+      }) }}
+    </div>
+  </div>
+
+  <hr class="govuk-section-break govuk-section-break--xl govuk-section-break--visible">
+
+  <div class="govuk-grid-row">
+    <div class="govuk-grid-column-two-thirds">
+      <form action="{{ action }}" method="post">
+        <input type="hidden" name="_csrf" value="{{ csrfToken }}"/>
+
+        {% if referralStatusRefData.hasConfirmation %}
+          <h2 class="govuk-heading-m">Confirm status change</h2>
+
+          {{ govukCheckboxes({
+            name: "confirmation",
+            items: [
+              {
+                value: "true",
+                text: referralStatusRefData.confirmationText
+              }
+            ],
+            errorMessage: errors.messages.confirmation
+          }) }}
+        {% else %}
+          <h2 class="govuk-heading-m">Give a reason</h2>
+
+          <p>You must give a reason why this referral is being moved to {{ formattedDescription }}.</p>
+
+          {{ govukCharacterCount({
+            id: "reason",
+            name: "reason",
+            maxlength: maxLength,
+            label: {
+              text: "Add reason"
+            },
+            value: formValues.reason,
+            classes: "govuk-!-width-three-quarters",
+            errorMessage: errors.messages.reason
+          }) }}
+        {% endif %}
+
+        {{ govukButton({
+          text: "Submit"
+        }) }}
+      </form>
+    </div>
+  </div>
+{% endblock content %}


### PR DESCRIPTION
## Context

When a new referral status decision has been made, then the selection must be confirmed by checking a confirmation checkbox or by entering a reason for the selection.


## Changes in this PR
- Add new controller with show method which calls a reference data endpoint to check if the status update requires just confirmation or `notes` (reason).
- 2 submit methods, one for the confirmation checkbox and one for the reason input, due to different validation.
- New template.

This is very generic at the moment and will continue to be updated as there are some differences in the page content in the designs, depending on the status selected, such as pausing, continuing, closing etc.

Still to do in future PRs.
- Error messaging to be confirmed.
- Back link behavaiour to be addressed separately. 


## Screenshots of UI changes

![localhost_3000_assess_referrals_73a18e7f-fdca-4967-8c80-cf563ace2bf9_update-status_selection (4)](https://github.com/ministryofjustice/hmpps-accredited-programmes-ui/assets/1067537/228aea9d-75a9-4a0b-822e-c737a765e52d)
![localhost_3000_assess_referrals_73a18e7f-fdca-4967-8c80-cf563ace2bf9_update-status_selection (5)](https://github.com/ministryofjustice/hmpps-accredited-programmes-ui/assets/1067537/a40aacab-957a-41ea-932f-c0855476c0ea)
![localhost_3000_assess_referrals_73a18e7f-fdca-4967-8c80-cf563ace2bf9_update-status_selection (2)](https://github.com/ministryofjustice/hmpps-accredited-programmes-ui/assets/1067537/3d8d0740-c177-417b-8ac4-239189a1720d)
![localhost_3000_assess_referrals_73a18e7f-fdca-4967-8c80-cf563ace2bf9_update-status_selection (3)](https://github.com/ministryofjustice/hmpps-accredited-programmes-ui/assets/1067537/66df9a96-4299-4235-9ab1-41142fdd2992)



## Release checklist

[Release process documentation](../doc/how-to/perform-a-release.md)

As part of our continuous deployment strategy we must ensure that this work is
ready to be released once merged.

### Pre-merge

- [ ] There are changes required to the Accredited Programmes API for this change to work...
  - [ ] ... and they have been released to production already

### Post-merge

<!-- The outer checkboxes can be completed pre-merge -->

- [ ] This adds, extends or meaningfully modifies a feature...
  - [ ] ... and I have written or updated an end-to-end test for the happy path in the [Accredited Programmes E2E repo](https://github.com/ministryofjustice/hmpps-accredited-programmes-e2e)
- [ ] This makes new expectations of the API...
  - [ ] ... and I have notified the API developer(s) of changes to the contract tests (Pact), or the API is already compliant
- [ ] [Manually approve](../doc/how-to/perform-a-release.md#releasing-to-the-preprod-environment) release to preprod
- [ ] [Manually approve](../doc/how-to/perform-a-release.md#releasing-to-the-production-environment) release to prod

<!-- Should a release fail at any step, you as the author should now lead the work to
fix it as soon as possible. You can monitor deployment failures in CircleCI
itself and application errors are found in
[Sentry](https://ministryofjustice.sentry.io/projects/hmpps-accredited-programmes-ui/?project=4505330122686464&referrer=sidebar&statsPeriod=24h). -->
