### PR TITLE
(1519b) Add extra information to Relationships and Lifestyle sections

### DIFF
--- a/integration_tests/pages/shared/showReferral/risksAndNeeds/lifestyleAndAssociates.ts
+++ b/integration_tests/pages/shared/showReferral/risksAndNeeds/lifestyleAndAssociates.ts
@@ -1,4 +1,4 @@
-import { CourseUtils, LifestyleAndAssociatesUtils } from '../../../../../server/utils'
+import { CourseUtils, LifestyleAndAssociatesUtils, ShowRisksAndNeedsUtils } from '../../../../../server/utils'
 import Page from '../../../page'
 import type { Course, Lifestyle } from '@accredited-programmes/models'
 
@@ -13,6 +13,16 @@ export default class LifestyleAndAssociatesPage extends Page {
     super(`Referral to ${coursePresenter.displayName}`)
 
     this.lifestyle = lifestyle
+  }
+
+  shouldContainLifestyleIssuesSummaryCard() {
+    cy.get('[data-testid="lifestyle-issues-summary-card"]').then(summaryCardElement => {
+      this.shouldContainKeylessSummaryCard(
+        'Lifestyle issues affecting risk of offending or harm',
+        ShowRisksAndNeedsUtils.textValue(this.lifestyle.lifestyleIssues),
+        summaryCardElement,
+      )
+    })
   }
 
   shouldContainNoLifestyleDataSummaryCard() {

--- a/integration_tests/pages/shared/showReferral/risksAndNeeds/relationships.ts
+++ b/integration_tests/pages/shared/showReferral/risksAndNeeds/relationships.ts
@@ -1,4 +1,4 @@
-import { CourseUtils, RelationshipsUtils } from '../../../../../server/utils'
+import { CourseUtils, RelationshipsUtils, ShowRisksAndNeedsUtils } from '../../../../../server/utils'
 import Page from '../../../page'
 import type { Course, Relationships } from '@accredited-programmes/models'
 
@@ -29,6 +29,16 @@ export default class RelationshipsPage extends Page {
       this.shouldContainKeylessSummaryCard(
         'Section 6 - Relationships',
         'No relationships found in OASys. Add relationships to OASys to see it here.',
+        summaryCardElement,
+      )
+    })
+  }
+
+  shouldContainRelationshipIssuesSummaryCard() {
+    cy.get('[data-testid="relationship-issues-summary-card"]').then(summaryCardElement => {
+      this.shouldContainKeylessSummaryCard(
+        'Relationship issues affecting risk of offending or harm',
+        ShowRisksAndNeedsUtils.textValue(this.relationships.relIssuesDetails),
         summaryCardElement,
       )
     })

--- a/integration_tests/support/sharedTests.ts
+++ b/integration_tests/support/sharedTests.ts
@@ -709,6 +709,7 @@ const sharedTests = {
       lifestyleAndAssociatesPage.shouldContainRisksAndNeedsSideNavigation(path, referral.id)
       lifestyleAndAssociatesPage.shouldContainImportedFromText('OASys')
       lifestyleAndAssociatesPage.shouldContainReoffendingSummaryList()
+      lifestyleAndAssociatesPage.shouldContainLifestyleIssuesSummaryCard()
     },
     showsLifestyleAndAssociatesPageWithoutData: (role: ApplicationRole): void => {
       sharedTests.referrals.beforeEach(role)
@@ -814,6 +815,7 @@ const sharedTests = {
       relationshipsPage.shouldContainRisksAndNeedsSideNavigation(path, referral.id)
       relationshipsPage.shouldContainImportedFromText('OASys')
       relationshipsPage.shouldContainDomesticViolenceSummaryList()
+      relationshipsPage.shouldContainRelationshipIssuesSummaryCard()
     },
     showsRelationshipsPageWithoutData: (role: ApplicationRole): void => {
       sharedTests.referrals.beforeEach(role)

--- a/server/@types/models/Lifestyle.ts
+++ b/server/@types/models/Lifestyle.ts
@@ -1,4 +1,5 @@
 export interface Lifestyle {
   activitiesEncourageOffending?: string
+  easilyInfluenced?: string
   lifestyleIssues?: string
 }

--- a/server/@types/models/Relationships.ts
+++ b/server/@types/models/Relationships.ts
@@ -1,6 +1,9 @@
 export type Relationships = {
   dvEvidence?: boolean
+  emotionalCongruence?: string
   perpOfPartnerOrFamily?: boolean
+  prevCloseRelationships?: string
+  relCurrRelationshipStatus?: string
   relIssuesDetails?: string
   victimFamilyMember?: boolean
   victimFormerPartner?: boolean

--- a/server/controllers/shared/risksAndNeedsController.test.ts
+++ b/server/controllers/shared/risksAndNeedsController.test.ts
@@ -366,10 +366,13 @@ describe('RisksAndNeedsController', () => {
 
   describe('lifestyleAndAssociates', () => {
     it('renders the lifestyle and associates page with the correct response locals', async () => {
-      const lifestyle = lifestyleFactory.build({ activitiesEncourageOffending: '0 - No problems' })
+      const lifestyleIssues = 'Lifestyle issues comments.'
+      const lifestyle = lifestyleFactory.build({ activitiesEncourageOffending: '0 - No problems', lifestyleIssues })
       const reoffendingSummaryListRows = [{ key: { text: 'key-one' }, value: { text: 'value one' } }]
 
       mockLifestyleAndAssociatesUtils.reoffendingSummaryListRows.mockReturnValue(reoffendingSummaryListRows)
+
+      when(ShowRisksAndNeedsUtils.textValue).calledWith(lifestyle.lifestyleIssues).mockReturnValue(lifestyleIssues)
 
       when(oasysService.getLifestyle).calledWith(username, person.prisonNumber).mockResolvedValue(lifestyle)
 
@@ -384,6 +387,7 @@ describe('RisksAndNeedsController', () => {
         ...sharedPageData,
         hasData: true,
         importedFromText: `Imported from OASys on ${importedFromDate}.`,
+        lifestyleIssues,
         navigationItems,
         reoffendingSummaryListRows,
         subNavigationItems,
@@ -488,12 +492,17 @@ describe('RisksAndNeedsController', () => {
 
   describe('relationships', () => {
     it('renders the relationships page with the correct response locals', async () => {
-      const relationships = relationshipsFactory.build()
+      const relIssuesDetails = 'Relationship issues details.'
+      const relationships = relationshipsFactory.build({ relIssuesDetails })
       const domesticViolenceSummaryListRows = [{ key: { text: 'key-one' }, value: { text: 'value one' } }]
 
       mockRelationshipsUtils.domesticViolenceSummaryListRows.mockReturnValue(domesticViolenceSummaryListRows)
 
       when(oasysService.getRelationships).calledWith(username, person.prisonNumber).mockResolvedValue(relationships)
+
+      when(ShowRisksAndNeedsUtils.textValue)
+        .calledWith(relationships.relIssuesDetails)
+        .mockReturnValue(relIssuesDetails)
 
       request.path = referPaths.show.risksAndNeeds.relationships({ referralId: referral.id })
 
@@ -508,6 +517,7 @@ describe('RisksAndNeedsController', () => {
         hasData: true,
         importedFromText: `Imported from OASys on ${importedFromDate}.`,
         navigationItems,
+        relIssuesDetails,
         subNavigationItems,
       })
     })

--- a/server/controllers/shared/risksAndNeedsController.ts
+++ b/server/controllers/shared/risksAndNeedsController.ts
@@ -151,6 +151,7 @@ export default class RisksAndNeedsController {
         ? {
             hasData: true,
             importedFromText: `Imported from OASys on ${DateUtils.govukFormattedFullDateString()}.`,
+            lifestyleIssues: ShowRisksAndNeedsUtils.textValue(lifestyle.lifestyleIssues),
             reoffendingSummaryListRows: LifestyleAndAssociatesUtils.reoffendingSummaryListRows(lifestyle),
           }
         : {
@@ -216,6 +217,7 @@ export default class RisksAndNeedsController {
             domesticViolenceSummaryListRows: RelationshipsUtils.domesticViolenceSummaryListRows(relationships),
             hasData: true,
             importedFromText: `Imported from OASys on ${DateUtils.govukFormattedFullDateString()}.`,
+            relIssuesDetails: ShowRisksAndNeedsUtils.textValue(relationships.relIssuesDetails),
           }
         : {
             hasData: false,

--- a/server/views/referrals/show/risksAndNeeds/lifestyleAndAssociates.njk
+++ b/server/views/referrals/show/risksAndNeeds/lifestyleAndAssociates.njk
@@ -19,6 +19,8 @@
       },
       rows: reoffendingSummaryListRows
     }) }}
+
+    {{ keylessSummaryCard("Lifestyle issues affecting risk of offending or harm", bodyText=lifestyleIssues, testId="lifestyle-issues-summary-card") }}
   {% elseif not oasysNomisErrorMessage %}
     {% set noLifestyleDataString = "No lifestyle data found in OASys. Add lifestyle data to OASys to see them here." %}
 

--- a/server/views/referrals/show/risksAndNeeds/relationships.njk
+++ b/server/views/referrals/show/risksAndNeeds/relationships.njk
@@ -19,6 +19,8 @@
       },
       rows: domesticViolenceSummaryListRows
     }) }}
+
+    {{ keylessSummaryCard("Relationship issues affecting risk of offending or harm", bodyText=relIssuesDetails, testId="relationship-issues-summary-card") }}
   {% elseif not oasysNomisErrorMessage %}
     {% set noRelationshipsString = "No relationships found in OASys. Add relationships to OASys to see it here." %}
 


### PR DESCRIPTION
## Context

Based on the last round of research, the free text information captured in OASys Layer 3 sections 6 (Relationships) and 7 (Lifestyle and Associates) needs to be added to the Risks & Needs section of a referral (for both Referrer and PT journeys)

## Changes in this PR
Add required information to Relationships and Lifestyle pages within the Risks and needs section and handle when there is no information available.

## Screenshots of UI changes

<img width="1219" alt="image" src="https://github.com/ministryofjustice/hmpps-accredited-programmes-ui/assets/1067537/489e323e-3cbd-43f5-bfa8-a90ec32e99ac">
<img width="1214" alt="image" src="https://github.com/ministryofjustice/hmpps-accredited-programmes-ui/assets/1067537/e1f8fa5b-b7f6-463c-b355-480c13e4d7e5">



## Release checklist

[Release process documentation](../doc/how-to/perform-a-release.md)

As part of our continuous deployment strategy we must ensure that this work is
ready to be released once merged.

### Pre-merge

- [ ] There are changes required to the Accredited Programmes API for this change to work...
  - [ ] ... and they have been released to production already

### Post-merge

<!-- The outer checkboxes can be completed pre-merge -->

- [ ] This adds, extends or meaningfully modifies a feature...
  - [ ] ... and I have written or updated an end-to-end test for the happy path in the [Accredited Programmes E2E repo](https://github.com/ministryofjustice/hmpps-accredited-programmes-e2e)
- [ ] This makes new expectations of the API...
  - [ ] ... and I have notified the API developer(s) of changes to the contract tests (Pact), or the API is already compliant
- [ ] [Manually approve](../doc/how-to/perform-a-release.md#releasing-to-the-preprod-environment) release to preprod
- [ ] [Manually approve](../doc/how-to/perform-a-release.md#releasing-to-the-production-environment) release to prod

<!-- Should a release fail at any step, you as the author should now lead the work to
fix it as soon as possible. You can monitor deployment failures in CircleCI
itself and application errors are found in
[Sentry](https://ministryofjustice.sentry.io/projects/hmpps-accredited-programmes-ui/?project=4505330122686464&referrer=sidebar&statsPeriod=24h). -->
