### PR TITLE
(1539) Fix Withdraw referral button state

### DIFF
--- a/integration_tests/support/sharedTests.ts
+++ b/integration_tests/support/sharedTests.ts
@@ -140,7 +140,10 @@ const sharedTests = {
         }),
         addedByDisplayName: StringUtils.convertToTitleCase(user.name),
       }
-      statusTransitions = [referralStatusRefDataFactory.build({ hold: true })]
+      statusTransitions = [
+        referralStatusRefDataFactory.build({ hold: true }),
+        referralStatusRefDataFactory.build({ code: 'WITHDRAWN', hold: false }),
+      ]
 
       cy.task('reset')
       cy.task('stubSignIn', { authorities: [role] })

--- a/server/utils/referrals/showReferralUtils.test.ts
+++ b/server/utils/referrals/showReferralUtils.test.ts
@@ -64,7 +64,7 @@ describe('ShowReferralUtils', () => {
     })
 
     describe('when on the refer journey', () => {
-      it('contains the "Back to my referrals" and "Withdraw referral" buttons with the correct hrefs', () => {
+      it('contains the correct buttons, with the "Withdraw referral" and "Hold" buttons in a disabled state', () => {
         expect(
           ShowReferralUtils.buttons(
             referPaths.show.statusHistory({ referralId: submittedReferral.id }),
@@ -82,21 +82,26 @@ describe('ShowReferralUtils', () => {
           },
           {
             classes: 'govuk-button--secondary',
-            disabled: false,
-            href: `/refer/referrals/${submittedReferral.id}/withdraw`,
+            disabled: true,
             text: 'Withdraw referral',
           },
         ])
       })
 
       describe('and the referral is closed', () => {
-        it('disables the "Withdraw referral" button', () => {
+        it('disables the "Withdraw referral" and "Hold" buttons', () => {
           const closedReferral = referralFactory.closed().build()
 
           expect(
             ShowReferralUtils.buttons(referPaths.show.statusHistory({ referralId: closedReferral.id }), closedReferral),
           ).toEqual(
             expect.arrayContaining([
+              {
+                classes: 'govuk-button--secondary',
+                disabled: true,
+                href: undefined,
+                text: 'Put on hold',
+              },
               {
                 classes: 'govuk-button--secondary',
                 disabled: true,
@@ -155,6 +160,29 @@ describe('ShowReferralUtils', () => {
                   disabled: false,
                   href: `/refer/referrals/${submittedReferral.id}/manage-hold?status=REFERRAL_SUBMITTED`,
                   text: 'Remove hold',
+                },
+              ]),
+            )
+          })
+        })
+
+        describe('when `statusTransitions` includes the withdrawn status', () => {
+          const statusTransitions = [referralStatusRefDataFactory.build({ code: 'WITHDRAWN', hold: true })]
+
+          it('contains the "Withdraw referral" button with the correct href', () => {
+            expect(
+              ShowReferralUtils.buttons(
+                referPaths.show.statusHistory({ referralId: submittedReferral.id }),
+                submittedReferral,
+                statusTransitions,
+              ),
+            ).toEqual(
+              expect.arrayContaining([
+                {
+                  classes: 'govuk-button--secondary',
+                  disabled: false,
+                  href: `/refer/referrals/${submittedReferral.id}/withdraw`,
+                  text: 'Withdraw referral',
                 },
               ]),
             )

--- a/server/utils/referrals/showReferralUtils.ts
+++ b/server/utils/referrals/showReferralUtils.ts
@@ -47,7 +47,10 @@ export default class ShowReferralUtils {
         closed || !nextHoldOrReleaseStatus
           ? undefined
           : `${referPaths.manageHold({ referralId: referral.id })}?status=${nextHoldOrReleaseStatus}`
-      const withdrawHref = closed ? undefined : referPaths.withdraw({ referralId: referral.id })
+      const withdrawHref =
+        closed || !statusTransitions?.find(transition => transition.code === 'WITHDRAWN')
+          ? undefined
+          : referPaths.withdraw({ referralId: referral.id })
 
       buttons.push(
         {


### PR DESCRIPTION
## Context
When a referral is On programme, the Withdraw referral button is still enabled and clickable.

## Changes in this PR
Check if `WITHDRAWN` is within the available status transitions and use that to conditionally enable/disable the Withdraw referral button.


## Screenshots of UI changes

### Before
![image](https://github.com/ministryofjustice/hmpps-accredited-programmes-ui/assets/1067537/d0f9872f-3a86-46f5-8c13-5daf410bba83)


### After
![image](https://github.com/ministryofjustice/hmpps-accredited-programmes-ui/assets/1067537/04c179e9-80f4-4a19-b83e-4d0885dcaea3)



## Release checklist

[Release process documentation](../doc/how-to/perform-a-release.md)

As part of our continuous deployment strategy we must ensure that this work is
ready to be released once merged.

### Pre-merge

- [ ] There are changes required to the Accredited Programmes API for this change to work...
  - [ ] ... and they have been released to production already

### Post-merge

<!-- The outer checkboxes can be completed pre-merge -->

- [ ] This adds, extends or meaningfully modifies a feature...
  - [ ] ... and I have written or updated an end-to-end test for the happy path in the [Accredited Programmes E2E repo](https://github.com/ministryofjustice/hmpps-accredited-programmes-e2e)
- [ ] This makes new expectations of the API...
  - [ ] ... and I have notified the API developer(s) of changes to the contract tests (Pact), or the API is already compliant
- [ ] [Manually approve](../doc/how-to/perform-a-release.md#releasing-to-the-preprod-environment) release to preprod
- [ ] [Manually approve](../doc/how-to/perform-a-release.md#releasing-to-the-production-environment) release to prod

<!-- Should a release fail at any step, you as the author should now lead the work to
fix it as soon as possible. You can monitor deployment failures in CircleCI
itself and application errors are found in
[Sentry](https://ministryofjustice.sentry.io/projects/hmpps-accredited-programmes-ui/?project=4505330122686464&referrer=sidebar&statsPeriod=24h). -->
