### PR TITLE
(1514) Add text to course page when there are no offerings available

### DIFF
--- a/integration_tests/e2e/find.cy.ts
+++ b/integration_tests/e2e/find.cy.ts
@@ -62,6 +62,23 @@ context('Find', () => {
       coursePage.shouldHaveOrganisations(organisationsWithOfferingIds)
     })
 
+    describe('when there are no offerings for a course', () => {
+      it('shows a message that there are no offerings', () => {
+        cy.task('stubCourse', courses[0])
+
+        cy.task('stubOfferingsByCourse', { courseId: courses[0].id, courseOfferings: [] })
+
+        const path = findPaths.show({ courseId: courses[0].id })
+        cy.visit(path)
+
+        const coursePage = Page.verifyOnPage(CoursePage, courses[0])
+        coursePage.shouldContainBackLink(findPaths.index({}))
+        coursePage.shouldContainHomeLink()
+        coursePage.shouldHaveCourse()
+        coursePage.shouldContainNoOfferingsText()
+      })
+    })
+
     describe('Viewing a single offering', () => {
       it('shows a single offering with no secondary email address', () => {
         const courseOffering = courseOfferingFactory.build({

--- a/integration_tests/pages/find/course.ts
+++ b/integration_tests/pages/find/course.ts
@@ -15,6 +15,13 @@ export default class CoursePage extends Page {
     this.course = coursePresenter
   }
 
+  shouldContainNoOfferingsText() {
+    cy.get('[data-testid="no-offerings-text"]').should(
+      'have.text',
+      `To find out where ${this.course.displayName} is offered, speak to your Offender Management Unit (custody) or regional probation team (community).`,
+    )
+  }
+
   shouldHaveCourse() {
     this.shouldContainAudienceTag(this.course.audienceTag)
 

--- a/server/views/courses/show.njk
+++ b/server/views/courses/show.njk
@@ -32,7 +32,11 @@
 
       <h2 class="govuk-heading-m">Locations</h2>
 
-      {% include "./_locationsTable.njk" %}
+      {% if organisationsTableData | length %}
+        {% include "./_locationsTable.njk" %}
+      {% else %}
+        <p data-testid="no-offerings-text">To find out where {{ course.displayName }} is offered, speak to your Offender Management Unit (custody) or regional probation team (community).</p>
+      {% endif %}
     </div>
   </div>
 {% endblock content %}


### PR DESCRIPTION
## Context

<!-- Is there a Trello ticket you can link to? -->
<!-- Do you need to add any environment variables? -->
<!-- Is an ADR required? An ADR should be added if this PR introduces a change to the architecture. -->



## Changes in this PR



## Screenshots of UI changes

### Before


### After


## Release checklist

[Release process documentation](../doc/how-to/perform-a-release.md)

As part of our continuous deployment strategy we must ensure that this work is
ready to be released once merged.

### Pre-merge

- [ ] There are changes required to the Accredited Programmes API for this change to work...
  - [ ] ... and they have been released to production already

### Post-merge

<!-- The outer checkboxes can be completed pre-merge -->

- [ ] This adds, extends or meaningfully modifies a feature...
  - [ ] ... and I have written or updated an end-to-end test for the happy path in the [Accredited Programmes E2E repo](https://github.com/ministryofjustice/hmpps-accredited-programmes-e2e)
- [ ] This makes new expectations of the API...
  - [ ] ... and I have notified the API developer(s) of changes to the contract tests (Pact), or the API is already compliant
- [ ] [Manually approve](../doc/how-to/perform-a-release.md#releasing-to-the-preprod-environment) release to preprod
- [ ] [Manually approve](../doc/how-to/perform-a-release.md#releasing-to-the-production-environment) release to prod

<!-- Should a release fail at any step, you as the author should now lead the work to
fix it as soon as possible. You can monitor deployment failures in CircleCI
itself and application errors are found in
[Sentry](https://ministryofjustice.sentry.io/projects/hmpps-accredited-programmes-ui/?project=4505330122686464&referrer=sidebar&statsPeriod=24h). -->
