### PR TITLE
(1484a) Update label and legend styling on some form components

### DIFF
--- a/server/views/referrals/new/additionalInformation/show.njk
+++ b/server/views/referrals/new/additionalInformation/show.njk
@@ -55,7 +55,7 @@
           id: "additionalInformation",
           label: {
             text: "Provide additional information",
-            classes: "govuk-!-font-weight-bold"
+            classes: "govuk-fieldset__legend--s"
           },
           value: referral.additionalInformation,
           attributes: {

--- a/server/views/referrals/new/courseParticipations/details/show.njk
+++ b/server/views/referrals/new/courseParticipations/details/show.njk
@@ -95,7 +95,8 @@
           name: "setting[type]",
           fieldset: {
             legend: {
-              text: "Select the setting (if known)"
+              text: "Select the setting (if known)",
+              classes: "govuk-fieldset__legend--s"
             }
           },
           items: [
@@ -131,7 +132,8 @@
           name: "outcome[status]",
           fieldset: {
             legend: {
-              text: "Select the outcome (if known)"
+              text: "Select the outcome (if known)",
+              classes: "govuk-fieldset__legend--s"
             }
           },
           items: [
@@ -167,7 +169,8 @@
           name: "detail",
           id: "detail",
           label: {
-            text: "Provide additional detail (if known)"
+            text: "Provide additional detail (if known)",
+            classes: "govuk-fieldset__legend--s"
           },
           value: formValues.detail
         }) }}
@@ -176,7 +179,8 @@
           name: "source",
           id: "source",
           label: {
-            text: "Provide the source"
+            text: "Provide the source",
+            classes: "govuk-fieldset__legend--s"
           },
           hint: {
             text: "Include where you got this information from"

--- a/server/views/referrals/updateStatus/selection/show.njk
+++ b/server/views/referrals/updateStatus/selection/show.njk
@@ -33,7 +33,8 @@
         name: "reason",
         maxlength: maxLength,
         label: {
-          text: "Add reason"
+          text: "Add reason",
+          classes: 'govuk-fieldset__legend--s'
         },
         value: formValues.reason,
         classes: "govuk-!-width-three-quarters",


### PR DESCRIPTION
## Context
To ensure consistency, some font styles need to be updated across the service.

## Changes in this PR
Added `govuk-fieldset__legend--s` to some legends and labels. 


## Release checklist

[Release process documentation](../doc/how-to/perform-a-release.md)

As part of our continuous deployment strategy we must ensure that this work is
ready to be released once merged.

### Pre-merge

- [ ] There are changes required to the Accredited Programmes API for this change to work...
  - [ ] ... and they have been released to production already

### Post-merge

<!-- The outer checkboxes can be completed pre-merge -->

- [ ] This adds, extends or meaningfully modifies a feature...
  - [ ] ... and I have written or updated an end-to-end test for the happy path in the [Accredited Programmes E2E repo](https://github.com/ministryofjustice/hmpps-accredited-programmes-e2e)
- [ ] This makes new expectations of the API...
  - [ ] ... and I have notified the API developer(s) of changes to the contract tests (Pact), or the API is already compliant
- [ ] [Manually approve](../doc/how-to/perform-a-release.md#releasing-to-the-preprod-environment) release to preprod
- [ ] [Manually approve](../doc/how-to/perform-a-release.md#releasing-to-the-production-environment) release to prod

<!-- Should a release fail at any step, you as the author should now lead the work to
fix it as soon as possible. You can monitor deployment failures in CircleCI
itself and application errors are found in
[Sentry](https://ministryofjustice.sentry.io/projects/hmpps-accredited-programmes-ui/?project=4505330122686464&referrer=sidebar&statsPeriod=24h). -->
