### PR TITLE
(1453) Deselect and close referral

### DIFF
--- a/server/@types/express/index.d.ts
+++ b/server/@types/express/index.d.ts
@@ -2,7 +2,7 @@
 // @ts-expect-error to fix later: https://github.com/microsoft/TypeScript/issues/16472
 import type { Request as ConnectFlashRequest } from '@types/connect-flash'
 
-import type { ReferralStatus, ReferralStatusUppercase } from '@accredited-programmes/models'
+import type { ReferralStatusUppercase } from '@accredited-programmes/models'
 import type { UserDetails } from '@accredited-programmes/users'
 
 declare module 'express-session' {
@@ -44,8 +44,8 @@ type RequestWithUser = Express.RequestWithUser
 
 interface ReferralStatusUpdateSessionData {
   referralId: string
-  status: ReferralStatus | ReferralStatusUppercase
   previousPath?: string
+  status?: ReferralStatusUppercase
   statusCategoryCode?: Uppercase<string>
   statusReasonCode?: Uppercase<string>
 }

--- a/server/controllers/assess/updateStatusDecisionController.ts
+++ b/server/controllers/assess/updateStatusDecisionController.ts
@@ -3,6 +3,7 @@ import type { Request, Response, TypedRequestHandler } from 'express'
 import { assessPaths } from '../../paths'
 import type { ReferralService } from '../../services'
 import { FormUtils, ReferralUtils, ShowReferralUtils, TypeUtils } from '../../utils'
+import type { ReferralStatusUppercase } from '@accredited-programmes/models'
 
 export default class UpdateStatusDecisionController {
   constructor(private readonly referralService: ReferralService) {}
@@ -44,7 +45,7 @@ export default class UpdateStatusDecisionController {
   submit(): TypedRequestHandler<Request, Response> {
     return async (req: Request, res: Response) => {
       const { referralId } = req.params
-      const { statusDecision } = req.body
+      const { statusDecision } = req.body as { statusDecision: ReferralStatusUppercase }
 
       if (!statusDecision) {
         req.flash('statusDecisionError', 'Select a status decision')
@@ -53,13 +54,12 @@ export default class UpdateStatusDecisionController {
       }
 
       req.session.referralStatusUpdateData = {
-        previousPath: req.path,
         referralId,
         status: statusDecision,
       }
 
-      if (statusDecision === 'WITHDRAWN') {
-        return res.redirect(assessPaths.withdraw.category({ referralId }))
+      if (statusDecision === 'DESELECTED' || statusDecision === 'WITHDRAWN') {
+        return res.redirect(assessPaths.updateStatus.category.show({ referralId }))
       }
 
       return res.redirect(assessPaths.updateStatus.selection.show({ referralId }))

--- a/server/controllers/shared/categoryController.test.ts
+++ b/server/controllers/shared/categoryController.test.ts
@@ -1,0 +1,256 @@
+import type { DeepMocked } from '@golevelup/ts-jest'
+import { createMock } from '@golevelup/ts-jest'
+import type { NextFunction, Request, Response } from 'express'
+
+import CategoryController from './categoryController'
+import type { ReferralStatusUpdateSessionData } from '../../@types/express'
+import { assessPaths, referPaths } from '../../paths'
+import type { ReferenceDataService, ReferralService } from '../../services'
+import { referralFactory, referralStatusCategoryFactory, referralStatusHistoryFactory } from '../../testutils/factories'
+import Helpers from '../../testutils/helpers'
+import { FormUtils, ReferralUtils, ShowReferralUtils } from '../../utils'
+import type { Referral, ReferralStatusCategory } from '@accredited-programmes/models'
+import type { MojTimelineItem, ReferralStatusHistoryPresenter } from '@accredited-programmes/ui'
+import type { GovukFrontendRadiosItem } from '@govuk-frontend'
+
+jest.mock('../../utils/formUtils')
+jest.mock('../../utils/referrals/referralUtils')
+jest.mock('../../utils/referrals/showReferralUtils')
+
+const mockReferralUtils = ReferralUtils as jest.Mocked<typeof ReferralUtils>
+const mockShowReferralUtils = ShowReferralUtils as jest.Mocked<typeof ShowReferralUtils>
+
+describe('CategoryController', () => {
+  const userToken = 'SOME_TOKEN'
+  const username = 'USERNAME'
+
+  let request: DeepMocked<Request>
+  let response: DeepMocked<Response>
+  const next: DeepMocked<NextFunction> = createMock<NextFunction>({})
+
+  const referenceDataService = createMock<ReferenceDataService>({})
+  const referralService = createMock<ReferralService>({})
+
+  const radioItems: Array<GovukFrontendRadiosItem> = [
+    { text: 'Category A', value: 'A' },
+    { text: 'Category B', value: 'B' },
+  ]
+  const timelineItems: Array<MojTimelineItem> = [
+    {
+      byline: { text: 'Test User' },
+      datetime: { timestamp: new Date().toISOString(), type: 'datetime' },
+      html: 'html',
+      label: { text: 'Referral submitted' },
+    },
+    {
+      byline: { text: 'Test User' },
+      datetime: { timestamp: new Date().toISOString(), type: 'datetime' },
+      html: 'html',
+      label: { text: 'Referral started' },
+    },
+  ]
+  let referral: Referral
+  let referralStatusCodeCategories: Array<ReferralStatusCategory>
+  let referralStatusHistory: Array<ReferralStatusHistoryPresenter>
+  let referralStatusUpdateData: ReferralStatusUpdateSessionData
+
+  let controller: CategoryController
+
+  beforeEach(() => {
+    referral = referralFactory.submitted().build({})
+    referralStatusCodeCategories = referralStatusCategoryFactory.buildList(2, { referralStatusCode: 'WITHDRAWN' })
+    referralStatusHistory = [{ ...referralStatusHistoryFactory.started().build(), byLineText: 'You' }]
+    referralStatusUpdateData = { referralId: referral.id, status: 'DESELECTED' }
+    mockReferralUtils.statusOptionsToRadioItems.mockReturnValue(radioItems)
+    mockShowReferralUtils.statusHistoryTimelineItems.mockReturnValue(timelineItems)
+
+    referralService.getReferralStatusHistory.mockResolvedValue(referralStatusHistory)
+    referenceDataService.getReferralStatusCodeCategories.mockResolvedValue(referralStatusCodeCategories)
+
+    controller = new CategoryController(referenceDataService, referralService)
+
+    request = createMock<Request>({
+      params: { referralId: referral.id },
+      path: referPaths.updateStatus.category.show({ referralId: referral.id }),
+      session: { referralStatusUpdateData },
+      user: { token: userToken, username },
+    })
+    response = Helpers.createMockResponseWithCaseloads()
+  })
+
+  describe('show', () => {
+    it('should render the show template with the correct response locals', async () => {
+      const requestHandler = controller.show()
+      await requestHandler(request, response, next)
+
+      expect(response.render).toHaveBeenCalledWith('referrals/updateStatus/category/show', {
+        backLinkHref: '#',
+        pageDescription: 'If you deselect the referral, it will be closed.',
+        pageHeading: 'Deselection category',
+        radioItems,
+        radioLegend: 'Choose the deselection category',
+        timelineItems: timelineItems.slice(0, 1),
+      })
+
+      expect(referenceDataService.getReferralStatusCodeCategories).toHaveBeenCalledWith(username, 'DESELECTED')
+      expect(referralService.getReferralStatusHistory).toHaveBeenCalledWith(userToken, username, referral.id)
+
+      expect(FormUtils.setFieldErrors).toHaveBeenCalledWith(request, response, ['categoryCode'])
+      expect(ReferralUtils.statusOptionsToRadioItems).toHaveBeenCalledWith(referralStatusCodeCategories, undefined)
+      expect(ShowReferralUtils.statusHistoryTimelineItems).toHaveBeenCalledWith(referralStatusHistory)
+    })
+
+    describe('when `referralStatusUpdateData.status` is `WITHDRAWN', () => {
+      it('should render the show template with the correct response locals', async () => {
+        request.session.referralStatusUpdateData = {
+          ...referralStatusUpdateData,
+          status: 'WITHDRAWN',
+        }
+
+        const requestHandler = controller.show()
+        await requestHandler(request, response, next)
+
+        expect(response.render).toHaveBeenCalledWith('referrals/updateStatus/category/show', {
+          backLinkHref: '#',
+          pageDescription: 'If you withdraw the referral, it will be closed.',
+          pageHeading: 'Withdrawal category',
+          radioItems,
+          radioLegend: 'Select the withdrawal category',
+          timelineItems: timelineItems.slice(0, 1),
+        })
+
+        expect(referenceDataService.getReferralStatusCodeCategories).toHaveBeenCalledWith(username, 'WITHDRAWN')
+        expect(referralService.getReferralStatusHistory).toHaveBeenCalledWith(userToken, username, referral.id)
+
+        expect(FormUtils.setFieldErrors).toHaveBeenCalledWith(request, response, ['categoryCode'])
+        expect(ReferralUtils.statusOptionsToRadioItems).toHaveBeenCalledWith(referralStatusCodeCategories, undefined)
+        expect(ShowReferralUtils.statusHistoryTimelineItems).toHaveBeenCalledWith(referralStatusHistory)
+      })
+    })
+
+    describe('when there is no `referralStatusUpdateData`', () => {
+      it('should redirect to the status history page', async () => {
+        delete request.session.referralStatusUpdateData
+
+        const requestHandler = controller.show()
+        await requestHandler(request, response, next)
+
+        expect(response.redirect).toHaveBeenCalledWith(referPaths.show.statusHistory({ referralId: referral.id }))
+      })
+    })
+
+    describe('when `referralStatusUpdateData.referralId` is for a different referral', () => {
+      it('should redirect to the status history page', async () => {
+        request.session.referralStatusUpdateData = {
+          ...referralStatusUpdateData,
+          referralId: 'ANOTHER-REFERRAL',
+        }
+
+        const requestHandler = controller.show()
+        await requestHandler(request, response, next)
+
+        expect(response.redirect).toHaveBeenCalledWith(referPaths.show.statusHistory({ referralId: referral.id }))
+      })
+    })
+
+    describe('when there is no `referralStatusUpdateData.status` value', () => {
+      it('should redirect to the status history page', async () => {
+        delete request.session.referralStatusUpdateData?.status
+
+        const requestHandler = controller.show()
+        await requestHandler(request, response, next)
+
+        expect(response.redirect).toHaveBeenCalledWith(referPaths.show.statusHistory({ referralId: referral.id }))
+      })
+    })
+
+    describe('when `referralStatusUpdateData.status` does not require a category selection', () => {
+      it('should redirect to the status history page', async () => {
+        request.session.referralStatusUpdateData = {
+          ...referralStatusUpdateData,
+          status: 'AWAITING_ASSESSMENT',
+        }
+
+        const requestHandler = controller.show()
+        await requestHandler(request, response, next)
+
+        expect(response.redirect).toHaveBeenCalledWith(referPaths.show.statusHistory({ referralId: referral.id }))
+      })
+    })
+  })
+
+  describe('submit', () => {
+    beforeEach(() => {
+      request.body = { categoryCode: 'STATUS-CAT-A' }
+    })
+
+    it('should update `referralStatusUpdateData` and redirect to refer select reason page', async () => {
+      const requestHandler = controller.submit()
+      await requestHandler(request, response, next)
+
+      expect(request.session.referralStatusUpdateData).toEqual({
+        ...referralStatusUpdateData,
+        statusCategoryCode: 'STATUS-CAT-A',
+        statusReasonCode: undefined,
+      })
+      expect(response.redirect).toHaveBeenCalledWith(referPaths.updateStatus.reason.show({ referralId: referral.id }))
+    })
+
+    describe('when submitting the form on the assess journey', () => {
+      it('should update `referralStatusUpdateData` and redirect to the assess select reason page', async () => {
+        request.path = assessPaths.updateStatus.category.show({ referralId: referral.id })
+
+        const requestHandler = controller.submit()
+        await requestHandler(request, response, next)
+
+        expect(request.session.referralStatusUpdateData).toEqual({
+          ...referralStatusUpdateData,
+          statusCategoryCode: 'STATUS-CAT-A',
+          statusReasonCode: undefined,
+        })
+        expect(response.redirect).toHaveBeenCalledWith(
+          assessPaths.updateStatus.reason.show({ referralId: referral.id }),
+        )
+      })
+    })
+
+    describe('when `referralStatusUpdateData.referralId` is for a different referral', () => {
+      it('should redirect to the status history page', async () => {
+        request.session.referralStatusUpdateData = {
+          ...referralStatusUpdateData,
+          referralId: 'ANOTHER-REFERRAL',
+        }
+
+        const requestHandler = controller.submit()
+        await requestHandler(request, response, next)
+
+        expect(response.redirect).toHaveBeenCalledWith(referPaths.show.statusHistory({ referralId: referral.id }))
+      })
+    })
+
+    describe('when there is no `referralStatusUpdateData.status` value', () => {
+      it('should redirect to the status history page', async () => {
+        delete request.session.referralStatusUpdateData?.status
+
+        const requestHandler = controller.submit()
+        await requestHandler(request, response, next)
+
+        expect(response.redirect).toHaveBeenCalledWith(referPaths.show.statusHistory({ referralId: referral.id }))
+      })
+    })
+
+    describe('when there is no `categoryCode` value is in the request body', () => {
+      it('should redirect back to the category show page with a flash message', async () => {
+        request.body = { categoryCode: '' }
+
+        const requestHandler = controller.submit()
+        await requestHandler(request, response, next)
+
+        expect(response.redirect).toHaveBeenCalledWith(
+          referPaths.updateStatus.category.show({ referralId: referral.id }),
+        )
+        expect(request.flash).toHaveBeenCalledWith('categoryCodeError', 'Select a category')
+      })
+    })
+  })
+})

--- a/server/controllers/shared/categoryController.ts
+++ b/server/controllers/shared/categoryController.ts
@@ -1,0 +1,106 @@
+import type { Request, Response, TypedRequestHandler } from 'express'
+
+import { assessPathBase, assessPaths, referPaths } from '../../paths'
+import type { ReferenceDataService, ReferralService } from '../../services'
+import { FormUtils, ReferralUtils, ShowReferralUtils, TypeUtils } from '../../utils'
+import type { ReferralStatusUppercase } from '@accredited-programmes/models'
+
+type SelectCategoryPageContent = Record<
+  ReferralStatusUppercase,
+  {
+    pageDescription: string
+    pageHeading: string
+    radioLegend: string
+  }
+>
+
+const content: Partial<SelectCategoryPageContent> = {
+  DESELECTED: {
+    pageDescription: 'If you deselect the referral, it will be closed.',
+    pageHeading: 'Deselection category',
+    radioLegend: 'Choose the deselection category',
+  },
+  WITHDRAWN: {
+    pageDescription: 'If you withdraw the referral, it will be closed.',
+    pageHeading: 'Withdrawal category',
+    radioLegend: 'Select the withdrawal category',
+  },
+}
+
+export default class CategoryController {
+  constructor(
+    private readonly referenceDataService: ReferenceDataService,
+    private readonly referralService: ReferralService,
+  ) {}
+
+  show(): TypedRequestHandler<Request, Response> {
+    return async (req: Request, res: Response) => {
+      TypeUtils.assertHasUser(req)
+
+      const paths = this.getPaths(req)
+      const { referralId } = req.params
+      const { token: userToken, username } = req.user
+      const { referralStatusUpdateData } = req.session
+
+      if (
+        referralStatusUpdateData?.referralId !== referralId ||
+        !referralStatusUpdateData.status ||
+        !content[referralStatusUpdateData.status]
+      ) {
+        return res.redirect(paths.show.statusHistory({ referralId }))
+      }
+
+      const selectedStatus = referralStatusUpdateData.status
+
+      const [statusHistory, categories] = await Promise.all([
+        this.referralService.getReferralStatusHistory(userToken, username, referralId),
+        this.referenceDataService.getReferralStatusCodeCategories(username, selectedStatus),
+      ])
+
+      const radioItems = ReferralUtils.statusOptionsToRadioItems(
+        categories,
+        referralStatusUpdateData.statusCategoryCode,
+      )
+
+      FormUtils.setFieldErrors(req, res, ['categoryCode'])
+
+      return res.render('referrals/updateStatus/category/show', {
+        backLinkHref: '#',
+        radioItems,
+        timelineItems: ShowReferralUtils.statusHistoryTimelineItems(statusHistory).slice(0, 1),
+        ...content[selectedStatus],
+      })
+    }
+  }
+
+  submit(): TypedRequestHandler<Request, Response> {
+    return async (req: Request, res: Response) => {
+      const paths = this.getPaths(req)
+      const { referralId } = req.params
+      const { categoryCode } = req.body
+      const { referralStatusUpdateData } = req.session
+
+      if (referralStatusUpdateData?.referralId !== referralId || !referralStatusUpdateData.status) {
+        return res.redirect(paths.show.statusHistory({ referralId }))
+      }
+
+      if (!categoryCode) {
+        req.flash('categoryCodeError', 'Select a category')
+
+        return res.redirect(paths.updateStatus.category.show({ referralId }))
+      }
+
+      req.session.referralStatusUpdateData = {
+        ...referralStatusUpdateData,
+        statusCategoryCode: categoryCode,
+        statusReasonCode: undefined,
+      }
+
+      return res.redirect(paths.updateStatus.reason.show({ referralId }))
+    }
+  }
+
+  private getPaths(req: Request) {
+    return req.path.startsWith(assessPathBase.pattern) ? assessPaths : referPaths
+  }
+}

--- a/server/controllers/shared/index.ts
+++ b/server/controllers/shared/index.ts
@@ -1,6 +1,7 @@
 /* istanbul ignore file */
 
 import CategoryController from './categoryController'
+import ReasonController from './reasonController'
 import ReferralsController from './referralsController'
 import RisksAndNeedsController from './risksAndNeedsController'
 import StatusHistoryController from './statusHistoryController'
@@ -42,6 +43,7 @@ const controllers = (services: Services) => {
   )
 
   const categoryController = new CategoryController(services.referenceDataService, services.referralService)
+  const reasonController = new ReasonController(services.referenceDataService, services.referralService)
 
   const withdrawReasonController = new WithdrawReasonController(services.referenceDataService, services.referralService)
 
@@ -49,6 +51,7 @@ const controllers = (services: Services) => {
 
   return {
     categoryController,
+    reasonController,
     referralsController,
     risksAndNeedsController,
     statusHistoryController,

--- a/server/controllers/shared/index.ts
+++ b/server/controllers/shared/index.ts
@@ -1,5 +1,6 @@
 /* istanbul ignore file */
 
+import CategoryController from './categoryController'
 import ReferralsController from './referralsController'
 import RisksAndNeedsController from './risksAndNeedsController'
 import StatusHistoryController from './statusHistoryController'
@@ -40,11 +41,14 @@ const controllers = (services: Services) => {
     services.referralService,
   )
 
+  const categoryController = new CategoryController(services.referenceDataService, services.referralService)
+
   const withdrawReasonController = new WithdrawReasonController(services.referenceDataService, services.referralService)
 
   const withdrawReasonInformationController = new WithdrawReasonInformationController(services.referralService)
 
   return {
+    categoryController,
     referralsController,
     risksAndNeedsController,
     statusHistoryController,

--- a/server/controllers/shared/reasonController.test.ts
+++ b/server/controllers/shared/reasonController.test.ts
@@ -1,0 +1,253 @@
+import type { DeepMocked } from '@golevelup/ts-jest'
+import { createMock } from '@golevelup/ts-jest'
+import type { NextFunction, Request, Response } from 'express'
+
+import ReasonController from './reasonController'
+import type { ReferralStatusUpdateSessionData } from '../../@types/express'
+import { assessPaths, referPaths } from '../../paths'
+import type { ReferenceDataService, ReferralService } from '../../services'
+import { referralFactory, referralStatusHistoryFactory, referralStatusReasonFactory } from '../../testutils/factories'
+import Helpers from '../../testutils/helpers'
+import { FormUtils, ReferralUtils, ShowReferralUtils } from '../../utils'
+import type { Referral, ReferralStatusReason } from '@accredited-programmes/models'
+import type { MojTimelineItem, ReferralStatusHistoryPresenter } from '@accredited-programmes/ui'
+import type { GovukFrontendRadiosItem } from '@govuk-frontend'
+
+jest.mock('../../utils/formUtils')
+jest.mock('../../utils/referrals/referralUtils')
+jest.mock('../../utils/referrals/showReferralUtils')
+
+const mockReferralUtils = ReferralUtils as jest.Mocked<typeof ReferralUtils>
+const mockShowReferralUtils = ShowReferralUtils as jest.Mocked<typeof ShowReferralUtils>
+
+describe('ReasonController', () => {
+  const userToken = 'SOME_TOKEN'
+  const username = 'USERNAME'
+
+  let request: DeepMocked<Request>
+  let response: DeepMocked<Response>
+  const next: DeepMocked<NextFunction> = createMock<NextFunction>({})
+
+  const referenceDataService = createMock<ReferenceDataService>({})
+  const referralService = createMock<ReferralService>({})
+
+  const radioItems: Array<GovukFrontendRadiosItem> = [
+    { text: 'Reason A', value: 'STATUS-REASON-A' },
+    { text: 'Reason B', value: 'STATUS-REASON-B' },
+  ]
+  const timelineItems: Array<MojTimelineItem> = [
+    {
+      byline: { text: 'Test User' },
+      datetime: { timestamp: new Date().toISOString(), type: 'datetime' },
+      html: 'html',
+      label: { text: 'Referral submitted' },
+    },
+    {
+      byline: { text: 'Test User' },
+      datetime: { timestamp: new Date().toISOString(), type: 'datetime' },
+      html: 'html',
+      label: { text: 'Referral started' },
+    },
+  ]
+  let referral: Referral
+  let referralStatusCodeReasons: Array<ReferralStatusReason>
+  let referralStatusHistory: Array<ReferralStatusHistoryPresenter>
+  let referralStatusUpdateData: ReferralStatusUpdateSessionData
+
+  let controller: ReasonController
+
+  beforeEach(() => {
+    referral = referralFactory.submitted().build({})
+    referralStatusCodeReasons = referralStatusReasonFactory.buildList(2, { referralCategoryCode: 'A' })
+    referralStatusHistory = [{ ...referralStatusHistoryFactory.started().build(), byLineText: 'You' }]
+    referralStatusUpdateData = { referralId: referral.id, status: 'DESELECTED', statusCategoryCode: 'STATUS-CAT-A' }
+    mockReferralUtils.statusOptionsToRadioItems.mockReturnValue(radioItems)
+    mockShowReferralUtils.statusHistoryTimelineItems.mockReturnValue(timelineItems)
+
+    referralService.getReferralStatusHistory.mockResolvedValue(referralStatusHistory)
+    referenceDataService.getReferralStatusCodeReasons.mockResolvedValue(referralStatusCodeReasons)
+
+    controller = new ReasonController(referenceDataService, referralService)
+
+    request = createMock<Request>({
+      params: { referralId: referral.id },
+      path: referPaths.updateStatus.reason.show({ referralId: referral.id }),
+      session: { referralStatusUpdateData },
+      user: { token: userToken, username },
+    })
+    response = Helpers.createMockResponseWithCaseloads()
+  })
+
+  describe('show', () => {
+    it('should render the show template with the correct response locals', async () => {
+      const requestHandler = controller.show()
+      await requestHandler(request, response, next)
+
+      expect(response.render).toHaveBeenCalledWith('referrals/updateStatus/reason/show', {
+        backLinkHref: '#',
+        cancelLink: referPaths.show.statusHistory({ referralId: referral.id }),
+        pageDescription: 'Deselecting someone means they cannot continue the programme. The referral will be closed.',
+        pageHeading: 'Deselection reason',
+        radioItems,
+        radioLegend: 'Choose the deselection reason',
+
+        timelineItems: timelineItems.slice(0, 1),
+      })
+
+      expect(referenceDataService.getReferralStatusCodeReasons).toHaveBeenCalledWith(
+        username,
+        'STATUS-CAT-A',
+        'DESELECTED',
+      )
+      expect(referralService.getReferralStatusHistory).toHaveBeenCalledWith(userToken, username, referral.id)
+
+      expect(FormUtils.setFieldErrors).toHaveBeenCalledWith(request, response, ['reasonCode'])
+      expect(ReferralUtils.statusOptionsToRadioItems).toHaveBeenCalledWith(referralStatusCodeReasons, undefined)
+      expect(ShowReferralUtils.statusHistoryTimelineItems).toHaveBeenCalledWith(referralStatusHistory)
+    })
+
+    describe('when `referralStatusUpdateData.status` is `WITHDRAWN', () => {
+      it('should render the show template with the correct response locals', async () => {
+        request.session.referralStatusUpdateData = {
+          ...referralStatusUpdateData,
+          status: 'WITHDRAWN',
+        }
+
+        const requestHandler = controller.show()
+        await requestHandler(request, response, next)
+
+        expect(response.render).toHaveBeenCalledWith('referrals/updateStatus/reason/show', {
+          backLinkHref: '#',
+          cancelLink: referPaths.show.statusHistory({ referralId: referral.id }),
+          pageDescription: 'If you withdraw the referral, it will be closed.',
+          pageHeading: 'Withdrawal reason',
+          radioItems,
+          radioLegend: 'Select the reason for withdrawal',
+          timelineItems: timelineItems.slice(0, 1),
+        })
+
+        expect(referenceDataService.getReferralStatusCodeReasons).toHaveBeenCalledWith(
+          username,
+          'STATUS-CAT-A',
+          'WITHDRAWN',
+        )
+        expect(referralService.getReferralStatusHistory).toHaveBeenCalledWith(userToken, username, referral.id)
+
+        expect(FormUtils.setFieldErrors).toHaveBeenCalledWith(request, response, ['reasonCode'])
+        expect(ReferralUtils.statusOptionsToRadioItems).toHaveBeenCalledWith(referralStatusCodeReasons, undefined)
+        expect(ShowReferralUtils.statusHistoryTimelineItems).toHaveBeenCalledWith(referralStatusHistory)
+      })
+    })
+
+    describe('when there is  no `referralStatusUpdateData`', () => {
+      it('should redirect to the status history page', async () => {
+        delete request.session.referralStatusUpdateData
+
+        const requestHandler = controller.show()
+        await requestHandler(request, response, next)
+
+        expect(response.redirect).toHaveBeenCalledWith(referPaths.show.statusHistory({ referralId: referral.id }))
+      })
+    })
+
+    describe('when `referralStatusUpdateData.referralId` is for a different referral', () => {
+      it('should redirect to the status history page', async () => {
+        request.session.referralStatusUpdateData = {
+          ...referralStatusUpdateData,
+          referralId: 'ANOTHER-REFERRAL',
+        }
+
+        const requestHandler = controller.show()
+        await requestHandler(request, response, next)
+
+        expect(response.redirect).toHaveBeenCalledWith(referPaths.show.statusHistory({ referralId: referral.id }))
+      })
+    })
+
+    describe('when there is no `referralStatusUpdateData.status` value', () => {
+      it('should redirect to the status history page', async () => {
+        delete request.session.referralStatusUpdateData?.status
+
+        const requestHandler = controller.show()
+        await requestHandler(request, response, next)
+
+        expect(response.redirect).toHaveBeenCalledWith(referPaths.show.statusHistory({ referralId: referral.id }))
+      })
+    })
+
+    describe('when `referralStatusUpdateData.status` does not require a category selection', () => {
+      it('should redirect to the status history page', async () => {
+        request.session.referralStatusUpdateData = {
+          ...referralStatusUpdateData,
+          status: 'AWAITING_ASSESSMENT',
+        }
+
+        const requestHandler = controller.show()
+        await requestHandler(request, response, next)
+
+        expect(response.redirect).toHaveBeenCalledWith(referPaths.show.statusHistory({ referralId: referral.id }))
+      })
+    })
+  })
+
+  describe('submit', () => {
+    beforeEach(() => {
+      request.body = { reasonCode: 'STATUS-REASON-A' }
+    })
+
+    it('should update `referralStatusUpdateData` and redirect to refer selection page', async () => {
+      const requestHandler = controller.submit()
+      await requestHandler(request, response, next)
+
+      expect(request.session.referralStatusUpdateData).toEqual({
+        ...referralStatusUpdateData,
+        statusReasonCode: 'STATUS-REASON-A',
+      })
+      expect(response.redirect).toHaveBeenCalledWith(
+        referPaths.updateStatus.selection.show({ referralId: referral.id }),
+      )
+    })
+
+    describe('when submitting the form on the assess journey', () => {
+      it('should update `referralStatusUpdateData` and redirect to the assess selection page', async () => {
+        request.path = assessPaths.updateStatus.reason.show({ referralId: referral.id })
+
+        const requestHandler = controller.submit()
+        await requestHandler(request, response, next)
+
+        expect(request.session.referralStatusUpdateData).toEqual({
+          ...referralStatusUpdateData,
+          statusReasonCode: 'STATUS-REASON-A',
+        })
+        expect(response.redirect).toHaveBeenCalledWith(
+          assessPaths.updateStatus.selection.show({ referralId: referral.id }),
+        )
+      })
+    })
+
+    describe('when there is no `referralStatusUpdateData.statusCategoryCode` value', () => {
+      it('should redirect to the select category page', async () => {
+        delete request.session.referralStatusUpdateData?.statusCategoryCode
+
+        const requestHandler = controller.submit()
+        await requestHandler(request, response, next)
+
+        expect(response.redirect).toHaveBeenCalledWith(
+          referPaths.updateStatus.category.show({ referralId: referral.id }),
+        )
+      })
+    })
+
+    describe('when there is no `reasonCode` value is in the request body', () => {
+      it('should redirect back to the reason show page with a flash message', async () => {
+        request.body = { reasonCode: '' }
+
+        const requestHandler = controller.submit()
+        await requestHandler(request, response, next)
+
+        expect(response.redirect).toHaveBeenCalledWith(referPaths.updateStatus.reason.show({ referralId: referral.id }))
+        expect(request.flash).toHaveBeenCalledWith('reasonCodeError', 'Select a reason')
+      })
+    })
+  })
+})

--- a/server/controllers/shared/reasonController.ts
+++ b/server/controllers/shared/reasonController.ts
@@ -1,0 +1,118 @@
+import type { Request, Response, TypedRequestHandler } from 'express'
+
+import { assessPathBase, assessPaths, referPaths } from '../../paths'
+import type { ReferenceDataService, ReferralService } from '../../services'
+import { FormUtils, ReferralUtils, ShowReferralUtils, TypeUtils } from '../../utils'
+import type { ReferralStatusUppercase } from '@accredited-programmes/models'
+
+type SelectReasonPageContent = Record<
+  ReferralStatusUppercase,
+  {
+    pageDescription: string
+    pageHeading: string
+    radioLegend: string
+  }
+>
+
+const content: Partial<SelectReasonPageContent> = {
+  DESELECTED: {
+    pageDescription: 'Deselecting someone means they cannot continue the programme. The referral will be closed.',
+    pageHeading: 'Deselection reason',
+    radioLegend: 'Choose the deselection reason',
+  },
+  WITHDRAWN: {
+    pageDescription: 'If you withdraw the referral, it will be closed.',
+    pageHeading: 'Withdrawal reason',
+    radioLegend: 'Select the reason for withdrawal',
+  },
+}
+
+export default class ReasonController {
+  constructor(
+    private readonly referenceDataService: ReferenceDataService,
+    private readonly referralService: ReferralService,
+  ) {}
+
+  show(): TypedRequestHandler<Request, Response> {
+    return async (req: Request, res: Response) => {
+      TypeUtils.assertHasUser(req)
+
+      const paths = this.getPaths(req)
+      const { referralId } = req.params
+      const { token: userToken, username } = req.user
+      const { referralStatusUpdateData } = req.session
+
+      if (
+        referralStatusUpdateData?.referralId !== referralId ||
+        !referralStatusUpdateData.status ||
+        !referralStatusUpdateData.statusCategoryCode ||
+        !content[referralStatusUpdateData.status]
+      ) {
+        return res.redirect(paths.show.statusHistory({ referralId }))
+      }
+
+      const selectedStatus = referralStatusUpdateData.status
+
+      const [statusHistory, reasons] = await Promise.all([
+        this.referralService.getReferralStatusHistory(userToken, username, referralId),
+        this.referenceDataService.getReferralStatusCodeReasons(
+          username,
+          referralStatusUpdateData.statusCategoryCode,
+          selectedStatus,
+        ),
+      ])
+
+      // Redirect to final page if no options
+      if (reasons.length === 0) {
+        req.session.referralStatusUpdateData = {
+          ...referralStatusUpdateData,
+          statusReasonCode: undefined,
+        }
+
+        return res.redirect(paths.updateStatus.selection.show({ referralId }))
+      }
+
+      const radioItems = ReferralUtils.statusOptionsToRadioItems(reasons, referralStatusUpdateData.statusReasonCode)
+
+      FormUtils.setFieldErrors(req, res, ['reasonCode'])
+
+      return res.render('referrals/updateStatus/reason/show', {
+        backLinkHref: '#',
+        cancelLink: paths.show.statusHistory({ referralId }),
+        radioItems,
+        timelineItems: ShowReferralUtils.statusHistoryTimelineItems(statusHistory).slice(0, 1),
+        ...content[selectedStatus],
+      })
+    }
+  }
+
+  submit(): TypedRequestHandler<Request, Response> {
+    return async (req: Request, res: Response) => {
+      const paths = this.getPaths(req)
+      const { referralId } = req.params
+      const { reasonCode } = req.body
+      const { referralStatusUpdateData } = req.session
+
+      if (!referralStatusUpdateData?.statusCategoryCode) {
+        return res.redirect(paths.updateStatus.category.show({ referralId }))
+      }
+
+      if (!reasonCode) {
+        req.flash('reasonCodeError', 'Select a reason')
+
+        return res.redirect(paths.updateStatus.reason.show({ referralId }))
+      }
+
+      req.session.referralStatusUpdateData = {
+        ...referralStatusUpdateData,
+        statusReasonCode: reasonCode,
+      }
+
+      return res.redirect(paths.updateStatus.selection.show({ referralId }))
+    }
+  }
+
+  private getPaths(req: Request) {
+    return req.path.startsWith(assessPathBase.pattern) ? assessPaths : referPaths
+  }
+}

--- a/server/controllers/shared/statusHistoryController.test.ts
+++ b/server/controllers/shared/statusHistoryController.test.ts
@@ -110,6 +110,15 @@ describe('StatusHistoryController', () => {
       expect(mockShowReferralUtils.statusHistoryTimelineItems).toHaveBeenCalledWith(referralStatusHistory)
     })
 
+    it('should reset the `referralStatusUpdateData` session data', async () => {
+      request.session.referralStatusUpdateData = { referralId: referral.id, status: 'WITHDRAWN' }
+
+      const requestHandler = controller.show()
+      await requestHandler(request, response, next)
+
+      expect(request.session.referralStatusUpdateData).toBeUndefined()
+    })
+
     describe('when the page has been visited with an `updatePerson` query parameter', () => {
       it('should pass the `updatePerson` query parameter to the `getReferral` method', async () => {
         const updatePerson = 'true'

--- a/server/controllers/shared/statusHistoryController.ts
+++ b/server/controllers/shared/statusHistoryController.ts
@@ -14,6 +14,8 @@ export default class StatusHistoryController {
     return async (req: Request, res: Response) => {
       TypeUtils.assertHasUser(req)
 
+      delete req.session.referralStatusUpdateData
+
       const { referralId } = req.params
       const { token: userToken, username } = req.user
       const { updatePerson } = req.query as Record<string, string>

--- a/server/controllers/shared/updateStatusSelectionController.test.ts
+++ b/server/controllers/shared/updateStatusSelectionController.test.ts
@@ -153,6 +153,20 @@ describe('UpdateStatusSelectionController', () => {
       expect(response.redirect).toHaveBeenCalledWith(assessPaths.show.statusHistory({ referralId: referral.id }))
     })
 
+    describe('when `referralStatusUpdateData` is for a different referral', () => {
+      it('should redirect to the status history route', async () => {
+        request.session.referralStatusUpdateData = {
+          referralId: 'DIFFERENT_REFERRAL_ID',
+          status: 'ON_PROGRAMME',
+        }
+
+        const requestHandler = controller.submitConfirmation()
+        await requestHandler(request, response, next)
+
+        expect(response.redirect).toHaveBeenCalledWith(assessPaths.show.statusHistory({ referralId: referral.id }))
+      })
+    })
+
     describe('when there is no `referralStatusUpdateData`', () => {
       it('should redirect to the status history route', async () => {
         request.session.referralStatusUpdateData = undefined
@@ -200,7 +214,12 @@ describe('UpdateStatusSelectionController', () => {
 
     beforeEach(() => {
       request.body = { reason }
-      request.session.referralStatusUpdateData = { referralId: referral.id, status: 'NOT_SUITABLE' }
+      request.session.referralStatusUpdateData = {
+        referralId: referral.id,
+        status: 'NOT_SUITABLE',
+        statusCategoryCode: 'STATUS_CATEGORY_CODE',
+        statusReasonCode: 'STATUS_REASON_CODE',
+      }
     })
 
     it('should update the referral status, delete `referralStatusUpdateData` and redirect back to the status history page of the referral', async () => {
@@ -208,12 +227,28 @@ describe('UpdateStatusSelectionController', () => {
       await requestHandler(request, response, next)
 
       expect(referralService.updateReferralStatus).toHaveBeenCalledWith(username, referral.id, {
+        category: 'STATUS_CATEGORY_CODE',
         notes: reason,
         ptUser: true,
+        reason: 'STATUS_REASON_CODE',
         status: 'NOT_SUITABLE',
       })
       expect(request.session.referralStatusUpdateData).toBeUndefined()
       expect(response.redirect).toHaveBeenCalledWith(assessPaths.show.statusHistory({ referralId: referral.id }))
+    })
+
+    describe('when `referralStatusUpdateData` is for a different referral', () => {
+      it('should redirect to the status history route', async () => {
+        request.session.referralStatusUpdateData = {
+          referralId: 'DIFFERENT_REFERRAL_ID',
+          status: 'ON_PROGRAMME',
+        }
+
+        const requestHandler = controller.submitReason()
+        await requestHandler(request, response, next)
+
+        expect(response.redirect).toHaveBeenCalledWith(assessPaths.show.statusHistory({ referralId: referral.id }))
+      })
     })
 
     describe('when there is no `referralStatusUpdateData`', () => {
@@ -235,8 +270,10 @@ describe('UpdateStatusSelectionController', () => {
         await requestHandler(request, response, next)
 
         expect(referralService.updateReferralStatus).toHaveBeenCalledWith(username, referral.id, {
+          category: 'STATUS_CATEGORY_CODE',
           notes: reason,
           ptUser: false,
+          reason: 'STATUS_REASON_CODE',
           status: 'NOT_SUITABLE',
         })
         expect(request.session.referralStatusUpdateData).toBeUndefined()

--- a/server/controllers/shared/updateStatusSelectionController.ts
+++ b/server/controllers/shared/updateStatusSelectionController.ts
@@ -23,7 +23,7 @@ export default class UpdateStatusSelectionController {
       const { token: userToken, username } = req.user
       const { referralStatusUpdateData } = req.session
 
-      if (!referralStatusUpdateData?.status || referralStatusUpdateData.referralId !== referralId) {
+      if (referralStatusUpdateData?.referralId !== referralId || !referralStatusUpdateData.status) {
         return res.redirect(paths.show.statusHistory({ referralId }))
       }
 
@@ -62,7 +62,7 @@ export default class UpdateStatusSelectionController {
       const { confirmation } = req.body
       const { referralStatusUpdateData } = req.session
 
-      if (!referralStatusUpdateData?.status) {
+      if (referralStatusUpdateData?.referralId !== referralId || !referralStatusUpdateData.status) {
         return res.redirect(paths.show.statusHistory({ referralId }))
       }
 
@@ -85,7 +85,7 @@ export default class UpdateStatusSelectionController {
       const { referralStatusUpdateData } = req.session
       const reason = req.body.reason?.trim()
 
-      if (!referralStatusUpdateData?.status) {
+      if (referralStatusUpdateData?.referralId !== referralId || !referralStatusUpdateData.status) {
         return res.redirect(paths.show.statusHistory({ referralId }))
       }
 
@@ -125,10 +125,13 @@ export default class UpdateStatusSelectionController {
 
     const { username } = req.user
     const { referralId } = req.params
+    const { referralStatusUpdateData } = req.session
 
     await this.referralService.updateReferralStatus(username, referralId, {
+      category: referralStatusUpdateData?.statusCategoryCode,
       notes,
       ptUser: isAssess,
+      reason: referralStatusUpdateData?.statusReasonCode,
       status,
     })
 

--- a/server/paths/assess.ts
+++ b/server/paths/assess.ts
@@ -10,6 +10,8 @@ const risksAndNeedsPathBase = referralShowPathBase.path('risks-and-needs')
 const withdrawBasePath = referralShowPathBase.path('withdraw')
 
 const updateStatusPathBase = referralShowPathBase.path('update-status')
+const updateStatusSelectCategory = updateStatusPathBase.path('category')
+const updateStatusSelectReason = updateStatusPathBase.path('reason')
 const updateStatusSelectionShowPath = updateStatusPathBase.path('selection')
 
 export default {
@@ -39,9 +41,17 @@ export default {
     statusHistory: referralShowPathBase.path('status-history'),
   },
   updateStatus: {
+    category: {
+      show: updateStatusSelectCategory,
+      submit: updateStatusSelectCategory,
+    },
     decision: {
       show: updateStatusPathBase,
       submit: updateStatusPathBase,
+    },
+    reason: {
+      show: updateStatusSelectReason,
+      submit: updateStatusSelectReason,
     },
     selection: {
       confirmation: {

--- a/server/paths/refer.ts
+++ b/server/paths/refer.ts
@@ -26,6 +26,8 @@ const risksAndNeedsPathBase = referralShowPathBase.path('risks-and-needs')
 const withdrawBasePath = referralShowPathBase.path('withdraw')
 
 const updateStatusPathBase = referralShowPathBase.path('update-status')
+const updateStatusSelectCategory = updateStatusPathBase.path('category')
+const updateStatusSelectReason = updateStatusPathBase.path('reason')
 const updateStatusSelectionShowPath = updateStatusPathBase.path('selection')
 
 export default {
@@ -91,6 +93,14 @@ export default {
     statusHistory: referralShowPathBase.path('status-history'),
   },
   updateStatus: {
+    category: {
+      show: updateStatusSelectCategory,
+      submit: updateStatusSelectCategory,
+    },
+    reason: {
+      show: updateStatusSelectReason,
+      submit: updateStatusSelectReason,
+    },
     selection: {
       confirmation: {
         submit: updateStatusSelectionShowPath.path('confirmation'),

--- a/server/routes/assess.ts
+++ b/server/routes/assess.ts
@@ -10,6 +10,8 @@ export default function routes(controllers: Controllers, router: Router): Router
 
   const {
     assessCaseListController,
+    categoryController,
+    reasonController,
     referralsController,
     risksAndNeedsController,
     statusHistoryController,
@@ -59,6 +61,12 @@ export default function routes(controllers: Controllers, router: Router): Router
   post(assessPaths.withdraw.reason.pattern, withdrawReasonController.submit())
   get(assessPaths.withdraw.reasonInformation.pattern, withdrawReasonInformationController.show())
   post(assessPaths.withdraw.reasonInformation.pattern, withdrawReasonInformationController.submit())
+
+  get(assessPaths.updateStatus.category.show.pattern, categoryController.show())
+  post(assessPaths.updateStatus.category.submit.pattern, categoryController.submit())
+
+  get(assessPaths.updateStatus.reason.show.pattern, reasonController.show())
+  post(assessPaths.updateStatus.reason.submit.pattern, reasonController.submit())
 
   return router
 }

--- a/server/views/referrals/updateStatus/category/show.njk
+++ b/server/views/referrals/updateStatus/category/show.njk
@@ -1,0 +1,68 @@
+{% from "govuk/components/back-link/macro.njk" import govukBackLink %}
+{% from "govuk/components/button/macro.njk" import govukButton %}
+{% from "govuk/components/error-summary/macro.njk" import govukErrorSummary %}
+{% from "govuk/components/radios/macro.njk" import govukRadios %}
+{% from "moj/components/timeline/macro.njk" import mojTimeline %}
+
+{% extends "../../../partials/layout.njk" %}
+
+{% block backLink %}
+  {{ govukBackLink({
+    text: "Back",
+    href: backLinkHref
+  }) }}
+{% endblock backLink %}
+
+{% block content %}
+  <div class="govuk-grid-row">
+    <div class="govuk-grid-column-two-thirds">
+      {% if errors.list | length %}
+        {{ govukErrorSummary({
+          titleText: "There is a problem",
+          errorList: errors.list
+        }) }}
+      {% endif %}
+
+      <h1 class="govuk-heading-l">{{ pageHeading }}</h1>
+
+      <p>{{ pageDescription }}</p>
+
+      {{ mojTimeline({
+        items: timelineItems,
+        attributes: {
+          "data-testid": "status-history-timeline"
+        },
+        classes: "govuk-!-margin-bottom-0"
+      }) }}
+    </div>
+  </div>
+
+  <hr class="govuk-section-break govuk-section-break--xl govuk-section-break--visible">
+
+  <div class="govuk-grid-row">
+    <div class="govuk-grid-column-two-thirds">
+      <form method="post">
+        <input type="hidden" name="_csrf" value="{{ csrfToken }}"/>
+
+        {{ govukRadios({
+          name: "categoryCode",
+          fieldset: {
+            legend: {
+              text: radioLegend,
+              classes: "govuk-fieldset__legend--m"
+            }
+          },
+          items: radioItems,
+          errorMessage: errors.messages.categoryCode,
+          attributes: {
+            "data-testid": "category-options"
+          }
+        }) }}
+
+        {{ govukButton({
+          text: "Continue"
+        }) }}
+      </form>
+    </div>
+  </div>
+{% endblock content %}

--- a/server/views/referrals/updateStatus/reason/show.njk
+++ b/server/views/referrals/updateStatus/reason/show.njk
@@ -1,0 +1,74 @@
+{% from "govuk/components/back-link/macro.njk" import govukBackLink %}
+{% from "govuk/components/button/macro.njk" import govukButton %}
+{% from "govuk/components/error-summary/macro.njk" import govukErrorSummary %}
+{% from "govuk/components/radios/macro.njk" import govukRadios %}
+{% from "moj/components/timeline/macro.njk" import mojTimeline %}
+
+{% extends "../../../partials/layout.njk" %}
+
+{% block backLink %}
+  {{ govukBackLink({
+    text: "Back",
+    href: backLinkHref
+  }) }}
+{% endblock backLink %}
+
+{% block content %}
+  <div class="govuk-grid-row">
+    <div class="govuk-grid-column-two-thirds">
+      {% if errors.list | length %}
+        {{ govukErrorSummary({
+          titleText: "There is a problem",
+          errorList: errors.list
+        }) }}
+      {% endif %}
+
+      <h1 class="govuk-heading-l">{{ pageHeading }}</h1>
+
+      <p>{{ pageDescription }}</p>
+
+      <h2 class="govuk-heading-m">Current status</h2>
+
+      {{ mojTimeline({
+        items: timelineItems,
+        attributes: {
+          "data-testid": "status-history-timeline"
+        },
+        classes: "govuk-!-margin-bottom-0"
+      }) }}
+    </div>
+  </div>
+
+  <hr class="govuk-section-break govuk-section-break--xl govuk-section-break--visible">
+
+  <div class="govuk-grid-row">
+    <div class="govuk-grid-column-two-thirds">
+      <form method="post">
+        <input type="hidden" name="_csrf" value="{{ csrfToken }}"/>
+
+        {{ govukRadios({
+          name: "reasonCode",
+          fieldset: {
+            legend: {
+              text: radioLegend,
+              classes: "govuk-fieldset__legend--m"
+            }
+          },
+          items: radioItems,
+          errorMessage: errors.messages.reasonCode,
+          attributes: {
+            "data-testid": "reason-options"
+          }
+        }) }}
+
+        <div class="govuk-button-group">
+          {{ govukButton({
+            text: "Continue"
+          }) }}
+
+          <a href={{ cancelLink }}>Cancel</a>
+        </div>
+      </form>
+    </div>
+  </div>
+{% endblock content %}


### PR DESCRIPTION
## Context

To deselect a referral, a category code and a reason code is required, similar to the withdraw journey.

## Changes in this PR
- Add `CategoryController`
- Add `Reason Controller`

Both of these new controllers can be used for both `WITHDRAWN` and `DESELECTED` status decisions.  The plan is to remove the withdrawl specific controllers when this has been applied for the referrer user paths.

## Screenshots of UI changes

![localhost_3000_assess_referrals_44a8c727-7d48-4472-841b-d72f78234ded_update-status_category](https://github.com/ministryofjustice/hmpps-accredited-programmes-ui/assets/1067537/b881b701-5e0b-4d13-89f7-f7bfb0c1f7fa)

![localhost_3000_assess_referrals_44a8c727-7d48-4472-841b-d72f78234ded_update-status_reason](https://github.com/ministryofjustice/hmpps-accredited-programmes-ui/assets/1067537/1f0e09c4-f81b-41fe-9712-a7465c600a62)



## Release checklist

[Release process documentation](../doc/how-to/perform-a-release.md)

As part of our continuous deployment strategy we must ensure that this work is
ready to be released once merged.

### Pre-merge

- [ ] There are changes required to the Accredited Programmes API for this change to work...
  - [ ] ... and they have been released to production already

### Post-merge

<!-- The outer checkboxes can be completed pre-merge -->

- [ ] This adds, extends or meaningfully modifies a feature...
  - [ ] ... and I have written or updated an end-to-end test for the happy path in the [Accredited Programmes E2E repo](https://github.com/ministryofjustice/hmpps-accredited-programmes-e2e)
- [ ] This makes new expectations of the API...
  - [ ] ... and I have notified the API developer(s) of changes to the contract tests (Pact), or the API is already compliant
- [ ] [Manually approve](../doc/how-to/perform-a-release.md#releasing-to-the-preprod-environment) release to preprod
- [ ] [Manually approve](../doc/how-to/perform-a-release.md#releasing-to-the-production-environment) release to prod

<!-- Should a release fail at any step, you as the author should now lead the work to
fix it as soon as possible. You can monitor deployment failures in CircleCI
itself and application errors are found in
[Sentry](https://ministryofjustice.sentry.io/projects/hmpps-accredited-programmes-ui/?project=4505330122686464&referrer=sidebar&statsPeriod=24h). -->
