### PR TITLE
1443 - CTA Accredited Programmes History

### DIFF
--- a/integration_tests/e2e/refer/new/programmeHistory.cy.ts
+++ b/integration_tests/e2e/refer/new/programmeHistory.cy.ts
@@ -112,7 +112,7 @@ context('Programme history', () => {
         programmeHistoryPage.shouldContainPreHistoryParagraph()
         programmeHistoryPage.shouldContainHistorySummaryCards(courseParticipationsPresenter, referral.id)
         programmeHistoryPage.shouldContainButtonLink('Add a programme', newParticipationPath)
-        programmeHistoryPage.shouldContainButton('Skip this section')
+        programmeHistoryPage.shouldContainButton('Return to tasklist')
       })
 
       describe('and the programme history has been reviewed', () => {
@@ -168,7 +168,7 @@ context('Programme history', () => {
         programmeHistoryPage.shouldContainNoHistoryText()
         programmeHistoryPage.shouldContainNoHistoryParagraphs()
         programmeHistoryPage.shouldContainButtonLink('Add a programme', newParticipationPath)
-        programmeHistoryPage.shouldContainButton('Skip this section')
+        programmeHistoryPage.shouldContainButton('Return to tasklist')
       })
 
       describe('and the programme history has been reviewed', () => {

--- a/integration_tests/pages/refer/new/programmeHistory.ts
+++ b/integration_tests/pages/refer/new/programmeHistory.ts
@@ -23,7 +23,7 @@ export default class NewReferralProgrammeHistoryPage extends Page {
     this.referral = { ...this.referral, hasReviewedProgrammeHistory: true }
     // We're stubbing the referral here to make sure the updated referral is available on the task list page
     cy.task('stubReferral', this.referral)
-    this.shouldContainButton('Skip this section').click()
+    this.shouldContainButton('Return to tasklist').click()
   }
 
   shouldContainNoHistoryParagraphs() {
@@ -51,7 +51,7 @@ export default class NewReferralProgrammeHistoryPage extends Page {
   shouldContainPreHistoryParagraph() {
     cy.get('[data-testid="pre-history-paragraph"]').should(
       'have.text',
-      'Add another programme if you know that they started or completed a programme which is not listed below or skip this section of the referral if the history is not known.',
+      'Add a programme if you know they completed or started a programme not listed here. Return to the tasklist once you’ve added all known programme history.',
     )
   }
 

--- a/server/views/referrals/new/courseParticipations/index.njk
+++ b/server/views/referrals/new/courseParticipations/index.njk
@@ -42,7 +42,7 @@
       }) }}
 
       {% if summaryListsOptions.length %}
-        <p class="govuk-body" data-testid="pre-history-paragraph">Add another programme if you know that they started or completed a programme which is not listed below or skip this section of the referral if the history is not known.</p>
+        <p class="govuk-body" data-testid="pre-history-paragraph">Add a programme if you know they completed or started a programme not listed here. Return to the tasklist once you’ve added all known programme history.</p>
       {% else %}
         <p class="govuk-body" data-testid="no-history-paragraph-1">The programme team may use information about a person's Accredited Programme history to assess whether they are suitable.</p>
 
@@ -67,7 +67,7 @@
           }) }}
 
           {{ govukButton({
-            text: "Skip this section",
+            text: "Return to tasklist",
             classes: "govuk-button--secondary"
           }) }}
         </div>


### PR DESCRIPTION
## Context

<!-- Is there a Trello ticket you can link to? -->
<!-- Do you need to add any environment variables? -->
<!-- Is an ADR required? An ADR should be added if this PR introduces a change to the architecture. -->



## Changes in this PR
Updated the CTA and body text on the Accredited Programme History page


## Screenshots of UI changes

### Before


### After


## Release checklist

[Release process documentation](../doc/how-to/perform-a-release.md)

As part of our continuous deployment strategy we must ensure that this work is
ready to be released once merged.

### Pre-merge

- [ ] There are changes required to the Accredited Programmes API for this change to work...
  - [ ] ... and they have been released to production already

### Post-merge

<!-- The outer checkboxes can be completed pre-merge -->

- [ ] This adds, extends or meaningfully modifies a feature...
  - [ ] ... and I have written or updated an end-to-end test for the happy path in the [Accredited Programmes E2E repo](https://github.com/ministryofjustice/hmpps-accredited-programmes-e2e)
- [ ] This makes new expectations of the API...
  - [ ] ... and I have notified the API developer(s) of changes to the contract tests (Pact), or the API is already compliant
- [ ] [Manually approve](../doc/how-to/perform-a-release.md#releasing-to-the-preprod-environment) release to preprod
- [ ] [Manually approve](../doc/how-to/perform-a-release.md#releasing-to-the-production-environment) release to prod

<!-- Should a release fail at any step, you as the author should now lead the work to
fix it as soon as possible. You can monitor deployment failures in CircleCI
itself and application errors are found in
[Sentry](https://ministryofjustice.sentry.io/projects/hmpps-accredited-programmes-ui/?project=4505330122686464&referrer=sidebar&statsPeriod=24h). -->
