### PR TITLE
Update `ReasonController.show` to redirect correctly

### DIFF
--- a/server/controllers/shared/reasonController.test.ts
+++ b/server/controllers/shared/reasonController.test.ts
@@ -196,9 +196,11 @@ describe('ReasonController', () => {
     })
 
     describe('when there are no reasons for the provided category and status', () => {
-      it('should redirect to the selection page and set `statusReasonCode` to `undefined` ', async () => {
+      beforeEach(() => {
         referenceDataService.getReferralStatusCodeReasons.mockResolvedValue([])
+      })
 
+      it('should redirect to the selection page and set `statusReasonCode` to `undefined` ', async () => {
         const requestHandler = controller.show()
         await requestHandler(request, response, next)
 
@@ -209,6 +211,23 @@ describe('ReasonController', () => {
         expect(response.redirect).toHaveBeenCalledWith(
           referPaths.updateStatus.selection.show({ referralId: referral.id }),
         )
+      })
+
+      describe('and the initialStatusDecision is `DESELECTED|OPEN`', () => {
+        it('should redirect to the decision show page with a `deselectAndKeepOpen` query param set to `true`', async () => {
+          request.session.referralStatusUpdateData = {
+            ...referralStatusUpdateData,
+            initialStatusDecision: 'DESELECTED|OPEN',
+          }
+          referenceDataService.getReferralStatusCodeReasons.mockResolvedValue([])
+
+          const requestHandler = controller.show()
+          await requestHandler(request, response, next)
+
+          expect(response.redirect).toHaveBeenCalledWith(
+            `${assessPaths.updateStatus.decision.show({ referralId: referral.id })}?deselectAndKeepOpen=true`,
+          )
+        })
       })
     })
   })

--- a/server/controllers/shared/reasonController.ts
+++ b/server/controllers/shared/reasonController.ts
@@ -68,6 +68,10 @@ export default class ReasonController {
           statusReasonCode: undefined,
         }
 
+        if (referralStatusUpdateData.initialStatusDecision === 'DESELECTED|OPEN') {
+          return res.redirect(`${assessPaths.updateStatus.decision.show({ referralId })}?deselectAndKeepOpen=true`)
+        }
+
         return res.redirect(paths.updateStatus.selection.show({ referralId }))
       }
 


### PR DESCRIPTION
## Context
When on the deselected and open journey and there are no reasons for the selected category, we should redirect directly to the decision step so the correct status can be selected. At the moment it goes to the selection page with the `DESELECTED` status, which is incorrect.

## Changes in this PR
Update `ReasonController.show` to redirect to the decision step with `?deselectAndKeepOpen=true` when the `initialStatusDecision` is `'DESELECTED|OPEN'`


## Release checklist

[Release process documentation](../doc/how-to/perform-a-release.md)

As part of our continuous deployment strategy we must ensure that this work is
ready to be released once merged.

### Pre-merge

- [ ] There are changes required to the Accredited Programmes API for this change to work...
  - [ ] ... and they have been released to production already

### Post-merge

<!-- The outer checkboxes can be completed pre-merge -->

- [ ] This adds, extends or meaningfully modifies a feature...
  - [ ] ... and I have written or updated an end-to-end test for the happy path in the [Accredited Programmes E2E repo](https://github.com/ministryofjustice/hmpps-accredited-programmes-e2e)
- [ ] This makes new expectations of the API...
  - [ ] ... and I have notified the API developer(s) of changes to the contract tests (Pact), or the API is already compliant
- [ ] [Manually approve](../doc/how-to/perform-a-release.md#releasing-to-the-preprod-environment) release to preprod
- [ ] [Manually approve](../doc/how-to/perform-a-release.md#releasing-to-the-production-environment) release to prod

<!-- Should a release fail at any step, you as the author should now lead the work to
fix it as soon as possible. You can monitor deployment failures in CircleCI
itself and application errors are found in
[Sentry](https://ministryofjustice.sentry.io/projects/hmpps-accredited-programmes-ui/?project=4505330122686464&referrer=sidebar&statsPeriod=24h). -->
