### PR TITLE
(1504) Show person details on update status journey pages

### DIFF
--- a/assets/scss/components/_api-error.scss
+++ b/assets/scss/components/_api-error.scss
@@ -1,8 +1,8 @@
 .api-error-banner {
+  margin: govuk-spacing(5) 0;
   padding: govuk-spacing(3) govuk-spacing(5);
   background-color: govuk-colour('light-grey');
   border-left: 8px solid govuk-colour('red');
-  margin: govuk-spacing(5) 0;
 
   :last-child {
     margin-bottom: 0;

--- a/server/controllers/assess/index.ts
+++ b/server/controllers/assess/index.ts
@@ -11,7 +11,10 @@ const controllers = (services: Services) => {
     services.referenceDataService,
   )
 
-  const updateStatusDecisionController = new UpdateStatusDecisionController(services.referralService)
+  const updateStatusDecisionController = new UpdateStatusDecisionController(
+    services.personService,
+    services.referralService,
+  )
 
   return {
     assessCaseListController,

--- a/server/controllers/shared/index.ts
+++ b/server/controllers/shared/index.ts
@@ -30,11 +30,22 @@ const controllers = (services: Services) => {
     services.referralService,
   )
 
-  const categoryController = new CategoryController(services.referenceDataService, services.referralService)
+  const categoryController = new CategoryController(
+    services.personService,
+    services.referenceDataService,
+    services.referralService,
+  )
 
-  const reasonController = new ReasonController(services.referenceDataService, services.referralService)
+  const reasonController = new ReasonController(
+    services.personService,
+    services.referenceDataService,
+    services.referralService,
+  )
 
-  const updateStatusSelectionController = new UpdateStatusSelectionController(services.referralService)
+  const updateStatusSelectionController = new UpdateStatusSelectionController(
+    services.personService,
+    services.referralService,
+  )
 
   return {
     categoryController,

--- a/server/controllers/shared/reasonController.test.ts
+++ b/server/controllers/shared/reasonController.test.ts
@@ -5,11 +5,16 @@ import type { NextFunction, Request, Response } from 'express'
 import ReasonController from './reasonController'
 import type { ReferralStatusUpdateSessionData } from '../../@types/express'
 import { assessPaths, referPaths } from '../../paths'
-import type { ReferenceDataService, ReferralService } from '../../services'
-import { referralFactory, referralStatusHistoryFactory, referralStatusReasonFactory } from '../../testutils/factories'
+import type { PersonService, ReferenceDataService, ReferralService } from '../../services'
+import {
+  personFactory,
+  referralFactory,
+  referralStatusHistoryFactory,
+  referralStatusReasonFactory,
+} from '../../testutils/factories'
 import Helpers from '../../testutils/helpers'
 import { FormUtils, ReferralUtils, ShowReferralUtils } from '../../utils'
-import type { Referral, ReferralStatusReason } from '@accredited-programmes/models'
+import type { Person, Referral, ReferralStatusReason } from '@accredited-programmes/models'
 import type { MojTimelineItem, ReferralStatusHistoryPresenter } from '@accredited-programmes/ui'
 import type { GovukFrontendRadiosItem } from '@govuk-frontend'
 
@@ -28,9 +33,11 @@ describe('ReasonController', () => {
   let response: DeepMocked<Response>
   const next: DeepMocked<NextFunction> = createMock<NextFunction>({})
 
+  const personService = createMock<PersonService>({})
   const referenceDataService = createMock<ReferenceDataService>({})
   const referralService = createMock<ReferralService>({})
 
+  let person: Person
   const radioItems: Array<GovukFrontendRadiosItem> = [
     { text: 'Reason A', value: 'STATUS-REASON-A' },
     { text: 'Reason B', value: 'STATUS-REASON-B' },
@@ -57,7 +64,8 @@ describe('ReasonController', () => {
   let controller: ReasonController
 
   beforeEach(() => {
-    referral = referralFactory.submitted().build({})
+    person = personFactory.build()
+    referral = referralFactory.submitted().build({ prisonNumber: person.prisonNumber })
     referralStatusCodeReasons = referralStatusReasonFactory.buildList(2, { referralCategoryCode: 'A' })
     referralStatusHistory = [{ ...referralStatusHistoryFactory.started().build(), byLineText: 'You' }]
     referralStatusUpdateData = {
@@ -70,10 +78,12 @@ describe('ReasonController', () => {
     mockReferralUtils.statusOptionsToRadioItems.mockReturnValue(radioItems)
     mockShowReferralUtils.statusHistoryTimelineItems.mockReturnValue(timelineItems)
 
+    personService.getPerson.mockResolvedValue(person)
+    referralService.getReferral.mockResolvedValue(referral)
     referralService.getReferralStatusHistory.mockResolvedValue(referralStatusHistory)
     referenceDataService.getReferralStatusCodeReasons.mockResolvedValue(referralStatusCodeReasons)
 
-    controller = new ReasonController(referenceDataService, referralService)
+    controller = new ReasonController(personService, referenceDataService, referralService)
 
     request = createMock<Request>({
       params: { referralId: referral.id },
@@ -93,6 +103,7 @@ describe('ReasonController', () => {
         backLinkHref: referPaths.show.statusHistory({ referralId: referral.id }),
         pageDescription: 'Deselecting someone means they cannot continue the programme. The referral will be closed.',
         pageHeading: 'Deselection reason',
+        person,
         radioItems,
         radioLegend: 'Choose the deselection reason',
 
@@ -104,7 +115,13 @@ describe('ReasonController', () => {
         'STATUS-CAT-A',
         'DESELECTED',
       )
+      expect(referralService.getReferral).toHaveBeenCalledWith(username, referral.id)
       expect(referralService.getReferralStatusHistory).toHaveBeenCalledWith(userToken, username, referral.id)
+      expect(personService.getPerson).toHaveBeenCalledWith(
+        username,
+        referral.prisonNumber,
+        response.locals.user.caseloads,
+      )
 
       expect(FormUtils.setFieldErrors).toHaveBeenCalledWith(request, response, ['reasonCode'])
       expect(ReferralUtils.statusOptionsToRadioItems).toHaveBeenCalledWith(referralStatusCodeReasons, undefined)
@@ -141,6 +158,7 @@ describe('ReasonController', () => {
           backLinkHref: referPaths.show.statusHistory({ referralId: referral.id }),
           pageDescription: 'If you withdraw the referral, it will be closed.',
           pageHeading: 'Withdrawal reason',
+          person,
           radioItems,
           radioLegend: 'Select the reason for this withdrawal',
           timelineItems: timelineItems.slice(0, 1),

--- a/server/views/referrals/updateStatus/category/show.njk
+++ b/server/views/referrals/updateStatus/category/show.njk
@@ -1,71 +1,30 @@
-{% from "govuk/components/back-link/macro.njk" import govukBackLink %}
-{% from "govuk/components/button/macro.njk" import govukButton %}
-{% from "govuk/components/error-summary/macro.njk" import govukErrorSummary %}
-{% from "govuk/components/radios/macro.njk" import govukRadios %}
-{% from "moj/components/timeline/macro.njk" import mojTimeline %}
+{% extends "../partials/layout.njk" %}
 
-{% extends "../../../partials/layout.njk" %}
+{% block statusContent %}
+  <p>{{ pageDescription }}</p>
+{% endblock statusContent %}
 
-{% block backLink %}
-  {{ govukBackLink({
-    classes: "js-back-link",
-    text: "Back",
-    href: backLinkHref
-  }) }}
-{% endblock backLink %}
+{% block statusAction %}
+  <form method="post">
+    <input type="hidden" name="_csrf" value="{{ csrfToken }}"/>
 
-{% block content %}
-  <div class="govuk-grid-row">
-    <div class="govuk-grid-column-two-thirds">
-      {% if errors.list | length %}
-        {{ govukErrorSummary({
-          titleText: "There is a problem",
-          errorList: errors.list
-        }) }}
-      {% endif %}
+    {{ govukRadios({
+      name: "categoryCode",
+      fieldset: {
+        legend: {
+          text: radioLegend,
+          classes: "govuk-fieldset__legend--m"
+        }
+      },
+      items: radioItems,
+      errorMessage: errors.messages.categoryCode,
+      attributes: {
+        "data-testid": "category-options"
+      }
+    }) }}
 
-      <h1 class="govuk-heading-l">{{ pageHeading }}</h1>
-
-      <p>{{ pageDescription }}</p>
-
-      <h2 class="govuk-heading-m">Current status</h2>
-
-      {{ mojTimeline({
-        items: timelineItems,
-        attributes: {
-          "data-testid": "status-history-timeline"
-        },
-        classes: "govuk-!-margin-bottom-0"
-      }) }}
-    </div>
-  </div>
-
-  <hr class="govuk-section-break govuk-section-break--xl govuk-section-break--visible">
-
-  <div class="govuk-grid-row">
-    <div class="govuk-grid-column-two-thirds">
-      <form method="post">
-        <input type="hidden" name="_csrf" value="{{ csrfToken }}"/>
-
-        {{ govukRadios({
-          name: "categoryCode",
-          fieldset: {
-            legend: {
-              text: radioLegend,
-              classes: "govuk-fieldset__legend--m"
-            }
-          },
-          items: radioItems,
-          errorMessage: errors.messages.categoryCode,
-          attributes: {
-            "data-testid": "category-options"
-          }
-        }) }}
-
-        {{ govukButton({
-          text: "Continue"
-        }) }}
-      </form>
-    </div>
-  </div>
-{% endblock content %}
+    {{ govukButton({
+      text: "Continue"
+    }) }}
+  </form>
+{% endblock statusAction %}

--- a/server/views/referrals/updateStatus/decision/show.njk
+++ b/server/views/referrals/updateStatus/decision/show.njk
@@ -1,74 +1,33 @@
-{% from "govuk/components/back-link/macro.njk" import govukBackLink %}
-{% from "govuk/components/button/macro.njk" import govukButton %}
-{% from "govuk/components/error-summary/macro.njk" import govukErrorSummary %}
-{% from "govuk/components/radios/macro.njk" import govukRadios %}
-{% from "moj/components/timeline/macro.njk" import mojTimeline %}
+{% extends "../partials/layout.njk" %}
 
-{% extends "../../../partials/layout.njk" %}
+{% block statusContent %}
+  <p>{{ confirmationText.primaryDescription }}</p>
+{% endblock statusContent %}
 
-{% block backLink %}
-  {{ govukBackLink({
-    classes: "js-back-link",
-    text: "Back",
-    href: backLinkHref
-  }) }}
-{% endblock backLink %}
+{% block statusAction %}
+  <form method="post">
+    <input type="hidden" name="_csrf" value="{{ csrfToken }}"/>
 
-{% block content %}
-  <div class="govuk-grid-row">
-    <div class="govuk-grid-column-two-thirds">
-      {% if errors.list | length %}
-        {{ govukErrorSummary({
-          titleText: "There is a problem",
-          errorList: errors.list
-        }) }}
-      {% endif %}
+    {{ govukRadios({
+      name: "statusDecision",
+      fieldset: {
+        legend: {
+          text: confirmationText.secondaryHeading,
+          classes: "govuk-fieldset__legend--m"
+        }
+      },
+      hint: {
+        text: confirmationText.secondaryDescription
+      },
+      items: radioItems,
+      errorMessage: errors.messages.statusDecision,
+      attributes: {
+        "data-testid": "status-decision-options"
+      }
+    }) }}
 
-      <h1 class="govuk-heading-l">{{ pageHeading }}</h1>
-
-      <p>{{ confirmationText.primaryDescription }}</p>
-
-      <h2 class="govuk-heading-m">Current status</h2>
-
-      {{ mojTimeline({
-        items: timelineItems,
-        attributes: {
-          "data-testid": "status-history-timeline"
-        },
-        classes: "govuk-!-margin-bottom-0"
-      }) }}
-    </div>
-  </div>
-
-  <hr class="govuk-section-break govuk-section-break--xl govuk-section-break--visible">
-
-  <div class="govuk-grid-row">
-    <div class="govuk-grid-column-two-thirds">
-      <form method="post">
-        <input type="hidden" name="_csrf" value="{{ csrfToken }}"/>
-
-        {{ govukRadios({
-          name: "statusDecision",
-          fieldset: {
-            legend: {
-              text: confirmationText.secondaryHeading,
-              classes: "govuk-fieldset__legend--m"
-            }
-          },
-          hint: {
-            text: confirmationText.secondaryDescription
-          },
-          items: radioItems,
-          errorMessage: errors.messages.statusDecision,
-          attributes: {
-            "data-testid": "status-decision-options"
-          }
-        }) }}
-
-        {{ govukButton({
-          text: "Continue"
-        }) }}
-      </form>
-    </div>
-  </div>
-{% endblock content %}
+    {{ govukButton({
+      text: "Continue"
+    }) }}
+  </form>
+{% endblock statusAction %}

--- a/server/views/referrals/updateStatus/partials/layout.njk
+++ b/server/views/referrals/updateStatus/partials/layout.njk
@@ -1,0 +1,54 @@
+{% from "govuk/components/back-link/macro.njk" import govukBackLink %}
+{% from "govuk/components/button/macro.njk" import govukButton %}
+{% from "govuk/components/error-summary/macro.njk" import govukErrorSummary %}
+{% from "govuk/components/radios/macro.njk" import govukRadios %}
+{% from "moj/components/timeline/macro.njk" import mojTimeline %}
+
+{% extends "../../../partials/layout.njk" %}
+
+{% block personBanner %}
+  {% include "../../_personBanner.njk" %}
+{% endblock personBanner %}
+
+{% block backLink %}
+  {{ govukBackLink({
+    classes: "js-back-link",
+    text: "Back",
+    href: backLinkHref
+  }) }}
+{% endblock backLink %}
+
+{% block content %}
+  <div class="govuk-grid-row">
+    <div class="govuk-grid-column-two-thirds">
+      {% if errors.list | length %}
+        {{ govukErrorSummary({
+            titleText: "There is a problem",
+            errorList: errors.list
+          }) }}
+      {% endif %}
+
+      <h1 class="govuk-heading-l">{{ pageHeading }}</h1>
+
+      {% block statusContent %}{% endblock statusContent %}
+
+      <h2 class="govuk-heading-m">Current status</h2>
+
+      {{ mojTimeline({
+          items: timelineItems,
+          attributes: {
+            "data-testid": "status-history-timeline"
+          },
+          classes: "govuk-!-margin-bottom-0"
+        }) }}
+    </div>
+  </div>
+
+  <hr class="govuk-section-break govuk-section-break--xl govuk-section-break--visible">
+
+  <div class="govuk-grid-row">
+    <div class="govuk-grid-column-two-thirds">
+      {% block statusAction %}{% endblock statusAction %}
+    </div>
+  </div>
+{% endblock content %}

--- a/server/views/referrals/updateStatus/reason/show.njk
+++ b/server/views/referrals/updateStatus/reason/show.njk
@@ -1,71 +1,30 @@
-{% from "govuk/components/back-link/macro.njk" import govukBackLink %}
-{% from "govuk/components/button/macro.njk" import govukButton %}
-{% from "govuk/components/error-summary/macro.njk" import govukErrorSummary %}
-{% from "govuk/components/radios/macro.njk" import govukRadios %}
-{% from "moj/components/timeline/macro.njk" import mojTimeline %}
+{% extends "../partials/layout.njk" %}
 
-{% extends "../../../partials/layout.njk" %}
+{% block statusContent %}
+  <p>{{ pageDescription }}</p>
+{% endblock statusContent %}
 
-{% block backLink %}
-  {{ govukBackLink({
-    classes: "js-back-link",
-    text: "Back",
-    href: backLinkHref
-  }) }}
-{% endblock backLink %}
+{% block statusAction %}
+  <form method="post">
+    <input type="hidden" name="_csrf" value="{{ csrfToken }}"/>
 
-{% block content %}
-  <div class="govuk-grid-row">
-    <div class="govuk-grid-column-two-thirds">
-      {% if errors.list | length %}
-        {{ govukErrorSummary({
-          titleText: "There is a problem",
-          errorList: errors.list
-        }) }}
-      {% endif %}
+    {{ govukRadios({
+      name: "reasonCode",
+      fieldset: {
+        legend: {
+          text: radioLegend,
+          classes: "govuk-fieldset__legend--m"
+        }
+      },
+      items: radioItems,
+      errorMessage: errors.messages.reasonCode,
+      attributes: {
+        "data-testid": "reason-options"
+      }
+    }) }}
 
-      <h1 class="govuk-heading-l">{{ pageHeading }}</h1>
-
-      <p>{{ pageDescription }}</p>
-
-      <h2 class="govuk-heading-m">Current status</h2>
-
-      {{ mojTimeline({
-        items: timelineItems,
-        attributes: {
-          "data-testid": "status-history-timeline"
-        },
-        classes: "govuk-!-margin-bottom-0"
-      }) }}
-    </div>
-  </div>
-
-  <hr class="govuk-section-break govuk-section-break--xl govuk-section-break--visible">
-
-  <div class="govuk-grid-row">
-    <div class="govuk-grid-column-two-thirds">
-      <form method="post">
-        <input type="hidden" name="_csrf" value="{{ csrfToken }}"/>
-
-        {{ govukRadios({
-          name: "reasonCode",
-          fieldset: {
-            legend: {
-              text: radioLegend,
-              classes: "govuk-fieldset__legend--m"
-            }
-          },
-          items: radioItems,
-          errorMessage: errors.messages.reasonCode,
-          attributes: {
-            "data-testid": "reason-options"
-          }
-        }) }}
-
-        {{ govukButton({
-            text: "Continue"
-        }) }}
-      </form>
-    </div>
-  </div>
-{% endblock content %}
+    {{ govukButton({
+      text: "Continue"
+    }) }}
+  </form>
+{% endblock statusAction %}

--- a/server/views/referrals/updateStatus/selection/show.njk
+++ b/server/views/referrals/updateStatus/selection/show.njk
@@ -1,98 +1,59 @@
-{% from "govuk/components/back-link/macro.njk" import govukBackLink %}
-{% from "govuk/components/button/macro.njk" import govukButton %}
 {% from "govuk/components/character-count/macro.njk" import govukCharacterCount %}
 {% from "govuk/components/checkboxes/macro.njk" import govukCheckboxes %}
-{% from "govuk/components/error-summary/macro.njk" import govukErrorSummary %}
 {% from "govuk/components/warning-text/macro.njk" import govukWarningText %}
-{% from "moj/components/timeline/macro.njk" import mojTimeline %}
 
-{% extends "../../../partials/layout.njk" %}
+{% extends "../partials/layout.njk" %}
 
-{% block backLink %}
-  {{ govukBackLink({
-    classes: "js-back-link",
-    text: "Back",
-    href: backLinkHref
-  }) }}
-{% endblock backLink %}
+{% block statusContent %}
+  <p>{{ confirmationText.primaryDescription }}</p>
+{% endblock statusContent %}
 
-{% block content %}
-  <div class="govuk-grid-row">
-    <div class="govuk-grid-column-two-thirds">
-      {% if errors.list | length %}
-        {{ govukErrorSummary({
-          titleText: "There is a problem",
-          errorList: errors.list
-        }) }}
-      {% endif %}
+{% block statusAction %}
+  <form action="{{ action }}" method="post">
+    <input type="hidden" name="_csrf" value="{{ csrfToken }}"/>
 
-      <h1 class="govuk-heading-l">{{ pageHeading }}</h1>
+    <h2 class="govuk-heading-m">{{ confirmationText.secondaryHeading }}</h2>
 
-      <p>{{ confirmationText.primaryDescription }}</p>
-
-      <h2 class="govuk-heading-m">Current status</h2>
-
-      {{ mojTimeline({
-        items: timelineItems,
-        attributes: {
-          "data-testid": "status-history-timeline"
-        },
-        classes: "govuk-!-margin-bottom-0"
+    {% if confirmationText.hasConfirmation %}
+      {{ govukCheckboxes({
+        name: "confirmation",
+        items: [
+          {
+            value: "true",
+            text: confirmationText.secondaryDescription
+          }
+        ],
+        errorMessage: errors.messages.confirmation
       }) }}
+    {% else %}
+      <p>{{ confirmationText.secondaryDescription }}</p>
+
+      {{ govukCharacterCount({
+        id: "reason",
+        name: "reason",
+        maxlength: maxLength,
+        label: {
+          text: "Add reason"
+        },
+        value: formValues.reason,
+        classes: "govuk-!-width-three-quarters",
+        errorMessage: errors.messages.reason
+      }) }}
+    {% endif %}
+
+    {% if confirmationText.warningText %}
+      {{ govukWarningText({
+        text: confirmationText.warningText,
+        iconFallbackText: "Warning"
+      }) }}
+    {% endif %}
+
+    <div class="govuk-button-group">
+      {{ govukButton({
+        text: "Submit"
+      }) }}
+
+      <a href={{ backLinkHref }}>Cancel</a>
     </div>
-  </div>
-
-  <hr class="govuk-section-break govuk-section-break--xl govuk-section-break--visible">
-
-  <div class="govuk-grid-row">
-    <div class="govuk-grid-column-two-thirds">
-      <form action="{{ action }}" method="post">
-        <input type="hidden" name="_csrf" value="{{ csrfToken }}"/>
-
-        <h2 class="govuk-heading-m">{{ confirmationText.secondaryHeading }}</h2>
-
-        {% if confirmationText.hasConfirmation %}
-          {{ govukCheckboxes({
-            name: "confirmation",
-            items: [
-              {
-                value: "true",
-                text: confirmationText.secondaryDescription
-              }
-            ],
-            errorMessage: errors.messages.confirmation
-          }) }}
-        {% else %}
-          <p>{{ confirmationText.secondaryDescription }}</p>
-
-          {{ govukCharacterCount({
-            id: "reason",
-            name: "reason",
-            maxlength: maxLength,
-            label: {
-              text: "Add reason"
-            },
-            value: formValues.reason,
-            classes: "govuk-!-width-three-quarters",
-            errorMessage: errors.messages.reason
-          }) }}
-        {% endif %}
-
-        {% if confirmationText.warningText %}
-          {{ govukWarningText({
-            text: confirmationText.warningText,
-            iconFallbackText: "Warning"
-          }) }}
-        {% endif %}
-
-        <div class="govuk-button-group">
-          {{ govukButton({
-            text: "Submit"
-          }) }}
-
-          <a href={{ backLinkHref }}>Cancel</a>
-        </div>
-      </form>
-    </div>
-  </div>
-{% endblock content %}
+  </form>
+{% endblock statusAction %}


### PR DESCRIPTION
## Context

We need to show the blue person banner on the update status journey pages.

## Changes in this PR
- Add new update status layout partial
- Update the 4 status update status related controllers to call the person service and pass those details to the template.


## Screenshots of UI changes

<img width="1245" alt="image" src="https://github.com/ministryofjustice/hmpps-accredited-programmes-ui/assets/1067537/7fe83336-d196-4ffe-9eb7-2597ff3f2104">


## Release checklist

[Release process documentation](../doc/how-to/perform-a-release.md)

As part of our continuous deployment strategy we must ensure that this work is
ready to be released once merged.

### Pre-merge

- [ ] There are changes required to the Accredited Programmes API for this change to work...
  - [ ] ... and they have been released to production already

### Post-merge

<!-- The outer checkboxes can be completed pre-merge -->

- [ ] This adds, extends or meaningfully modifies a feature...
  - [ ] ... and I have written or updated an end-to-end test for the happy path in the [Accredited Programmes E2E repo](https://github.com/ministryofjustice/hmpps-accredited-programmes-e2e)
- [ ] This makes new expectations of the API...
  - [ ] ... and I have notified the API developer(s) of changes to the contract tests (Pact), or the API is already compliant
- [ ] [Manually approve](../doc/how-to/perform-a-release.md#releasing-to-the-preprod-environment) release to preprod
- [ ] [Manually approve](../doc/how-to/perform-a-release.md#releasing-to-the-production-environment) release to prod

<!-- Should a release fail at any step, you as the author should now lead the work to
fix it as soon as possible. You can monitor deployment failures in CircleCI
itself and application errors are found in
[Sentry](https://ministryofjustice.sentry.io/projects/hmpps-accredited-programmes-ui/?project=4505330122686464&referrer=sidebar&statsPeriod=24h). -->
