### PR TITLE
(APG-71) Add character count to additional information page

### DIFF
--- a/integration_tests/e2e/refer/new/additionalInformation.cy.ts
+++ b/integration_tests/e2e/refer/new/additionalInformation.cy.ts
@@ -102,5 +102,28 @@ context('Additional information', () => {
         },
       ])
     })
+
+    it('displays an error when too much information is provided', () => {
+      const path = referPaths.new.additionalInformation.show({ referralId: referral.id })
+      cy.visit(path)
+
+      const tooMuchInformation = 'a'.repeat(4001)
+
+      const additionalInformationPage = Page.verifyOnPage(NewReferralAdditionalInformationPage, { person, referral })
+      additionalInformationPage.submitAdditionalInformation(tooMuchInformation)
+      additionalInformationPage.shouldContainButton('Save and continue').click()
+
+      const additionalInformationPageWithError = Page.verifyOnPage(NewReferralAdditionalInformationPage, {
+        person,
+        referral,
+      })
+      additionalInformationPageWithError.shouldHaveErrors([
+        {
+          field: 'additionalInformation',
+          message: 'Additional information must be 4000 characters or fewer',
+        },
+      ])
+      additionalInformationPageWithError.shouldContainEnteredAdditionalInformation(tooMuchInformation)
+    })
   })
 })

--- a/integration_tests/pages/refer/new/additionalInformation.ts
+++ b/integration_tests/pages/refer/new/additionalInformation.ts
@@ -19,6 +19,10 @@ export default class NewReferralAdditionalInformationPage extends Page {
     this.shouldContainTextArea('additionalInformation', 'Provide additional information')
   }
 
+  shouldContainEnteredAdditionalInformation(additionalInformation: string) {
+    cy.get('[data-testid="additional-information-text-area"]').should('have.text', additionalInformation)
+  }
+
   shouldContainInstructions() {
     cy.get('[data-testid="instructions-paragraph"]').should(
       'have.text',
@@ -40,9 +44,8 @@ export default class NewReferralAdditionalInformationPage extends Page {
     this.shouldContainButton('Save and continue')
   }
 
-  submitAdditionalInformation() {
-    const additionalInformation = 'Wheat gluten makes great fake chicken'
-    cy.get('[data-testid="additional-information-text-area"]').type(additionalInformation)
+  submitAdditionalInformation(additionalInformation = 'Wheat gluten makes great fake chicken') {
+    cy.get('[data-testid="additional-information-text-area"]').type(additionalInformation, { delay: 0 })
     this.referral = { ...this.referral, additionalInformation }
     // We're stubbing the referral here to make sure the updated referral is available on the task list page
     cy.task('stubReferral', this.referral)

--- a/server/controllers/refer/new/additionalInformationController.test.ts
+++ b/server/controllers/refer/new/additionalInformationController.test.ts
@@ -67,6 +67,7 @@ describe('NewReferralsAdditionalInformationController', () => {
 
       expect(referralService.getReferral).toHaveBeenCalledWith(username, referralId)
       expect(response.render).toHaveBeenCalledWith('referrals/new/additionalInformation/show', {
+        maxLength: 4000,
         pageHeading: 'Add additional information',
         person,
         referral: draftReferral,
@@ -189,6 +190,27 @@ describe('NewReferralsAdditionalInformationController', () => {
         expect(referralService.getReferral).toHaveBeenCalledWith(username, referralId)
         expect(response.redirect).toHaveBeenCalledWith(referPaths.new.additionalInformation.show({ referralId }))
         expect(request.flash).toHaveBeenCalledWith('additionalInformationError', 'Enter additional information')
+      })
+    })
+
+    describe('when `additionalInformation` is too long', () => {
+      it('redirects to the additional information show action with an error', async () => {
+        const longAdditionalInformation = 'a'.repeat(4001)
+
+        referralService.getReferral.mockResolvedValue(draftReferral)
+        request.body = { additionalInformation: longAdditionalInformation }
+
+        const requestHandler = controller.update()
+        await requestHandler(request, response, next)
+
+        expect(request.flash).toHaveBeenCalledWith(
+          'additionalInformationError',
+          'Additional information must be 4000 characters or fewer',
+        )
+        expect(request.flash).toHaveBeenCalledWith('formValues', [
+          JSON.stringify({ formattedAdditionalInformation: longAdditionalInformation }),
+        ])
+        expect(response.redirect).toHaveBeenCalledWith(referPaths.new.additionalInformation.show({ referralId }))
       })
     })
   })

--- a/server/views/referrals/new/additionalInformation/show.njk
+++ b/server/views/referrals/new/additionalInformation/show.njk
@@ -1,8 +1,8 @@
 {% from "govuk/components/back-link/macro.njk" import govukBackLink %}
 {% from "govuk/components/button/macro.njk" import govukButton %}
+{% from "govuk/components/character-count/macro.njk" import govukCharacterCount %}
 {% from "govuk/components/details/macro.njk" import govukDetails %}
 {% from "govuk/components/error-summary/macro.njk" import govukErrorSummary %}
-{% from "govuk/components/textarea/macro.njk" import govukTextarea %}
 {% from "govuk/components/warning-text/macro.njk" import govukWarningText %}
 
 {% extends "../../../partials/layout.njk" %}
@@ -50,17 +50,18 @@
       <form action="{{ referPaths.new.additionalInformation.update({ referralId: referral.id }) }}?_method=PUT" method="post">
         <input type="hidden" name="_csrf" value="{{ csrfToken }}"/>
 
-        {{ govukTextarea({
-          name: "additionalInformation",
+        {{ govukCharacterCount({
           id: "additionalInformation",
+          name: "additionalInformation",
+          maxlength: maxLength,
           label: {
             text: "Provide additional information",
             classes: "govuk-fieldset__legend--s"
           },
-          value: referral.additionalInformation,
           attributes: {
             "data-testid": "additional-information-text-area"
           },
+          value: formValues.formattedAdditionalInformation or referral.additionalInformation,
           errorMessage: errors.messages.additionalInformation
         }) }}
 


### PR DESCRIPTION
## Context

The ‘Add Additional Information’ screen needs a character limit on the free text box. What should the character limit be? (suggest 4000) and error text if you go over 4000.

## Changes in this PR
Replace govuk text area with govuk character count and apply limit of 4000 characters.
Unit and integration tests updated and added to.


## Screenshots of UI changes
![image](https://github.com/ministryofjustice/hmpps-accredited-programmes-ui/assets/1067537/afd2cc6d-2de1-4633-8a66-0e56d41b773a)



## Release checklist

[Release process documentation](../doc/how-to/perform-a-release.md)

As part of our continuous deployment strategy we must ensure that this work is
ready to be released once merged.

### Pre-merge

- [ ] There are changes required to the Accredited Programmes API for this change to work...
  - [ ] ... and they have been released to production already

### Post-merge

<!-- The outer checkboxes can be completed pre-merge -->

- [ ] This adds, extends or meaningfully modifies a feature...
  - [ ] ... and I have written or updated an end-to-end test for the happy path in the [Accredited Programmes E2E repo](https://github.com/ministryofjustice/hmpps-accredited-programmes-e2e)
- [ ] This makes new expectations of the API...
  - [ ] ... and I have notified the API developer(s) of changes to the contract tests (Pact), or the API is already compliant
- [ ] [Manually approve](../doc/how-to/perform-a-release.md#releasing-to-the-preprod-environment) release to preprod
- [ ] [Manually approve](../doc/how-to/perform-a-release.md#releasing-to-the-production-environment) release to prod

<!-- Should a release fail at any step, you as the author should now lead the work to
fix it as soon as possible. You can monitor deployment failures in CircleCI
itself and application errors are found in
[Sentry](https://ministryofjustice.sentry.io/projects/hmpps-accredited-programmes-ui/?project=4505330122686464&referrer=sidebar&statsPeriod=24h). -->
