### PR TITLE
(1469) Add `ptUser` and `deselectAndKeepOpen` query parameters to confirmation-text call

### DIFF
--- a/integration_tests/mockApis/referrals.ts
+++ b/integration_tests/mockApis/referrals.ts
@@ -42,12 +42,14 @@ export default {
   stubConfirmationText: (args: {
     chosenStatusCode: ReferralStatusRefData['code']
     confirmationText: ConfirmationFields
+    queryParameters: QueryParameters
     referralId: Referral['id']
   }): SuperAgentRequest =>
     stubFor({
       request: {
         method: 'GET',
-        url: apiPaths.referrals.confirmationText({
+        queryParameters: args.queryParameters,
+        urlPath: apiPaths.referrals.confirmationText({
           chosenStatusCode: args.chosenStatusCode,
           referralId: args.referralId,
         }),

--- a/server/controllers/shared/updateStatusSelectionController.ts
+++ b/server/controllers/shared/updateStatusSelectionController.ts
@@ -26,7 +26,10 @@ export default class UpdateStatusSelectionController {
 
       const [statusHistory, confirmationText] = await Promise.all([
         this.referralService.getReferralStatusHistory(userToken, username, referralId),
-        this.referralService.getConfirmationText(username, referralId, referralStatusUpdateData.finalStatusDecision),
+        this.referralService.getConfirmationText(username, referralId, referralStatusUpdateData.finalStatusDecision, {
+          deselectAndKeepOpen: referralStatusUpdateData.initialStatusDecision === 'DESELECTED|OPEN',
+          ptUser: req.path.startsWith(assessPathBase.pattern),
+        }),
       ])
 
       const { hasConfirmation } = confirmationText


### PR DESCRIPTION
## Context

The `confirmation-text` endpoint needs to know when the status update is by a `ptUser` and if it is for the `deselectAndKeepOpen` journey.

## Changes in this PR
- Update the update status selection controller to pass these query parameters


## Release checklist

[Release process documentation](../doc/how-to/perform-a-release.md)

As part of our continuous deployment strategy we must ensure that this work is
ready to be released once merged.

### Pre-merge

- [ ] There are changes required to the Accredited Programmes API for this change to work...
  - [ ] ... and they have been released to production already

### Post-merge

<!-- The outer checkboxes can be completed pre-merge -->

- [ ] This adds, extends or meaningfully modifies a feature...
  - [ ] ... and I have written or updated an end-to-end test for the happy path in the [Accredited Programmes E2E repo](https://github.com/ministryofjustice/hmpps-accredited-programmes-e2e)
- [ ] This makes new expectations of the API...
  - [ ] ... and I have notified the API developer(s) of changes to the contract tests (Pact), or the API is already compliant
- [ ] [Manually approve](../doc/how-to/perform-a-release.md#releasing-to-the-preprod-environment) release to preprod
- [ ] [Manually approve](../doc/how-to/perform-a-release.md#releasing-to-the-production-environment) release to prod

<!-- Should a release fail at any step, you as the author should now lead the work to
fix it as soon as possible. You can monitor deployment failures in CircleCI
itself and application errors are found in
[Sentry](https://ministryofjustice.sentry.io/projects/hmpps-accredited-programmes-ui/?project=4505330122686464&referrer=sidebar&statsPeriod=24h). -->
