### PR TITLE
Use course ID for assess case list navigation

### DIFF
--- a/integration_tests/e2e/assess/caseList.cy.ts
+++ b/integration_tests/e2e/assess/caseList.cy.ts
@@ -61,7 +61,7 @@ context('Referral case lists', () => {
   })
 
   it('shows the correct information', () => {
-    const path = assessPaths.caseList.show({ courseName: 'lime-course', referralStatusGroup: 'open' })
+    const path = assessPaths.caseList.show({ courseId: limeCourse.id, referralStatusGroup: 'open' })
     cy.visit(path)
 
     const caseListPage = Page.verifyOnPage(CaseListPage, {
@@ -95,7 +95,7 @@ context('Referral case lists', () => {
     })
 
     const path = PathUtils.pathWithQuery(
-      assessPaths.caseList.show({ courseName: 'lime-course', referralStatusGroup: 'open' }),
+      assessPaths.caseList.show({ courseId: limeCourse.id, referralStatusGroup: 'open' }),
       [{ key: 'page', value: '4' }],
     )
     cy.visit(path)
@@ -120,7 +120,7 @@ context('Referral case lists', () => {
 
   describe('when using the filters', () => {
     it('shows the correct information', () => {
-      const path = assessPaths.caseList.show({ courseName: 'lime-course', referralStatusGroup: 'open' })
+      const path = assessPaths.caseList.show({ courseId: limeCourse.id, referralStatusGroup: 'open' })
       cy.visit(path)
 
       const caseListPage = Page.verifyOnPage(CaseListPage, {
@@ -174,7 +174,7 @@ context('Referral case lists', () => {
         referralViews: blueCourseReferralViews,
       })
       caseListPage.shouldContainCourseNavigation(
-        assessPaths.caseList.show({ courseName: 'blue-course', referralStatusGroup: 'open' }),
+        assessPaths.caseList.show({ courseId: blueCourse.id, referralStatusGroup: 'open' }),
         courses,
       )
       caseListPage.shouldHaveSelectedFilterValues('', '')

--- a/integration_tests/pages/shared/caseList.ts
+++ b/integration_tests/pages/shared/caseList.ts
@@ -30,7 +30,7 @@ export default class CaseListPage extends Page {
       .map(course => {
         return {
           href: assessPaths.caseList.show({
-            courseName: StringUtils.convertToUrlSlug(course.name),
+            courseId: course.id,
             referralStatusGroup: 'open',
           }),
           text: `${course.name} referrals`,

--- a/server/controllers/assess/caseListController.ts
+++ b/server/controllers/assess/caseListController.ts
@@ -3,7 +3,7 @@ import createError from 'http-errors'
 
 import { assessPaths } from '../../paths'
 import type { CourseService, ReferenceDataService, ReferralService } from '../../services'
-import { CaseListUtils, CourseUtils, PaginationUtils, PathUtils, StringUtils, TypeUtils } from '../../utils'
+import { CaseListUtils, CourseUtils, PaginationUtils, PathUtils, TypeUtils } from '../../utils'
 import type { ReferralStatusGroup } from '@accredited-programmes/models'
 import type { CaseListColumnHeader, SortableCaseListColumnKey } from '@accredited-programmes/ui'
 
@@ -18,11 +18,11 @@ export default class AssessCaseListController {
     return async (req: Request, res: Response) => {
       TypeUtils.assertHasUser(req)
 
-      const { courseName, referralStatusGroup } = req.params
+      const { courseId, referralStatusGroup } = req.params
 
       return res.redirect(
         PathUtils.pathWithQuery(
-          assessPaths.caseList.show({ courseName, referralStatusGroup }),
+          assessPaths.caseList.show({ courseId, referralStatusGroup }),
           CaseListUtils.queryParamsExcludingPage(req.body.audience, req.body.status),
         ),
       )
@@ -41,9 +41,8 @@ export default class AssessCaseListController {
       }
 
       const sortedCourses = courses.sort((courseA, courseB) => courseA.name.localeCompare(courseB.name))
-      const firstCourseName = StringUtils.convertToUrlSlug(sortedCourses[0].name)
 
-      res.redirect(assessPaths.caseList.show({ courseName: firstCourseName, referralStatusGroup: 'open' }))
+      res.redirect(assessPaths.caseList.show({ courseId: sortedCourses[0].id, referralStatusGroup: 'open' }))
     }
   }
 
@@ -51,7 +50,7 @@ export default class AssessCaseListController {
     return async (req: Request, res: Response) => {
       TypeUtils.assertHasUser(req)
 
-      const { courseName } = req.params
+      const { courseId } = req.params
       const { page, status, strand: audience, sortColumn, sortDirection } = req.query as Record<string, string>
       const { referralStatusGroup } = req.params as { referralStatusGroup: ReferralStatusGroup }
 
@@ -65,11 +64,10 @@ export default class AssessCaseListController {
 
       const courses = await this.courseService.getCoursesByOrganisation(username, activeCaseLoadId)
 
-      const formattedCourseName = StringUtils.convertFromUrlSlug(courseName)
-      const selectedCourse = courses.find(course => course.name === formattedCourseName)
+      const selectedCourse = courses.find(course => course.id === courseId)
 
       if (!selectedCourse) {
-        throw createError(404, `${formattedCourseName} not found.`)
+        throw createError(404, `Course with ID ${courseId} not found.`)
       }
 
       const [paginatedReferralViews, referralStatuses] = await Promise.all([
@@ -97,7 +95,7 @@ export default class AssessCaseListController {
       )
 
       const basePathExcludingSort = PathUtils.pathWithQuery(
-        assessPaths.caseList.show({ courseName, referralStatusGroup }),
+        assessPaths.caseList.show({ courseId, referralStatusGroup }),
         CaseListUtils.queryParamsExcludingSort(audience, status, page),
       )
 
@@ -113,7 +111,7 @@ export default class AssessCaseListController {
       /* eslint-enable sort-keys */
 
       return res.render('referrals/caseList/assess/show', {
-        action: assessPaths.caseList.filter({ courseName, referralStatusGroup }),
+        action: assessPaths.caseList.filter({ courseId, referralStatusGroup }),
         audienceSelectItems: CaseListUtils.audienceSelectItems(audience),
         pageHeading: CourseUtils.courseNameWithAlternateName(selectedCourse),
         pagination,

--- a/server/paths/assess.ts
+++ b/server/paths/assess.ts
@@ -2,7 +2,7 @@ import { path } from 'static-path'
 
 const assessPathBase = path('/assess')
 const caseListIndex = assessPathBase.path('referrals/case-list')
-const courseCaseListPath = assessPathBase.path('referrals/:courseName/case-list')
+const courseCaseListPath = assessPathBase.path('referrals/course/:courseId/case-list')
 const referralShowPathBase = assessPathBase.path('referrals/:referralId')
 
 const risksAndNeedsPathBase = referralShowPathBase.path('risks-and-needs')

--- a/server/utils/referrals/caseListUtils.test.ts
+++ b/server/utils/referrals/caseListUtils.test.ts
@@ -39,26 +39,27 @@ describe('CaseListUtils', () => {
 
   describe('primaryNavigationItems', () => {
     it('returns primary navigation items, with no duplicate course names, sorted alphabetically by course name and sets the correct item as active', () => {
-      const courses = [
-        courseFactory.build({ name: 'Lime Course' }),
-        courseFactory.build({ name: 'Orange Course' }),
-        courseFactory.build({ name: 'Blue Course' }),
-      ]
+      const blueCourse = courseFactory.build({ name: 'Blue Course' })
+      const limeCourse = courseFactory.build({ name: 'Lime Course' })
+      const orangeCourse = courseFactory.build({ name: 'Orange Course' })
+      const courses = [limeCourse, orangeCourse, blueCourse]
 
-      expect(CaseListUtils.primaryNavigationItems('/assess/referrals/orange-course/case-list/open', courses)).toEqual([
+      expect(
+        CaseListUtils.primaryNavigationItems(`/assess/referrals/course/${orangeCourse.id}/case-list/open`, courses),
+      ).toEqual([
         {
           active: false,
-          href: '/assess/referrals/blue-course/case-list/open',
+          href: `/assess/referrals/course/${blueCourse.id}/case-list/open`,
           text: 'Blue Course referrals',
         },
         {
           active: false,
-          href: '/assess/referrals/lime-course/case-list/open',
+          href: `/assess/referrals/course/${limeCourse.id}/case-list/open`,
           text: 'Lime Course referrals',
         },
         {
           active: true,
-          href: '/assess/referrals/orange-course/case-list/open',
+          href: `/assess/referrals/course/${orangeCourse.id}/case-list/open`,
           text: 'Orange Course referrals',
         },
       ])

--- a/server/utils/referrals/caseListUtils.ts
+++ b/server/utils/referrals/caseListUtils.ts
@@ -35,7 +35,7 @@ export default class CaseListUtils {
 
     return sortedCourses.map(course => {
       const path = assessPaths.caseList.show({
-        courseName: StringUtils.convertToUrlSlug(course.name),
+        courseId: course.id,
         referralStatusGroup: 'open',
       })
 

--- a/server/utils/stringUtils.test.ts
+++ b/server/utils/stringUtils.test.ts
@@ -1,12 +1,6 @@
 import StringUtils from './stringUtils'
 
 describe('StringUtils', () => {
-  describe('convertFromUrlSlug', () => {
-    it('formats a lowercase, hyphenated string to capitalised words', () => {
-      expect(StringUtils.convertFromUrlSlug('a-url-slug')).toEqual('A Url Slug')
-    })
-  })
-
   describe('convertToTitleCase', () => {
     it.each([
       [null, null, ''],
@@ -20,12 +14,6 @@ describe('StringUtils', () => {
       ['hyphenation', 'Robert-John SmiTH-jONes-WILSON', 'Robert-John Smith-Jones-Wilson'],
     ])('handles %s: %s -> %s', (_inputType: string | null, input: string | null, expectedOutput: string) => {
       expect(StringUtils.convertToTitleCase(input)).toEqual(expectedOutput)
-    })
-  })
-
-  describe('convertToUrlSlug', () => {
-    it('formats a string by making it lowercase and replacing the spaces with a hyphen', () => {
-      expect(StringUtils.convertToUrlSlug('The course name')).toEqual('the-course-name')
     })
   })
 

--- a/server/utils/stringUtils.ts
+++ b/server/utils/stringUtils.ts
@@ -1,19 +1,8 @@
 export default class StringUtils {
-  static convertFromUrlSlug(slug: string): string {
-    return slug
-      .split('-')
-      .map(word => this.properCase(word))
-      .join(' ')
-  }
-
   static convertToTitleCase(sentence: string | null): string {
     return sentence === null || StringUtils.isBlank(sentence)
       ? ''
       : sentence.split(' ').map(StringUtils.properCaseName).join(' ')
-  }
-
-  static convertToUrlSlug(string: string): string {
-    return string.toLowerCase().replace(/\s/g, '-')
   }
 
   static initialiseName(fullName?: string): string | null {


### PR DESCRIPTION
## Context

Course names will now be suffixed with the strand, e.g. `Becoming new me plus: sexual offence`. This was causing an issue with the way we linked to the assess case lists for those courses, as we used a formatted version of the name in the url path.

## Changes in this PR
Changed to use the course ID instead of the name and added `/course/` to the URL path so it won't be confused with a referral id.



## Release checklist

[Release process documentation](../doc/how-to/perform-a-release.md)

As part of our continuous deployment strategy we must ensure that this work is
ready to be released once merged.

### Pre-merge

- [ ] There are changes required to the Accredited Programmes API for this change to work...
  - [ ] ... and they have been released to production already

### Post-merge

<!-- The outer checkboxes can be completed pre-merge -->

- [ ] This adds, extends or meaningfully modifies a feature...
  - [ ] ... and I have written or updated an end-to-end test for the happy path in the [Accredited Programmes E2E repo](https://github.com/ministryofjustice/hmpps-accredited-programmes-e2e)
- [ ] This makes new expectations of the API...
  - [ ] ... and I have notified the API developer(s) of changes to the contract tests (Pact), or the API is already compliant
- [ ] [Manually approve](../doc/how-to/perform-a-release.md#releasing-to-the-preprod-environment) release to preprod
- [ ] [Manually approve](../doc/how-to/perform-a-release.md#releasing-to-the-production-environment) release to prod

<!-- Should a release fail at any step, you as the author should now lead the work to
fix it as soon as possible. You can monitor deployment failures in CircleCI
itself and application errors are found in
[Sentry](https://ministryofjustice.sentry.io/projects/hmpps-accredited-programmes-ui/?project=4505330122686464&referrer=sidebar&statsPeriod=24h). -->
