### PR TITLE
(1399) Check if course offering is at an enabled site

### DIFF
--- a/integration_tests/e2e/find.cy.ts
+++ b/integration_tests/e2e/find.cy.ts
@@ -138,22 +138,46 @@ context('Find', () => {
     })
 
     describe('and a referable course offering', () => {
-      it('shows the "Make a referral" button on an offering', () => {
-        const referableCourseOffering = courseOfferingFactory.build({
-          id: courseOfferingId,
-          organisationId,
-          referable: true,
-        })
-        cy.task('stubOffering', { courseOffering: referableCourseOffering })
+      describe('and in an organisation where refer IS enabled', () => {
+        it('shows the "Make a referral" button on an offering', () => {
+          const courseOffering = courseOfferingFactory.build({
+            id: courseOfferingId,
+            organisationEnabled: true,
+            organisationId,
+            referable: true,
+          })
+          cy.task('stubOffering', { courseOffering })
 
-        cy.visit(path)
+          cy.visit(path)
 
-        const courseOfferingPage = Page.verifyOnPage(CourseOfferingPage, {
-          course,
-          courseOffering: referableCourseOffering,
-          organisation,
+          const courseOfferingPage = Page.verifyOnPage(CourseOfferingPage, {
+            course,
+            courseOffering,
+            organisation,
+          })
+          courseOfferingPage.shouldContainMakeAReferralButtonLink()
         })
-        courseOfferingPage.shouldContainMakeAReferralButtonLink()
+      })
+
+      describe('and in an organisation where refer IS NOT enabled', () => {
+        it('does not show the "Make a referral" button on an offering', () => {
+          const courseOffering = courseOfferingFactory.build({
+            id: courseOfferingId,
+            organisationEnabled: false,
+            organisationId,
+            referable: true,
+          })
+          cy.task('stubOffering', { courseOffering })
+
+          cy.visit(path)
+
+          const courseOfferingPage = Page.verifyOnPage(CourseOfferingPage, {
+            course,
+            courseOffering,
+            organisation,
+          })
+          courseOfferingPage.shouldNotContainMakeAReferralButtonLink()
+        })
       })
     })
 

--- a/server/@types/models/CourseOffering.ts
+++ b/server/@types/models/CourseOffering.ts
@@ -1,6 +1,7 @@
 export type CourseOffering = {
   id: string // eslint-disable-next-line @typescript-eslint/member-ordering
   contactEmail: string
+  organisationEnabled: boolean
   organisationId: string
   referable: boolean
   secondaryContactEmail: string | null

--- a/server/testutils/factories/courseOffering.ts
+++ b/server/testutils/factories/courseOffering.ts
@@ -9,6 +9,7 @@ export default Factory.define<CourseOffering>(({ params }) => {
   return {
     id: faker.string.uuid(), // eslint-disable-next-line sort-keys
     contactEmail: `nobody-${organisationId.toLowerCase()}@digital.justice.gov.uk`,
+    organisationEnabled: faker.datatype.boolean(),
     organisationId,
     referable: faker.datatype.boolean(),
     secondaryContactEmail: faker.helpers.arrayElement([

--- a/server/views/courses/offerings/show.njk
+++ b/server/views/courses/offerings/show.njk
@@ -29,7 +29,7 @@
         rows: organisation.summaryListRows
       }) }}
 
-      {% if referEnabled and user.hasReferrerRole and courseOffering.referable %}
+      {% if referEnabled and user.hasReferrerRole and courseOffering.referable and courseOffering.organisationEnabled %}
         {{ govukButton({
             text: "Make a referral",
             href: referPaths.new.start({ courseOfferingId: courseOffering.id })


### PR DESCRIPTION
## Context

We need a way for the FIND service to restrict referrals to certain sites.

A `CourseOffering` now has an `organisationEnabled` property. 


## Changes in this PR
- Add extra check for `organisationEnabled` before showing Make a referral button




## Release checklist

[Release process documentation](../doc/how-to/perform-a-release.md)

As part of our continuous deployment strategy we must ensure that this work is
ready to be released once merged.

### Pre-merge

- [ ] There are changes required to the Accredited Programmes API for this change to work...
  - [ ] ... and they have been released to production already

### Post-merge

<!-- The outer checkboxes can be completed pre-merge -->

- [ ] This adds, extends or meaningfully modifies a feature...
  - [ ] ... and I have written or updated an end-to-end test for the happy path in the [Accredited Programmes E2E repo](https://github.com/ministryofjustice/hmpps-accredited-programmes-e2e)
- [ ] This makes new expectations of the API...
  - [ ] ... and I have notified the API developer(s) of changes to the contract tests (Pact), or the API is already compliant
- [ ] [Manually approve](../doc/how-to/perform-a-release.md#releasing-to-the-preprod-environment) release to preprod
- [ ] [Manually approve](../doc/how-to/perform-a-release.md#releasing-to-the-production-environment) release to prod

<!-- Should a release fail at any step, you as the author should now lead the work to
fix it as soon as possible. You can monitor deployment failures in CircleCI
itself and application errors are found in
[Sentry](https://ministryofjustice.sentry.io/projects/hmpps-accredited-programmes-ui/?project=4505330122686464&referrer=sidebar&statsPeriod=24h). -->
