### PR TITLE
(1520) Improve offering call to actions on course page

### DIFF
--- a/integration_tests/e2e/find.cy.ts
+++ b/integration_tests/e2e/find.cy.ts
@@ -59,6 +59,7 @@ context('Find', () => {
       coursePage.shouldContainBackLink(findPaths.index({}))
       coursePage.shouldContainHomeLink()
       coursePage.shouldHaveCourse()
+      coursePage.shouldContainOfferingsText()
       coursePage.shouldHaveOrganisations(organisationsWithOfferingIds)
     })
 

--- a/integration_tests/pages/find/course.ts
+++ b/integration_tests/pages/find/course.ts
@@ -22,6 +22,13 @@ export default class CoursePage extends Page {
     )
   }
 
+  shouldContainOfferingsText() {
+    cy.get('[data-testid="offerings-text"]').should(
+      'have.text',
+      'Select a prison to contact the programme team or make a referral. Online referrals are not yet available at all sites.',
+    )
+  }
+
   shouldHaveCourse() {
     this.shouldContainAudienceTag(this.course.audienceTag)
 
@@ -43,14 +50,13 @@ export default class CoursePage extends Page {
 
         cy.wrap(tableRowElement).within(() => {
           cy.get('.govuk-table__cell:first-of-type').should('have.text', organisation.name)
-          cy.get('.govuk-table__cell:nth-of-type(2)').should('have.text', organisation.category)
-          cy.get('.govuk-table__cell:nth-of-type(3)').should('have.text', organisation.address.county || 'Not found')
-          cy.get('.govuk-table__cell:nth-of-type(4)').should('have.text', `Contact prison (${organisation.name})`)
-          cy.get('.govuk-table__cell:nth-of-type(4) .govuk-link').should(
+          cy.get('.govuk-table__cell:first-of-type a').should(
             'have.attr',
             'href',
             findPaths.offerings.show({ courseOfferingId: organisation.courseOfferingId }),
           )
+          cy.get('.govuk-table__cell:nth-of-type(2)').should('have.text', organisation.category)
+          cy.get('.govuk-table__cell:nth-of-type(3)').should('have.text', organisation.address.county || 'Not found')
         })
       })
     })

--- a/server/utils/organisationUtils.test.ts
+++ b/server/utils/organisationUtils.test.ts
@@ -51,28 +51,34 @@ describe('OrganisationUtils', () => {
 
         expect(OrganisationUtils.organisationTableRows(organisationsWithOfferingIds)).toEqual([
           [
-            { text: organisationsWithOfferingIds[0].name },
+            {
+              attributes: {
+                'data-sort-value': organisationsWithOfferingIds[0].name,
+              },
+              html: `<a href="/find/offerings/${organisationsWithOfferingIds[0].courseOfferingId}">${organisationsWithOfferingIds[0].name}</a>`,
+            },
             { text: organisationsWithOfferingIds[0].category },
             { text: organisationsWithOfferingIds[0].address.county },
-            {
-              html: `<a class="govuk-link" href="/find/offerings/${organisationsWithOfferingIds[0].courseOfferingId}">Contact prison <span class="govuk-visually-hidden">(${organisationsWithOfferingIds[0].name})</span></a>`,
-            },
           ],
           [
-            { text: organisationsWithOfferingIds[1].name },
+            {
+              attributes: {
+                'data-sort-value': organisationsWithOfferingIds[1].name,
+              },
+              html: `<a href="/find/offerings/${organisationsWithOfferingIds[1].courseOfferingId}">${organisationsWithOfferingIds[1].name}</a>`,
+            },
             { text: organisationsWithOfferingIds[1].category },
             { text: organisationsWithOfferingIds[1].address.county },
-            {
-              html: `<a class="govuk-link" href="/find/offerings/${organisationsWithOfferingIds[1].courseOfferingId}">Contact prison <span class="govuk-visually-hidden">(${organisationsWithOfferingIds[1].name})</span></a>`,
-            },
           ],
           [
-            { text: organisationsWithOfferingIds[2].name },
+            {
+              attributes: {
+                'data-sort-value': organisationsWithOfferingIds[2].name,
+              },
+              html: `<a href="/find/offerings/${organisationsWithOfferingIds[2].courseOfferingId}">${organisationsWithOfferingIds[2].name}</a>`,
+            },
             { text: organisationsWithOfferingIds[2].category },
             { text: organisationsWithOfferingIds[2].address.county },
-            {
-              html: `<a class="govuk-link" href="/find/offerings/${organisationsWithOfferingIds[2].courseOfferingId}">Contact prison <span class="govuk-visually-hidden">(${organisationsWithOfferingIds[2].name})</span></a>`,
-            },
           ],
         ])
       })
@@ -85,12 +91,14 @@ describe('OrganisationUtils', () => {
 
         expect(OrganisationUtils.organisationTableRows([organisationWithOfferingId])).toEqual([
           [
-            { text: organisationWithOfferingId.name },
+            {
+              attributes: {
+                'data-sort-value': organisationWithOfferingId.name,
+              },
+              html: `<a href="/find/offerings/${organisationWithOfferingId.courseOfferingId}">${organisationWithOfferingId.name}</a>`,
+            },
             { text: organisationWithOfferingId.category },
             { text: 'Not found' },
-            {
-              html: `<a class="govuk-link" href="/find/offerings/${organisationWithOfferingId.courseOfferingId}">Contact prison <span class="govuk-visually-hidden">(${organisationWithOfferingId.name})</span></a>`,
-            },
           ],
         ])
       })

--- a/server/utils/organisationUtils.ts
+++ b/server/utils/organisationUtils.ts
@@ -26,14 +26,17 @@ export default class OrganisationUtils {
       const offeringPath = findPaths.offerings.show({
         courseOfferingId: organisation.courseOfferingId,
       })
-      const visuallyHiddenPrisonInformation = `<span class="govuk-visually-hidden">(${organisation.name})</span>`
-      const contactLink = `<a class="govuk-link" href="${offeringPath}">Contact prison ${visuallyHiddenPrisonInformation}</a>`
+      const contactOrganisationLink = `<a href="${offeringPath}">${organisation.name}</a>`
 
       return [
-        { text: organisation.name },
+        {
+          attributes: {
+            'data-sort-value': organisation.name,
+          },
+          html: contactOrganisationLink,
+        },
         { text: organisation.category },
         { text: organisation.address.county || 'Not found' },
-        { html: contactLink },
       ]
     })
   }

--- a/server/views/courses/_locationsTable.njk
+++ b/server/views/courses/_locationsTable.njk
@@ -22,9 +22,6 @@
       attributes: {
         "aria-sort": "none"
       }
-    },
-    {
-      html: '<span class="govuk-visually-hidden">Link to contact prison</span>'
     }
   ],
   rows: organisationsTableData

--- a/server/views/courses/show.njk
+++ b/server/views/courses/show.njk
@@ -33,6 +33,8 @@
       <h2 class="govuk-heading-m">Locations</h2>
 
       {% if organisationsTableData | length %}
+        <p data-testid="offerings-text">Select a prison to contact the programme team or make a referral. Online referrals are not yet available at all sites.</p>
+
         {% include "./_locationsTable.njk" %}
       {% else %}
         <p data-testid="no-offerings-text">To find out where {{ course.displayName }} is offered, speak to your Offender Management Unit (custody) or regional probation team (community).</p>


### PR DESCRIPTION
## Context

The CTAs under the programme locations have some usability and accessibility issues.

## Changes in this PR
- Remove contact prison links and made location name clickable
- Added supporting content above list of offerings


## Screenshots of UI changes

![image](https://github.com/ministryofjustice/hmpps-accredited-programmes-ui/assets/1067537/35a55d79-47e3-466d-b83f-7b01a3005072)



## Release checklist

[Release process documentation](../doc/how-to/perform-a-release.md)

As part of our continuous deployment strategy we must ensure that this work is
ready to be released once merged.

### Pre-merge

- [ ] There are changes required to the Accredited Programmes API for this change to work...
  - [ ] ... and they have been released to production already

### Post-merge

<!-- The outer checkboxes can be completed pre-merge -->

- [ ] This adds, extends or meaningfully modifies a feature...
  - [ ] ... and I have written or updated an end-to-end test for the happy path in the [Accredited Programmes E2E repo](https://github.com/ministryofjustice/hmpps-accredited-programmes-e2e)
- [ ] This makes new expectations of the API...
  - [ ] ... and I have notified the API developer(s) of changes to the contract tests (Pact), or the API is already compliant
- [ ] [Manually approve](../doc/how-to/perform-a-release.md#releasing-to-the-preprod-environment) release to preprod
- [ ] [Manually approve](../doc/how-to/perform-a-release.md#releasing-to-the-production-environment) release to prod

<!-- Should a release fail at any step, you as the author should now lead the work to
fix it as soon as possible. You can monitor deployment failures in CircleCI
itself and application errors are found in
[Sentry](https://ministryofjustice.sentry.io/projects/hmpps-accredited-programmes-ui/?project=4505330122686464&referrer=sidebar&statsPeriod=24h). -->
