### PR TITLE
(1469b) Get confirmation text on decision step for deselect and keep open journey

### DIFF
--- a/server/views/referrals/updateStatus/decision/show.njk
+++ b/server/views/referrals/updateStatus/decision/show.njk
@@ -26,7 +26,7 @@
 
       <h1 class="govuk-heading-l">{{ pageHeading }}</h1>
 
-      <p>Record all decisions to keep the status up to date.</p>
+      <p>{{ confirmationText.primaryDescription }}</p>
 
       <h2 class="govuk-heading-m">Current status</h2>
 
@@ -51,9 +51,12 @@
           name: "statusDecision",
           fieldset: {
             legend: {
-              text: "Select decision",
+              text: confirmationText.secondaryHeading,
               classes: "govuk-fieldset__legend--m"
             }
+          },
+          hint: {
+            text: confirmationText.secondaryDescription
           },
           items: radioItems,
           errorMessage: errors.messages.statusDecision,


### PR DESCRIPTION
## Context

The decision step is revisited when on the deselect and keep open journey and we need to display the correct content.

## Changes in this PR
- Call the confirmation-text endpoint on the decision step, only when on the deselect and keep open journey. Otherwise, show default content.


## Screenshots of UI changes

### Before


### After


## Release checklist

[Release process documentation](../doc/how-to/perform-a-release.md)

As part of our continuous deployment strategy we must ensure that this work is
ready to be released once merged.

### Pre-merge

- [ ] There are changes required to the Accredited Programmes API for this change to work...
  - [ ] ... and they have been released to production already

### Post-merge

<!-- The outer checkboxes can be completed pre-merge -->

- [ ] This adds, extends or meaningfully modifies a feature...
  - [ ] ... and I have written or updated an end-to-end test for the happy path in the [Accredited Programmes E2E repo](https://github.com/ministryofjustice/hmpps-accredited-programmes-e2e)
- [ ] This makes new expectations of the API...
  - [ ] ... and I have notified the API developer(s) of changes to the contract tests (Pact), or the API is already compliant
- [ ] [Manually approve](../doc/how-to/perform-a-release.md#releasing-to-the-preprod-environment) release to preprod
- [ ] [Manually approve](../doc/how-to/perform-a-release.md#releasing-to-the-production-environment) release to prod

<!-- Should a release fail at any step, you as the author should now lead the work to
fix it as soon as possible. You can monitor deployment failures in CircleCI
itself and application errors are found in
[Sentry](https://ministryofjustice.sentry.io/projects/hmpps-accredited-programmes-ui/?project=4505330122686464&referrer=sidebar&statsPeriod=24h). -->
