### PR TITLE
(BUG) Allow referrals to be viewed when person in prison is not in users caseloads

### DIFF
--- a/server/controllers/assess/updateStatusDecisionController.test.ts
+++ b/server/controllers/assess/updateStatusDecisionController.test.ts
@@ -123,11 +123,7 @@ describe('UpdateStatusDecisionController', () => {
         ptUser: true,
       })
       expect(referralService.getConfirmationText).not.toHaveBeenCalled()
-      expect(personService.getPerson).toHaveBeenCalledWith(
-        username,
-        referral.prisonNumber,
-        response.locals.user.caseloads,
-      )
+      expect(personService.getPerson).toHaveBeenCalledWith(username, referral.prisonNumber)
     })
 
     describe('when the available status transitions have a `deselectAndKeepOpen` property', () => {

--- a/server/controllers/assess/updateStatusDecisionController.ts
+++ b/server/controllers/assess/updateStatusDecisionController.ts
@@ -45,7 +45,7 @@ export default class UpdateStatusDecisionController {
             },
       ])
 
-      const person = await this.personService.getPerson(username, referral.prisonNumber, res.locals.user.caseloads)
+      const person = await this.personService.getPerson(username, referral.prisonNumber)
 
       const statusTransitions = statusTransitionsForReferral.map(statusTransition => {
         if (statusTransition.deselectAndKeepOpen) {

--- a/server/controllers/shared/categoryController.test.ts
+++ b/server/controllers/shared/categoryController.test.ts
@@ -111,11 +111,7 @@ describe('CategoryController', () => {
       expect(referenceDataService.getReferralStatusCodeCategories).toHaveBeenCalledWith(username, 'DESELECTED')
       expect(referralService.getReferral).toHaveBeenCalledWith(username, referral.id)
       expect(referralService.getReferralStatusHistory).toHaveBeenCalledWith(userToken, username, referral.id)
-      expect(personService.getPerson).toHaveBeenCalledWith(
-        username,
-        referral.prisonNumber,
-        response.locals.user.caseloads,
-      )
+      expect(personService.getPerson).toHaveBeenCalledWith(username, referral.prisonNumber)
 
       expect(FormUtils.setFieldErrors).toHaveBeenCalledWith(request, response, ['categoryCode'])
       expect(ReferralUtils.statusOptionsToRadioItems).toHaveBeenCalledWith(referralStatusCodeCategories, undefined)
@@ -146,11 +142,7 @@ describe('CategoryController', () => {
         expect(referenceDataService.getReferralStatusCodeCategories).toHaveBeenCalledWith(username, 'DESELECTED')
         expect(referralService.getReferral).toHaveBeenCalledWith(username, referral.id)
         expect(referralService.getReferralStatusHistory).toHaveBeenCalledWith(userToken, username, referral.id)
-        expect(personService.getPerson).toHaveBeenCalledWith(
-          username,
-          referral.prisonNumber,
-          response.locals.user.caseloads,
-        )
+        expect(personService.getPerson).toHaveBeenCalledWith(username, referral.prisonNumber)
 
         expect(FormUtils.setFieldErrors).toHaveBeenCalledWith(request, response, ['categoryCode'])
         expect(ReferralUtils.statusOptionsToRadioItems).toHaveBeenCalledWith(referralStatusCodeCategories, undefined)
@@ -198,11 +190,7 @@ describe('CategoryController', () => {
         expect(referenceDataService.getReferralStatusCodeCategories).toHaveBeenCalledWith(username, 'WITHDRAWN')
         expect(referralService.getReferral).toHaveBeenCalledWith(username, referral.id)
         expect(referralService.getReferralStatusHistory).toHaveBeenCalledWith(userToken, username, referral.id)
-        expect(personService.getPerson).toHaveBeenCalledWith(
-          username,
-          referral.prisonNumber,
-          response.locals.user.caseloads,
-        )
+        expect(personService.getPerson).toHaveBeenCalledWith(username, referral.prisonNumber)
 
         expect(FormUtils.setFieldErrors).toHaveBeenCalledWith(request, response, ['categoryCode'])
         expect(ReferralUtils.statusOptionsToRadioItems).toHaveBeenCalledWith(referralStatusCodeCategories, undefined)

--- a/server/controllers/shared/categoryController.ts
+++ b/server/controllers/shared/categoryController.ts
@@ -65,7 +65,7 @@ export default class CategoryController {
         this.referenceDataService.getReferralStatusCodeCategories(username, decisionForCategoryAndReason),
       ])
 
-      const person = await this.personService.getPerson(username, referral.prisonNumber, res.locals.user.caseloads)
+      const person = await this.personService.getPerson(username, referral.prisonNumber)
 
       const radioItems = ReferralUtils.statusOptionsToRadioItems(
         categories,

--- a/server/controllers/shared/reasonController.test.ts
+++ b/server/controllers/shared/reasonController.test.ts
@@ -122,11 +122,7 @@ describe('ReasonController', () => {
       )
       expect(referralService.getReferral).toHaveBeenCalledWith(username, referral.id)
       expect(referralService.getReferralStatusHistory).toHaveBeenCalledWith(userToken, username, referral.id)
-      expect(personService.getPerson).toHaveBeenCalledWith(
-        username,
-        referral.prisonNumber,
-        response.locals.user.caseloads,
-      )
+      expect(personService.getPerson).toHaveBeenCalledWith(username, referral.prisonNumber)
 
       expect(FormUtils.setFieldErrors).toHaveBeenCalledWith(request, response, ['reasonCode'])
       expect(ReferralUtils.statusOptionsToRadioItems).toHaveBeenCalledWith(referralStatusCodeReasons, undefined)

--- a/server/controllers/shared/reasonController.ts
+++ b/server/controllers/shared/reasonController.ts
@@ -71,7 +71,7 @@ export default class ReasonController {
         ),
       ])
 
-      const person = await this.personService.getPerson(username, referral.prisonNumber, res.locals.user.caseloads)
+      const person = await this.personService.getPerson(username, referral.prisonNumber)
 
       if (reasons.length === 0) {
         req.session.referralStatusUpdateData = {

--- a/server/controllers/shared/referralsController.test.ts
+++ b/server/controllers/shared/referralsController.test.ts
@@ -406,7 +406,7 @@ describe('ReferralsController', () => {
     })
     expect(courseService.getCourseByOffering).toHaveBeenCalledWith(username, referral.offeringId)
     expect(courseService.getOffering).toHaveBeenCalledWith(username, referral.offeringId)
-    expect(personService.getPerson).toHaveBeenCalledWith(username, person.prisonNumber, response.locals.user.caseloads)
+    expect(personService.getPerson).toHaveBeenCalledWith(username, person.prisonNumber)
     expect(organisationService.getOrganisation).toHaveBeenCalledWith(userToken, organisation.id)
     expect(mockShowReferralUtils.buttons).toHaveBeenCalledWith(path, referral, isRefer ? statusTransitions : undefined)
 

--- a/server/controllers/shared/referralsController.ts
+++ b/server/controllers/shared/referralsController.ts
@@ -157,7 +157,7 @@ export default class ReferralsController {
       await Promise.all([
         this.courseService.getCourseByOffering(username, referral.offeringId),
         this.courseService.getOffering(username, referral.offeringId),
-        this.personService.getPerson(username, referral.prisonNumber, res.locals.user.caseloads),
+        this.personService.getPerson(username, referral.prisonNumber),
         this.userService.getFullNameFromUsername(userToken, referral.referrerUsername),
         this.userService.getEmailFromUsername(userToken, referral.referrerUsername),
         isRefer ? this.referralService.getStatusTransitions(username, referral.id) : undefined,

--- a/server/controllers/shared/risksAndNeedsController.test.ts
+++ b/server/controllers/shared/risksAndNeedsController.test.ts
@@ -783,7 +783,7 @@ describe('RisksAndNeedsController', () => {
 
     expect(referralService.getReferral).toHaveBeenCalledWith(username, referral.id)
     expect(courseService.getCourseByOffering).toHaveBeenCalledWith(username, referral.offeringId)
-    expect(personService.getPerson).toHaveBeenCalledWith(username, person.prisonNumber, response.locals.user.caseloads)
+    expect(personService.getPerson).toHaveBeenCalledWith(username, person.prisonNumber)
     expect(mockShowReferralUtils.buttons).toHaveBeenCalledWith(path, referral, isRefer ? statusTransitions : undefined)
 
     if (isRefer) {

--- a/server/controllers/shared/risksAndNeedsController.ts
+++ b/server/controllers/shared/risksAndNeedsController.ts
@@ -360,7 +360,7 @@ export default class RisksAndNeedsController {
 
     const [course, person, statusTransitions] = await Promise.all([
       this.courseService.getCourseByOffering(username, referral.offeringId),
-      this.personService.getPerson(username, referral.prisonNumber, res.locals.user.caseloads),
+      this.personService.getPerson(username, referral.prisonNumber),
       isRefer ? this.referralService.getStatusTransitions(username, referral.id) : undefined,
     ])
 

--- a/server/controllers/shared/statusHistoryController.test.ts
+++ b/server/controllers/shared/statusHistoryController.test.ts
@@ -105,11 +105,7 @@ describe('StatusHistoryController', () => {
       expect(courseService.getCourseByOffering).toHaveBeenCalledWith(username, referral.offeringId)
       expect(referralService.getReferralStatusHistory).toHaveBeenCalledWith(userToken, username, referral.id)
       expect(referralService.getStatusTransitions).toHaveBeenCalledWith(username, referral.id)
-      expect(personService.getPerson).toHaveBeenCalledWith(
-        username,
-        referral.prisonNumber,
-        response.locals.user.caseloads,
-      )
+      expect(personService.getPerson).toHaveBeenCalledWith(username, referral.prisonNumber)
       expect(mockShowReferralUtils.subNavigationItems).toHaveBeenCalledWith(
         `/refer/referrals/${referral.id}/status-history`,
         'statusHistory',

--- a/server/controllers/shared/statusHistoryController.ts
+++ b/server/controllers/shared/statusHistoryController.ts
@@ -27,7 +27,7 @@ export default class StatusHistoryController {
       const [course, statusHistory, person, statusTransitions] = await Promise.all([
         this.courseService.getCourseByOffering(username, referral.offeringId),
         this.referralService.getReferralStatusHistory(userToken, username, referralId),
-        this.personService.getPerson(username, referral.prisonNumber, res.locals.user.caseloads),
+        this.personService.getPerson(username, referral.prisonNumber),
         isRefer ? this.referralService.getStatusTransitions(username, referral.id) : undefined,
       ])
 

--- a/server/controllers/shared/updateStatusSelectionController.test.ts
+++ b/server/controllers/shared/updateStatusSelectionController.test.ts
@@ -106,11 +106,7 @@ describe('UpdateStatusSelectionController', () => {
         deselectAndKeepOpen: false,
         ptUser: true,
       })
-      expect(personService.getPerson).toHaveBeenCalledWith(
-        username,
-        referral.prisonNumber,
-        response.locals.user.caseloads,
-      )
+      expect(personService.getPerson).toHaveBeenCalledWith(username, referral.prisonNumber)
       expect(FormUtils.setFieldErrors).toHaveBeenCalledWith(request, response, ['confirmation'])
     })
 

--- a/server/controllers/shared/updateStatusSelectionController.ts
+++ b/server/controllers/shared/updateStatusSelectionController.ts
@@ -36,7 +36,7 @@ export default class UpdateStatusSelectionController {
         }),
       ])
 
-      const person = await this.personService.getPerson(username, referral.prisonNumber, res.locals.user.caseloads)
+      const person = await this.personService.getPerson(username, referral.prisonNumber)
 
       const { hasConfirmation } = confirmationText
 

--- a/server/data/accreditedProgrammesApi/personClient.ts
+++ b/server/data/accreditedProgrammesApi/personClient.ts
@@ -16,7 +16,7 @@ export default class PersonClient {
 
   async findPrisoner(
     prisonNumber: Prisoner['prisonerNumber'],
-    caseloadIds: Array<Caseload['caseLoadId']>,
+    caseloadIds?: Array<Caseload['caseLoadId']>,
   ): Promise<Prisoner | null> {
     const prisoners: Array<Prisoner> = (await this.restClient.post({
       data: {

--- a/server/services/personService.test.ts
+++ b/server/services/personService.test.ts
@@ -193,10 +193,10 @@ describe('PersonService', () => {
   })
 
   describe('getPerson', () => {
+    const prisoner = prisonerFactory.build()
+
     describe('when the prisoner client finds the corresponding prisoner', () => {
       it('converts the returned object to a Person', async () => {
-        const prisoner = prisonerFactory.build()
-
         const person = personFactory.build()
 
         personClient.findPrisoner.mockResolvedValue(prisoner)
@@ -255,6 +255,20 @@ describe('PersonService', () => {
           mdiCaseload.caseLoadId,
           bxiCaseload.caseLoadId,
         ])
+      })
+    })
+
+    describe('when `caseloads` are not provided', () => {
+      it('should call `personClient.findPrisoner` with `undefined` `caseLoadIds`', async () => {
+        personClient.findPrisoner.mockResolvedValue(prisoner)
+        const prisonNumber = prisoner.prisonerNumber
+
+        await service.getPerson(username, prisonNumber)
+
+        expect(hmppsAuthClientBuilder).toHaveBeenCalled()
+        expect(hmppsAuthClient.getSystemClientToken).toHaveBeenCalledWith(username)
+        expect(personClientBuilder).toHaveBeenCalledWith(systemToken)
+        expect(personClient.findPrisoner).toHaveBeenCalledWith(prisonNumber, undefined)
       })
     })
   })

--- a/server/services/personService.ts
+++ b/server/services/personService.ts
@@ -114,13 +114,13 @@ export default class PersonService {
   async getPerson(
     username: Express.User['username'],
     prisonNumber: Person['prisonNumber'],
-    caseloads: Array<Caseload>,
+    caseloads?: Array<Caseload>,
   ): Promise<Person> {
     const hmppsAuthClient = this.hmppsAuthClientBuilder()
     const systemToken = await hmppsAuthClient.getSystemClientToken(username)
     const personClient = this.personClientBuilder(systemToken)
 
-    const caseloadIds = caseloads.map(caseload => caseload.caseLoadId)
+    const caseloadIds = caseloads?.map(caseload => caseload.caseLoadId)
 
     try {
       const prisoner = await personClient.findPrisoner(prisonNumber, caseloadIds)


### PR DESCRIPTION
## Context

If a referral was made to a programme in a users caseload, but the person being referred was in another caseload which the user did not have, then the referral would 404.

## Changes in this PR
On referral view related pages, we should now search for a person in prison by their ID but not specify any caseloads so it doesn't restrict the search.




## Release checklist

[Release process documentation](../doc/how-to/perform-a-release.md)

As part of our continuous deployment strategy we must ensure that this work is
ready to be released once merged.

### Pre-merge

- [ ] There are changes required to the Accredited Programmes API for this change to work...
  - [ ] ... and they have been released to production already

### Post-merge

<!-- The outer checkboxes can be completed pre-merge -->

- [ ] This adds, extends or meaningfully modifies a feature...
  - [ ] ... and I have written or updated an end-to-end test for the happy path in the [Accredited Programmes E2E repo](https://github.com/ministryofjustice/hmpps-accredited-programmes-e2e)
- [ ] This makes new expectations of the API...
  - [ ] ... and I have notified the API developer(s) of changes to the contract tests (Pact), or the API is already compliant
- [ ] [Manually approve](../doc/how-to/perform-a-release.md#releasing-to-the-preprod-environment) release to preprod
- [ ] [Manually approve](../doc/how-to/perform-a-release.md#releasing-to-the-production-environment) release to prod

<!-- Should a release fail at any step, you as the author should now lead the work to
fix it as soon as possible. You can monitor deployment failures in CircleCI
itself and application errors are found in
[Sentry](https://ministryofjustice.sentry.io/projects/hmpps-accredited-programmes-ui/?project=4505330122686464&referrer=sidebar&statsPeriod=24h). -->
