### PR TITLE
(1512) Redirect back to check answers page when using change links

### DIFF
--- a/server/controllers/refer/new/additionalInformationController.ts
+++ b/server/controllers/refer/new/additionalInformationController.ts
@@ -75,6 +75,10 @@ export default class NewReferralsAdditionalInformationController {
 
       await this.referralService.updateReferral(req.user.username, referralId, referralUpdate)
 
+      if (req.session.returnTo === 'check-answers') {
+        return res.redirect(`${referPaths.new.checkAnswers({ referralId })}#additionalInformation`)
+      }
+
       return res.redirect(referPaths.new.show({ referralId }))
     }
   }

--- a/server/controllers/refer/new/courseParticipationDetailsController.ts
+++ b/server/controllers/refer/new/courseParticipationDetailsController.ts
@@ -84,6 +84,10 @@ export default class NewReferralsCourseParticipationDetailsController {
 
       req.flash('successMessage', 'You have successfully updated a programme.')
 
+      if (req.session.returnTo === 'check-answers') {
+        return res.redirect(`${referPaths.new.checkAnswers({ referralId })}#programmeHistory`)
+      }
+
       return res.redirect(referPaths.new.programmeHistory.index({ referralId }))
     }
   }

--- a/server/controllers/refer/new/referralsController.test.ts
+++ b/server/controllers/refer/new/referralsController.test.ts
@@ -70,7 +70,10 @@ describe('NewReferralsController', () => {
   let controller: NewReferralsController
 
   beforeEach(() => {
-    request = createMock<Request>({ user: { token: userToken, username } })
+    request = createMock<Request>({
+      flash: jest.fn().mockReturnValue([]),
+      user: { token: userToken, username },
+    })
     response = Helpers.createMockResponseWithCaseloads()
     controller = new NewReferralsController(
       courseService,
@@ -183,6 +186,7 @@ describe('NewReferralsController', () => {
 
     beforeEach(() => {
       request.params.referralId = referralId
+      request.session.returnTo = 'check-answers'
     })
 
     it('renders the referral task list page', async () => {
@@ -200,6 +204,7 @@ describe('NewReferralsController', () => {
       ;(CourseUtils.presentCourse as jest.Mock).mockReturnValue(coursePresenter)
 
       expect(referralService.getReferral).toHaveBeenCalledWith(username, referralId, { updatePerson: undefined })
+      expect(request.session.returnTo).toBeUndefined()
       expect(response.render).toHaveBeenCalledWith('referrals/new/show', {
         course: coursePresenter,
         organisation,
@@ -307,17 +312,23 @@ describe('NewReferralsController', () => {
   })
 
   describe('checkAnswers', () => {
-    it('renders the referral check answers page', async () => {
-      const courseOfferingSummaryListRows: Array<GovukFrontendSummaryListRowWithKeyAndValue> = [
-        { key: { text: 'Course offering item 1' }, value: { text: 'Value 1' } },
-        { key: { text: 'Course offering item 2' }, value: { html: 'value 2' } },
-      ]
-      const referrerSummaryListRows: Array<GovukFrontendSummaryListRowWithKeyAndValue> = [
-        { key: { text: 'Referrer item 1' }, value: { text: 'Value 1' } },
-        { key: { text: 'Referrer item 2' }, value: { html: 'value 2' } },
-      ]
-      const referrerName = 'Bobby Brown'
-      const referrerEmail = 'referrer.email@test-email.co.uk'
+    const courseOfferingSummaryListRows: Array<GovukFrontendSummaryListRowWithKeyAndValue> = [
+      { key: { text: 'Course offering item 1' }, value: { text: 'Value 1' } },
+      { key: { text: 'Course offering item 2' }, value: { html: 'value 2' } },
+    ]
+    const referrerSummaryListRows: Array<GovukFrontendSummaryListRowWithKeyAndValue> = [
+      { key: { text: 'Referrer item 1' }, value: { text: 'Value 1' } },
+      { key: { text: 'Referrer item 2' }, value: { html: 'value 2' } },
+    ]
+    const referrerName = 'Bobby Brown'
+    const referrerEmail = 'referrer.email@test-email.co.uk'
+    const coursePresenter = createMock<CoursePresenter>({
+      audience: courseAudienceFactory.build(),
+    })
+    const organisation = organisationFactory.build({ id: referableCourseOffering.organisationId })
+    const summaryListOptions = 'summary list options' as unknown as GovukFrontendSummaryListWithRowsWithKeysAndValues
+
+    beforeEach(() => {
       courseService.getCourseByOffering.mockResolvedValue(course)
       personService.getPerson.mockResolvedValue(person)
       userService.getFullNameFromUsername.mockResolvedValue(referrerName)
@@ -331,25 +342,22 @@ describe('NewReferralsController', () => {
 
       TypeUtils.assertHasUser(request)
 
-      const organisation = organisationFactory.build({ id: referableCourseOffering.organisationId })
       organisationService.getOrganisation.mockResolvedValue(organisation)
 
-      const coursePresenter = createMock<CoursePresenter>({
-        audience: courseAudienceFactory.build(),
-      })
       courseService.getCourse.mockResolvedValue(course)
       ;(CourseUtils.presentCourse as jest.Mock).mockReturnValue(coursePresenter)
 
-      const summaryListOptions = 'summary list options' as unknown as GovukFrontendSummaryListWithRowsWithKeysAndValues
       courseService.getAndPresentParticipationsByPerson.mockResolvedValue([summaryListOptions, summaryListOptions])
-
-      const requestHandler = controller.checkAnswers()
-      await requestHandler(request, response, next)
 
       const emptyErrorsLocal = { list: [], messages: {} }
       ;(FormUtils.setFieldErrors as jest.Mock).mockImplementation((_request, _response, _fields) => {
         response.locals.errors = emptyErrorsLocal
       })
+    })
+
+    it('renders the referral check answers page and sets the `returnTo` value in the sesssion', async () => {
+      const requestHandler = controller.checkAnswers()
+      await requestHandler(request, response, next)
 
       expect(referralService.getReferral).toHaveBeenCalledWith(username, referralId)
       expect(userService.getFullNameFromUsername).toHaveBeenCalledWith(userToken, submittableReferral.referrerUsername)
@@ -361,6 +369,7 @@ describe('NewReferralsController', () => {
         referralId,
         { change: true, remove: false },
       )
+      expect(request.session.returnTo).toBe('check-answers')
       expect(response.render).toHaveBeenCalledWith('referrals/new/checkAnswers', {
         additionalInformation: submittableReferral.additionalInformation,
         courseOfferingSummaryListRows,
@@ -378,6 +387,23 @@ describe('NewReferralsController', () => {
         person,
       )
       expect(NewReferralUtils.referrerSummaryListRows).toHaveBeenCalledWith(referrerName, referrerEmail)
+    })
+
+    describe('when there is a success message', () => {
+      it('passes the message to the template', async () => {
+        const successMessage = 'A success message'
+        ;(request.flash as jest.Mock).mockImplementation(() => [successMessage])
+
+        const requestHandler = controller.checkAnswers()
+        await requestHandler(request, response, next)
+
+        expect(response.render).toHaveBeenCalledWith(
+          'referrals/new/checkAnswers',
+          expect.objectContaining({
+            successMessage,
+          }),
+        )
+      })
     })
 
     describe('when the referral has been submitted', () => {

--- a/server/controllers/refer/new/referralsController.ts
+++ b/server/controllers/refer/new/referralsController.ts
@@ -58,6 +58,10 @@ export default class NewReferralsController {
 
       FormUtils.setFieldErrors(req, res, ['confirmation'])
 
+      const successMessage = req.flash('successMessage')[0]
+
+      req.session.returnTo = 'check-answers'
+
       return res.render('referrals/new/checkAnswers', {
         additionalInformation: referral.additionalInformation,
         courseOfferingSummaryListRows: NewReferralUtils.courseOfferingSummaryListRows(
@@ -72,6 +76,7 @@ export default class NewReferralsController {
         personSummaryListRows: PersonUtils.summaryListRows(person),
         referralId,
         referrerSummaryListRows: NewReferralUtils.referrerSummaryListRows(referrerName, referrerEmail),
+        successMessage,
       })
     }
   }
@@ -163,6 +168,8 @@ export default class NewReferralsController {
         res.locals.user.caseloads,
       )
       const coursePresenter = CourseUtils.presentCourse(course)
+
+      delete req.session.returnTo
 
       return res.render('referrals/new/show', {
         course: coursePresenter,

--- a/server/views/referrals/new/checkAnswers.njk
+++ b/server/views/referrals/new/checkAnswers.njk
@@ -3,6 +3,7 @@
 {% from "govuk/components/checkboxes/macro.njk" import govukCheckboxes %}
 {% from "govuk/components/error-summary/macro.njk" import govukErrorSummary %}
 {% from "govuk/components/summary-list/macro.njk" import govukSummaryList %}
+{% from "moj/components/banner/macro.njk" import mojBanner %}
 
 {% from "../../partials/keylessSummaryCard.njk" import keylessSummaryCard %}
 
@@ -74,7 +75,18 @@
       }) }}
 
       <section data-testid="programme-history">
-        <h2 class="govuk-heading-m">Accredited Programme history</h2>
+        <h2 class="govuk-heading-m" id="programmeHistory">Accredited Programme history</h2>
+
+        {% if successMessage %}
+          {{ mojBanner({
+            type: "success",
+            text: successMessage,
+            iconFallbackText: "Success",
+            attributes: {
+              "data-testid": "success-banner"
+            }
+          }) }}
+        {% endif %}
 
         {% if participationSummaryListsOptions.length %}
           {% for summaryListOptions in participationSummaryListsOptions %}
@@ -89,7 +101,7 @@
 
       {{ keylessSummaryCard("Confirm OASys information", bodyText="I confirm that the information is up to date.", testId="oasys-confirmation-summary-card") }}
 
-      <h2 class="govuk-heading-m">Additional information</h2>
+      <h2 class="govuk-heading-m" id="additionalInformation">Additional information</h2>
 
       {{ keylessSummaryCard(
         "Add additional information",


### PR DESCRIPTION
## Context

When in check your answers, if the user selects one of the change links and makes a change they are redirected to the task list view. This needs to be updated so it directs them back to Check your answers.







## Release checklist

[Release process documentation](../doc/how-to/perform-a-release.md)

As part of our continuous deployment strategy we must ensure that this work is
ready to be released once merged.

### Pre-merge

- [ ] There are changes required to the Accredited Programmes API for this change to work...
  - [ ] ... and they have been released to production already

### Post-merge

<!-- The outer checkboxes can be completed pre-merge -->

- [ ] This adds, extends or meaningfully modifies a feature...
  - [ ] ... and I have written or updated an end-to-end test for the happy path in the [Accredited Programmes E2E repo](https://github.com/ministryofjustice/hmpps-accredited-programmes-e2e)
- [ ] This makes new expectations of the API...
  - [ ] ... and I have notified the API developer(s) of changes to the contract tests (Pact), or the API is already compliant
- [ ] [Manually approve](../doc/how-to/perform-a-release.md#releasing-to-the-preprod-environment) release to preprod
- [ ] [Manually approve](../doc/how-to/perform-a-release.md#releasing-to-the-production-environment) release to prod

<!-- Should a release fail at any step, you as the author should now lead the work to
fix it as soon as possible. You can monitor deployment failures in CircleCI
itself and application errors are found in
[Sentry](https://ministryofjustice.sentry.io/projects/hmpps-accredited-programmes-ui/?project=4505330122686464&referrer=sidebar&statsPeriod=24h). -->
