### PR TITLE
(1444) Add `Go to my referrals` link to referral complete page

### DIFF
--- a/integration_tests/e2e/refer/new/submit.cy.ts
+++ b/integration_tests/e2e/refer/new/submit.cy.ts
@@ -229,5 +229,6 @@ context('Submitting a referral', () => {
     completePage.shouldContainPanel('Referral complete')
     completePage.shouldHaveProcessInformation()
     completePage.shouldContainFeedbackLink()
+    completePage.shouldContainMyReferralsLink()
   })
 })

--- a/integration_tests/pages/refer/new/complete.ts
+++ b/integration_tests/pages/refer/new/complete.ts
@@ -1,3 +1,4 @@
+import { referPaths } from '../../../../server/paths'
 import Helpers from '../../../support/helpers'
 import Page from '../../page'
 
@@ -12,6 +13,10 @@ export default class NewReferralCompletePage extends Page {
         .should('have.text', 'What did you think of this service?')
         .should('have.attr', 'href', 'https://eu.surveymonkey.com/r/P76THLY')
     })
+  }
+
+  shouldContainMyReferralsLink() {
+    this.shouldContainButtonLink('Go to my referrals', referPaths.caseList.index({}))
   }
 
   shouldHaveProcessInformation() {

--- a/server/controllers/refer/new/referralsController.test.ts
+++ b/server/controllers/refer/new/referralsController.test.ts
@@ -503,7 +503,10 @@ describe('NewReferralsController', () => {
         await requestHandler(request, response, next)
 
         expect(referralService.getReferral).toHaveBeenCalledWith(username, referralId)
-        expect(response.render).toHaveBeenCalledWith('referrals/new/complete', { pageHeading: 'Referral complete' })
+        expect(response.render).toHaveBeenCalledWith('referrals/new/complete', {
+          myReferralsLink: referPaths.caseList.index({}),
+          pageHeading: 'Referral complete',
+        })
       })
     })
 

--- a/server/controllers/refer/new/referralsController.ts
+++ b/server/controllers/refer/new/referralsController.ts
@@ -92,6 +92,7 @@ export default class NewReferralsController {
       }
 
       return res.render('referrals/new/complete', {
+        myReferralsLink: referPaths.caseList.index({}),
         pageHeading: 'Referral complete',
       })
     }

--- a/server/views/referrals/new/complete.njk
+++ b/server/views/referrals/new/complete.njk
@@ -14,25 +14,34 @@
 
       <h2 class="govuk-heading-m" data-testid="process-information-heading">What happens next</h2>
 
-      <p class="govuk-body" data-testid="process-information-paragraph-1">
+      <p data-testid="process-information-paragraph-1">
         Your referral has been sent to the programme team for evaluation.
       </p>
 
-      <p class="govuk-body" data-testid="process-information-paragraph-2">
+      <p data-testid="process-information-paragraph-2">
         The programme team might need to do further assessments to find out if a person is suitable or not.
       </p>
 
-      <p class="govuk-body" data-testid="process-information-paragraph-3">
+      <p data-testid="process-information-paragraph-3">
         If a person is suitable, they'll get added to a waiting list.
       </p>
 
-      <p class="govuk-body" data-testid="process-information-paragraph-4">
+      <p data-testid="process-information-paragraph-4">
         If you have any questions about your referral, contact the programme office.
       </p>
 
-      <p class="govuk-body" data-testid="feedback-paragraph">
+      <p data-testid="feedback-paragraph">
         <a href="{{ feedbackUrl }}" class="govuk-link">What did you think of this service?</a>
       </p>
+
+      {{ govukButton({
+        attributes: {
+          "data-testid": "my-referrals-link"
+        },
+        classes: "govuk-!-margin-top-4",
+        text: "Go to my referrals",
+        href: myReferralsLink
+      }) }}
     </div>
   </div>
 {% endblock content %}


### PR DESCRIPTION
## Context

After submitting a referral, a user needs to be able to go back to their referrals.

## Changes in this PR
- Add Go to my referrals button as a link


## Screenshots of UI changes

![image](https://github.com/ministryofjustice/hmpps-accredited-programmes-ui/assets/1067537/43773bd6-563f-4df8-809b-bcb0a9273682)



## Release checklist

[Release process documentation](../doc/how-to/perform-a-release.md)

As part of our continuous deployment strategy we must ensure that this work is
ready to be released once merged.

### Pre-merge

- [ ] There are changes required to the Accredited Programmes API for this change to work...
  - [ ] ... and they have been released to production already

### Post-merge

<!-- The outer checkboxes can be completed pre-merge -->

- [ ] This adds, extends or meaningfully modifies a feature...
  - [ ] ... and I have written or updated an end-to-end test for the happy path in the [Accredited Programmes E2E repo](https://github.com/ministryofjustice/hmpps-accredited-programmes-e2e)
- [ ] This makes new expectations of the API...
  - [ ] ... and I have notified the API developer(s) of changes to the contract tests (Pact), or the API is already compliant
- [ ] [Manually approve](../doc/how-to/perform-a-release.md#releasing-to-the-preprod-environment) release to preprod
- [ ] [Manually approve](../doc/how-to/perform-a-release.md#releasing-to-the-production-environment) release to prod

<!-- Should a release fail at any step, you as the author should now lead the work to
fix it as soon as possible. You can monitor deployment failures in CircleCI
itself and application errors are found in
[Sentry](https://ministryofjustice.sentry.io/projects/hmpps-accredited-programmes-ui/?project=4505330122686464&referrer=sidebar&statsPeriod=24h). -->
