### PR TITLE
(1037) Add `/find` path prefix to find pages

### DIFF
--- a/integration_tests/e2e/app.cy.ts
+++ b/integration_tests/e2e/app.cy.ts
@@ -69,7 +69,7 @@ context('App', () => {
       cy.visit('/')
 
       const indexPage = Page.verifyOnPage(IndexPage)
-      indexPage.shouldContainLink('Find a programme and make a referral', '/programmes')
+      indexPage.shouldContainLink('Find a programme and make a referral', '/find/programmes')
       indexPage.shouldContainLink('My referrals', '/refer/referrals/case-list')
     })
   })
@@ -81,7 +81,7 @@ context('App', () => {
       cy.visit('/')
 
       const indexPage = Page.verifyOnPage(IndexPage)
-      indexPage.shouldContainLink('Find a programme and make a referral', '/programmes')
+      indexPage.shouldContainLink('Find a programme and make a referral', '/find/programmes')
       indexPage.shouldContainLink('Manage your programme team’s referrals', '/assess/referrals/case-list')
     })
   })

--- a/server/@types/ui/index.d.ts
+++ b/server/@types/ui/index.d.ts
@@ -82,6 +82,7 @@ type CourseParticipationPresenter = CourseParticipation & {
 
 type CoursePresenter = Course & {
   audienceTag: GovukFrontendTagWithText
+  href: string
   prerequisiteSummaryListRows: Array<GovukFrontendSummaryListRowWithKeyAndValue>
 }
 

--- a/server/paths/find.ts
+++ b/server/paths/find.ts
@@ -1,9 +1,10 @@
 import { path } from 'static-path'
 
-const coursesPath = path('/programmes')
+const findPathBase = path('/find')
+const coursesPath = findPathBase.path('/programmes')
 const coursePath = coursesPath.path(':courseId')
 
-const courseOfferingPath = path('/offerings/:courseOfferingId')
+const courseOfferingPath = findPathBase.path('/offerings/:courseOfferingId')
 
 export default {
   index: coursesPath,

--- a/server/utils/courseUtils.test.ts
+++ b/server/utils/courseUtils.test.ts
@@ -30,6 +30,7 @@ describe('CourseUtils', () => {
           coursePrerequisiteFactory.equivalentLDCProgramme().build(),
           coursePrerequisiteFactory.timeToComplete().build(),
         ],
+        id: 'lime-course-1',
         name: 'Lime Course',
       })
 
@@ -40,6 +41,7 @@ describe('CourseUtils', () => {
           classes: 'govuk-tag govuk-tag--green audience-tag',
           text: 'Intimate partner violence offence',
         },
+        href: '/find/programmes/lime-course-1',
         prerequisiteSummaryListRows: [
           {
             key: { text: 'Setting' },

--- a/server/utils/courseUtils.ts
+++ b/server/utils/courseUtils.ts
@@ -1,3 +1,4 @@
+import { findPaths } from '../paths'
 import type { Course, CoursePrerequisite } from '@accredited-programmes/models'
 import type {
   CoursePresenter,
@@ -20,6 +21,7 @@ export default class CourseUtils {
     return {
       ...course,
       audienceTag: CourseUtils.audienceTag(course),
+      href: findPaths.show({ courseId: course.id }),
       prerequisiteSummaryListRows: CourseUtils.prerequisiteSummaryListRows(course.coursePrerequisites),
     }
   }

--- a/server/utils/organisationUtils.test.ts
+++ b/server/utils/organisationUtils.test.ts
@@ -55,7 +55,7 @@ describe('OrganisationUtils', () => {
             { text: organisationsWithOfferingIds[0].category },
             { text: organisationsWithOfferingIds[0].address.county },
             {
-              html: `<a class="govuk-link" href="/offerings/${organisationsWithOfferingIds[0].courseOfferingId}">Contact prison <span class="govuk-visually-hidden">(${organisationsWithOfferingIds[0].name})</span></a>`,
+              html: `<a class="govuk-link" href="/find/offerings/${organisationsWithOfferingIds[0].courseOfferingId}">Contact prison <span class="govuk-visually-hidden">(${organisationsWithOfferingIds[0].name})</span></a>`,
             },
           ],
           [
@@ -63,7 +63,7 @@ describe('OrganisationUtils', () => {
             { text: organisationsWithOfferingIds[1].category },
             { text: organisationsWithOfferingIds[1].address.county },
             {
-              html: `<a class="govuk-link" href="/offerings/${organisationsWithOfferingIds[1].courseOfferingId}">Contact prison <span class="govuk-visually-hidden">(${organisationsWithOfferingIds[1].name})</span></a>`,
+              html: `<a class="govuk-link" href="/find/offerings/${organisationsWithOfferingIds[1].courseOfferingId}">Contact prison <span class="govuk-visually-hidden">(${organisationsWithOfferingIds[1].name})</span></a>`,
             },
           ],
           [
@@ -71,7 +71,7 @@ describe('OrganisationUtils', () => {
             { text: organisationsWithOfferingIds[2].category },
             { text: organisationsWithOfferingIds[2].address.county },
             {
-              html: `<a class="govuk-link" href="/offerings/${organisationsWithOfferingIds[2].courseOfferingId}">Contact prison <span class="govuk-visually-hidden">(${organisationsWithOfferingIds[2].name})</span></a>`,
+              html: `<a class="govuk-link" href="/find/offerings/${organisationsWithOfferingIds[2].courseOfferingId}">Contact prison <span class="govuk-visually-hidden">(${organisationsWithOfferingIds[2].name})</span></a>`,
             },
           ],
         ])
@@ -89,7 +89,7 @@ describe('OrganisationUtils', () => {
             { text: organisationWithOfferingId.category },
             { text: 'Not found' },
             {
-              html: `<a class="govuk-link" href="/offerings/${organisationWithOfferingId.courseOfferingId}">Contact prison <span class="govuk-visually-hidden">(${organisationWithOfferingId.name})</span></a>`,
+              html: `<a class="govuk-link" href="/find/offerings/${organisationWithOfferingId.courseOfferingId}">Contact prison <span class="govuk-visually-hidden">(${organisationWithOfferingId.name})</span></a>`,
             },
           ],
         ])

--- a/server/views/courses/_indexCourseSummary.njk
+++ b/server/views/courses/_indexCourseSummary.njk
@@ -6,7 +6,7 @@
   <div class="govuk-grid-row" role="listitem">
     <div class="govuk-grid-column-two-thirds">
       <h2 class="govuk-heading-m">
-        <a class="govuk-link" href="/programmes/{{ course.id }}">{{ course.displayName }}</a>
+        <a class="govuk-link" href="{{ course.href }}">{{ course.displayName }}</a>
       </h2>
 
       {{ audienceTag(course.audienceTag) }}


### PR DESCRIPTION
## Context

Like `/refer` and `/assess`, we should prefix the find related page paths with `/find`.

## Changes in this PR
Add /find path prefix to find pages



## Release checklist

[Release process documentation](../doc/how-to/perform-a-release.md)

As part of our continuous deployment strategy we must ensure that this work is
ready to be released once merged.

### Pre-merge

- [ ] There are changes required to the Accredited Programmes API for this change to work...
  - [ ] ... and they have been released to production already

### Post-merge

<!-- The outer checkboxes can be completed pre-merge -->

- [ ] This adds, extends or meaningfully modifies a feature...
  - [ ] ... and I have written or updated an end-to-end test for the happy path in the [Accredited Programmes E2E repo](https://github.com/ministryofjustice/hmpps-accredited-programmes-e2e)
- [ ] This makes new expectations of the API...
  - [ ] ... and I have notified the API developer(s) of changes to the contract tests (Pact), or the API is already compliant
- [ ] [Manually approve](../doc/how-to/perform-a-release.md#releasing-to-the-preprod-environment) release to preprod
- [ ] [Manually approve](../doc/how-to/perform-a-release.md#releasing-to-the-production-environment) release to prod

<!-- Should a release fail at any step, you as the author should now lead the work to
fix it as soon as possible. You can monitor deployment failures in CircleCI
itself and application errors are found in
[Sentry](https://ministryofjustice.sentry.io/projects/hmpps-accredited-programmes-ui/?project=4505330122686464&referrer=sidebar&statsPeriod=24h). -->
