### PR TITLE
(1458) Programme team closed referrals

### DIFF
--- a/integration_tests/pages/shared/caseList.ts
+++ b/integration_tests/pages/shared/caseList.ts
@@ -59,30 +59,34 @@ export default class CaseListPage extends Page {
     })
   }
 
-  shouldContainStatusNavigation(currentReferralStatusGroup: ReferralStatusGroup) {
-    referralStatusGroups.forEach((referralStatusGroup, referralStatusGroupIndex) => {
-      cy.get('.moj-sub-navigation__item')
-        .eq(referralStatusGroupIndex)
-        .within(subNavigationItemElement => {
-          const { actual, expected } = Helpers.parseHtml(
-            subNavigationItemElement,
-            `${StringUtils.properCase(referralStatusGroup)} referrals`,
-          )
-          expect(actual).to.equal(expected)
-
-          cy.get('.moj-sub-navigation__link').then(subNavigationItemLinkElement => {
-            cy.wrap(subNavigationItemLinkElement).should(
-              'have.attr',
-              'href',
-              referPaths.caseList.show({ referralStatusGroup }),
+  shouldContainStatusNavigation(currentReferralStatusGroup: ReferralStatusGroup, courseId?: Course['id']) {
+    referralStatusGroups
+      .filter(statusGroup => (courseId ? statusGroup !== 'draft' : true))
+      .forEach((referralStatusGroup, referralStatusGroupIndex) => {
+        cy.get('.moj-sub-navigation__item')
+          .eq(referralStatusGroupIndex)
+          .within(subNavigationItemElement => {
+            const { actual, expected } = Helpers.parseHtml(
+              subNavigationItemElement,
+              `${StringUtils.properCase(referralStatusGroup)} referrals`,
             )
+            expect(actual).to.equal(expected)
 
-            if (currentReferralStatusGroup === referralStatusGroup) {
-              cy.wrap(subNavigationItemLinkElement).should('have.attr', 'aria-current', 'page')
-            }
+            cy.get('.moj-sub-navigation__link').then(subNavigationItemLinkElement => {
+              cy.wrap(subNavigationItemLinkElement).should(
+                'have.attr',
+                'href',
+                courseId
+                  ? assessPaths.caseList.show({ courseId, referralStatusGroup })
+                  : referPaths.caseList.show({ referralStatusGroup }),
+              )
+
+              if (currentReferralStatusGroup === referralStatusGroup) {
+                cy.wrap(subNavigationItemLinkElement).should('have.attr', 'aria-current', 'page')
+              }
+            })
           })
-        })
-    })
+      })
   }
 
   shouldContainTableOfReferralViews(paths: typeof assessPaths | typeof referPaths) {

--- a/server/controllers/assess/caseListController.ts
+++ b/server/controllers/assess/caseListController.ts
@@ -83,8 +83,8 @@ export default class AssessCaseListController {
         this.referenceDataService.getReferralStatuses(username),
       ])
 
-      const openReferralStatuses = referralStatuses.filter(
-        referralStatus => !referralStatus.closed && !referralStatus.draft,
+      const availableStatuses = referralStatuses.filter(referralStatus =>
+        referralStatusGroup === 'open' ? !referralStatus.closed && !referralStatus.draft : referralStatus.closed,
       )
 
       const pagination = PaginationUtils.pagination(
@@ -117,7 +117,8 @@ export default class AssessCaseListController {
         pagination,
         primaryNavigationItems: CaseListUtils.primaryNavigationItems(req.path, courses),
         referralStatusGroup,
-        referralStatusSelectItems: CaseListUtils.statusSelectItems(openReferralStatuses, status),
+        referralStatusSelectItems: CaseListUtils.statusSelectItems(availableStatuses, status),
+        subNavigationItems: CaseListUtils.assessSubNavigationItems(req.path, courseId),
         tableHeadings: CaseListUtils.sortableTableHeadings(
           basePathExcludingSort,
           caseListColumns,

--- a/server/controllers/refer/caseListController.test.ts
+++ b/server/controllers/refer/caseListController.test.ts
@@ -99,7 +99,7 @@ describe('ReferCaseListController', () => {
           isMyReferralsPage: true,
           pageHeading: 'My referrals',
           pagination,
-          subNavigationItems: CaseListUtils.subNavigationItems(request.path),
+          subNavigationItems: CaseListUtils.referSubNavigationItems(request.path),
           tableHeadings,
           tableRows,
         })
@@ -112,7 +112,7 @@ describe('ReferCaseListController', () => {
           paginatedReferralViews.pageNumber,
           paginatedReferralViews.totalPages,
         )
-        expect(CaseListUtils.subNavigationItems).toHaveBeenCalledWith(request.path)
+        expect(CaseListUtils.referSubNavigationItems).toHaveBeenCalledWith(request.path)
         expect(CaseListUtils.sortableTableHeadings).toHaveBeenCalledWith(
           pathWithQuery,
           {
@@ -160,7 +160,7 @@ describe('ReferCaseListController', () => {
             isMyReferralsPage: true,
             pageHeading: 'My referrals',
             pagination,
-            subNavigationItems: CaseListUtils.subNavigationItems(request.path),
+            subNavigationItems: CaseListUtils.referSubNavigationItems(request.path),
             tableHeadings,
             tableRows,
           })
@@ -243,7 +243,7 @@ describe('ReferCaseListController', () => {
           isMyReferralsPage: true,
           pageHeading: 'My referrals',
           pagination,
-          subNavigationItems: CaseListUtils.subNavigationItems(request.path),
+          subNavigationItems: CaseListUtils.referSubNavigationItems(request.path),
           tableHeadings: [...tableHeadings, { text: 'Progress' }],
           tableRows,
         })
@@ -260,7 +260,7 @@ describe('ReferCaseListController', () => {
           referPaths.caseList.show({ referralStatusGroup: 'draft' }),
           queryParamsExcludingSort,
         )
-        expect(CaseListUtils.subNavigationItems).toHaveBeenCalledWith(request.path)
+        expect(CaseListUtils.referSubNavigationItems).toHaveBeenCalledWith(request.path)
         expect(CaseListUtils.sortableTableHeadings).toHaveBeenCalledWith(
           pathWithQuery,
           {

--- a/server/controllers/refer/caseListController.ts
+++ b/server/controllers/refer/caseListController.ts
@@ -82,7 +82,7 @@ export default class ReferCaseListController {
         isMyReferralsPage: true,
         pageHeading: 'My referrals',
         pagination,
-        subNavigationItems: CaseListUtils.subNavigationItems(req.path),
+        subNavigationItems: CaseListUtils.referSubNavigationItems(req.path),
         tableHeadings: [
           ...CaseListUtils.sortableTableHeadings(
             basePathExcludingSort,

--- a/server/utils/referrals/caseListUtils.test.ts
+++ b/server/utils/referrals/caseListUtils.test.ts
@@ -197,6 +197,31 @@ describe('CaseListUtils', () => {
     })
   })
 
+  describe('referSubNavigationItems', () => {
+    it('returns an array of sub navigation items for my referrals', () => {
+      const currentPath = '/refer/referrals/case-list/open'
+      const expectedItems = [
+        {
+          active: true,
+          href: '/refer/referrals/case-list/open',
+          text: 'Open referrals',
+        },
+        {
+          active: false,
+          href: '/refer/referrals/case-list/draft',
+          text: 'Draft referrals',
+        },
+        {
+          active: false,
+          href: '/refer/referrals/case-list/closed',
+          text: 'Closed referrals',
+        },
+      ]
+
+      expect(CaseListUtils.referSubNavigationItems(currentPath)).toEqual(expectedItems)
+    })
+  })
+
   describe('sortableTableHeadings', () => {
     /* eslint-disable sort-keys */
     const caseListColumns: Partial<Record<SortableCaseListColumnKey, CaseListColumnHeader>> = {
@@ -350,31 +375,6 @@ describe('CaseListUtils', () => {
           '<strong class="govuk-tag govuk-tag--green">Unknown status</strong>',
         )
       })
-    })
-  })
-
-  describe('subNavigationItems', () => {
-    it('returns an array of sub navigation items for my referrals', () => {
-      const currentPath = '/refer/referrals/case-list/open'
-      const expectedItems = [
-        {
-          active: true,
-          href: '/refer/referrals/case-list/open',
-          text: 'Open referrals',
-        },
-        {
-          active: false,
-          href: '/refer/referrals/case-list/draft',
-          text: 'Draft referrals',
-        },
-        {
-          active: false,
-          href: '/refer/referrals/case-list/closed',
-          text: 'Closed referrals',
-        },
-      ]
-
-      expect(CaseListUtils.subNavigationItems(currentPath)).toEqual(expectedItems)
     })
   })
 

--- a/server/utils/referrals/caseListUtils.test.ts
+++ b/server/utils/referrals/caseListUtils.test.ts
@@ -12,6 +12,26 @@ describe('CaseListUtils', () => {
     jest.resetAllMocks()
   })
 
+  describe('assessSubNavigationItems', () => {
+    it('returns an array of sub navigation items for programme team referrals', () => {
+      const currentPath = '/assess/referrals/course/course-id/case-list/open'
+      const expectedItems = [
+        {
+          active: true,
+          href: '/assess/referrals/course/course-id/case-list/open',
+          text: 'Open referrals',
+        },
+        {
+          active: false,
+          href: '/assess/referrals/course/course-id/case-list/closed',
+          text: 'Closed referrals',
+        },
+      ]
+
+      expect(CaseListUtils.assessSubNavigationItems(currentPath, 'course-id')).toEqual(expectedItems)
+    })
+  })
+
   describe('audienceSelectItems', () => {
     const expectedItems = {
       'extremism offence': 'Extremism offence',

--- a/server/utils/referrals/caseListUtils.ts
+++ b/server/utils/referrals/caseListUtils.ts
@@ -89,6 +89,18 @@ export default class CaseListUtils {
     return queryParams
   }
 
+  static referSubNavigationItems(currentPath: Request['path']): Array<MojFrontendNavigationItem> {
+    return referralStatusGroups.map(referralStatusGroup => {
+      const path = referPaths.caseList.show({ referralStatusGroup })
+
+      return {
+        active: currentPath === path,
+        href: path,
+        text: `${StringUtils.properCase(referralStatusGroup)} referrals`,
+      }
+    })
+  }
+
   static sortableTableHeadings(
     basePath: string,
     columns: Record<string, CaseListColumnHeader>,
@@ -129,18 +141,6 @@ export default class CaseListUtils {
     statusDescription?: Referral['statusDescription'],
   ): string {
     return `<strong class="govuk-tag govuk-tag--${statusColour}">${statusDescription || 'Unknown status'}</strong>`
-  }
-
-  static subNavigationItems(currentPath: Request['path']): Array<MojFrontendNavigationItem> {
-    return referralStatusGroups.map(referralStatusGroup => {
-      const path = referPaths.caseList.show({ referralStatusGroup })
-
-      return {
-        active: currentPath === path,
-        href: path,
-        text: `${StringUtils.properCase(referralStatusGroup)} referrals`,
-      }
-    })
   }
 
   static tableRowContent(

--- a/server/utils/referrals/caseListUtils.ts
+++ b/server/utils/referrals/caseListUtils.ts
@@ -10,6 +10,21 @@ import type { CaseListColumnHeader, MojFrontendNavigationItem, QueryParam } from
 import type { GovukFrontendSelectItem, GovukFrontendTableHeadElement, GovukFrontendTableRow } from '@govuk-frontend'
 
 export default class CaseListUtils {
+  static assessSubNavigationItems(
+    currentPath: Request['path'],
+    courseId: Course['id'],
+  ): Array<MojFrontendNavigationItem> {
+    return ['open', 'closed'].map(referralStatusGroup => {
+      const path = assessPaths.caseList.show({ courseId, referralStatusGroup })
+
+      return {
+        active: currentPath === path,
+        href: path,
+        text: `${StringUtils.properCase(referralStatusGroup)} referrals`,
+      }
+    })
+  }
+
   static audienceSelectItems(selectedValue?: string): Array<GovukFrontendSelectItem> {
     return this.selectItems(
       [

--- a/server/views/referrals/caseList/assess/show.njk
+++ b/server/views/referrals/caseList/assess/show.njk
@@ -3,6 +3,7 @@
 {% from "govuk/components/select/macro.njk" import govukSelect %}
 {% from "govuk/components/table/macro.njk" import govukTable %}
 {% from "moj/components/primary-navigation/macro.njk" import mojPrimaryNavigation %}
+{% from "moj/components/sub-navigation/macro.njk" import mojSubNavigation %}
 
 {% extends "../../../partials/layout.njk" %}
 
@@ -55,6 +56,11 @@
       </span>
     </form>
   </div>
+
+  {{ mojSubNavigation({
+    label: 'Sub navigation',
+    items: subNavigationItems
+  }) }}
 
   {{ govukTable({
     head: tableHeadings,


### PR DESCRIPTION
## Context

We need to show closed referrals on the assess case list.


## Changes in this PR
- Add sub navigation for the `closed` referral status group and ensure that the available statuses in the filters are correct.


## Screenshots of UI changes

![image](https://github.com/ministryofjustice/hmpps-accredited-programmes-ui/assets/1067537/337a15bf-41c9-479f-b033-9c21bb3732d3)



## Release checklist

[Release process documentation](../doc/how-to/perform-a-release.md)

As part of our continuous deployment strategy we must ensure that this work is
ready to be released once merged.

### Pre-merge

- [ ] There are changes required to the Accredited Programmes API for this change to work...
  - [ ] ... and they have been released to production already

### Post-merge

<!-- The outer checkboxes can be completed pre-merge -->

- [ ] This adds, extends or meaningfully modifies a feature...
  - [ ] ... and I have written or updated an end-to-end test for the happy path in the [Accredited Programmes E2E repo](https://github.com/ministryofjustice/hmpps-accredited-programmes-e2e)
- [ ] This makes new expectations of the API...
  - [ ] ... and I have notified the API developer(s) of changes to the contract tests (Pact), or the API is already compliant
- [ ] [Manually approve](../doc/how-to/perform-a-release.md#releasing-to-the-preprod-environment) release to preprod
- [ ] [Manually approve](../doc/how-to/perform-a-release.md#releasing-to-the-production-environment) release to prod

<!-- Should a release fail at any step, you as the author should now lead the work to
fix it as soon as possible. You can monitor deployment failures in CircleCI
itself and application errors are found in
[Sentry](https://ministryofjustice.sentry.io/projects/hmpps-accredited-programmes-ui/?project=4505330122686464&referrer=sidebar&statsPeriod=24h). -->
