### PR TITLE
(1518) Remove 'referrals' text suffix from course name in case list navigation

### DIFF
--- a/integration_tests/pages/shared/caseList.ts
+++ b/integration_tests/pages/shared/caseList.ts
@@ -37,7 +37,7 @@ export default class CaseListPage extends Page {
             courseId: course.id,
             referralStatusGroup: 'open',
           }),
-          text: `${course.name} referrals`,
+          text: course.name,
         }
       })
 

--- a/server/utils/referrals/caseListUtils.test.ts
+++ b/server/utils/referrals/caseListUtils.test.ts
@@ -70,17 +70,17 @@ describe('CaseListUtils', () => {
         {
           active: false,
           href: `/assess/referrals/course/${blueCourse.id}/case-list/open`,
-          text: 'Blue Course referrals',
+          text: 'Blue Course',
         },
         {
           active: false,
           href: `/assess/referrals/course/${limeCourse.id}/case-list/open`,
-          text: 'Lime Course referrals',
+          text: 'Lime Course',
         },
         {
           active: true,
           href: `/assess/referrals/course/${orangeCourse.id}/case-list/open`,
-          text: 'Orange Course referrals',
+          text: 'Orange Course',
         },
       ])
     })

--- a/server/utils/referrals/caseListUtils.ts
+++ b/server/utils/referrals/caseListUtils.ts
@@ -57,7 +57,7 @@ export default class CaseListUtils {
       return {
         active: currentPath === path,
         href: path,
-        text: `${course.name} referrals`,
+        text: course.name,
       }
     })
   }


### PR DESCRIPTION
## Screenshots of UI changes

### Before
![image](https://github.com/ministryofjustice/hmpps-accredited-programmes-ui/assets/1067537/93f48f2b-9c3d-4940-aefd-bde579f53d16)


### After
![image](https://github.com/ministryofjustice/hmpps-accredited-programmes-ui/assets/1067537/ba6c68c2-f350-49a8-910a-90f2bd5e8103)



## Release checklist

[Release process documentation](../doc/how-to/perform-a-release.md)

As part of our continuous deployment strategy we must ensure that this work is
ready to be released once merged.

### Pre-merge

- [ ] There are changes required to the Accredited Programmes API for this change to work...
  - [ ] ... and they have been released to production already

### Post-merge

<!-- The outer checkboxes can be completed pre-merge -->

- [ ] This adds, extends or meaningfully modifies a feature...
  - [ ] ... and I have written or updated an end-to-end test for the happy path in the [Accredited Programmes E2E repo](https://github.com/ministryofjustice/hmpps-accredited-programmes-e2e)
- [ ] This makes new expectations of the API...
  - [ ] ... and I have notified the API developer(s) of changes to the contract tests (Pact), or the API is already compliant
- [ ] [Manually approve](../doc/how-to/perform-a-release.md#releasing-to-the-preprod-environment) release to preprod
- [ ] [Manually approve](../doc/how-to/perform-a-release.md#releasing-to-the-production-environment) release to prod

<!-- Should a release fail at any step, you as the author should now lead the work to
fix it as soon as possible. You can monitor deployment failures in CircleCI
itself and application errors are found in
[Sentry](https://ministryofjustice.sentry.io/projects/hmpps-accredited-programmes-ui/?project=4505330122686464&referrer=sidebar&statsPeriod=24h). -->
