### PR TITLE
(1445) Update label and hint text on course participation form

### DIFF
--- a/integration_tests/pages/refer/new/programmeHistoryDetails.ts
+++ b/integration_tests/pages/refer/new/programmeHistoryDetails.ts
@@ -70,7 +70,7 @@ export default class NewReferralProgrammeHistoryDetailsPage extends Page {
   }
 
   shouldContainSourceTextArea() {
-    this.shouldContainTextArea('source', 'Provide the source')
+    this.shouldContainTextArea('source', 'Provide the source (optional)')
   }
 
   shouldDisplayCommunityLocationInput() {

--- a/server/views/referrals/new/courseParticipations/details/show.njk
+++ b/server/views/referrals/new/courseParticipations/details/show.njk
@@ -172,6 +172,9 @@
             text: "Provide additional detail (if known)",
             classes: "govuk-fieldset__legend--s"
           },
+          hint: {
+            text: "Include information about the outcome"
+          },
           value: formValues.detail
         }) }}
 
@@ -179,7 +182,7 @@
           name: "source",
           id: "source",
           label: {
-            text: "Provide the source",
+            text: "Provide the source (optional)",
             classes: "govuk-fieldset__legend--s"
           },
           hint: {


### PR DESCRIPTION
## Changes in this PR

1. Added hint text to Provide additional detail (if known) text area
2. Added "(optional)" to Provide the source label


## Screenshots of UI changes

![image](https://github.com/ministryofjustice/hmpps-accredited-programmes-ui/assets/1067537/4eb0128c-bf00-43b4-a374-394481aff1f9)



## Release checklist

[Release process documentation](../doc/how-to/perform-a-release.md)

As part of our continuous deployment strategy we must ensure that this work is
ready to be released once merged.

### Pre-merge

- [ ] There are changes required to the Accredited Programmes API for this change to work...
  - [ ] ... and they have been released to production already

### Post-merge

<!-- The outer checkboxes can be completed pre-merge -->

- [ ] This adds, extends or meaningfully modifies a feature...
  - [ ] ... and I have written or updated an end-to-end test for the happy path in the [Accredited Programmes E2E repo](https://github.com/ministryofjustice/hmpps-accredited-programmes-e2e)
- [ ] This makes new expectations of the API...
  - [ ] ... and I have notified the API developer(s) of changes to the contract tests (Pact), or the API is already compliant
- [ ] [Manually approve](../doc/how-to/perform-a-release.md#releasing-to-the-preprod-environment) release to preprod
- [ ] [Manually approve](../doc/how-to/perform-a-release.md#releasing-to-the-production-environment) release to prod

<!-- Should a release fail at any step, you as the author should now lead the work to
fix it as soon as possible. You can monitor deployment failures in CircleCI
itself and application errors are found in
[Sentry](https://ministryofjustice.sentry.io/projects/hmpps-accredited-programmes-ui/?project=4505330122686464&referrer=sidebar&statsPeriod=24h). -->
