### PR TITLE
(1540) Update content on category and reason pages for deselect and keep open

### DIFF
--- a/server/controllers/refer/updateStatusActionsController.test.ts
+++ b/server/controllers/refer/updateStatusActionsController.test.ts
@@ -45,6 +45,7 @@ describe('UpdateStatusActionsController', () => {
       expect(request.session.referralStatusUpdateData).toEqual({
         decisionForCategoryAndReason: 'WITHDRAWN',
         finalStatusDecision: 'WITHDRAWN',
+        initialStatusDecision: 'WITHDRAWN',
         referralId,
       })
       expect(response.redirect).toHaveBeenCalledWith(referPaths.updateStatus.category.show({ referralId }))

--- a/server/controllers/refer/updateStatusActionsController.ts
+++ b/server/controllers/refer/updateStatusActionsController.ts
@@ -26,6 +26,7 @@ export default class UpdateStatusActionsController {
       req.session.referralStatusUpdateData = {
         decisionForCategoryAndReason: withdrawStatus,
         finalStatusDecision: withdrawStatus,
+        initialStatusDecision: withdrawStatus,
         referralId,
       }
 


### PR DESCRIPTION
## Context

Text incorrectly says that the referral will be closed, after selecting Deselect and keep open.

## Changes in this PR
Use the `initialStatusDecision` value for the content on the category and reason pages, which in this case will be `DESELECTED|OPEN`



## Release checklist

[Release process documentation](../doc/how-to/perform-a-release.md)

As part of our continuous deployment strategy we must ensure that this work is
ready to be released once merged.

### Pre-merge

- [ ] There are changes required to the Accredited Programmes API for this change to work...
  - [ ] ... and they have been released to production already

### Post-merge

<!-- The outer checkboxes can be completed pre-merge -->

- [ ] This adds, extends or meaningfully modifies a feature...
  - [ ] ... and I have written or updated an end-to-end test for the happy path in the [Accredited Programmes E2E repo](https://github.com/ministryofjustice/hmpps-accredited-programmes-e2e)
- [ ] This makes new expectations of the API...
  - [ ] ... and I have notified the API developer(s) of changes to the contract tests (Pact), or the API is already compliant
- [ ] [Manually approve](../doc/how-to/perform-a-release.md#releasing-to-the-preprod-environment) release to preprod
- [ ] [Manually approve](../doc/how-to/perform-a-release.md#releasing-to-the-production-environment) release to prod

<!-- Should a release fail at any step, you as the author should now lead the work to
fix it as soon as possible. You can monitor deployment failures in CircleCI
itself and application errors are found in
[Sentry](https://ministryofjustice.sentry.io/projects/hmpps-accredited-programmes-ui/?project=4505330122686464&referrer=sidebar&statsPeriod=24h). -->
