### PR TITLE
(1466) Confirmation text

### DIFF
--- a/integration_tests/e2e/refer/withdraw.cy.ts
+++ b/integration_tests/e2e/refer/withdraw.cy.ts
@@ -1,16 +1,16 @@
 import { ApplicationRoles } from '../../../server/middleware/roleBasedAccessMiddleware'
 import { referPaths } from '../../../server/paths'
 import {
+  confirmationFieldsFactory,
   referralFactory,
   referralStatusCategoryFactory,
   referralStatusHistoryFactory,
   referralStatusReasonFactory,
-  referralStatusRefDataFactory,
   userFactory,
 } from '../../../server/testutils/factories'
 import auth from '../../mockApis/auth'
 import Page from '../../pages/page'
-import { WithdrawCategoryPage, WithdrawReasonInformationPage, WithdrawReasonPage } from '../../pages/shared'
+import { WithdrawCategoryPage, WithdrawConfirmSelectionPage, WithdrawReasonPage } from '../../pages/shared'
 import type { ReferralStatusHistoryPresenter } from '@accredited-programmes/ui'
 
 context('Withdraw referral', () => {
@@ -56,7 +56,18 @@ context('Withdraw referral', () => {
       categories: referralStatusCategories,
       referralStatus: 'WITHDRAWN',
     })
-    cy.task('stubReferralStatusCodeData', referralStatusRefDataFactory.build({ code: 'WITHDRAWN', hasNotes: true }))
+    cy.task('stubConfirmationText', {
+      chosenStatusCode: 'WITHDRAWN',
+      confirmationText: confirmationFieldsFactory.build({
+        hasConfirmation: false,
+        primaryDescription: 'If you withdraw the referral, it will be closed.',
+        primaryHeading: 'Withdraw referral',
+        secondaryDescription: 'Provide more information about the reason for withdrawing this referral.',
+        secondaryHeading: 'Give a reason',
+        warningText: 'Submitting this will close the referral.',
+      }),
+      referralId: referral.id,
+    })
   })
 
   describe('withdrawal category', () => {
@@ -116,7 +127,7 @@ context('Withdraw referral', () => {
     })
   })
 
-  describe('withdrawal reason information', () => {
+  describe('withdrawal confirm selection', () => {
     beforeEach(() => {
       cy.visit(referPaths.withdraw({ referralId: referral.id }))
 
@@ -124,17 +135,17 @@ context('Withdraw referral', () => {
       withdrawCategoryPage.selectWithdrawalCategoryAndSubmit(selectedCategory, [])
     })
 
-    it('shows the withdrawal reason information page', () => {
-      const withdrawReasonInformationPage = Page.verifyOnPage(WithdrawReasonInformationPage)
-      withdrawReasonInformationPage.shouldContainBackLink(referPaths.show.statusHistory({ referralId: referral.id }))
-      withdrawReasonInformationPage.shouldContainCurrentStatusTimelineItem(presentedStatusHistory)
+    it('shows the withdrawal confirm selection page', () => {
+      const withdrawConfirmSelectionPage = Page.verifyOnPage(WithdrawConfirmSelectionPage)
+      withdrawConfirmSelectionPage.shouldContainBackLink(referPaths.show.statusHistory({ referralId: referral.id }))
+      withdrawConfirmSelectionPage.shouldContainCurrentStatusTimelineItem(presentedStatusHistory)
     })
 
-    describe('when submitting without entering reason information', () => {
+    describe('when submitting without entering a reason', () => {
       it('displays an error', () => {
-        const withdrawReasonInformationPage = Page.verifyOnPage(WithdrawReasonInformationPage)
-        withdrawReasonInformationPage.shouldContainButton('Submit').click()
-        withdrawReasonInformationPage.shouldHaveErrors([
+        const withdrawConfirmSelectionPage = Page.verifyOnPage(WithdrawConfirmSelectionPage)
+        withdrawConfirmSelectionPage.shouldContainButton('Submit').click()
+        withdrawConfirmSelectionPage.shouldHaveErrors([
           {
             field: 'reason',
             message: 'Enter a reason',
@@ -156,8 +167,8 @@ context('Withdraw referral', () => {
       const withdrawReasonPage = Page.verifyOnPage(WithdrawReasonPage)
       withdrawReasonPage.selectWithdrawalReasonAndSubmit(selectedReason)
 
-      const withdrawReasonInformationPage = Page.verifyOnPage(WithdrawReasonInformationPage)
-      withdrawReasonInformationPage.enterWithdrawalReasonInformationAndSubmit(reasonInformation)
+      const withdrawConfirmSelectionPage = Page.verifyOnPage(WithdrawConfirmSelectionPage)
+      withdrawConfirmSelectionPage.enterWithdrawalReasonInformationAndSubmit(reasonInformation)
 
       cy.location('pathname').should('equal', referPaths.show.statusHistory({ referralId: referral.id }))
     })

--- a/integration_tests/mockApis/referrals.ts
+++ b/integration_tests/mockApis/referrals.ts
@@ -3,6 +3,7 @@ import type { SuperAgentRequest } from 'superagent'
 import { apiPaths } from '../../server/paths'
 import { stubFor } from '../../wiremock'
 import type {
+  ConfirmationFields,
   Paginated,
   Referral,
   ReferralStatusGroup,
@@ -38,6 +39,26 @@ const referralViewsMetadata = (stubArgs: {
 }
 
 export default {
+  stubConfirmationText: (args: {
+    chosenStatusCode: ReferralStatusRefData['code']
+    confirmationText: ConfirmationFields
+    referralId: Referral['id']
+  }): SuperAgentRequest =>
+    stubFor({
+      request: {
+        method: 'GET',
+        url: apiPaths.referrals.confirmationText({
+          chosenStatusCode: args.chosenStatusCode,
+          referralId: args.referralId,
+        }),
+      },
+      response: {
+        headers: { 'Content-Type': 'application/json;charset=UTF-8' },
+        jsonBody: args.confirmationText,
+        status: 200,
+      },
+    }),
+
   stubCreateReferral: (referral: Referral): SuperAgentRequest =>
     stubFor({
       request: {

--- a/integration_tests/pages/shared/index.ts
+++ b/integration_tests/pages/shared/index.ts
@@ -17,7 +17,7 @@ import SentenceInformationPage from './showReferral/sentenceInformation'
 import StatusHistoryPage from './showReferral/statusHistory'
 import WithdrawCategoryPage from './withdraw/category'
 import WithdrawReasonPage from './withdraw/reason'
-import WithdrawReasonInformationPage from './withdraw/reasonInformation'
+import WithdrawConfirmSelectionPage from './withdraw/selection'
 
 export {
   AdditionalInformationPage,
@@ -38,6 +38,6 @@ export {
   StatusHistoryPage,
   ThinkingAndBehavingPage,
   WithdrawCategoryPage,
-  WithdrawReasonInformationPage,
+  WithdrawConfirmSelectionPage,
   WithdrawReasonPage,
 }

--- a/integration_tests/pages/shared/withdraw/selection.ts
+++ b/integration_tests/pages/shared/withdraw/selection.ts
@@ -1,8 +1,8 @@
 import Page from '../../page'
 
-export default class WithdrawReasonInformationPage extends Page {
+export default class WithdrawConfirmSelectionPage extends Page {
   constructor() {
-    super('Move referral to withdrawn')
+    super('Withdraw referral')
   }
 
   enterWithdrawalReasonInformationAndSubmit(value: string) {

--- a/server/@types/models/Referral.ts
+++ b/server/@types/models/Referral.ts
@@ -25,6 +25,15 @@ const referralStatuses = [
 
 const referralStatusGroups = ['open', 'draft', 'closed'] as const
 
+interface ConfirmationFields {
+  hasConfirmation: boolean
+  primaryDescription: string
+  primaryHeading: string
+  secondaryDescription: string
+  secondaryHeading: string
+  warningText: string
+}
+
 type Referral = {
   id: string // eslint-disable-next-line @typescript-eslint/member-ordering
   additionalInformation: string
@@ -131,6 +140,7 @@ type ReferralView = {
 export { referralStatusGroups, referralStatuses }
 
 export type {
+  ConfirmationFields,
   CreatedReferralResponse,
   Referral,
   ReferralStatus,

--- a/server/@types/models/index.d.ts
+++ b/server/@types/models/index.d.ts
@@ -20,6 +20,7 @@ import type { Paginated } from './Paginated'
 import type { Person } from './Person'
 import type { Psychiatric } from './Psychiatric'
 import type {
+  ConfirmationFields,
   CreatedReferralResponse,
   Referral,
   ReferralStatus,
@@ -40,6 +41,7 @@ import type { RoshAnalysis } from './RoshAnalysis'
 export type {
   Attitude,
   Behaviour,
+  ConfirmationFields,
   Course,
   CourseAudience,
   CourseOffering,

--- a/server/controllers/shared/index.ts
+++ b/server/controllers/shared/index.ts
@@ -34,10 +34,7 @@ const controllers = (services: Services) => {
 
   const reasonController = new ReasonController(services.referenceDataService, services.referralService)
 
-  const updateStatusSelectionController = new UpdateStatusSelectionController(
-    services.referenceDataService,
-    services.referralService,
-  )
+  const updateStatusSelectionController = new UpdateStatusSelectionController(services.referralService)
 
   return {
     categoryController,

--- a/server/data/accreditedProgrammesApi/referralClient.ts
+++ b/server/data/accreditedProgrammesApi/referralClient.ts
@@ -5,6 +5,7 @@ import config from '../../config'
 import { apiPaths } from '../../paths'
 import RestClient from '../restClient'
 import type {
+  ConfirmationFields,
   CreatedReferralResponse,
   Paginated,
   Referral,
@@ -12,6 +13,7 @@ import type {
   ReferralStatusHistory,
   ReferralStatusRefData,
   ReferralStatusUpdate,
+  ReferralStatusUppercase,
   ReferralUpdate,
   ReferralView,
 } from '@accredited-programmes/models'
@@ -46,6 +48,23 @@ export default class ReferralClient {
         ...(query?.updatePerson && { updatePerson: query.updatePerson }),
       },
     })) as Referral
+  }
+
+  async findConfirmationText(
+    referralId: Referral['id'],
+    chosenStatusCode: ReferralStatusUppercase,
+    query?: {
+      deselectAndKeepOpen?: boolean
+      ptUser?: boolean
+    },
+  ): Promise<ConfirmationFields> {
+    return (await this.restClient.get({
+      path: apiPaths.referrals.confirmationText({ chosenStatusCode, referralId }),
+      query: {
+        ...(query?.deselectAndKeepOpen && { deselectAndKeepOpen: 'true' }),
+        ...(query?.ptUser && { ptUser: 'true' }),
+      },
+    })) as ConfirmationFields
   }
 
   async findMyReferralViews(query?: {

--- a/server/paths/api.ts
+++ b/server/paths/api.ts
@@ -18,6 +18,7 @@ const dashboardPath = referralsPath.path('view/organisation/:organisationId/dash
 const myDashboardPath = referralsPath.path('view/me/dashboard')
 const statusHistoryPath = referralPath.path('status-history')
 const statusTransitionsPath = referralPath.path('status-transitions')
+const confirmationTextPath = referralPath.path('confirmation-text/:chosenStatusCode')
 
 const organisationsPath = path('/organisations')
 const coursesByOrganisationPath = organisationsPath.path(':organisationId/courses')
@@ -82,6 +83,7 @@ export default {
     },
   },
   referrals: {
+    confirmationText: confirmationTextPath,
     create: referralsPath,
     dashboard: dashboardPath,
     myDashboard: myDashboardPath,

--- a/server/services/referralService.ts
+++ b/server/services/referralService.ts
@@ -2,6 +2,7 @@ import type UserService from './userService'
 import logger from '../../logger'
 import type { HmppsAuthClient, ReferralClient, RestClientBuilder, RestClientBuilderWithoutToken } from '../data'
 import type {
+  ConfirmationFields,
   CreatedReferralResponse,
   Organisation,
   Paginated,
@@ -9,6 +10,7 @@ import type {
   ReferralStatusGroup,
   ReferralStatusRefData,
   ReferralStatusUpdate,
+  ReferralStatusUppercase,
   ReferralUpdate,
   ReferralView,
 } from '@accredited-programmes/models'
@@ -32,6 +34,22 @@ export default class ReferralService {
     const referralClient = this.referralClientBuilder(systemToken)
 
     return referralClient.create(courseOfferingId, prisonNumber)
+  }
+
+  async getConfirmationText(
+    username: Express.User['username'],
+    referralId: Referral['id'],
+    chosenStatusCode: ReferralStatusUppercase,
+    query?: {
+      deselectAndKeepOpen?: boolean
+      ptUser?: boolean
+    },
+  ): Promise<ConfirmationFields> {
+    const hmppsAuthClient = this.hmppsAuthClientBuilder()
+    const systemToken = await hmppsAuthClient.getSystemClientToken(username)
+    const referralClient = this.referralClientBuilder(systemToken)
+
+    return referralClient.findConfirmationText(referralId, chosenStatusCode, query)
   }
 
   async getMyReferralViews(

--- a/server/testutils/factories/confirmationFields.ts
+++ b/server/testutils/factories/confirmationFields.ts
@@ -1,0 +1,15 @@
+import { faker } from '@faker-js/faker'
+import { Factory } from 'fishery'
+
+import type { ConfirmationFields } from '@accredited-programmes/models'
+
+export default Factory.define<ConfirmationFields>(() => {
+  return {
+    hasConfirmation: faker.datatype.boolean(),
+    primaryDescription: faker.lorem.sentence(),
+    primaryHeading: faker.lorem.words({ max: 4, min: 2 }),
+    secondaryDescription: faker.lorem.sentence(),
+    secondaryHeading: faker.lorem.words({ max: 4, min: 2 }),
+    warningText: faker.lorem.words({ max: 4, min: 2 }),
+  }
+})

--- a/server/testutils/factories/index.ts
+++ b/server/testutils/factories/index.ts
@@ -1,6 +1,7 @@
 import attitudeFactory from './attitude'
 import behaviourFactory from './behaviour'
 import caseloadFactory from './caseload'
+import confirmationFieldsFactory from './confirmationFields'
 import courseFactory from './course'
 import courseAudienceFactory from './courseAudience'
 import courseOfferingFactory from './courseOffering'
@@ -38,6 +39,7 @@ export {
   attitudeFactory,
   behaviourFactory,
   caseloadFactory,
+  confirmationFieldsFactory,
   courseAudienceFactory,
   courseFactory,
   courseOfferingFactory,

--- a/server/views/referrals/updateStatus/selection/show.njk
+++ b/server/views/referrals/updateStatus/selection/show.njk
@@ -3,11 +3,10 @@
 {% from "govuk/components/character-count/macro.njk" import govukCharacterCount %}
 {% from "govuk/components/checkboxes/macro.njk" import govukCheckboxes %}
 {% from "govuk/components/error-summary/macro.njk" import govukErrorSummary %}
+{% from "govuk/components/warning-text/macro.njk" import govukWarningText %}
 {% from "moj/components/timeline/macro.njk" import mojTimeline %}
 
 {% extends "../../../partials/layout.njk" %}
-
-{% set formattedDescription = referralStatusRefData.description | lower %}
 
 {% block backLink %}
   {{ govukBackLink({
@@ -29,7 +28,7 @@
 
       <h1 class="govuk-heading-l">{{ pageHeading }}</h1>
 
-      <p>Submitting this will change the status to {{ formattedDescription }}.</p>
+      <p>{{ confirmationText.primaryDescription }}</p>
 
       <h2 class="govuk-heading-m">Current status</h2>
 
@@ -50,23 +49,21 @@
       <form action="{{ action }}" method="post">
         <input type="hidden" name="_csrf" value="{{ csrfToken }}"/>
 
-        {% if referralStatusRefData.hasConfirmation %}
-          <h2 class="govuk-heading-m">Confirm status change</h2>
+        <h2 class="govuk-heading-m">{{ confirmationText.secondaryHeading }}</h2>
 
+        {% if confirmationText.hasConfirmation %}
           {{ govukCheckboxes({
             name: "confirmation",
             items: [
               {
                 value: "true",
-                text: referralStatusRefData.confirmationText
+                text: confirmationText.secondaryDescription
               }
             ],
             errorMessage: errors.messages.confirmation
           }) }}
         {% else %}
-          <h2 class="govuk-heading-m">Give a reason</h2>
-
-          <p>You must give a reason why this referral is being moved to {{ formattedDescription }}.</p>
+          <p>{{ confirmationText.secondaryDescription }}</p>
 
           {{ govukCharacterCount({
             id: "reason",
@@ -78,6 +75,13 @@
             value: formValues.reason,
             classes: "govuk-!-width-three-quarters",
             errorMessage: errors.messages.reason
+          }) }}
+        {% endif %}
+
+        {% if confirmationText.warningText %}
+          {{ govukWarningText({
+            text: confirmationText.warningText,
+            iconFallbackText: "Warning"
           }) }}
         {% endif %}
 


### PR DESCRIPTION
## Context

The content of the final step of the status update journeys is different depending on the from and to referral status codes.  We need to use the new `confirmation-text` endpoint for the majority of the content on this page.

## Changes in this PR
- Add new `ConfirmationFields` type and test factory util
- Add new client and service methods for new `confirmation-text` endpoint
- Update the `UpdateStatusSelectionController.show` method to call new endpoint and pass values to the template
- Add warning text component to the bottom of the page, if required




## Release checklist

[Release process documentation](../doc/how-to/perform-a-release.md)

As part of our continuous deployment strategy we must ensure that this work is
ready to be released once merged.

### Pre-merge

- [ ] There are changes required to the Accredited Programmes API for this change to work...
  - [ ] ... and they have been released to production already

### Post-merge

<!-- The outer checkboxes can be completed pre-merge -->

- [ ] This adds, extends or meaningfully modifies a feature...
  - [ ] ... and I have written or updated an end-to-end test for the happy path in the [Accredited Programmes E2E repo](https://github.com/ministryofjustice/hmpps-accredited-programmes-e2e)
- [ ] This makes new expectations of the API...
  - [ ] ... and I have notified the API developer(s) of changes to the contract tests (Pact), or the API is already compliant
- [ ] [Manually approve](../doc/how-to/perform-a-release.md#releasing-to-the-preprod-environment) release to preprod
- [ ] [Manually approve](../doc/how-to/perform-a-release.md#releasing-to-the-production-environment) release to prod

<!-- Should a release fail at any step, you as the author should now lead the work to
fix it as soon as possible. You can monitor deployment failures in CircleCI
itself and application errors are found in
[Sentry](https://ministryofjustice.sentry.io/projects/hmpps-accredited-programmes-ui/?project=4505330122686464&referrer=sidebar&statsPeriod=24h). -->
