### PR TITLE
(1537) Add extra information to app insights

### DIFF
--- a/server/utils/appInsightsUtils.test.ts
+++ b/server/utils/appInsightsUtils.test.ts
@@ -2,9 +2,32 @@ import type { DataTelemetry, EnvelopeTelemetry } from 'applicationinsights/out/D
 
 import type { ContextObjects } from './appInsightsUtils'
 import AppInsightsUtils from './appInsightsUtils'
+import type { Caseload } from '@prison-api'
 
-const user = {
+const user: {
+  activeCaseLoadId: string
+  caseloads: Array<Caseload>
+  roles: Array<string>
+  username: string
+} = {
   activeCaseLoadId: 'MDI',
+  caseloads: [
+    {
+      caseLoadId: 'MDI',
+      caseloadFunction: 'GENERAL',
+      currentlyActive: false,
+      description: 'Moorland (HMP & YOI)',
+      type: 'INST',
+    },
+    {
+      caseLoadId: 'ONI',
+      caseloadFunction: 'GENERAL',
+      currentlyActive: false,
+      description: 'Onley (HMP & YOI)',
+      type: 'INST',
+    },
+  ],
+  roles: ['ROLE_ACP_PROGRAMME_TEAM', 'ROLE_ACP_REFERRER'],
   username: 'TEST_USER',
 }
 
@@ -16,13 +39,20 @@ const createEnvelope = (properties: Record<string, boolean | string> | undefined
     } as DataTelemetry,
   }) as EnvelopeTelemetry
 
-const createContext = (username?: string, activeCaseLoadId?: string) =>
+const createContext = (
+  username?: string,
+  activeCaseLoadId?: string,
+  roles?: Array<string>,
+  caseloads?: Array<Caseload>,
+) =>
   ({
     'http.ServerRequest': {
       res: {
         locals: {
           user: {
             activeCaseLoadId,
+            caseloads,
+            roles,
             username,
           },
         },
@@ -33,25 +63,32 @@ const createContext = (username?: string, activeCaseLoadId?: string) =>
 describe('AppInsightsUtils', () => {
   describe('addUserDataToRequests', () => {
     it('merges username and activeCaseloadId with existing properties when present for sending to ApplicationInsights', () => {
-      const contextWithUserDetails = createContext(user.username, user.activeCaseLoadId)
+      const contextWithUserDetails = createContext(user.username, user.activeCaseLoadId, user.roles, user.caseloads)
       const envelope = createEnvelope({ other: 'things' })
 
       AppInsightsUtils.addUserDataToRequests(envelope, contextWithUserDetails)
 
       expect(envelope.data.baseData!.properties).toEqual({
+        activeCaseLoadDescription: 'Moorland (HMP & YOI)',
         activeCaseLoadId: user.activeCaseLoadId,
         other: 'things',
+        roles: user.roles,
         username: user.username,
       })
     })
 
     it("sets the user fields in the envelope's baseData properties when no other envelope properties have been set", () => {
-      const context = createContext(user.username, user.activeCaseLoadId)
+      const context = createContext(user.username, user.activeCaseLoadId, user.roles, user.caseloads)
       const envelope = createEnvelope(undefined)
 
       AppInsightsUtils.addUserDataToRequests(envelope, context)
 
-      expect(envelope.data.baseData!.properties).toEqual(user)
+      expect(envelope.data.baseData!.properties).toEqual({
+        activeCaseLoadDescription: 'Moorland (HMP & YOI)',
+        activeCaseLoadId: user.activeCaseLoadId,
+        roles: user.roles,
+        username: user.username,
+      })
     })
 
     it('does not set user data when no username is present on the context object', () => {

--- a/server/utils/appInsightsUtils.ts
+++ b/server/utils/appInsightsUtils.ts
@@ -10,7 +10,9 @@ import type { UserDetails } from '@accredited-programmes/users'
 type ContextObjectWithUser = {
   res?: {
     locals?: {
-      user: Partial<UserDetails>
+      user: Partial<UserDetails> & {
+        roles: Array<string>
+      }
     }
   }
 }
@@ -20,12 +22,15 @@ export type ContextObjects = Record<string, ContextObjectWithUser> | undefined
 export default class AppInsightsUtils {
   static addUserDataToRequests = (envelope: EnvelopeTelemetry, contextObjects: ContextObjects): boolean => {
     const isRequest = envelope.data.baseType === Contracts.TelemetryTypeString.Request
-    const { username, activeCaseLoadId } = contextObjects?.['http.ServerRequest']?.res?.locals?.user || {}
+    const { username, activeCaseLoadId, caseloads, roles } =
+      contextObjects?.['http.ServerRequest']?.res?.locals?.user || {}
     if (isRequest && username && envelope.data.baseData) {
       const { properties } = envelope.data.baseData
       // eslint-disable-next-line no-param-reassign
       envelope.data.baseData.properties = {
+        activeCaseLoadDescription: caseloads?.find(caseload => caseload.caseLoadId === activeCaseLoadId)?.description,
         activeCaseLoadId,
+        roles,
         username,
         ...properties,
       }


### PR DESCRIPTION
## Context
It will be useful to know the full name of the users active case load as well as their roles, so we can create more in depth reports.



## Changes in this PR
- Send `activeCaseLoadDescription` (e.g. Moorland)
- Send `roles` as an array




## Release checklist

[Release process documentation](../doc/how-to/perform-a-release.md)

As part of our continuous deployment strategy we must ensure that this work is
ready to be released once merged.

### Pre-merge

- [ ] There are changes required to the Accredited Programmes API for this change to work...
  - [ ] ... and they have been released to production already

### Post-merge

<!-- The outer checkboxes can be completed pre-merge -->

- [ ] This adds, extends or meaningfully modifies a feature...
  - [ ] ... and I have written or updated an end-to-end test for the happy path in the [Accredited Programmes E2E repo](https://github.com/ministryofjustice/hmpps-accredited-programmes-e2e)
- [ ] This makes new expectations of the API...
  - [ ] ... and I have notified the API developer(s) of changes to the contract tests (Pact), or the API is already compliant
- [ ] [Manually approve](../doc/how-to/perform-a-release.md#releasing-to-the-preprod-environment) release to preprod
- [ ] [Manually approve](../doc/how-to/perform-a-release.md#releasing-to-the-production-environment) release to prod

<!-- Should a release fail at any step, you as the author should now lead the work to
fix it as soon as possible. You can monitor deployment failures in CircleCI
itself and application errors are found in
[Sentry](https://ministryofjustice.sentry.io/projects/hmpps-accredited-programmes-ui/?project=4505330122686464&referrer=sidebar&statsPeriod=24h). -->
