### PR TITLE
(1338) Refer journey hold statuses button

### DIFF
--- a/assets/scss/local.scss
+++ b/assets/scss/local.scss
@@ -42,6 +42,16 @@
   }
 }
 
+.header-with-actions {
+  @include govuk-media-query($from: 1024px) {
+    display: flex;
+
+    .header-with-actions__title {
+      flex: 1;
+    }
+  }
+}
+
 [aria-sort] a {
   position: relative;
   padding-right: 10px;
@@ -94,4 +104,3 @@
     top: 2px;
   }
 }
-

--- a/integration_tests/e2e/assess/caseList.cy.ts
+++ b/integration_tests/e2e/assess/caseList.cy.ts
@@ -14,12 +14,12 @@ context('Referral case lists', () => {
   const closedReferralStatuses = referralStatusRefDataFactory.buildList(3, { closed: true, draft: false })
   const draftReferralStatuses = referralStatusRefDataFactory.buildList(3, { closed: false, draft: true })
   const openReferralStatuses = [
-    referralStatusRefDataFactory.build({ closed: false, code: 'assessment_started', draft: false }),
-    referralStatusRefDataFactory.build({ closed: false, code: 'awaiting_assessment', draft: false }),
-    referralStatusRefDataFactory.build({ closed: false, code: 'referral_submitted', draft: false }),
+    referralStatusRefDataFactory.build({ closed: false, code: 'ASSESSMENT_STARTED', draft: false }),
+    referralStatusRefDataFactory.build({ closed: false, code: 'AWAITING_ASSESSMENT', draft: false }),
+    referralStatusRefDataFactory.build({ closed: false, code: 'REFERRAL_SUBMITTED', draft: false }),
   ]
   const referralStatuses = [...closedReferralStatuses, ...draftReferralStatuses, ...openReferralStatuses]
-  const availableStatuses = ['assessment_started', 'awaiting_assessment', 'referral_submitted']
+  const availableStatuses = ['ASSESSMENT_STARTED', 'AWAITING_ASSESSMENT', 'REFERRAL_SUBMITTED']
 
   const limeCourseReferralViews = FactoryHelpers.buildListWith(
     referralViewFactory,
@@ -133,7 +133,7 @@ context('Referral case lists', () => {
       caseListPage.shouldContainTableOfReferralViews(assessPaths)
 
       const programmeStrandSelectedValue = 'general offence'
-      const referralStatusSelectedValue = 'assessment_started'
+      const referralStatusSelectedValue = 'ASSESSMENT_STARTED'
       const filteredReferralViews = [
         referralViewFactory.build({
           audience: 'General offence',

--- a/integration_tests/e2e/assess/show.cy.ts
+++ b/integration_tests/e2e/assess/show.cy.ts
@@ -60,7 +60,7 @@ context('Viewing a submitted referral', () => {
     describe('When reviewing risks and alerts', () => {
       describe('and there are risks and alerts', () => {
         it('shows the correct information', () => {
-          sharedTests.risksAndNeeds.showsRisksAndAlertsPageWithData(ApplicationRoles.ACP_REFERRER)
+          sharedTests.risksAndNeeds.showsRisksAndAlertsPageWithData(ApplicationRoles.ACP_PROGRAMME_TEAM)
         })
       })
 
@@ -172,13 +172,13 @@ context('Viewing a submitted referral', () => {
     describe('When reviewing Learning needs', () => {
       describe('and there is learning needs data', () => {
         it('shows the correct information', () => {
-          sharedTests.risksAndNeeds.showsLearningNeedsPageWithData(ApplicationRoles.ACP_REFERRER)
+          sharedTests.risksAndNeeds.showsLearningNeedsPageWithData(ApplicationRoles.ACP_PROGRAMME_TEAM)
         })
       })
 
       describe('and there is no learning needs data', () => {
         it('shows the correct information', () => {
-          sharedTests.risksAndNeeds.showsLearningNeedsPageWithoutData(ApplicationRoles.ACP_REFERRER)
+          sharedTests.risksAndNeeds.showsLearningNeedsPageWithoutData(ApplicationRoles.ACP_PROGRAMME_TEAM)
         })
       })
     })

--- a/integration_tests/mockApis/referrals.ts
+++ b/integration_tests/mockApis/referrals.ts
@@ -7,6 +7,7 @@ import type {
   Referral,
   ReferralStatusGroup,
   ReferralStatusHistory,
+  ReferralStatusRefData,
   ReferralView,
 } from '@accredited-programmes/models'
 
@@ -166,6 +167,22 @@ export default {
       response: {
         headers: { 'Content-Type': 'application/json;charset=UTF-8' },
         jsonBody: args.statusHistory,
+        status: 200,
+      },
+    }),
+
+  stubStatusTransitions: (args: {
+    referralId: Referral['id']
+    statusTransitions: Array<ReferralStatusRefData>
+  }): SuperAgentRequest =>
+    stubFor({
+      request: {
+        method: 'GET',
+        url: apiPaths.referrals.statusTransitions({ referralId: args.referralId }),
+      },
+      response: {
+        headers: { 'Content-Type': 'application/json;charset=UTF-8' },
+        jsonBody: args.statusTransitions,
         status: 200,
       },
     }),

--- a/integration_tests/pages/page.ts
+++ b/integration_tests/pages/page.ts
@@ -10,7 +10,7 @@ import {
   ShowRisksAndNeedsUtils,
 } from '../../server/utils'
 import Helpers from '../support/helpers'
-import type { Organisation, Person, Referral } from '@accredited-programmes/models'
+import type { Organisation, Person, Referral, ReferralStatusRefData } from '@accredited-programmes/models'
 import type {
   CourseParticipationPresenter,
   CoursePresenter,
@@ -333,13 +333,17 @@ export default abstract class Page {
     })
   }
 
-  shouldContainShowReferralButtons(currentPath: string, referral: Referral): void {
+  shouldContainShowReferralButtons(
+    currentPath: string,
+    referral: Referral,
+    statusTransitions?: Array<ReferralStatusRefData>,
+  ): void {
     const currentBasePath = currentPath.startsWith(assessPathBase.pattern)
       ? assessPathBase.pattern
       : referPathBase.pattern
 
     cy.get('[data-testid="show-referral-buttons"]').then(buttonsElement => {
-      const buttons = ShowReferralUtils.buttons(currentBasePath, referral)
+      const buttons = ShowReferralUtils.buttons(currentBasePath, referral, statusTransitions)
 
       cy.wrap(buttonsElement).within(() => {
         buttons.forEach((button, buttonIndex) => {

--- a/integration_tests/support/sharedTests.ts
+++ b/integration_tests/support/sharedTests.ts
@@ -20,6 +20,7 @@ import {
   psychiatricFactory,
   referralFactory,
   referralStatusHistoryFactory,
+  referralStatusRefDataFactory,
   relationshipsFactory,
   risksAndAlertsFactory,
   roshAnalysisFactory,
@@ -48,7 +49,7 @@ import {
   ThinkingAndBehavingPage,
 } from '../pages/shared'
 import EmotionalWellbeing from '../pages/shared/showReferral/risksAndNeeds/emotionalWellbeing'
-import type { Person, Referral } from '@accredited-programmes/models'
+import type { Person, Referral, ReferralStatusRefData } from '@accredited-programmes/models'
 import type { CourseParticipationPresenter, ReferralStatusHistoryPresenter } from '@accredited-programmes/ui'
 import type { User } from '@manage-users-api'
 import type { PrisonerWithBookingId } from '@prisoner-search'
@@ -97,6 +98,7 @@ const organisation = OrganisationUtils.organisationFromPrison(prison)
 const user = userFactory.build()
 let courseParticipationPresenter1: CourseParticipationPresenter
 let courseParticipationPresenter2: CourseParticipationPresenter
+let statusTransitions: Array<ReferralStatusRefData>
 
 const pathsByRole = (role: ApplicationRole): typeof assessPaths | typeof referPaths => {
   return role === 'ROLE_ACP_PROGRAMME_TEAM' ? assessPaths : referPaths
@@ -132,6 +134,7 @@ const sharedTests = {
         }),
         addedByDisplayName: StringUtils.convertToTitleCase(user.name),
       }
+      statusTransitions = [referralStatusRefDataFactory.build({ hold: true })]
 
       cy.task('reset')
       cy.task('stubSignIn', { authorities: [role] })
@@ -145,6 +148,10 @@ const sharedTests = {
       cy.task('stubPrisoner', prisoner)
       cy.task('stubReferral', referral)
       cy.task('stubUserDetails', referringUser)
+      cy.task('stubStatusTransitions', {
+        referralId: referral.id,
+        statusTransitions,
+      })
     },
 
     showsAdditionalInformationPage: (role: ApplicationRole): void => {
@@ -159,7 +166,7 @@ const sharedTests = {
       })
       additionalInformationPage.shouldHavePersonDetails(person)
       additionalInformationPage.shouldContainNavigation(path)
-      additionalInformationPage.shouldContainShowReferralButtons(path, referral)
+      additionalInformationPage.shouldContainShowReferralButtons(path, referral, statusTransitions)
       additionalInformationPage.shouldContainShowReferralSubNavigation(path, 'referral', referral.id)
       additionalInformationPage.shouldContainCourseOfferingSummaryList(coursePresenter, organisation.name)
       additionalInformationPage.shouldContainSubmissionSummaryList(referral.submittedOn, referringUser.name)
@@ -187,7 +194,7 @@ const sharedTests = {
       })
       offenceHistoryPage.shouldHavePersonDetails(person)
       offenceHistoryPage.shouldContainNavigation(path)
-      offenceHistoryPage.shouldContainShowReferralButtons(path, referral)
+      offenceHistoryPage.shouldContainShowReferralButtons(path, referral, statusTransitions)
       offenceHistoryPage.shouldContainShowReferralSubNavigation(path, 'referral', referral.id)
       offenceHistoryPage.shouldContainCourseOfferingSummaryList(coursePresenter, organisation.name)
       offenceHistoryPage.shouldContainSubmissionSummaryList(referral.submittedOn, referringUser.name)
@@ -213,7 +220,7 @@ const sharedTests = {
 
       programmeHistoryPage.shouldHavePersonDetails(person)
       programmeHistoryPage.shouldContainNavigation(path)
-      programmeHistoryPage.shouldContainShowReferralButtons(path, referral)
+      programmeHistoryPage.shouldContainShowReferralButtons(path, referral, statusTransitions)
       programmeHistoryPage.shouldContainShowReferralSubNavigation(path, 'referral', referral.id)
       programmeHistoryPage.shouldContainCourseOfferingSummaryList(coursePresenter, organisation.name)
       programmeHistoryPage.shouldContainSubmissionSummaryList(referral.submittedOn, referringUser.name)
@@ -271,7 +278,7 @@ const sharedTests = {
       })
       offenceHistoryPage.shouldHavePersonDetails(person)
       offenceHistoryPage.shouldContainNavigation(path)
-      offenceHistoryPage.shouldContainShowReferralButtons(path, referral)
+      offenceHistoryPage.shouldContainShowReferralButtons(path, referral, statusTransitions)
       offenceHistoryPage.shouldContainShowReferralSubNavigation(path, 'referral', referral.id)
       offenceHistoryPage.shouldContainCourseOfferingSummaryList(coursePresenter, organisation.name)
       offenceHistoryPage.shouldContainSubmissionSummaryList(referral.submittedOn, referringUser.name)
@@ -293,7 +300,7 @@ const sharedTests = {
       })
       personalDetailsPage.shouldHavePersonDetails(person)
       personalDetailsPage.shouldContainNavigation(path)
-      personalDetailsPage.shouldContainShowReferralButtons(path, referral)
+      personalDetailsPage.shouldContainShowReferralButtons(path, referral, statusTransitions)
       personalDetailsPage.shouldContainShowReferralSubNavigation(path, 'referral', referral.id)
       personalDetailsPage.shouldContainCourseOfferingSummaryList(coursePresenter, organisation.name)
       personalDetailsPage.shouldContainSubmissionSummaryList(referral.submittedOn, referringUser.name)
@@ -325,7 +332,7 @@ const sharedTests = {
 
       programmeHistoryPage.shouldHavePersonDetails(person)
       programmeHistoryPage.shouldContainNavigation(path)
-      programmeHistoryPage.shouldContainShowReferralButtons(path, referral)
+      programmeHistoryPage.shouldContainShowReferralButtons(path, referral, statusTransitions)
       programmeHistoryPage.shouldContainShowReferralSubNavigation(path, 'referral', referral.id)
       programmeHistoryPage.shouldContainCourseOfferingSummaryList(coursePresenter, organisation.name)
       programmeHistoryPage.shouldContainSubmissionSummaryList(referral.submittedOn, referringUser.name)
@@ -353,7 +360,7 @@ const sharedTests = {
       })
       sentenceInformationPage.shouldHavePersonDetails(person)
       sentenceInformationPage.shouldContainNavigation(path)
-      sentenceInformationPage.shouldContainShowReferralButtons(path, referral)
+      sentenceInformationPage.shouldContainShowReferralButtons(path, referral, statusTransitions)
       sentenceInformationPage.shouldContainShowReferralSubNavigation(path, 'referral', referral.id)
       sentenceInformationPage.shouldContainCourseOfferingSummaryList(coursePresenter, organisation.name)
       sentenceInformationPage.shouldContainSubmissionSummaryList(referral.submittedOn, referringUser.name)
@@ -388,7 +395,7 @@ const sharedTests = {
       })
       sentenceInformationPage.shouldHavePersonDetails(person)
       sentenceInformationPage.shouldContainNavigation(path)
-      sentenceInformationPage.shouldContainShowReferralButtons(path, referral)
+      sentenceInformationPage.shouldContainShowReferralButtons(path, referral, statusTransitions)
       sentenceInformationPage.shouldContainShowReferralSubNavigation(path, 'referral', referral.id)
       sentenceInformationPage.shouldContainCourseOfferingSummaryList(coursePresenter, organisation.name)
       sentenceInformationPage.shouldContainSubmissionSummaryList(referral.submittedOn, referringUser.name)
@@ -417,7 +424,7 @@ const sharedTests = {
       })
       attitudePage.shouldHavePersonDetails(person)
       attitudePage.shouldContainNavigation(path)
-      attitudePage.shouldContainShowReferralButtons(path, referral)
+      attitudePage.shouldContainShowReferralButtons(path, referral, statusTransitions)
       attitudePage.shouldContainShowReferralSubNavigation(path, 'risksAndNeeds', referral.id)
       attitudePage.shouldContainShowReferralSubHeading('Risks and needs')
       attitudePage.shouldContainRisksAndNeedsOasysMessage()
@@ -442,7 +449,7 @@ const sharedTests = {
       })
       attitudesPage.shouldHavePersonDetails(person)
       attitudesPage.shouldContainNavigation(path)
-      attitudesPage.shouldContainShowReferralButtons(path, referral)
+      attitudesPage.shouldContainShowReferralButtons(path, referral, statusTransitions)
       attitudesPage.shouldContainShowReferralSubNavigation(path, 'risksAndNeeds', referral.id)
       attitudesPage.shouldContainShowReferralSubHeading('Risks and needs')
       attitudesPage.shouldContainRisksAndNeedsOasysMessage()
@@ -467,7 +474,7 @@ const sharedTests = {
       })
       emotionalWellbeingPage.shouldHavePersonDetails(person)
       emotionalWellbeingPage.shouldContainNavigation(path)
-      emotionalWellbeingPage.shouldContainShowReferralButtons(path, referral)
+      emotionalWellbeingPage.shouldContainShowReferralButtons(path, referral, statusTransitions)
       emotionalWellbeingPage.shouldContainShowReferralSubNavigation(path, 'risksAndNeeds', referral.id)
       emotionalWellbeingPage.shouldContainShowReferralSubHeading('Risks and needs')
       emotionalWellbeingPage.shouldContainRisksAndNeedsOasysMessage()
@@ -492,7 +499,7 @@ const sharedTests = {
       })
       emotionalWellbeingPage.shouldHavePersonDetails(person)
       emotionalWellbeingPage.shouldContainNavigation(path)
-      emotionalWellbeingPage.shouldContainShowReferralButtons(path, referral)
+      emotionalWellbeingPage.shouldContainShowReferralButtons(path, referral, statusTransitions)
       emotionalWellbeingPage.shouldContainShowReferralSubNavigation(path, 'risksAndNeeds', referral.id)
       emotionalWellbeingPage.shouldContainShowReferralSubHeading('Risks and needs')
       emotionalWellbeingPage.shouldContainRisksAndNeedsOasysMessage()
@@ -517,7 +524,7 @@ const sharedTests = {
       })
       healthPage.shouldHavePersonDetails(person)
       healthPage.shouldContainNavigation(path)
-      healthPage.shouldContainShowReferralButtons(path, referral)
+      healthPage.shouldContainShowReferralButtons(path, referral, statusTransitions)
       healthPage.shouldContainShowReferralSubNavigation(path, 'risksAndNeeds', referral.id)
       healthPage.shouldContainShowReferralSubHeading('Risks and needs')
       healthPage.shouldContainRisksAndNeedsOasysMessage()
@@ -542,7 +549,7 @@ const sharedTests = {
       })
       healthPage.shouldHavePersonDetails(person)
       healthPage.shouldContainNavigation(path)
-      healthPage.shouldContainShowReferralButtons(path, referral)
+      healthPage.shouldContainShowReferralButtons(path, referral, statusTransitions)
       healthPage.shouldContainShowReferralSubNavigation(path, 'risksAndNeeds', referral.id)
       healthPage.shouldContainShowReferralSubHeading('Risks and needs')
       healthPage.shouldContainRisksAndNeedsSideNavigation(path, referral.id)
@@ -566,7 +573,7 @@ const sharedTests = {
       })
       learningNeedsPage.shouldHavePersonDetails(person)
       learningNeedsPage.shouldContainNavigation(path)
-      learningNeedsPage.shouldContainShowReferralButtons(path, referral)
+      learningNeedsPage.shouldContainShowReferralButtons(path, referral, statusTransitions)
       learningNeedsPage.shouldContainShowReferralSubNavigation(path, 'risksAndNeeds', referral.id)
       learningNeedsPage.shouldContainShowReferralSubHeading('Risks and needs')
       learningNeedsPage.shouldContainRisksAndNeedsOasysMessage()
@@ -592,7 +599,7 @@ const sharedTests = {
       })
       learningNeedsPage.shouldHavePersonDetails(person)
       learningNeedsPage.shouldContainNavigation(path)
-      learningNeedsPage.shouldContainShowReferralButtons(path, referral)
+      learningNeedsPage.shouldContainShowReferralButtons(path, referral, statusTransitions)
       learningNeedsPage.shouldContainShowReferralSubNavigation(path, 'risksAndNeeds', referral.id)
       learningNeedsPage.shouldContainShowReferralSubHeading('Risks and needs')
       learningNeedsPage.shouldContainRisksAndNeedsOasysMessage()
@@ -617,7 +624,7 @@ const sharedTests = {
       })
       lifestyleAndAssociatesPage.shouldHavePersonDetails(person)
       lifestyleAndAssociatesPage.shouldContainNavigation(path)
-      lifestyleAndAssociatesPage.shouldContainShowReferralButtons(path, referral)
+      lifestyleAndAssociatesPage.shouldContainShowReferralButtons(path, referral, statusTransitions)
       lifestyleAndAssociatesPage.shouldContainShowReferralSubNavigation(path, 'risksAndNeeds', referral.id)
       lifestyleAndAssociatesPage.shouldContainShowReferralSubHeading('Risks and needs')
       lifestyleAndAssociatesPage.shouldContainRisksAndNeedsOasysMessage()
@@ -642,7 +649,7 @@ const sharedTests = {
       })
       lifestyleAndAssociatesPage.shouldHavePersonDetails(person)
       lifestyleAndAssociatesPage.shouldContainNavigation(path)
-      lifestyleAndAssociatesPage.shouldContainShowReferralButtons(path, referral)
+      lifestyleAndAssociatesPage.shouldContainShowReferralButtons(path, referral, statusTransitions)
       lifestyleAndAssociatesPage.shouldContainShowReferralSubNavigation(path, 'risksAndNeeds', referral.id)
       lifestyleAndAssociatesPage.shouldContainShowReferralSubHeading('Risks and needs')
       lifestyleAndAssociatesPage.shouldContainRisksAndNeedsOasysMessage()
@@ -667,7 +674,7 @@ const sharedTests = {
       })
       offenceAnalysisPage.shouldHavePersonDetails(person)
       offenceAnalysisPage.shouldContainNavigation(path)
-      offenceAnalysisPage.shouldContainShowReferralButtons(path, referral)
+      offenceAnalysisPage.shouldContainShowReferralButtons(path, referral, statusTransitions)
       offenceAnalysisPage.shouldContainShowReferralSubNavigation(path, 'risksAndNeeds', referral.id)
       offenceAnalysisPage.shouldContainShowReferralSubHeading('Risks and needs')
       offenceAnalysisPage.shouldContainRisksAndNeedsOasysMessage()
@@ -698,7 +705,7 @@ const sharedTests = {
       })
       offenceAnalysisPage.shouldHavePersonDetails(person)
       offenceAnalysisPage.shouldContainNavigation(path)
-      offenceAnalysisPage.shouldContainShowReferralButtons(path, referral)
+      offenceAnalysisPage.shouldContainShowReferralButtons(path, referral, statusTransitions)
       offenceAnalysisPage.shouldContainShowReferralSubNavigation(path, 'risksAndNeeds', referral.id)
       offenceAnalysisPage.shouldContainShowReferralSubHeading('Risks and needs')
       offenceAnalysisPage.shouldContainNoOffenceDetailsSummaryCard()
@@ -722,7 +729,7 @@ const sharedTests = {
       })
       relationshipsPage.shouldHavePersonDetails(person)
       relationshipsPage.shouldContainNavigation(path)
-      relationshipsPage.shouldContainShowReferralButtons(path, referral)
+      relationshipsPage.shouldContainShowReferralButtons(path, referral, statusTransitions)
       relationshipsPage.shouldContainShowReferralSubNavigation(path, 'risksAndNeeds', referral.id)
       relationshipsPage.shouldContainShowReferralSubHeading('Risks and needs')
       relationshipsPage.shouldContainRisksAndNeedsOasysMessage()
@@ -747,7 +754,7 @@ const sharedTests = {
       })
       relationshipsPage.shouldHavePersonDetails(person)
       relationshipsPage.shouldContainNavigation(path)
-      relationshipsPage.shouldContainShowReferralButtons(path, referral)
+      relationshipsPage.shouldContainShowReferralButtons(path, referral, statusTransitions)
       relationshipsPage.shouldContainShowReferralSubNavigation(path, 'risksAndNeeds', referral.id)
       relationshipsPage.shouldContainShowReferralSubHeading('Risks and needs')
       relationshipsPage.shouldContainRisksAndNeedsSideNavigation(path, referral.id)
@@ -771,7 +778,7 @@ const sharedTests = {
       })
       risksAndAlertsPage.shouldHavePersonDetails(person)
       risksAndAlertsPage.shouldContainNavigation(path)
-      risksAndAlertsPage.shouldContainShowReferralButtons(path, referral)
+      risksAndAlertsPage.shouldContainShowReferralButtons(path, referral, statusTransitions)
       risksAndAlertsPage.shouldContainShowReferralSubNavigation(path, 'risksAndNeeds', referral.id)
       risksAndAlertsPage.shouldContainShowReferralSubHeading('Risks and needs')
       risksAndAlertsPage.shouldContainRisksAndNeedsOasysMessage()
@@ -802,7 +809,7 @@ const sharedTests = {
       })
       risksAndAlertsPage.shouldHavePersonDetails(person)
       risksAndAlertsPage.shouldContainNavigation(path)
-      risksAndAlertsPage.shouldContainShowReferralButtons(path, referral)
+      risksAndAlertsPage.shouldContainShowReferralButtons(path, referral, statusTransitions)
       risksAndAlertsPage.shouldContainShowReferralSubNavigation(path, 'risksAndNeeds', referral.id)
       risksAndAlertsPage.shouldContainShowReferralSubHeading('Risks and needs')
       risksAndAlertsPage.shouldContainRisksAndNeedsSideNavigation(path, referral.id)
@@ -826,7 +833,7 @@ const sharedTests = {
       })
       roshAnalysisPage.shouldHavePersonDetails(person)
       roshAnalysisPage.shouldContainNavigation(path)
-      roshAnalysisPage.shouldContainShowReferralButtons(path, referral)
+      roshAnalysisPage.shouldContainShowReferralButtons(path, referral, statusTransitions)
       roshAnalysisPage.shouldContainShowReferralSubNavigation(path, 'risksAndNeeds', referral.id)
       roshAnalysisPage.shouldContainShowReferralSubHeading('Risks and needs')
       roshAnalysisPage.shouldContainRisksAndNeedsOasysMessage()
@@ -851,7 +858,7 @@ const sharedTests = {
       })
       roshAnalysisPage.shouldHavePersonDetails(person)
       roshAnalysisPage.shouldContainNavigation(path)
-      roshAnalysisPage.shouldContainShowReferralButtons(path, referral)
+      roshAnalysisPage.shouldContainShowReferralButtons(path, referral, statusTransitions)
       roshAnalysisPage.shouldContainShowReferralSubNavigation(path, 'risksAndNeeds', referral.id)
       roshAnalysisPage.shouldContainShowReferralSubHeading('Risks and needs')
       roshAnalysisPage.shouldContainRisksAndNeedsSideNavigation(path, referral.id)
@@ -875,7 +882,7 @@ const sharedTests = {
       })
       thinkingAndBehavingPage.shouldHavePersonDetails(person)
       thinkingAndBehavingPage.shouldContainNavigation(path)
-      thinkingAndBehavingPage.shouldContainShowReferralButtons(path, referral)
+      thinkingAndBehavingPage.shouldContainShowReferralButtons(path, referral, statusTransitions)
       thinkingAndBehavingPage.shouldContainShowReferralSubNavigation(path, 'risksAndNeeds', referral.id)
       thinkingAndBehavingPage.shouldContainShowReferralSubHeading('Risks and needs')
       thinkingAndBehavingPage.shouldContainRisksAndNeedsOasysMessage()
@@ -900,7 +907,7 @@ const sharedTests = {
       })
       thinkingAndBehavingPage.shouldHavePersonDetails(person)
       thinkingAndBehavingPage.shouldContainNavigation(path)
-      thinkingAndBehavingPage.shouldContainShowReferralButtons(path, referral)
+      thinkingAndBehavingPage.shouldContainShowReferralButtons(path, referral, statusTransitions)
       thinkingAndBehavingPage.shouldContainShowReferralSubNavigation(path, 'risksAndNeeds', referral.id)
       thinkingAndBehavingPage.shouldContainShowReferralSubHeading('Risks and needs')
       thinkingAndBehavingPage.shouldContainRisksAndNeedsSideNavigation(path, referral.id)
@@ -945,7 +952,7 @@ const sharedTests = {
 
       const statusHistoryPage = Page.verifyOnPage(StatusHistoryPage, { course })
       statusHistoryPage.shouldHavePersonDetails(person)
-      statusHistoryPage.shouldContainShowReferralButtons(path, referral)
+      statusHistoryPage.shouldContainShowReferralButtons(path, referral, statusTransitions)
       statusHistoryPage.shouldContainNavigation(path)
       statusHistoryPage.shouldContainShowReferralSubNavigation(path, 'statusHistory', referral.id)
       statusHistoryPage.shouldContainShowReferralSubHeading('Status history')

--- a/server/@types/models/Referral.ts
+++ b/server/@types/models/Referral.ts
@@ -13,6 +13,8 @@ const referralStatuses = [
   'deselected',
   'not_suitable',
   'on_hold_awaiting_assessment',
+  'on_hold_assessment_started',
+  'on_hold_referral_submitted',
   'on_programme',
   'programme_complete',
   'referral_started',
@@ -89,7 +91,7 @@ type ReferralStatusUpdate = {
 }
 
 type ReferralStatusRefData = {
-  code: ReferralStatus | ReferralStatusUppercase
+  code: ReferralStatusUppercase
   colour: TagColour
   description: string
   closed?: boolean
@@ -98,6 +100,8 @@ type ReferralStatusRefData = {
   hasConfirmation?: boolean
   hasNotes?: boolean
   hintText?: string
+  hold?: boolean
+  release?: boolean
 }
 
 type ReferralView = {

--- a/server/controllers/refer/updateStatusActionsController.test.ts
+++ b/server/controllers/refer/updateStatusActionsController.test.ts
@@ -24,6 +24,20 @@ describe('UpdateStatusActionsController', () => {
     response = createMock<Response>({})
   })
 
+  describe('manageHold', () => {
+    it('should set `referralStatusUpdateData` in the session and redirect to the update status select category show page', async () => {
+      request.query = { status: 'ON_HOLD_REFERRAL_SUBMITTED' }
+
+      controller.manageHold()(request, response, next)
+
+      expect(request.session.referralStatusUpdateData).toEqual({
+        referralId,
+        status: 'ON_HOLD_REFERRAL_SUBMITTED',
+      })
+      expect(response.redirect).toHaveBeenCalledWith(referPaths.updateStatus.selection.show({ referralId }))
+    })
+  })
+
   describe('withdraw', () => {
     it('should set `referralStatusUpdateData` in the session and redirect to the update status select category show page', async () => {
       controller.withdraw()(request, response, next)

--- a/server/controllers/refer/updateStatusActionsController.ts
+++ b/server/controllers/refer/updateStatusActionsController.ts
@@ -1,8 +1,23 @@
 import type { Request, Response, TypedRequestHandler } from 'express'
 
 import { referPaths } from '../../paths'
+import type { ReferralStatusUppercase } from '@accredited-programmes/models'
 
 export default class UpdateStatusActionsController {
+  manageHold(): TypedRequestHandler<Request, Response> {
+    return (req: Request, res: Response) => {
+      const { referralId } = req.params
+      const { status } = req.query as { status: ReferralStatusUppercase }
+
+      req.session.referralStatusUpdateData = {
+        referralId,
+        status,
+      }
+
+      return res.redirect(referPaths.updateStatus.selection.show({ referralId }))
+    }
+  }
+
   withdraw(): TypedRequestHandler<Request, Response> {
     return (req: Request, res: Response) => {
       const { referralId } = req.params

--- a/server/controllers/shared/referralsController.ts
+++ b/server/controllers/shared/referralsController.ts
@@ -1,6 +1,7 @@
 import type { Request, Response, TypedRequestHandler } from 'express'
 import createError from 'http-errors'
 
+import { referPathBase } from '../../paths'
 import type { CourseService, OrganisationService, PersonService, ReferralService, UserService } from '../../services'
 import {
   CourseUtils,
@@ -159,13 +160,15 @@ export default class ReferralsController {
     const { referralId } = req.params
     const { token: userToken, username } = req.user
     const { updatePerson } = req.query as Record<string, string>
+    const isRefer = req.path.startsWith(referPathBase.pattern)
 
     const referral = await this.referralService.getReferral(username, referralId, { updatePerson })
-    const [course, courseOffering, person, referrerUserFullName] = await Promise.all([
+    const [course, courseOffering, person, referrerUserFullName, statusTransitions] = await Promise.all([
       this.courseService.getCourseByOffering(username, referral.offeringId),
       this.courseService.getOffering(username, referral.offeringId),
       this.personService.getPerson(username, referral.prisonNumber, res.locals.user.caseloads),
       this.userService.getFullNameFromUsername(userToken, referral.referrerUsername),
+      isRefer ? this.referralService.getStatusTransitions(username, referral.id) : undefined,
     ])
 
     const organisation = await this.organisationService.getOrganisation(userToken, courseOffering.organisationId)
@@ -173,7 +176,7 @@ export default class ReferralsController {
     const coursePresenter = CourseUtils.presentCourse(course)
 
     return {
-      buttons: ShowReferralUtils.buttons(req.path, referral),
+      buttons: ShowReferralUtils.buttons(req.path, referral, statusTransitions),
       courseOfferingSummaryListRows: ShowReferralUtils.courseOfferingSummaryListRows(
         coursePresenter,
         organisation.name,

--- a/server/paths/index.ts
+++ b/server/paths/index.ts
@@ -4,7 +4,7 @@ import authPaths from './auth'
 import findPaths from './find'
 import prisonApiPaths from './prisonApi'
 import prisonRegisterApiPaths from './prisonRegisterApi'
-import referPaths from './refer'
+import referPaths, { referPathBase } from './refer'
 
 export {
   apiPaths,
@@ -14,5 +14,6 @@ export {
   findPaths,
   prisonApiPaths,
   prisonRegisterApiPaths,
+  referPathBase,
   referPaths,
 }

--- a/server/paths/refer.ts
+++ b/server/paths/refer.ts
@@ -33,6 +33,7 @@ export default {
     index: caseListPath,
     show: caseListPath.path(':referralStatusGroup'),
   },
+  manageHold: referralShowPathBase.path('manage-hold'),
   new: {
     additionalInformation: {
       show: newReferralAdditionalInformationPath,

--- a/server/routes/refer.ts
+++ b/server/routes/refer.ts
@@ -102,6 +102,7 @@ export default function routes(controllers: Controllers, router: Router): Router
   )
   post(referPaths.updateStatus.selection.reason.submit.pattern, updateStatusSelectionController.submitReason())
 
+  get(referPaths.manageHold.pattern, updateStatusActionController.manageHold())
   get(referPaths.withdraw.pattern, updateStatusActionController.withdraw())
 
   return router

--- a/server/testutils/factories/referralStatusRefData.ts
+++ b/server/testutils/factories/referralStatusRefData.ts
@@ -3,13 +3,13 @@ import { Factory } from 'fishery'
 
 import { statusDescriptionAndColour } from './referral'
 import { referralStatuses } from '../../@types/models/Referral'
-import type { ReferralStatus, ReferralStatusRefData } from '@accredited-programmes/models'
+import type { ReferralStatusRefData, ReferralStatusUppercase } from '@accredited-programmes/models'
 import type { TagColour } from '@accredited-programmes/ui'
 
 export default Factory.define<ReferralStatusRefData>(({ params }) => {
   const { hasConfirmation: hasConfirmationParam, hasNotes: hasNotesParam } = params
 
-  const code = params.code || (faker.helpers.arrayElement(referralStatuses).toUpperCase() as ReferralStatus)
+  const code = params.code || (faker.helpers.arrayElement(referralStatuses).toUpperCase() as ReferralStatusUppercase)
   const { statusColour, statusDescription } = statusDescriptionAndColour(code)
   const colour = statusColour as TagColour
   const description = statusDescription as string

--- a/server/utils/referrals/caseListUtils.test.ts
+++ b/server/utils/referrals/caseListUtils.test.ts
@@ -311,12 +311,12 @@ describe('CaseListUtils', () => {
 
   describe('statusSelectItems', () => {
     const referralStatuses = [
-      referralStatusRefDataFactory.build({ code: 'assessment_started' }),
-      referralStatusRefDataFactory.build({ code: 'referral_submitted' }),
+      referralStatusRefDataFactory.build({ code: 'ASSESSMENT_STARTED' }),
+      referralStatusRefDataFactory.build({ code: 'REFERRAL_SUBMITTED' }),
     ]
     const expectedItems = {
-      assessment_started: 'Assessment started',
-      referral_submitted: 'Referral submitted',
+      ASSESSMENT_STARTED: 'Assessment started',
+      REFERRAL_SUBMITTED: 'Referral submitted',
     }
 
     it('makes a call to the `FormUtils.getSelectItems` method with an `undefined` `selectedValue` parameter', () => {
@@ -327,7 +327,7 @@ describe('CaseListUtils', () => {
 
     describe('when a selected value is provided', () => {
       it('makes a call to the `FormUtils.getSelectItems` method with the correct `selectedValue` parameter', () => {
-        const selectedValue = 'assessment_started'
+        const selectedValue = 'ASSESSMENT_STARTED'
 
         CaseListUtils.statusSelectItems(referralStatuses, selectedValue)
 

--- a/server/utils/referrals/showReferralUtils.test.ts
+++ b/server/utils/referrals/showReferralUtils.test.ts
@@ -6,6 +6,7 @@ import {
   organisationFactory,
   referralFactory,
   referralStatusHistoryFactory,
+  referralStatusRefDataFactory,
 } from '../../testutils/factories'
 import CourseUtils from '../courseUtils'
 import type { ReferralStatusHistoryPresenter } from '@accredited-programmes/ui'
@@ -76,6 +77,11 @@ describe('ShowReferralUtils', () => {
           },
           {
             classes: 'govuk-button--secondary',
+            disabled: true,
+            text: 'Put on hold',
+          },
+          {
+            classes: 'govuk-button--secondary',
             disabled: false,
             href: `/refer/referrals/${submittedReferral.id}/withdraw`,
             text: 'Withdraw referral',
@@ -99,6 +105,60 @@ describe('ShowReferralUtils', () => {
               },
             ]),
           )
+        })
+      })
+
+      describe('with `statusTransitions`', () => {
+        describe('when `statusTransitions` includes a hold status', () => {
+          const statusTransitions = [
+            referralStatusRefDataFactory.build({ code: 'ON_HOLD_REFERRAL_SUBMITTED', hold: true }),
+            referralStatusRefDataFactory.build({ code: 'NOT_SUITABLE', hold: false }),
+          ]
+
+          it('contains the "Put on hold" button with the correct href', () => {
+            expect(
+              ShowReferralUtils.buttons(
+                referPaths.show.statusHistory({ referralId: submittedReferral.id }),
+                submittedReferral,
+                statusTransitions,
+              ),
+            ).toEqual(
+              expect.arrayContaining([
+                {
+                  classes: 'govuk-button--secondary',
+                  disabled: false,
+                  href: `/refer/referrals/${submittedReferral.id}/manage-hold?status=ON_HOLD_REFERRAL_SUBMITTED`,
+                  text: 'Put on hold',
+                },
+              ]),
+            )
+          })
+        })
+
+        describe('when `statusTransitions` includes a release status', () => {
+          const statusTransitions = [
+            referralStatusRefDataFactory.build({ code: 'REFERRAL_SUBMITTED', release: true }),
+            referralStatusRefDataFactory.build({ code: 'NOT_SUITABLE', release: false }),
+          ]
+
+          it('contains the "Remove hold" button with the correct href', () => {
+            expect(
+              ShowReferralUtils.buttons(
+                referPaths.show.statusHistory({ referralId: submittedReferral.id }),
+                submittedReferral,
+                statusTransitions,
+              ),
+            ).toEqual(
+              expect.arrayContaining([
+                {
+                  classes: 'govuk-button--secondary',
+                  disabled: false,
+                  href: `/refer/referrals/${submittedReferral.id}/manage-hold?status=REFERRAL_SUBMITTED`,
+                  text: 'Remove hold',
+                },
+              ]),
+            )
+          })
         })
       })
     })

--- a/server/views/referrals/show/partials/rootLayout.njk
+++ b/server/views/referrals/show/partials/rootLayout.njk
@@ -10,25 +10,19 @@
 {% endblock personBanner %}
 
 {% block content %}
-  <div class="moj-page-header-actions">
-    <div class="moj-page-header-actions__title">
-      <h1 class="govuk-heading-l">{{ pageHeading }}</h1>
-    </div>
+  <div class="header-with-actions">
+    <h1 class="header-with-actions__title govuk-heading-l">{{ pageHeading }}</h1>
 
     {% if buttons | length %}
-      <div class="moj-page-header-actions__actions">
-        <div class="moj-button-menu">
-          <div class="moj-button-menu__wrapper"  data-testid="show-referral-buttons">
-            {% for button in buttons %}
-              {{ govukButton({
-                classes: 'moj-button-menu__item moj-page-header-actions__action ' + button.classes,
-                disabled: button.disabled,
-                href: button.href,
-                text: button.text
-              }) }}
-            {% endfor %}
-          </div>
-        </div>
+      <div class="govuk-button-group"  data-testid="show-referral-buttons">
+        {% for button in buttons %}
+          {{ govukButton({
+            classes: button.classes,
+            disabled: button.disabled,
+            href: button.href,
+            text: button.text
+          }) }}
+        {% endfor %}
       </div>
     {% endif %}
   </div>


### PR DESCRIPTION
## Context

When viewing the referral details on the refer paths, a user needs to be able to:

- Put a referral on hold, if the available status transitions allow
- Remove a hold, if the available status transitions allow



## Changes in this PR

- Updates the `ShowReferralUtils.button` method to check if the provided status transitions include a transition with a `hold` or `release` property and then display the correct button with the correct href.
- If neither of those are an option, then button will be disabled.
- Add `UpdateStatusActionsController.manageHold` method which takes the status from the query parameter and redirects to the selection page with the status code added to the session.
- Updated the required controllers to make the call to the `/status-transitions` endpoint, only on refer, not assess.


## Screenshots of UI changes
![image](https://github.com/ministryofjustice/hmpps-accredited-programmes-ui/assets/1067537/61845c1d-33c8-463a-865b-73ea70766981)

![image](https://github.com/ministryofjustice/hmpps-accredited-programmes-ui/assets/1067537/36e69d25-afc3-423c-9c18-90f5263f3905)



## Release checklist

[Release process documentation](../doc/how-to/perform-a-release.md)

As part of our continuous deployment strategy we must ensure that this work is
ready to be released once merged.

### Pre-merge

- [ ] There are changes required to the Accredited Programmes API for this change to work...
  - [ ] ... and they have been released to production already

### Post-merge

<!-- The outer checkboxes can be completed pre-merge -->

- [ ] This adds, extends or meaningfully modifies a feature...
  - [ ] ... and I have written or updated an end-to-end test for the happy path in the [Accredited Programmes E2E repo](https://github.com/ministryofjustice/hmpps-accredited-programmes-e2e)
- [ ] This makes new expectations of the API...
  - [ ] ... and I have notified the API developer(s) of changes to the contract tests (Pact), or the API is already compliant
- [ ] [Manually approve](../doc/how-to/perform-a-release.md#releasing-to-the-preprod-environment) release to preprod
- [ ] [Manually approve](../doc/how-to/perform-a-release.md#releasing-to-the-production-environment) release to prod

<!-- Should a release fail at any step, you as the author should now lead the work to
fix it as soon as possible. You can monitor deployment failures in CircleCI
itself and application errors are found in
[Sentry](https://ministryofjustice.sentry.io/projects/hmpps-accredited-programmes-ui/?project=4505330122686464&referrer=sidebar&statsPeriod=24h). -->
