### PR TITLE
Replace use of `precision` with `multipleOf`

### DIFF
--- a/server/testutils/factories/risksAndAlerts.ts
+++ b/server/testutils/factories/risksAndAlerts.ts
@@ -35,7 +35,7 @@ class RiskAndAlertsFactory extends Factory<RisksAndAlerts> {
       riskStaffCommunity: riskLevel(),
       riskStaffCustody: riskLevel(),
       rsrRisk: riskLevel(),
-      rsrScore: faker.number.float({ max: 100, min: 0, precision: 0.01 }),
+      rsrScore: faker.number.float({ max: 100, min: 0, multipleOf: 0.01 }),
     })
   }
 }
@@ -68,6 +68,6 @@ export default RiskAndAlertsFactory.define(
     riskStaffCommunity: FactoryHelpers.optionalArrayElement(riskLevel()),
     riskStaffCustody: FactoryHelpers.optionalArrayElement(riskLevel()),
     rsrRisk: FactoryHelpers.optionalArrayElement(riskLevel()),
-    rsrScore: FactoryHelpers.optionalArrayElement(faker.number.float({ max: 100, min: 0, precision: 0.01 })),
+    rsrScore: FactoryHelpers.optionalArrayElement(faker.number.float({ max: 100, min: 0, multipleOf: 0.01 })),
   }),
 )


### PR DESCRIPTION
`precision` is now deprecated and will be removed in v9. Also removes warning message from test run logs.


## Release checklist

[Release process documentation](../doc/how-to/perform-a-release.md)

As part of our continuous deployment strategy we must ensure that this work is
ready to be released once merged.

### Pre-merge

- [ ] There are changes required to the Accredited Programmes API for this change to work...
  - [ ] ... and they have been released to production already

### Post-merge

<!-- The outer checkboxes can be completed pre-merge -->

- [ ] This adds, extends or meaningfully modifies a feature...
  - [ ] ... and I have written or updated an end-to-end test for the happy path in the [Accredited Programmes E2E repo](https://github.com/ministryofjustice/hmpps-accredited-programmes-e2e)
- [ ] This makes new expectations of the API...
  - [ ] ... and I have notified the API developer(s) of changes to the contract tests (Pact), or the API is already compliant
- [ ] [Manually approve](../doc/how-to/perform-a-release.md#releasing-to-the-preprod-environment) release to preprod
- [ ] [Manually approve](../doc/how-to/perform-a-release.md#releasing-to-the-production-environment) release to prod

<!-- Should a release fail at any step, you as the author should now lead the work to
fix it as soon as possible. You can monitor deployment failures in CircleCI
itself and application errors are found in
[Sentry](https://ministryofjustice.sentry.io/projects/hmpps-accredited-programmes-ui/?project=4505330122686464&referrer=sidebar&statsPeriod=24h). -->
