### PR TITLE
APG-90 Call status reasons endpoint with `deselectAndKeepOpen` query parameter

### DIFF
--- a/server/controllers/shared/reasonController.test.ts
+++ b/server/controllers/shared/reasonController.test.ts
@@ -118,6 +118,7 @@ describe('ReasonController', () => {
         username,
         'STATUS-CAT-A',
         'DESELECTED',
+        { deselectAndKeepOpen: false },
       )
       expect(referralService.getReferral).toHaveBeenCalledWith(username, referral.id)
       expect(referralService.getReferralStatusHistory).toHaveBeenCalledWith(userToken, username, referral.id)
@@ -173,6 +174,7 @@ describe('ReasonController', () => {
           username,
           'STATUS-CAT-A',
           'WITHDRAWN',
+          { deselectAndKeepOpen: false },
         )
         expect(referralService.getReferralStatusHistory).toHaveBeenCalledWith(userToken, username, referral.id)
 
@@ -207,6 +209,7 @@ describe('ReasonController', () => {
           username,
           'STATUS-CAT-A',
           'DESELECTED',
+          { deselectAndKeepOpen: true },
         )
         expect(referralService.getReferralStatusHistory).toHaveBeenCalledWith(userToken, username, referral.id)
 

--- a/server/controllers/shared/reasonController.ts
+++ b/server/controllers/shared/reasonController.ts
@@ -67,6 +67,7 @@ export default class ReasonController {
           username,
           referralStatusUpdateData.statusCategoryCode,
           decisionForCategoryAndReason,
+          { deselectAndKeepOpen: referralStatusUpdateData.initialStatusDecision === 'DESELECTED|OPEN' },
         ),
       ])
 

--- a/server/data/accreditedProgrammesApi/referenceDataClient.ts
+++ b/server/data/accreditedProgrammesApi/referenceDataClient.ts
@@ -41,9 +41,15 @@ export default class ReferenceDataClient {
   async findReferralStatusCodeReasons(
     categoryCode: Uppercase<string>,
     referralStatusCode: ReferralStatusUppercase,
+    query?: {
+      deselectAndKeepOpen?: boolean
+    },
   ): Promise<Array<ReferralStatusReason>> {
     return (await this.restClient.get({
       path: apiPaths.referenceData.referralStatuses.statusCodeReasons({ categoryCode, referralStatusCode }),
+      query: {
+        ...(query?.deselectAndKeepOpen && { deselectAndKeepOpen: 'true' }),
+      },
     })) as Array<ReferralStatusReason>
   }
 

--- a/server/services/referenceDataService.test.ts
+++ b/server/services/referenceDataService.test.ts
@@ -71,12 +71,28 @@ describe('ReferenceDataService', () => {
       const reasons = referralStatusReasonFactory.buildList(2, { referralCategoryCode: categoryCode })
 
       when(referenceDataClient.findReferralStatusCodeReasons)
-        .calledWith(categoryCode, referralStatusCode)
+        .calledWith(categoryCode, referralStatusCode, undefined)
         .mockResolvedValue(reasons)
 
       const result = await service.getReferralStatusCodeReasons(username, categoryCode, referralStatusCode)
 
       expect(result).toEqual(reasons)
+    })
+
+    describe('with query parameters', () => {
+      it('calls the `getReferralStatusCodeReasons` method with those same query parameters', async () => {
+        const categoryCode = 'B'
+        const reasons = referralStatusReasonFactory.buildList(2, { referralCategoryCode: categoryCode })
+        const query = { deselectAndKeepOpen: true }
+
+        when(referenceDataClient.findReferralStatusCodeReasons)
+          .calledWith(categoryCode, referralStatusCode, query)
+          .mockResolvedValue(reasons)
+
+        const result = await service.getReferralStatusCodeReasons(username, categoryCode, referralStatusCode, query)
+
+        expect(result).toEqual(reasons)
+      })
     })
   })
 

--- a/server/services/referenceDataService.ts
+++ b/server/services/referenceDataService.ts
@@ -39,12 +39,15 @@ export default class ReferenceDataService {
     username: Express.User['username'],
     categoryCode: Uppercase<string>,
     referralStatusCode: ReferralStatusUppercase,
+    query?: {
+      deselectAndKeepOpen?: boolean
+    },
   ): Promise<Array<ReferralStatusReason>> {
     const hmppsAuthClient = this.hmppsAuthClientBuilder()
     const systemToken = await hmppsAuthClient.getSystemClientToken(username)
     const referenceDataClient = this.referenceDataClient(systemToken)
 
-    return referenceDataClient.findReferralStatusCodeReasons(categoryCode, referralStatusCode)
+    return referenceDataClient.findReferralStatusCodeReasons(categoryCode, referralStatusCode, query)
   }
 
   async getReferralStatuses(username: Express.User['username']): Promise<Array<ReferralStatusRefData>> {


### PR DESCRIPTION
## Context
We need to display different reasons between the deselect close and deselect open status update journeys.


## Changes in this PR
Call status reasons endpoint with `deselectAndKeepOpen` query parameter set to `'true'` when on the Deselect and keep open journey.

[APG-90](https://dsdmoj.atlassian.net/jira/software/c/projects/APG/boards/1435?selectedIssue=APG-89)
## Release checklist

[Release process documentation](../doc/how-to/perform-a-release.md)

As part of our continuous deployment strategy we must ensure that this work is
ready to be released once merged.

### Pre-merge

- [ ] There are changes required to the Accredited Programmes API for this change to work...
  - [ ] ... and they have been released to production already

### Post-merge

<!-- The outer checkboxes can be completed pre-merge -->

- [ ] This adds, extends or meaningfully modifies a feature...
  - [ ] ... and I have written or updated an end-to-end test for the happy path in the [Accredited Programmes E2E repo](https://github.com/ministryofjustice/hmpps-accredited-programmes-e2e)
- [ ] This makes new expectations of the API...
  - [ ] ... and I have notified the API developer(s) of changes to the contract tests (Pact), or the API is already compliant
- [ ] [Manually approve](../doc/how-to/perform-a-release.md#releasing-to-the-preprod-environment) release to preprod
- [ ] [Manually approve](../doc/how-to/perform-a-release.md#releasing-to-the-production-environment) release to prod

<!-- Should a release fail at any step, you as the author should now lead the work to
fix it as soon as possible. You can monitor deployment failures in CircleCI
itself and application errors are found in
[Sentry](https://ministryofjustice.sentry.io/projects/hmpps-accredited-programmes-ui/?project=4505330122686464&referrer=sidebar&statsPeriod=24h). -->


[APG-90]: https://dsdmoj.atlassian.net/browse/APG-90?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ