### PR TITLE
(1169) Allow tables to scroll horizontally if required when screen size is reduced

### DIFF
--- a/assets/scss/local.scss
+++ b/assets/scss/local.scss
@@ -19,6 +19,10 @@
   }
 }
 
+.table-scroll {
+  overflow-x: auto;
+}
+
 .filters {
   @include govuk-responsive-padding(3);
   @include govuk-responsive-margin(7, 'bottom');

--- a/server/views/referrals/caseList/assess/show.njk
+++ b/server/views/referrals/caseList/assess/show.njk
@@ -67,10 +67,12 @@
   }) }}
 
   {% if tableRows | length %}
-    {{ govukTable({
-      head: tableHeadings,
-      rows: tableRows
-    }) }}
+    <div class="table-scroll">
+      {{ govukTable({
+        head: tableHeadings,
+        rows: tableRows
+      }) }}
+    </div>
 
     {{ govukPagination(pagination) }}
   {% else %}

--- a/server/views/referrals/caseList/refer/show.njk
+++ b/server/views/referrals/caseList/refer/show.njk
@@ -13,11 +13,12 @@
   }) }}
 
   {% if tableRows | length %}
-
-    {{ govukTable({
-      head: tableHeadings,
-      rows: tableRows
-    }) }}
+    <div class="table-scroll">
+      {{ govukTable({
+        head: tableHeadings,
+        rows: tableRows
+      }) }}
+    </div>
 
     {{ govukPagination(pagination) }}
 


### PR DESCRIPTION
## Context

When reducing the width of the browser, the case list tables break the layout of the page.

## Changes in this PR
Wrap the tables in a div which allows horizontal scroll.

## Release checklist

[Release process documentation](../doc/how-to/perform-a-release.md)

As part of our continuous deployment strategy we must ensure that this work is
ready to be released once merged.

### Pre-merge

- [ ] There are changes required to the Accredited Programmes API for this change to work...
  - [ ] ... and they have been released to production already

### Post-merge

<!-- The outer checkboxes can be completed pre-merge -->

- [ ] This adds, extends or meaningfully modifies a feature...
  - [ ] ... and I have written or updated an end-to-end test for the happy path in the [Accredited Programmes E2E repo](https://github.com/ministryofjustice/hmpps-accredited-programmes-e2e)
- [ ] This makes new expectations of the API...
  - [ ] ... and I have notified the API developer(s) of changes to the contract tests (Pact), or the API is already compliant
- [ ] [Manually approve](../doc/how-to/perform-a-release.md#releasing-to-the-preprod-environment) release to preprod
- [ ] [Manually approve](../doc/how-to/perform-a-release.md#releasing-to-the-production-environment) release to prod

<!-- Should a release fail at any step, you as the author should now lead the work to
fix it as soon as possible. You can monitor deployment failures in CircleCI
itself and application errors are found in
[Sentry](https://ministryofjustice.sentry.io/projects/hmpps-accredited-programmes-ui/?project=4505330122686464&referrer=sidebar&statsPeriod=24h). -->
