### PR TITLE
(1454a) Use `displayName` from API for course/programme names

### DIFF
--- a/integration_tests/pages/find/course.ts
+++ b/integration_tests/pages/find/course.ts
@@ -10,7 +10,7 @@ export default class CoursePage extends Page {
   constructor(course: Course) {
     const coursePresenter = CourseUtils.presentCourse(course)
 
-    super(coursePresenter.nameAndAlternateName)
+    super(coursePresenter.displayName)
 
     this.course = coursePresenter
   }

--- a/integration_tests/pages/find/courseOffering.ts
+++ b/integration_tests/pages/find/courseOffering.ts
@@ -15,8 +15,8 @@ export default class CourseOfferingPage extends Page {
     const { courseOffering, organisation, course } = args
     const coursePresenter = CourseUtils.presentCourse(course)
 
-    super(coursePresenter.nameAndAlternateName, {
-      customPageTitleEnd: `${coursePresenter.nameAndAlternateName}, ${organisation.name}`,
+    super(coursePresenter.displayName, {
+      customPageTitleEnd: `${coursePresenter.displayName}, ${organisation.name}`,
     })
 
     this.courseOffering = courseOffering

--- a/integration_tests/pages/find/courses.ts
+++ b/integration_tests/pages/find/courses.ts
@@ -5,7 +5,7 @@ import type { Course } from '@accredited-programmes/models'
 
 export default class CoursesPage extends Page {
   constructor() {
-    super('List of accredited programmes')
+    super('Find an Accredited Programme')
   }
 
   shouldHaveCourses(courses: Array<Course>) {
@@ -14,7 +14,7 @@ export default class CoursesPage extends Page {
         const course = CourseUtils.presentCourse(courses[courseElementIndex])
 
         cy.get('.govuk-link').should('have.attr', 'href', findPaths.show({ courseId: course.id }))
-        cy.get('.govuk-heading-m .govuk-link').should('have.text', course.nameAndAlternateName)
+        cy.get('.govuk-heading-m .govuk-link').should('have.text', course.displayName)
 
         cy.get('.govuk-tag').then(tagElement => {
           this.shouldContainTag(course.audienceTag, tagElement)

--- a/integration_tests/pages/page.ts
+++ b/integration_tests/pages/page.ts
@@ -249,7 +249,7 @@ export default abstract class Page {
     const { course, organisation } = pageWithOrganisationAndCoursePresenter
 
     cy.get('.govuk-grid-column-two-thirds > h2:first-child').then(organisationAndCourseHeading => {
-      const expectedText = `${organisation.name} | ${course.nameAndAlternateName}`
+      const expectedText = `${organisation.name} | ${course.displayName}`
       const { actual, expected } = Helpers.parseHtml(organisationAndCourseHeading, expectedText)
       expect(actual).to.equal(expected)
     })

--- a/integration_tests/pages/shared/caseList.ts
+++ b/integration_tests/pages/shared/caseList.ts
@@ -1,6 +1,6 @@
 import { referralStatusGroups } from '../../../server/@types/models/Referral'
 import { assessPaths, referPaths } from '../../../server/paths'
-import { CaseListUtils, CourseUtils, StringUtils } from '../../../server/utils'
+import { CaseListUtils, StringUtils } from '../../../server/utils'
 import Helpers from '../../support/helpers'
 import Page from '../page'
 import type { Course, ReferralStatusGroup, ReferralView } from '@accredited-programmes/models'
@@ -18,7 +18,7 @@ export default class CaseListPage extends Page {
   }) {
     const { columnHeaders, course, referralViews } = args
 
-    super(course ? CourseUtils.courseNameWithAlternateName(course) : 'My referrals')
+    super(course ? course.displayName : 'My referrals')
 
     this.columnHeaders = columnHeaders
     this.referralViews = referralViews

--- a/integration_tests/pages/shared/showReferral/additionalInformation.ts
+++ b/integration_tests/pages/shared/showReferral/additionalInformation.ts
@@ -11,7 +11,7 @@ export default class AdditionalInformationPage extends Page {
 
     const coursePresenter = CourseUtils.presentCourse(course)
 
-    super(`Referral to ${coursePresenter.nameAndAlternateName}`)
+    super(`Referral to ${coursePresenter.displayName}`)
 
     this.referral = referral
   }

--- a/integration_tests/pages/shared/showReferral/offenceHistory.ts
+++ b/integration_tests/pages/shared/showReferral/offenceHistory.ts
@@ -19,7 +19,7 @@ export default class OffenceHistoryPage extends Page {
     const { course, offenderBooking, person } = args
     const coursePresenter = CourseUtils.presentCourse(course)
 
-    super(`Referral to ${coursePresenter.nameAndAlternateName}`)
+    super(`Referral to ${coursePresenter.displayName}`)
 
     this.offenceCodes = args.offenceCodes
     this.offenderBooking = offenderBooking

--- a/integration_tests/pages/shared/showReferral/personalDetails.ts
+++ b/integration_tests/pages/shared/showReferral/personalDetails.ts
@@ -9,7 +9,7 @@ export default class PersonalDetailsPage extends Page {
     const { course, person } = args
     const coursePresenter = CourseUtils.presentCourse(course)
 
-    super(`Referral to ${coursePresenter.nameAndAlternateName}`)
+    super(`Referral to ${coursePresenter.displayName}`)
 
     this.person = person
   }

--- a/integration_tests/pages/shared/showReferral/programmeHistory.ts
+++ b/integration_tests/pages/shared/showReferral/programmeHistory.ts
@@ -9,7 +9,7 @@ export default class ProgrammeHistoryPage extends Page {
     const { course, person } = args
     const coursePresenter = CourseUtils.presentCourse(course)
 
-    super(`Referral to ${coursePresenter.nameAndAlternateName}`)
+    super(`Referral to ${coursePresenter.displayName}`)
 
     this.person = person
   }

--- a/integration_tests/pages/shared/showReferral/risksAndNeeds/attitudes.ts
+++ b/integration_tests/pages/shared/showReferral/risksAndNeeds/attitudes.ts
@@ -10,7 +10,7 @@ export default class AttitudesPage extends Page {
 
     const coursePresenter = CourseUtils.presentCourse(course)
 
-    super(`Referral to ${coursePresenter.nameAndAlternateName}`)
+    super(`Referral to ${coursePresenter.displayName}`)
 
     this.attitude = attitude
   }

--- a/integration_tests/pages/shared/showReferral/risksAndNeeds/emotionalWellbeing.ts
+++ b/integration_tests/pages/shared/showReferral/risksAndNeeds/emotionalWellbeing.ts
@@ -10,7 +10,7 @@ export default class EmotionalWellbeing extends Page {
 
     const coursePresenter = CourseUtils.presentCourse(course)
 
-    super(`Referral to ${coursePresenter.nameAndAlternateName}`)
+    super(`Referral to ${coursePresenter.displayName}`)
 
     this.psychiatric = psychiatric
   }

--- a/integration_tests/pages/shared/showReferral/risksAndNeeds/health.ts
+++ b/integration_tests/pages/shared/showReferral/risksAndNeeds/health.ts
@@ -10,7 +10,7 @@ export default class HealthPage extends Page {
 
     const coursePresenter = CourseUtils.presentCourse(course)
 
-    super(`Referral to ${coursePresenter.nameAndAlternateName}`)
+    super(`Referral to ${coursePresenter.displayName}`)
 
     this.health = health
   }

--- a/integration_tests/pages/shared/showReferral/risksAndNeeds/learningNeeds.ts
+++ b/integration_tests/pages/shared/showReferral/risksAndNeeds/learningNeeds.ts
@@ -10,7 +10,7 @@ export default class LearningNeedsPage extends Page {
 
     const coursePresenter = CourseUtils.presentCourse(course)
 
-    super(`Referral to ${coursePresenter.nameAndAlternateName}`)
+    super(`Referral to ${coursePresenter.displayName}`)
 
     this.learningNeeds = learningNeeds
   }

--- a/integration_tests/pages/shared/showReferral/risksAndNeeds/lifestyleAndAssociates.ts
+++ b/integration_tests/pages/shared/showReferral/risksAndNeeds/lifestyleAndAssociates.ts
@@ -10,7 +10,7 @@ export default class LifestyleAndAssociatesPage extends Page {
 
     const coursePresenter = CourseUtils.presentCourse(course)
 
-    super(`Referral to ${coursePresenter.nameAndAlternateName}`)
+    super(`Referral to ${coursePresenter.displayName}`)
 
     this.lifestyle = lifestyle
   }

--- a/integration_tests/pages/shared/showReferral/risksAndNeeds/offenceAnalysis.ts
+++ b/integration_tests/pages/shared/showReferral/risksAndNeeds/offenceAnalysis.ts
@@ -10,7 +10,7 @@ export default class OffenceAnalysisPage extends Page {
 
     const coursePresenter = CourseUtils.presentCourse(course)
 
-    super(`Referral to ${coursePresenter.nameAndAlternateName}`)
+    super(`Referral to ${coursePresenter.displayName}`)
 
     this.offenceDetail = offenceDetail
   }

--- a/integration_tests/pages/shared/showReferral/risksAndNeeds/relationships.ts
+++ b/integration_tests/pages/shared/showReferral/risksAndNeeds/relationships.ts
@@ -10,7 +10,7 @@ export default class RelationshipsPage extends Page {
 
     const coursePresenter = CourseUtils.presentCourse(course)
 
-    super(`Referral to ${coursePresenter.nameAndAlternateName}`)
+    super(`Referral to ${coursePresenter.displayName}`)
 
     this.relationships = relationships
   }

--- a/integration_tests/pages/shared/showReferral/risksAndNeeds/risksAndAlerts.ts
+++ b/integration_tests/pages/shared/showReferral/risksAndNeeds/risksAndAlerts.ts
@@ -12,7 +12,7 @@ export default class RisksAndAlertsPage extends Page {
 
     const coursePresenter = CourseUtils.presentCourse(course)
 
-    super(`Referral to ${coursePresenter.nameAndAlternateName}`)
+    super(`Referral to ${coursePresenter.displayName}`)
 
     this.risksAndAlerts = risksAndAlerts
   }

--- a/integration_tests/pages/shared/showReferral/risksAndNeeds/roshAnalysis.ts
+++ b/integration_tests/pages/shared/showReferral/risksAndNeeds/roshAnalysis.ts
@@ -10,7 +10,7 @@ export default class RoshAnalysisPage extends Page {
 
     const coursePresenter = CourseUtils.presentCourse(course)
 
-    super(`Referral to ${coursePresenter.nameAndAlternateName}`)
+    super(`Referral to ${coursePresenter.displayName}`)
 
     this.roshAnalysis = roshAnalysis
   }

--- a/integration_tests/pages/shared/showReferral/risksAndNeeds/thinkingAndBehaving.ts
+++ b/integration_tests/pages/shared/showReferral/risksAndNeeds/thinkingAndBehaving.ts
@@ -10,7 +10,7 @@ export default class ThinkingAndBehavingPage extends Page {
 
     const coursePresenter = CourseUtils.presentCourse(course)
 
-    super(`Referral to ${coursePresenter.nameAndAlternateName}`)
+    super(`Referral to ${coursePresenter.displayName}`)
 
     this.behaviour = behaviour
   }

--- a/integration_tests/pages/shared/showReferral/sentenceInformation.ts
+++ b/integration_tests/pages/shared/showReferral/sentenceInformation.ts
@@ -11,7 +11,7 @@ export default class SentenceInformationPage extends Page {
     const { course, person, sentenceDetails } = args
     const coursePresenter = CourseUtils.presentCourse(course)
 
-    super(`Referral to ${coursePresenter.nameAndAlternateName}`)
+    super(`Referral to ${coursePresenter.displayName}`)
 
     this.person = person
     this.sentenceDetails = sentenceDetails

--- a/integration_tests/pages/shared/showReferral/statusHistory.ts
+++ b/integration_tests/pages/shared/showReferral/statusHistory.ts
@@ -8,7 +8,7 @@ export default class StatusHistoryPage extends Page {
     const { course } = args
     const coursePresenter = CourseUtils.presentCourse(course)
 
-    super(`Referral to ${coursePresenter.nameAndAlternateName}`)
+    super(`Referral to ${coursePresenter.displayName}`)
   }
 
   shouldContainStatusHistoryTimeline(statusHistoryPresenter: Array<ReferralStatusHistoryPresenter>) {

--- a/server/@types/models/Course.ts
+++ b/server/@types/models/Course.ts
@@ -7,5 +7,6 @@ export type Course = {
   audience: CourseAudience
   coursePrerequisites: Array<CoursePrerequisite>
   description: string
+  displayName: string
   name: string
 }

--- a/server/@types/ui/index.d.ts
+++ b/server/@types/ui/index.d.ts
@@ -82,7 +82,6 @@ type CourseParticipationPresenter = CourseParticipation & {
 
 type CoursePresenter = Course & {
   audienceTag: GovukFrontendTagWithText
-  nameAndAlternateName: string
   prerequisiteSummaryListRows: Array<GovukFrontendSummaryListRowWithKeyAndValue>
 }
 

--- a/server/controllers/assess/caseListController.test.ts
+++ b/server/controllers/assess/caseListController.test.ts
@@ -181,7 +181,7 @@ describe('AssessCaseListController', () => {
         expect(response.render).toHaveBeenCalledWith('referrals/caseList/assess/show', {
           action: assessPaths.caseList.filter({ courseId: limeCourse.id, referralStatusGroup }),
           audienceSelectItems,
-          pageHeading: 'Lime Course: gang offence (LC)',
+          pageHeading: 'Lime Course Course: gang offence',
           pagination,
           primaryNavigationItems,
           referralStatusGroup,
@@ -259,7 +259,7 @@ describe('AssessCaseListController', () => {
           expect(response.render).toHaveBeenCalledWith('referrals/caseList/assess/show', {
             action: assessPaths.caseList.filter({ courseId: limeCourse.id, referralStatusGroup }),
             audienceSelectItems: CaseListUtils.audienceSelectItems('general offence'),
-            pageHeading: 'Lime Course: gang offence (LC)',
+            pageHeading: 'Lime Course Course: gang offence',
             pagination,
             primaryNavigationItems: CaseListUtils.primaryNavigationItems(request.path, sortedCourses),
             referralStatusGroup,
@@ -341,7 +341,7 @@ describe('AssessCaseListController', () => {
         expect(response.render).toHaveBeenCalledWith('referrals/caseList/assess/show', {
           action: assessPaths.caseList.filter({ courseId: limeCourse.id, referralStatusGroup: 'closed' }),
           audienceSelectItems,
-          pageHeading: 'Lime Course: gang offence (LC)',
+          pageHeading: 'Lime Course Course: gang offence',
           pagination,
           primaryNavigationItems,
           referralStatusGroup: 'closed',

--- a/server/controllers/assess/caseListController.ts
+++ b/server/controllers/assess/caseListController.ts
@@ -3,7 +3,7 @@ import createError from 'http-errors'
 
 import { assessPaths } from '../../paths'
 import type { CourseService, ReferenceDataService, ReferralService } from '../../services'
-import { CaseListUtils, CourseUtils, PaginationUtils, PathUtils, TypeUtils } from '../../utils'
+import { CaseListUtils, PaginationUtils, PathUtils, TypeUtils } from '../../utils'
 import type { ReferralStatusGroup } from '@accredited-programmes/models'
 import type { CaseListColumnHeader, SortableCaseListColumnKey } from '@accredited-programmes/ui'
 
@@ -115,7 +115,7 @@ export default class AssessCaseListController {
       return res.render('referrals/caseList/assess/show', {
         action: assessPaths.caseList.filter({ courseId, referralStatusGroup }),
         audienceSelectItems: CaseListUtils.audienceSelectItems(audience),
-        pageHeading: CourseUtils.courseNameWithAlternateName(selectedCourse),
+        pageHeading: selectedCourse.displayName,
         pagination,
         primaryNavigationItems: CaseListUtils.primaryNavigationItems(req.path, courses),
         referralStatusGroup,

--- a/server/controllers/find/courseOfferingsController.test.ts
+++ b/server/controllers/find/courseOfferingsController.test.ts
@@ -46,7 +46,7 @@ describe('CoursesOfferingsController', () => {
           courseOffering,
           course.name,
         ),
-        pageHeading: coursePresenter.nameAndAlternateName,
+        pageHeading: coursePresenter.displayName,
       })
     })
   })

--- a/server/controllers/find/courseOfferingsController.ts
+++ b/server/controllers/find/courseOfferingsController.ts
@@ -36,7 +36,7 @@ export default class CourseOfferingsController {
           courseOffering,
           course.name,
         ),
-        pageHeading: coursePresenter.nameAndAlternateName,
+        pageHeading: coursePresenter.displayName,
       })
     }
   }

--- a/server/controllers/find/coursesController.test.ts
+++ b/server/controllers/find/coursesController.test.ts
@@ -39,7 +39,7 @@ describe('CoursesController', () => {
 
       expect(response.render).toHaveBeenCalledWith('courses/index', {
         courses: sortedCourses.map(course => CourseUtils.presentCourse(course)),
-        pageHeading: 'List of accredited programmes',
+        pageHeading: 'Find an Accredited Programme',
       })
 
       expect(courseService.getCourses).toHaveBeenCalledWith(userToken)
@@ -80,7 +80,7 @@ describe('CoursesController', () => {
         expect(response.render).toHaveBeenCalledWith('courses/show', {
           course: coursePresenter,
           organisationsTableData: OrganisationUtils.organisationTableRows(organisationsWithOfferingIds),
-          pageHeading: coursePresenter.nameAndAlternateName,
+          pageHeading: coursePresenter.displayName,
         })
       })
     })
@@ -119,7 +119,7 @@ describe('CoursesController', () => {
         expect(response.render).toHaveBeenCalledWith('courses/show', {
           course: coursePresenter,
           organisationsTableData: OrganisationUtils.organisationTableRows(existingOrganisationsWithOfferingIds),
-          pageHeading: coursePresenter.nameAndAlternateName,
+          pageHeading: coursePresenter.displayName,
         })
       })
     })

--- a/server/controllers/find/coursesController.ts
+++ b/server/controllers/find/coursesController.ts
@@ -20,7 +20,7 @@ export default class CoursesController {
         courses: courses
           .sort((courseA, courseB) => courseA.name.localeCompare(courseB.name))
           .map(course => CourseUtils.presentCourse(course)),
-        pageHeading: 'List of accredited programmes',
+        pageHeading: 'Find an Accredited Programme',
       })
     }
   }
@@ -47,7 +47,7 @@ export default class CoursesController {
       res.render('courses/show', {
         course: coursePresenter,
         organisationsTableData,
-        pageHeading: coursePresenter.nameAndAlternateName,
+        pageHeading: coursePresenter.displayName,
       })
     }
   }

--- a/server/controllers/refer/new/referralsController.test.ts
+++ b/server/controllers/refer/new/referralsController.test.ts
@@ -336,7 +336,6 @@ describe('NewReferralsController', () => {
 
       const coursePresenter = createMock<CoursePresenter>({
         audience: courseAudienceFactory.build(),
-        nameAndAlternateName: `${course.name} (${course.alternateName})`,
       })
       courseService.getCourse.mockResolvedValue(course)
       ;(CourseUtils.presentCourse as jest.Mock).mockReturnValue(coursePresenter)

--- a/server/controllers/shared/referralsController.test.ts
+++ b/server/controllers/shared/referralsController.test.ts
@@ -84,7 +84,7 @@ describe('ReferralsController', () => {
         referrerEmail,
         organisation.name,
       ),
-      pageHeading: `Referral to ${coursePresenter.nameAndAlternateName}`,
+      pageHeading: `Referral to ${coursePresenter.displayName}`,
       pageSubHeading: 'Referral summary',
       person,
       referral,

--- a/server/controllers/shared/referralsController.ts
+++ b/server/controllers/shared/referralsController.ts
@@ -176,7 +176,7 @@ export default class ReferralsController {
         organisation.name,
       ),
       navigationItems: ShowReferralUtils.viewReferralNavigationItems(req.path, referral.id),
-      pageHeading: `Referral to ${coursePresenter.nameAndAlternateName}`,
+      pageHeading: `Referral to ${coursePresenter.displayName}`,
       pageSubHeading: 'Referral summary',
       person,
       referral,

--- a/server/controllers/shared/risksAndNeedsController.test.ts
+++ b/server/controllers/shared/risksAndNeedsController.test.ts
@@ -110,7 +110,7 @@ describe('RisksAndNeedsController', () => {
 
     sharedPageData = {
       buttons,
-      pageHeading: `Referral to ${coursePresenter.nameAndAlternateName}`,
+      pageHeading: `Referral to ${coursePresenter.displayName}`,
       pageSubHeading: 'Risks and needs',
       person,
       referral,

--- a/server/controllers/shared/risksAndNeedsController.ts
+++ b/server/controllers/shared/risksAndNeedsController.ts
@@ -355,7 +355,7 @@ export default class RisksAndNeedsController {
     return {
       buttons: ShowReferralUtils.buttons(req.path, referral, statusTransitions),
       navigationItems: ShowRisksAndNeedsUtils.navigationItems(req.path, referral.id),
-      pageHeading: `Referral to ${coursePresenter.nameAndAlternateName}`,
+      pageHeading: `Referral to ${coursePresenter.displayName}`,
       pageSubHeading: 'Risks and needs',
       person,
       referral,

--- a/server/controllers/shared/statusHistoryController.test.ts
+++ b/server/controllers/shared/statusHistoryController.test.ts
@@ -93,7 +93,7 @@ describe('StatusHistoryController', () => {
 
       expect(response.render).toHaveBeenCalledWith('referrals/show/statusHistory/show', {
         buttons,
-        pageHeading: `Referral to ${coursePresenter.nameAndAlternateName}`,
+        pageHeading: `Referral to ${coursePresenter.displayName}`,
         pageSubHeading: 'Status history',
         person,
         referral,

--- a/server/controllers/shared/statusHistoryController.ts
+++ b/server/controllers/shared/statusHistoryController.ts
@@ -35,7 +35,7 @@ export default class StatusHistoryController {
 
       return res.render('referrals/show/statusHistory/show', {
         buttons: ShowReferralUtils.buttons(req.path, referral, statusTransitions),
-        pageHeading: `Referral to ${coursePresenter.nameAndAlternateName}`,
+        pageHeading: `Referral to ${coursePresenter.displayName}`,
         pageSubHeading: 'Status history',
         person,
         referral,

--- a/server/testutils/factories/course.ts
+++ b/server/testutils/factories/course.ts
@@ -7,12 +7,14 @@ import { StringUtils } from '../../utils'
 import type { Course } from '@accredited-programmes/models'
 
 export default Factory.define<Course>(({ params }) => {
-  const name = `${StringUtils.convertToTitleCase(faker.color.human())} Course`
+  const audience = params.audience || courseAudienceFactory.build()
+  const name = `${params.name || StringUtils.convertToTitleCase(faker.color.human())} Course`
+  const displayName = `${name}: ${audience.toLowerCase()}`
 
   return {
     id: faker.string.uuid(), // eslint-disable-next-line sort-keys
     alternateName: StringUtils.initialiseTitle(params.name || name),
-    audience: courseAudienceFactory.build(),
+    audience,
     coursePrerequisites: [
       coursePrerequisiteFactory.gender().build(),
       coursePrerequisiteFactory.learningNeeds().build(),
@@ -21,6 +23,7 @@ export default Factory.define<Course>(({ params }) => {
       coursePrerequisiteFactory.setting().build(),
     ],
     description: faker.lorem.sentences(),
+    displayName,
     name,
   }
 })

--- a/server/utils/courseUtils.test.ts
+++ b/server/utils/courseUtils.test.ts
@@ -2,24 +2,6 @@ import CourseUtils from './courseUtils'
 import { courseFactory, coursePrerequisiteFactory } from '../testutils/factories'
 
 describe('CourseUtils', () => {
-  describe('courseNameWithAlternateName', () => {
-    describe('when a course has an `alternateName`', () => {
-      it('returns the `name` and `alternateName` in brackets', () => {
-        const course = courseFactory.build({ alternateName: 'LC', audience: 'Extremism offence', name: 'Lime Course' })
-
-        expect(CourseUtils.courseNameWithAlternateName(course)).toEqual('Lime Course: extremism offence (LC)')
-      })
-    })
-
-    describe('when a course has no `alternateName`', () => {
-      it('just returns the `name`', () => {
-        const course = courseFactory.build({ alternateName: null, name: 'Lime Course' })
-
-        expect(CourseUtils.courseNameWithAlternateName(course)).toEqual('Lime Course')
-      })
-    })
-  })
-
   describe('courseRadioOptions', () => {
     it('returns a formatted array of courses to use with UI radios', () => {
       const courses = courseFactory.buildList(2)
@@ -53,7 +35,6 @@ describe('CourseUtils', () => {
           classes: 'govuk-tag govuk-tag--green audience-tag',
           text: 'Intimate partner violence offence',
         },
-        nameAndAlternateName: 'Lime Course: intimate partner violence offence (LC)',
         prerequisiteSummaryListRows: [
           {
             key: { text: 'Setting' },
@@ -86,14 +67,6 @@ describe('CourseUtils', () => {
           key: { text: 'Risk criteria' },
           value: { text: `${riskCriteriaPrerequisites[0].description}, ${riskCriteriaPrerequisites[1].description}` },
         })
-      })
-    })
-
-    describe('when a course has no `alternateName`', () => {
-      it('just uses the `name` as the `nameAndAlternateName`', () => {
-        const course = courseFactory.build({ alternateName: null })
-
-        expect(CourseUtils.presentCourse(course).nameAndAlternateName).toEqual(course.name)
       })
     })
   })

--- a/server/utils/courseUtils.ts
+++ b/server/utils/courseUtils.ts
@@ -8,12 +8,6 @@ import type {
 } from '@accredited-programmes/ui'
 
 export default class CourseUtils {
-  static courseNameWithAlternateName(course: Course): string {
-    return course.alternateName
-      ? `${course.name}: ${course.audience?.toLowerCase()} (${course.alternateName})`
-      : course.name
-  }
-
   static courseRadioOptions(courseNames: Array<Course['name']>): Array<GovukFrontendTagWithText> {
     return courseNames.map(courseName => {
       return {
@@ -27,7 +21,6 @@ export default class CourseUtils {
     return {
       ...course,
       audienceTag: CourseUtils.audienceTag(course.audience),
-      nameAndAlternateName: CourseUtils.courseNameWithAlternateName(course),
       prerequisiteSummaryListRows: CourseUtils.prerequisiteSummaryListRows(course.coursePrerequisites),
     }
   }

--- a/server/utils/referrals/newReferralUtils.test.ts
+++ b/server/utils/referrals/newReferralUtils.test.ts
@@ -31,7 +31,7 @@ describe('NewReferralUtils', () => {
         },
         {
           key: { text: 'Programme name' },
-          value: { text: 'Test Course: general offence (TC+)' },
+          value: { text: 'Test Course Course: general offence' },
         },
         {
           key: { text: 'Programme strand' },

--- a/server/utils/referrals/newReferralUtils.ts
+++ b/server/utils/referrals/newReferralUtils.ts
@@ -23,7 +23,7 @@ export default class NewReferralUtils {
       },
       {
         key: { text: 'Programme name' },
-        value: { text: coursePresenter.nameAndAlternateName },
+        value: { text: coursePresenter.displayName },
       },
       {
         key: { text: 'Programme strand' },

--- a/server/utils/referrals/showReferralUtils.test.ts
+++ b/server/utils/referrals/showReferralUtils.test.ts
@@ -184,7 +184,7 @@ describe('ShowReferralUtils', () => {
         },
         {
           key: { text: 'Programme name' },
-          value: { text: 'Test Course: general offence (TC+)' },
+          value: { text: 'Test Course Course: general offence' },
         },
         {
           key: { text: 'Programme strand' },

--- a/server/utils/referrals/showReferralUtils.ts
+++ b/server/utils/referrals/showReferralUtils.ts
@@ -81,7 +81,7 @@ export default class ShowReferralUtils {
       },
       {
         key: { text: 'Programme name' },
-        value: { text: coursePresenter.nameAndAlternateName },
+        value: { text: coursePresenter.displayName },
       },
       {
         key: { text: 'Programme strand' },

--- a/server/views/courses/_indexCourseSummary.njk
+++ b/server/views/courses/_indexCourseSummary.njk
@@ -6,7 +6,7 @@
   <div class="govuk-grid-row" role="listitem">
     <div class="govuk-grid-column-two-thirds">
       <h2 class="govuk-heading-m">
-        <a class="govuk-link" href="/programmes/{{ course.id }}">{{ course.nameAndAlternateName }}</a>
+        <a class="govuk-link" href="/programmes/{{ course.id }}">{{ course.displayName }}</a>
       </h2>
 
       {{ audienceTag(course.audienceTag) }}

--- a/server/views/courses/offerings/show.njk
+++ b/server/views/courses/offerings/show.njk
@@ -6,7 +6,7 @@
 
 {% extends "../../partials/layout.njk" %}
 
-{% set customPageTitleEnd = course.nameAndAlternateName + ", " + organisation.name %}
+{% set customPageTitleEnd = course.displayName + ", " + organisation.name %}
 
 {% block backLink %}
   {{ govukBackLink({

--- a/server/views/referrals/new/_organisationAndCourse.njk
+++ b/server/views/referrals/new/_organisationAndCourse.njk
@@ -1,3 +1,3 @@
 <h2 class="govuk-heading-m">
-  <span class="govuk-!-font-weight-regular">{{ organisation.name }} | </span>{{ course.nameAndAlternateName }}
+  <span class="govuk-!-font-weight-regular">{{ organisation.name }} | </span>{{ course.displayName }}
 </h2>


### PR DESCRIPTION
## Context

We need to show course names as `Course name: audience/strand` without the abbreviation on brackets.

## Changes in this PR
- No longer create our own course name on the FE and instead use `displayName` from the API.




## Release checklist

[Release process documentation](../doc/how-to/perform-a-release.md)

As part of our continuous deployment strategy we must ensure that this work is
ready to be released once merged.

### Pre-merge

- [ ] There are changes required to the Accredited Programmes API for this change to work...
  - [ ] ... and they have been released to production already

### Post-merge

<!-- The outer checkboxes can be completed pre-merge -->

- [ ] This adds, extends or meaningfully modifies a feature...
  - [ ] ... and I have written or updated an end-to-end test for the happy path in the [Accredited Programmes E2E repo](https://github.com/ministryofjustice/hmpps-accredited-programmes-e2e)
- [ ] This makes new expectations of the API...
  - [ ] ... and I have notified the API developer(s) of changes to the contract tests (Pact), or the API is already compliant
- [ ] [Manually approve](../doc/how-to/perform-a-release.md#releasing-to-the-preprod-environment) release to preprod
- [ ] [Manually approve](../doc/how-to/perform-a-release.md#releasing-to-the-production-environment) release to prod

<!-- Should a release fail at any step, you as the author should now lead the work to
fix it as soon as possible. You can monitor deployment failures in CircleCI
itself and application errors are found in
[Sentry](https://ministryofjustice.sentry.io/projects/hmpps-accredited-programmes-ui/?project=4505330122686464&referrer=sidebar&statsPeriod=24h). -->
