### PR TITLE
(1537b) Only send ACP related roles to app insights

### DIFF
--- a/server/utils/appInsightsUtils.test.ts
+++ b/server/utils/appInsightsUtils.test.ts
@@ -4,6 +4,8 @@ import type { ContextObjects } from './appInsightsUtils'
 import AppInsightsUtils from './appInsightsUtils'
 import type { Caseload } from '@prison-api'
 
+const acpRoles = ['ROLE_ACP_PROGRAMME_TEAM', 'ROLE_ACP_REFERRER']
+
 const user: {
   activeCaseLoadId: string
   caseloads: Array<Caseload>
@@ -27,7 +29,7 @@ const user: {
       type: 'INST',
     },
   ],
-  roles: ['ROLE_ACP_PROGRAMME_TEAM', 'ROLE_ACP_REFERRER'],
+  roles: [...acpRoles, 'ROLE_CREATE_USER', 'ROLE_VIEW_PRISONER_DATA'],
   username: 'TEST_USER',
 }
 
@@ -69,10 +71,10 @@ describe('AppInsightsUtils', () => {
       AppInsightsUtils.addUserDataToRequests(envelope, contextWithUserDetails)
 
       expect(envelope.data.baseData!.properties).toEqual({
+        acpRoles,
         activeCaseLoadDescription: 'Moorland (HMP & YOI)',
         activeCaseLoadId: user.activeCaseLoadId,
         other: 'things',
-        roles: user.roles,
         username: user.username,
       })
     })
@@ -84,9 +86,9 @@ describe('AppInsightsUtils', () => {
       AppInsightsUtils.addUserDataToRequests(envelope, context)
 
       expect(envelope.data.baseData!.properties).toEqual({
+        acpRoles,
         activeCaseLoadDescription: 'Moorland (HMP & YOI)',
         activeCaseLoadId: user.activeCaseLoadId,
-        roles: user.roles,
         username: user.username,
       })
     })

--- a/server/utils/appInsightsUtils.ts
+++ b/server/utils/appInsightsUtils.ts
@@ -28,9 +28,9 @@ export default class AppInsightsUtils {
       const { properties } = envelope.data.baseData
       // eslint-disable-next-line no-param-reassign
       envelope.data.baseData.properties = {
+        acpRoles: roles?.filter(role => role.startsWith('ROLE_ACP_')),
         activeCaseLoadDescription: caseloads?.find(caseload => caseload.caseLoadId === activeCaseLoadId)?.description,
         activeCaseLoadId,
-        roles,
         username,
         ...properties,
       }


### PR DESCRIPTION
## Context
We don't need to know all the other users roles

## Changes in this PR
Change `roles` to `acpRoles` in the app insights properties and only send roles starting with `ROLES_ACP_`




## Release checklist

[Release process documentation](../doc/how-to/perform-a-release.md)

As part of our continuous deployment strategy we must ensure that this work is
ready to be released once merged.

### Pre-merge

- [ ] There are changes required to the Accredited Programmes API for this change to work...
  - [ ] ... and they have been released to production already

### Post-merge

<!-- The outer checkboxes can be completed pre-merge -->

- [ ] This adds, extends or meaningfully modifies a feature...
  - [ ] ... and I have written or updated an end-to-end test for the happy path in the [Accredited Programmes E2E repo](https://github.com/ministryofjustice/hmpps-accredited-programmes-e2e)
- [ ] This makes new expectations of the API...
  - [ ] ... and I have notified the API developer(s) of changes to the contract tests (Pact), or the API is already compliant
- [ ] [Manually approve](../doc/how-to/perform-a-release.md#releasing-to-the-preprod-environment) release to preprod
- [ ] [Manually approve](../doc/how-to/perform-a-release.md#releasing-to-the-production-environment) release to prod

<!-- Should a release fail at any step, you as the author should now lead the work to
fix it as soon as possible. You can monitor deployment failures in CircleCI
itself and application errors are found in
[Sentry](https://ministryofjustice.sentry.io/projects/hmpps-accredited-programmes-ui/?project=4505330122686464&referrer=sidebar&statsPeriod=24h). -->
