### PR TITLE
(1411) Show referral navigation

### DIFF
--- a/server/controllers/shared/statusHistoryController.test.ts
+++ b/server/controllers/shared/statusHistoryController.test.ts
@@ -93,7 +93,7 @@ describe('StatusHistoryController', () => {
         timelineItems,
       })
 
-      expect(referralService.getReferral).toHaveBeenCalledWith(username, referral.id)
+      expect(referralService.getReferral).toHaveBeenCalledWith(username, referral.id, {})
       expect(courseService.getCourseByOffering).toHaveBeenCalledWith(username, referral.offeringId)
       expect(referralService.getReferralStatusHistory).toHaveBeenCalledWith(userToken, username, referral.id)
       expect(personService.getPerson).toHaveBeenCalledWith(
@@ -108,6 +108,18 @@ describe('StatusHistoryController', () => {
       )
       expect(mockShowReferralUtils.buttons).toHaveBeenCalledWith(request.path, referral)
       expect(mockShowReferralUtils.statusHistoryTimelineItems).toHaveBeenCalledWith(referralStatusHistory)
+    })
+
+    describe('when the page has been visited with an `updatePerson` query parameter', () => {
+      it('should pass the `updatePerson` query parameter to the `getReferral` method', async () => {
+        const updatePerson = 'true'
+        request.query = { updatePerson }
+
+        const requestHandler = controller.show()
+        await requestHandler(request, response, next)
+
+        expect(referralService.getReferral).toHaveBeenCalledWith(username, referral.id, { updatePerson })
+      })
     })
   })
 })

--- a/server/controllers/shared/statusHistoryController.ts
+++ b/server/controllers/shared/statusHistoryController.ts
@@ -16,8 +16,9 @@ export default class StatusHistoryController {
 
       const { referralId } = req.params
       const { token: userToken, username } = req.user
+      const { updatePerson } = req.query as Record<string, string>
 
-      const referral = await this.referralService.getReferral(username, referralId)
+      const referral = await this.referralService.getReferral(username, referralId, { updatePerson })
 
       const [course, statusHistory, person] = await Promise.all([
         this.courseService.getCourseByOffering(username, referral.offeringId),

--- a/server/utils/referrals/caseListUtils.test.ts
+++ b/server/utils/referrals/caseListUtils.test.ts
@@ -454,9 +454,9 @@ describe('CaseListUtils', () => {
       })
 
       describe('when referPaths is passed in as the paths argument', () => {
-        it('links to a Refer show referral page', () => {
+        it('links to the Refer show status history referral page', () => {
           expect(CaseListUtils.tableRowContent(referralView, 'Name / Prison number', referPaths)).toEqual(
-            '<a class="govuk-link" href="/refer/referrals/referral-123/personal-details?updatePerson=true">Del Hatton</a><br>ABC1234',
+            '<a class="govuk-link" href="/refer/referrals/referral-123/status-history?updatePerson=true">Del Hatton</a><br>ABC1234',
           )
         })
       })

--- a/server/utils/referrals/caseListUtils.ts
+++ b/server/utils/referrals/caseListUtils.ts
@@ -272,12 +272,24 @@ export default class CaseListUtils {
     referralView: ReferralView,
     paths: typeof assessPaths | typeof referPaths,
   ): string {
-    const path =
-      referralView.status === 'referral_started'
-        ? referPaths.new.show({ referralId: referralView.id })
-        : paths.show.personalDetails({
-            referralId: referralView.id,
-          })
+    const isAssess = paths === assessPaths
+
+    let path = paths.show.statusHistory({
+      referralId: referralView.id,
+    })
+
+    if (isAssess) {
+      path = assessPaths.show.personalDetails({
+        referralId: referralView.id,
+      })
+    }
+
+    if (referralView.status === 'referral_started') {
+      path = referPaths.new.show({
+        referralId: referralView.id,
+      })
+    }
+
     const nameAndPrisonNumberHtmlStart = `<a class="govuk-link" href="${path}?updatePerson=true">`
     const prisonerName = CaseListUtils.formattedPrisonerName(referralView?.forename, referralView?.surname)
     const nameAndPrisonNumberHtmlEnd = prisonerName

--- a/server/utils/referrals/showReferralUtils.test.ts
+++ b/server/utils/referrals/showReferralUtils.test.ts
@@ -217,7 +217,7 @@ describe('ShowReferralUtils', () => {
     const mockReferralId = 'mock-referral-id'
 
     describe('when on the refer journey', () => {
-      it('returns navigation items for the referral pages with the refer paths and sets the Status history link as active', () => {
+      it('returns navigation items for the show referral pages, in the correct order, with the refer paths and sets the Status history link as active', () => {
         const currentRequestPath = referPaths.show.statusHistory({ referralId: mockReferralId })
 
         expect(ShowReferralUtils.subNavigationItems(currentRequestPath, 'statusHistory', mockReferralId)).toEqual([
@@ -239,7 +239,7 @@ describe('ShowReferralUtils', () => {
         ])
       })
 
-      it('returns navigation items for the referral pages with the refer paths and sets the Referral details link as active', () => {
+      it('returns navigation items for the show referral pages, in the correct order, with the refer paths and sets the Referral details link as active', () => {
         const currentRequestPath = referPaths.show.personalDetails({ referralId: mockReferralId })
 
         expect(ShowReferralUtils.subNavigationItems(currentRequestPath, 'referral', mockReferralId)).toEqual([
@@ -261,7 +261,7 @@ describe('ShowReferralUtils', () => {
         ])
       })
 
-      it('returns navigation items for the risks and needs pages with the refer paths and sets the Risks and needs link as active', () => {
+      it('returns navigation items for the show referral pages, in the correct order, with the refer paths and sets the Risks and needs link as active', () => {
         const currentRequestPath = referPaths.show.risksAndNeeds.offenceAnalysis({ referralId: mockReferralId })
 
         expect(ShowReferralUtils.subNavigationItems(currentRequestPath, 'risksAndNeeds', mockReferralId)).toEqual([
@@ -285,38 +285,11 @@ describe('ShowReferralUtils', () => {
     })
 
     describe('when on the assess journey', () => {
-      it('returns navigation items for the referral pages with the refer paths and sets the Status history link as active', () => {
-        const currentRequestPath = assessPaths.show.statusHistory({ referralId: mockReferralId })
-
-        expect(ShowReferralUtils.subNavigationItems(currentRequestPath, 'statusHistory', mockReferralId)).toEqual([
-          {
-            active: true,
-            href: '/assess/referrals/mock-referral-id/status-history',
-            text: 'Status history',
-          },
-          {
-            active: false,
-            href: '/assess/referrals/mock-referral-id/personal-details',
-            text: 'Referral details',
-          },
-          {
-            active: false,
-            href: '/assess/referrals/mock-referral-id/risks-and-needs/risks-and-alerts',
-            text: 'Risks and needs',
-          },
-        ])
-      })
-
-      it('returns navigation items for the referral pages with the assess paths and sets the Referral details link as active', () => {
+      it('returns navigation items for the show referral pages, in the correct order,   with the assess paths and sets the Referral details link as active', () => {
         const currentRequestPath = assessPaths.show.personalDetails({ referralId: mockReferralId })
 
         expect(ShowReferralUtils.subNavigationItems(currentRequestPath, 'referral', mockReferralId)).toEqual([
           {
-            active: false,
-            href: '/assess/referrals/mock-referral-id/status-history',
-            text: 'Status history',
-          },
-          {
             active: true,
             href: '/assess/referrals/mock-referral-id/personal-details',
             text: 'Referral details',
@@ -326,20 +299,20 @@ describe('ShowReferralUtils', () => {
             href: '/assess/referrals/mock-referral-id/risks-and-needs/risks-and-alerts',
             text: 'Risks and needs',
           },
+          {
+            active: false,
+            href: '/assess/referrals/mock-referral-id/status-history',
+            text: 'Status history',
+          },
         ])
       })
 
-      it('returns navigation items for the risks and needs pages with the assess paths and sets the Risks and needs link as active', () => {
+      it('returns navigation items for the show referral pages, in the correct order, with the assess paths and sets the Risks and needs link as active', () => {
         const currentRequestPath = assessPaths.show.risksAndNeeds.offenceAnalysis({ referralId: mockReferralId })
 
         expect(ShowReferralUtils.subNavigationItems(currentRequestPath, 'risksAndNeeds', mockReferralId)).toEqual([
           {
             active: false,
-            href: '/assess/referrals/mock-referral-id/status-history',
-            text: 'Status history',
-          },
-          {
-            active: false,
             href: '/assess/referrals/mock-referral-id/personal-details',
             text: 'Referral details',
           },
@@ -347,6 +320,33 @@ describe('ShowReferralUtils', () => {
             active: true,
             href: '/assess/referrals/mock-referral-id/risks-and-needs/risks-and-alerts',
             text: 'Risks and needs',
+          },
+          {
+            active: false,
+            href: '/assess/referrals/mock-referral-id/status-history',
+            text: 'Status history',
+          },
+        ])
+      })
+
+      it('returns navigation items for the show referral pages, in the correct order, with the assess paths and sets the Status history link as active', () => {
+        const currentRequestPath = assessPaths.show.statusHistory({ referralId: mockReferralId })
+
+        expect(ShowReferralUtils.subNavigationItems(currentRequestPath, 'statusHistory', mockReferralId)).toEqual([
+          {
+            active: false,
+            href: '/assess/referrals/mock-referral-id/personal-details',
+            text: 'Referral details',
+          },
+          {
+            active: false,
+            href: '/assess/referrals/mock-referral-id/risks-and-needs/risks-and-alerts',
+            text: 'Risks and needs',
+          },
+          {
+            active: true,
+            href: '/assess/referrals/mock-referral-id/status-history',
+            text: 'Status history',
           },
         ])
       })

--- a/server/utils/referrals/showReferralUtils.ts
+++ b/server/utils/referrals/showReferralUtils.ts
@@ -115,14 +115,16 @@ export default class ShowReferralUtils {
     currentSection: 'referral' | 'risksAndNeeds' | 'statusHistory',
     referralId: Referral['id'],
   ): Array<MojFrontendNavigationItem> {
-    const paths = currentPath.startsWith(assessPathBase.pattern) ? assessPaths : referPaths
+    const isAssess = currentPath.startsWith(assessPathBase.pattern)
+    const paths = isAssess ? assessPaths : referPaths
 
-    return [
-      {
-        active: currentSection === 'statusHistory',
-        href: paths.show.statusHistory({ referralId }),
-        text: 'Status history',
-      },
+    const statusHistoryLink: MojFrontendNavigationItem = {
+      active: currentSection === 'statusHistory',
+      href: paths.show.statusHistory({ referralId }),
+      text: 'Status history',
+    }
+
+    const navigationItems: Array<MojFrontendNavigationItem> = [
       {
         active: currentSection === 'referral',
         href: paths.show.personalDetails({ referralId }),
@@ -134,6 +136,14 @@ export default class ShowReferralUtils {
         text: 'Risks and needs',
       },
     ]
+
+    if (isAssess) {
+      navigationItems.push(statusHistoryLink)
+    } else {
+      navigationItems.unshift(statusHistoryLink)
+    }
+
+    return navigationItems
   }
 
   static viewReferralNavigationItems(


### PR DESCRIPTION
## Context

A referrer is more interested in the status of their referral so we need to link direct to the status history page from the My referrals case list.

Assess case lists should contain to link to Referral details.



## Changes in this PR
- Link to status history page from my referrals case list
- Change ordering of navigation items so status history appears first for refer path


## Screenshots of UI changes

Refer view:
![image](https://github.com/ministryofjustice/hmpps-accredited-programmes-ui/assets/1067537/99ab635f-2ed2-4486-802a-3db99660f0e9)

Assess view:
![image](https://github.com/ministryofjustice/hmpps-accredited-programmes-ui/assets/1067537/97bff318-ee7f-47b8-ad46-e5f5e1abffae)



## Release checklist

[Release process documentation](../doc/how-to/perform-a-release.md)

As part of our continuous deployment strategy we must ensure that this work is
ready to be released once merged.

### Pre-merge

- [ ] There are changes required to the Accredited Programmes API for this change to work...
  - [ ] ... and they have been released to production already

### Post-merge

<!-- The outer checkboxes can be completed pre-merge -->

- [ ] This adds, extends or meaningfully modifies a feature...
  - [ ] ... and I have written or updated an end-to-end test for the happy path in the [Accredited Programmes E2E repo](https://github.com/ministryofjustice/hmpps-accredited-programmes-e2e)
- [ ] This makes new expectations of the API...
  - [ ] ... and I have notified the API developer(s) of changes to the contract tests (Pact), or the API is already compliant
- [ ] [Manually approve](../doc/how-to/perform-a-release.md#releasing-to-the-preprod-environment) release to preprod
- [ ] [Manually approve](../doc/how-to/perform-a-release.md#releasing-to-the-production-environment) release to prod

<!-- Should a release fail at any step, you as the author should now lead the work to
fix it as soon as possible. You can monitor deployment failures in CircleCI
itself and application errors are found in
[Sentry](https://ministryofjustice.sentry.io/projects/hmpps-accredited-programmes-ui/?project=4505330122686464&referrer=sidebar&statsPeriod=24h). -->
