### PR TITLE
(1456) Show all open referrals on PT case list

### DIFF
--- a/integration_tests/e2e/assess/caseList.cy.ts
+++ b/integration_tests/e2e/assess/caseList.cy.ts
@@ -44,13 +44,14 @@ context('Referral case lists', () => {
       organisationId: 'MRI',
       queryParameters: {
         courseName: { equalTo: limeCourse.name },
+        statusGroup: { equalTo: 'open' },
       },
       referralViews: limeCourseReferralViews,
     })
   })
 
   it('shows the correct information', () => {
-    const path = assessPaths.caseList.show({ courseName: 'lime-course' })
+    const path = assessPaths.caseList.show({ courseName: 'lime-course', referralStatusGroup: 'open' })
     cy.visit(path)
 
     const caseListPage = Page.verifyOnPage(CaseListPage, {
@@ -66,20 +67,27 @@ context('Referral case lists', () => {
   it('includes pagination', () => {
     cy.task('stubFindReferralViews', {
       organisationId: 'MRI',
-      queryParameters: { page: { equalTo: '3' } },
+      queryParameters: {
+        page: { equalTo: '3' },
+        statusGroup: { equalTo: 'open' },
+      },
       referralViews: limeCourseReferralViews,
       totalPages: 7,
     })
     cy.task('stubFindReferralViews', {
       organisationId: 'MRI',
-      queryParameters: { page: { equalTo: '4' } },
+      queryParameters: {
+        page: { equalTo: '4' },
+        statusGroup: { equalTo: 'open' },
+      },
       referralViews: limeCourseReferralViews,
       totalPages: 7,
     })
 
-    const path = PathUtils.pathWithQuery(assessPaths.caseList.show({ courseName: 'lime-course' }), [
-      { key: 'page', value: '4' },
-    ])
+    const path = PathUtils.pathWithQuery(
+      assessPaths.caseList.show({ courseName: 'lime-course', referralStatusGroup: 'open' }),
+      [{ key: 'page', value: '4' }],
+    )
     cy.visit(path)
 
     const caseListPage = Page.verifyOnPage(CaseListPage, {
@@ -102,7 +110,7 @@ context('Referral case lists', () => {
 
   describe('when using the filters', () => {
     it('shows the correct information', () => {
-      const path = assessPaths.caseList.show({ courseName: 'lime-course' })
+      const path = assessPaths.caseList.show({ courseName: 'lime-course', referralStatusGroup: 'open' })
       cy.visit(path)
 
       const caseListPage = Page.verifyOnPage(CaseListPage, {
@@ -155,7 +163,10 @@ context('Referral case lists', () => {
         course: blueCourse,
         referralViews: blueCourseReferralViews,
       })
-      caseListPage.shouldContainCourseNavigation(assessPaths.caseList.show({ courseName: 'blue-course' }), courses)
+      caseListPage.shouldContainCourseNavigation(
+        assessPaths.caseList.show({ courseName: 'blue-course', referralStatusGroup: 'open' }),
+        courses,
+      )
       caseListPage.shouldHaveSelectedFilterValues('', '')
       caseListPage.shouldContainTableOfReferralViews(assessPaths)
     })

--- a/integration_tests/mockApis/referenceData.ts
+++ b/integration_tests/mockApis/referenceData.ts
@@ -5,6 +5,7 @@ import { stubFor } from '../../wiremock'
 import type {
   ReferralStatusCategory,
   ReferralStatusReason,
+  ReferralStatusRefData,
   ReferralStatusUppercase,
 } from '@accredited-programmes/models'
 
@@ -41,6 +42,19 @@ export default {
       response: {
         headers: { 'Content-Type': 'application/json;charset=UTF-8' },
         jsonBody: args.reasons,
+        status: 200,
+      },
+    }),
+
+  stubReferralStatuses: (referralStatuses: Array<ReferralStatusRefData>): SuperAgentRequest =>
+    stubFor({
+      request: {
+        method: 'GET',
+        url: apiPaths.referenceData.referralStatuses.show({}),
+      },
+      response: {
+        headers: { 'Content-Type': 'application/json;charset=UTF-8' },
+        jsonBody: referralStatuses,
         status: 200,
       },
     }),

--- a/integration_tests/pages/shared/caseList.ts
+++ b/integration_tests/pages/shared/caseList.ts
@@ -29,7 +29,10 @@ export default class CaseListPage extends Page {
       .sort((courseA, courseB) => courseA.name.localeCompare(courseB.name))
       .map(course => {
         return {
-          href: assessPaths.caseList.show({ courseName: StringUtils.convertToUrlSlug(course.name) }),
+          href: assessPaths.caseList.show({
+            courseName: StringUtils.convertToUrlSlug(course.name),
+            referralStatusGroup: 'open',
+          }),
           text: `${course.name} referrals`,
         }
       })
@@ -172,6 +175,7 @@ export default class CaseListPage extends Page {
       queryParameters: {
         audience: { equalTo: CaseListUtils.uiToApiAudienceQueryParam(programmeStrandSelectedValue) },
         status: { equalTo: CaseListUtils.uiToApiStatusQueryParam(referralStatusSelectedValue) },
+        statusGroup: { equalTo: 'open' },
       },
       referralViews: filteredReferralViews,
     })

--- a/integration_tests/pages/shared/caseList.ts
+++ b/integration_tests/pages/shared/caseList.ts
@@ -174,7 +174,7 @@ export default class CaseListPage extends Page {
       organisationId: 'MRI',
       queryParameters: {
         audience: { equalTo: CaseListUtils.uiToApiAudienceQueryParam(programmeStrandSelectedValue) },
-        status: { equalTo: CaseListUtils.uiToApiStatusQueryParam(referralStatusSelectedValue) },
+        status: { equalTo: referralStatusSelectedValue },
         statusGroup: { equalTo: 'open' },
       },
       referralViews: filteredReferralViews,

--- a/server/controllers/assess/caseListController.ts
+++ b/server/controllers/assess/caseListController.ts
@@ -4,6 +4,7 @@ import createError from 'http-errors'
 import { assessPaths } from '../../paths'
 import type { CourseService, ReferralService } from '../../services'
 import { CaseListUtils, CourseUtils, PaginationUtils, PathUtils, StringUtils, TypeUtils } from '../../utils'
+import type { ReferralStatusGroup } from '@accredited-programmes/models'
 import type { CaseListColumnHeader, SortableCaseListColumnKey } from '@accredited-programmes/ui'
 
 export default class AssessCaseListController {
@@ -16,11 +17,11 @@ export default class AssessCaseListController {
     return async (req: Request, res: Response) => {
       TypeUtils.assertHasUser(req)
 
-      const { courseName } = req.params
+      const { courseName, referralStatusGroup } = req.params
 
       return res.redirect(
         PathUtils.pathWithQuery(
-          assessPaths.caseList.show({ courseName }),
+          assessPaths.caseList.show({ courseName, referralStatusGroup }),
           CaseListUtils.queryParamsExcludingPage(req.body.audience, req.body.status),
         ),
       )
@@ -41,7 +42,7 @@ export default class AssessCaseListController {
       const sortedCourses = courses.sort((courseA, courseB) => courseA.name.localeCompare(courseB.name))
       const firstCourseName = StringUtils.convertToUrlSlug(sortedCourses[0].name)
 
-      res.redirect(assessPaths.caseList.show({ courseName: firstCourseName }))
+      res.redirect(assessPaths.caseList.show({ courseName: firstCourseName, referralStatusGroup: 'open' }))
     }
   }
 
@@ -51,6 +52,13 @@ export default class AssessCaseListController {
 
       const { courseName } = req.params
       const { page, status, strand: audience, sortColumn, sortDirection } = req.query as Record<string, string>
+      const { referralStatusGroup } = req.params as { referralStatusGroup: ReferralStatusGroup }
+
+      const isValidReferralStatusGroup = ['open', 'closed'].includes(referralStatusGroup)
+
+      if (!isValidReferralStatusGroup) {
+        throw createError(404, 'Not found')
+      }
 
       const { activeCaseLoadId, username } = res.locals.user
 
@@ -63,15 +71,14 @@ export default class AssessCaseListController {
         throw createError(404, `${formattedCourseName} not found.`)
       }
 
-      const statusQuery = status || ['assessment_started', 'awaiting_assessment', 'referral_submitted'].join(',')
-
       const paginatedReferralViews = await this.referralService.getReferralViews(username, activeCaseLoadId, {
         audience: CaseListUtils.uiToApiAudienceQueryParam(audience),
         courseName: selectedCourse.name,
         page: page ? (Number(page) - 1).toString() : undefined,
         sortColumn,
         sortDirection,
-        status: CaseListUtils.uiToApiStatusQueryParam(statusQuery),
+        status: CaseListUtils.uiToApiStatusQueryParam(status),
+        statusGroup: referralStatusGroup,
       })
 
       const pagination = PaginationUtils.pagination(
@@ -82,7 +89,7 @@ export default class AssessCaseListController {
       )
 
       const basePathExcludingSort = PathUtils.pathWithQuery(
-        assessPaths.caseList.show({ courseName }),
+        assessPaths.caseList.show({ courseName, referralStatusGroup }),
         CaseListUtils.queryParamsExcludingSort(audience, status, page),
       )
 
@@ -98,7 +105,7 @@ export default class AssessCaseListController {
       /* eslint-enable sort-keys */
 
       return res.render('referrals/caseList/assess/show', {
-        action: assessPaths.caseList.filter({ courseName }),
+        action: assessPaths.caseList.filter({ courseName, referralStatusGroup }),
         audienceSelectItems: CaseListUtils.audienceSelectItems(audience),
         pageHeading: CourseUtils.courseNameWithAlternateName(selectedCourse),
         pagination,

--- a/server/controllers/assess/index.ts
+++ b/server/controllers/assess/index.ts
@@ -5,7 +5,11 @@ import UpdateStatusDecisionController from './updateStatusDecisionController'
 import type { Services } from '../../services'
 
 const controllers = (services: Services) => {
-  const assessCaseListController = new AssessCaseListController(services.courseService, services.referralService)
+  const assessCaseListController = new AssessCaseListController(
+    services.courseService,
+    services.referralService,
+    services.referenceDataService,
+  )
 
   const updateStatusDecisionController = new UpdateStatusDecisionController(services.referralService)
 

--- a/server/data/accreditedProgrammesApi/referenceDataClient.ts
+++ b/server/data/accreditedProgrammesApi/referenceDataClient.ts
@@ -42,4 +42,10 @@ export default class ReferenceDataClient {
       path: apiPaths.referenceData.referralStatuses.statusCodeReasons({ categoryCode, referralStatusCode }),
     })) as Array<ReferralStatusReason>
   }
+
+  async findReferralStatuses(): Promise<Array<ReferralStatusRefData>> {
+    return (await this.restClient.get({
+      path: apiPaths.referenceData.referralStatuses.show({}),
+    })) as Array<ReferralStatusRefData>
+  }
 }

--- a/server/data/accreditedProgrammesApi/referralClient.ts
+++ b/server/data/accreditedProgrammesApi/referralClient.ts
@@ -83,6 +83,7 @@ export default class ReferralClient {
       sortColumn?: string
       sortDirection?: string
       status?: string
+      statusGroup?: ReferralStatusGroup
     },
   ): Promise<Paginated<ReferralView>> {
     return (await this.restClient.get({
@@ -94,6 +95,7 @@ export default class ReferralClient {
         ...(query?.sortColumn && { sortColumn: query.sortColumn }),
         ...(query?.sortDirection && { sortDirection: query.sortDirection }),
         ...(query?.status && { status: query.status }),
+        ...(query?.statusGroup && { statusGroup: query.statusGroup }),
         size: '15',
       },
     })) as Paginated<ReferralView>

--- a/server/paths/api.ts
+++ b/server/paths/api.ts
@@ -76,6 +76,7 @@ export default {
   referenceData: {
     referralStatuses: {
       codeData: referralStatusesCodeDataPath,
+      show: referralStatusesPath,
       statusCodeCategories: referralStatusCodeCategoriesPath,
       statusCodeReasons: referralStatusCodeReasonsPath,
     },

--- a/server/paths/assess.ts
+++ b/server/paths/assess.ts
@@ -14,9 +14,9 @@ const updateStatusSelectionShowPath = updateStatusPathBase.path('selection')
 
 export default {
   caseList: {
-    filter: courseCaseListPath,
+    filter: courseCaseListPath.path(':referralStatusGroup'),
     index: caseListIndex,
-    show: courseCaseListPath,
+    show: courseCaseListPath.path(':referralStatusGroup'),
   },
   show: {
     additionalInformation: referralShowPathBase.path('additional-information'),

--- a/server/services/referenceDataService.test.ts
+++ b/server/services/referenceDataService.test.ts
@@ -79,4 +79,16 @@ describe('ReferenceDataService', () => {
       expect(result).toEqual(reasons)
     })
   })
+
+  describe('getReferralStatuses', () => {
+    it('should return referral statuses', async () => {
+      const referralStatuses = referralStatusRefDataFactory.buildList(2)
+
+      when(referenceDataClient.findReferralStatuses).mockResolvedValue(referralStatuses)
+
+      const result = await service.getReferralStatuses(username)
+
+      expect(result).toEqual(referralStatuses)
+    })
+  })
 })

--- a/server/services/referenceDataService.ts
+++ b/server/services/referenceDataService.ts
@@ -46,4 +46,12 @@ export default class ReferenceDataService {
 
     return referenceDataClient.findReferralStatusCodeReasons(categoryCode, referralStatusCode)
   }
+
+  async getReferralStatuses(username: Express.User['username']): Promise<Array<ReferralStatusRefData>> {
+    const hmppsAuthClient = this.hmppsAuthClientBuilder()
+    const systemToken = await hmppsAuthClient.getSystemClientToken(username)
+    const referenceDataClient = this.referenceDataClient(systemToken)
+
+    return referenceDataClient.findReferralStatuses()
+  }
 }

--- a/server/services/referralService.test.ts
+++ b/server/services/referralService.test.ts
@@ -288,13 +288,22 @@ describe('ReferralService', () => {
 
     describe('with query values', () => {
       it('makes the correct call to the referral client', async () => {
-        const query = {
+        const query: {
+          audience: string
+          courseName: string
+          page: string
+          sortColumn: string
+          sortDirection: string
+          status: string
+          statusGroup: ReferralStatusGroup
+        } = {
           audience: 'General offence',
           courseName: 'Lime Course',
           page: '1',
           sortColumn: 'surname',
           sortDirection: 'ascending',
           status: 'REFERRAL_SUBMITTED',
+          statusGroup: 'open',
         }
 
         await service.getReferralViews(username, organisationId, query)

--- a/server/services/referralService.ts
+++ b/server/services/referralService.ts
@@ -118,6 +118,7 @@ export default class ReferralService {
       sortColumn?: string
       sortDirection?: string
       status?: string
+      statusGroup?: ReferralStatusGroup
     },
   ): Promise<Paginated<ReferralView>> {
     const hmppsAuthClient = this.hmppsAuthClientBuilder()

--- a/server/testutils/factories/referral.ts
+++ b/server/testutils/factories/referral.ts
@@ -2,7 +2,7 @@ import { faker } from '@faker-js/faker'
 import { Factory } from 'fishery'
 
 import { referralStatuses } from '../../@types/models/Referral'
-import type { Referral, ReferralStatus } from '@accredited-programmes/models'
+import type { Referral, ReferralStatus, ReferralStatusUppercase } from '@accredited-programmes/models'
 
 class ReferralFactory extends Factory<Referral> {
   closed() {
@@ -44,8 +44,12 @@ const closedStatuses: Array<ReferralStatus> = ['programme_complete', 'deselected
 const randomStatus = (availableStatuses?: Array<ReferralStatus>) =>
   faker.helpers.arrayElement(availableStatuses || referralStatuses)
 
-const statusDescriptionAndColour = (status?: ReferralStatus): Pick<Referral, 'statusColour' | 'statusDescription'> => {
-  switch (status) {
+const statusDescriptionAndColour = (
+  status?: ReferralStatus | ReferralStatusUppercase,
+): Pick<Referral, 'statusColour' | 'statusDescription'> => {
+  const lowercaseStatus = status?.toLowerCase()
+
+  switch (lowercaseStatus) {
     case 'awaiting_assessment':
       return { statusColour: 'light-blue', statusDescription: 'Awaiting Assessment' }
     case 'on_hold_awaiting_assessment':

--- a/server/testutils/factories/referralStatusRefData.ts
+++ b/server/testutils/factories/referralStatusRefData.ts
@@ -9,7 +9,7 @@ import type { TagColour } from '@accredited-programmes/ui'
 export default Factory.define<ReferralStatusRefData>(({ params }) => {
   const { hasConfirmation: hasConfirmationParam, hasNotes: hasNotesParam } = params
 
-  const code = faker.helpers.arrayElement(referralStatuses).toUpperCase() as ReferralStatus
+  const code = params.code || (faker.helpers.arrayElement(referralStatuses).toUpperCase() as ReferralStatus)
   const { statusColour, statusDescription } = statusDescriptionAndColour(code)
   const colour = statusColour as TagColour
   const description = statusDescription as string

--- a/server/utils/referrals/caseListUtils.test.ts
+++ b/server/utils/referrals/caseListUtils.test.ts
@@ -724,16 +724,4 @@ describe('CaseListUtils', () => {
       })
     })
   })
-
-  describe('uiToApiStatusQueryParam', () => {
-    it('returns the UI query param formatted to match the API data', () => {
-      expect(CaseListUtils.uiToApiStatusQueryParam('referral submitted')).toEqual('REFERRAL_SUBMITTED')
-    })
-
-    describe('when the param is falsey', () => {
-      it('returns `undefined`', () => {
-        expect(CaseListUtils.uiToApiStatusQueryParam(undefined)).toEqual(undefined)
-      })
-    })
-  })
 })

--- a/server/utils/referrals/caseListUtils.test.ts
+++ b/server/utils/referrals/caseListUtils.test.ts
@@ -41,20 +41,20 @@ describe('CaseListUtils', () => {
         courseFactory.build({ name: 'Blue Course' }),
       ]
 
-      expect(CaseListUtils.primaryNavigationItems('/assess/referrals/orange-course/case-list', courses)).toEqual([
+      expect(CaseListUtils.primaryNavigationItems('/assess/referrals/orange-course/case-list/open', courses)).toEqual([
         {
           active: false,
-          href: '/assess/referrals/blue-course/case-list',
+          href: '/assess/referrals/blue-course/case-list/open',
           text: 'Blue Course referrals',
         },
         {
           active: false,
-          href: '/assess/referrals/lime-course/case-list',
+          href: '/assess/referrals/lime-course/case-list/open',
           text: 'Lime Course referrals',
         },
         {
           active: true,
-          href: '/assess/referrals/orange-course/case-list',
+          href: '/assess/referrals/orange-course/case-list/open',
           text: 'Orange Course referrals',
         },
       ])

--- a/server/utils/referrals/caseListUtils.test.ts
+++ b/server/utils/referrals/caseListUtils.test.ts
@@ -1,6 +1,6 @@
 import CaseListUtils from './caseListUtils'
 import { assessPaths, referPaths } from '../../paths'
-import { courseFactory, referralViewFactory } from '../../testutils/factories'
+import { courseFactory, referralStatusRefDataFactory, referralViewFactory } from '../../testutils/factories'
 import FormUtils from '../formUtils'
 import type { ReferralStatus } from '@accredited-programmes/models'
 import type { CaseListColumnHeader, SortableCaseListColumnKey } from '@accredited-programmes/ui'
@@ -8,6 +8,10 @@ import type { CaseListColumnHeader, SortableCaseListColumnKey } from '@accredite
 jest.mock('../formUtils')
 
 describe('CaseListUtils', () => {
+  beforeEach(() => {
+    jest.resetAllMocks()
+  })
+
   describe('audienceSelectItems', () => {
     const expectedItems = {
       'extremism offence': 'Extremism offence',
@@ -306,23 +310,28 @@ describe('CaseListUtils', () => {
   })
 
   describe('statusSelectItems', () => {
+    const referralStatuses = [
+      referralStatusRefDataFactory.build({ code: 'assessment_started' }),
+      referralStatusRefDataFactory.build({ code: 'referral_submitted' }),
+    ]
     const expectedItems = {
-      'assessment started': 'Assessment started',
-      'awaiting assessment': 'Awaiting assessment',
-      'referral submitted': 'Referral submitted',
+      assessment_started: 'Assessment started',
+      referral_submitted: 'Referral submitted',
     }
 
     it('makes a call to the `FormUtils.getSelectItems` method with an `undefined` `selectedValue` parameter', () => {
-      CaseListUtils.statusSelectItems()
+      CaseListUtils.statusSelectItems(referralStatuses)
 
       expect(FormUtils.getSelectItems).toHaveBeenCalledWith(expectedItems, undefined)
     })
 
     describe('when a selected value is provided', () => {
       it('makes a call to the `FormUtils.getSelectItems` method with the correct `selectedValue` parameter', () => {
-        CaseListUtils.statusSelectItems('referral submitted')
+        const selectedValue = 'assessment_started'
 
-        expect(FormUtils.getSelectItems).toHaveBeenCalledWith(expectedItems, 'referral submitted')
+        CaseListUtils.statusSelectItems(referralStatuses, selectedValue)
+
+        expect(FormUtils.getSelectItems).toHaveBeenCalledWith(expectedItems, selectedValue)
       })
     })
   })

--- a/server/utils/referrals/caseListUtils.ts
+++ b/server/utils/referrals/caseListUtils.ts
@@ -5,7 +5,7 @@ import { assessPaths, referPaths } from '../../paths'
 import DateUtils from '../dateUtils'
 import FormUtils from '../formUtils'
 import StringUtils from '../stringUtils'
-import type { Course, Referral, ReferralView } from '@accredited-programmes/models'
+import type { Course, Referral, ReferralStatusRefData, ReferralView } from '@accredited-programmes/models'
 import type { CaseListColumnHeader, MojFrontendNavigationItem, QueryParam } from '@accredited-programmes/ui'
 import type { GovukFrontendSelectItem, GovukFrontendTableHeadElement, GovukFrontendTableRow } from '@govuk-frontend'
 
@@ -114,8 +114,14 @@ export default class CaseListUtils {
     })
   }
 
-  static statusSelectItems(selectedValue?: string): Array<GovukFrontendSelectItem> {
-    return this.selectItems(['Assessment started', 'Awaiting assessment', 'Referral submitted'], selectedValue)
+  static statusSelectItems(
+    statuses: Array<ReferralStatusRefData>,
+    selectedValue?: string,
+  ): Array<GovukFrontendSelectItem> {
+    return FormUtils.getSelectItems(
+      Object.fromEntries(statuses.map(({ code, description }) => [code, description])),
+      selectedValue,
+    )
   }
 
   static statusTagHtml(

--- a/server/utils/referrals/caseListUtils.ts
+++ b/server/utils/referrals/caseListUtils.ts
@@ -34,7 +34,10 @@ export default class CaseListUtils {
     const sortedCourses = coursesWithDuplicatesRemoved.sort((a, b) => a.name.localeCompare(b.name))
 
     return sortedCourses.map(course => {
-      const path = assessPaths.caseList.show({ courseName: StringUtils.convertToUrlSlug(course.name) })
+      const path = assessPaths.caseList.show({
+        courseName: StringUtils.convertToUrlSlug(course.name),
+        referralStatusGroup: 'open',
+      })
 
       return {
         active: currentPath === path,

--- a/server/utils/referrals/caseListUtils.ts
+++ b/server/utils/referrals/caseListUtils.ts
@@ -269,10 +269,6 @@ export default class CaseListUtils {
     return uiAudienceQueryParam ? StringUtils.properCase(uiAudienceQueryParam) : undefined
   }
 
-  static uiToApiStatusQueryParam(uiStatusQueryParam: string | undefined): string | undefined {
-    return uiStatusQueryParam ? uiStatusQueryParam.toUpperCase().replace(/\s/g, '_') : undefined
-  }
-
   private static formattedPrisonerName(forename?: ReferralView['forename'], surname?: ReferralView['surname']): string {
     return StringUtils.convertToTitleCase([forename, surname].filter(nameComponent => nameComponent).join(' '))
   }


### PR DESCRIPTION
## Context

We need to show all open referrals and the correct filters on a PT case list.

Closed to come at a later date.


## Changes in this PR
- Update case list to fetch referrals with `statusGroup=open` query param.
- Update status filter to include only open statuses



## Release checklist

[Release process documentation](../doc/how-to/perform-a-release.md)

As part of our continuous deployment strategy we must ensure that this work is
ready to be released once merged.

### Pre-merge

- [ ] There are changes required to the Accredited Programmes API for this change to work...
  - [ ] ... and they have been released to production already

### Post-merge

<!-- The outer checkboxes can be completed pre-merge -->

- [ ] This adds, extends or meaningfully modifies a feature...
  - [ ] ... and I have written or updated an end-to-end test for the happy path in the [Accredited Programmes E2E repo](https://github.com/ministryofjustice/hmpps-accredited-programmes-e2e)
- [ ] This makes new expectations of the API...
  - [ ] ... and I have notified the API developer(s) of changes to the contract tests (Pact), or the API is already compliant
- [ ] [Manually approve](../doc/how-to/perform-a-release.md#releasing-to-the-preprod-environment) release to preprod
- [ ] [Manually approve](../doc/how-to/perform-a-release.md#releasing-to-the-production-environment) release to prod

<!-- Should a release fail at any step, you as the author should now lead the work to
fix it as soon as possible. You can monitor deployment failures in CircleCI
itself and application errors are found in
[Sentry](https://ministryofjustice.sentry.io/projects/hmpps-accredited-programmes-ui/?project=4505330122686464&referrer=sidebar&statsPeriod=24h). -->
