### PR TITLE
(APG-111) Allow referrals to still be viewable if user no longer has caseload of PiP

### DIFF
--- a/server/controllers/refer/new/additionalInformationController.test.ts
+++ b/server/controllers/refer/new/additionalInformationController.test.ts
@@ -73,6 +73,7 @@ describe('NewReferralsAdditionalInformationController', () => {
         referral: draftReferral,
       })
       expect(FormUtils.setFieldErrors).toHaveBeenCalledWith(request, response, ['additionalInformation'])
+      expect(personService.getPerson).toHaveBeenCalledWith(username, draftReferral.prisonNumber)
     })
 
     describe('when the referral has been submitted', () => {

--- a/server/controllers/refer/new/additionalInformationController.ts
+++ b/server/controllers/refer/new/additionalInformationController.ts
@@ -29,11 +29,7 @@ export default class NewReferralsAdditionalInformationController {
         return res.redirect(authPaths.error({}))
       }
 
-      const person = await this.personService.getPerson(
-        req.user.username,
-        referral.prisonNumber,
-        res.locals.user.caseloads,
-      )
+      const person = await this.personService.getPerson(req.user.username, referral.prisonNumber)
 
       FormUtils.setFieldErrors(req, res, ['additionalInformation'])
       FormUtils.setFormValues(req, res)

--- a/server/controllers/refer/new/courseParticipationDetailsController.test.ts
+++ b/server/controllers/refer/new/courseParticipationDetailsController.test.ts
@@ -82,6 +82,7 @@ describe('NewReferralsCourseParticipationDetailsController', () => {
         person,
         referralId,
       })
+      expect(personService.getPerson).toHaveBeenCalledWith(username, draftReferral.prisonNumber)
       expect(FormUtils.setFieldErrors).toHaveBeenCalledWith(request, response, ['yearCompleted', 'yearStarted'])
       expect(FormUtils.setFormValues).toHaveBeenCalledWith(request, response, {
         detail: courseParticipation.detail,

--- a/server/controllers/refer/new/courseParticipationDetailsController.ts
+++ b/server/controllers/refer/new/courseParticipationDetailsController.ts
@@ -27,11 +27,7 @@ export default class NewReferralsCourseParticipationDetailsController {
         courseParticipationId,
       )
 
-      const person = await this.personService.getPerson(
-        req.user.username,
-        referral.prisonNumber,
-        res.locals.user.caseloads,
-      )
+      const person = await this.personService.getPerson(req.user.username, referral.prisonNumber)
 
       FormUtils.setFieldErrors(req, res, ['yearCompleted', 'yearStarted'])
       FormUtils.setFormValues(req, res, {

--- a/server/controllers/refer/new/courseParticipationsController.test.ts
+++ b/server/controllers/refer/new/courseParticipationsController.test.ts
@@ -195,6 +195,7 @@ describe('NewReferralsCourseParticipationsController', () => {
           remove: false,
         },
       )
+      expect(personService.getPerson).toHaveBeenCalledWith(username, draftReferral.prisonNumber)
       expect(response.render).toHaveBeenCalledWith('referrals/new/courseParticipations/delete', {
         action: `${referPaths.new.programmeHistory.destroy({ courseParticipationId, referralId })}?_method=DELETE`,
         pageHeading: 'Remove programme',
@@ -281,6 +282,7 @@ describe('NewReferralsCourseParticipationsController', () => {
           const isKnownCourse = courseNameType === 'a known'
 
           expect(referralService.getReferral).toHaveBeenCalledWith(username, referralId)
+          expect(personService.getPerson).toHaveBeenCalledWith(username, draftReferral.prisonNumber)
           expect(response.render).toHaveBeenCalledWith('referrals/new/courseParticipations/course', {
             action: `${referPaths.new.programmeHistory.updateProgramme({
               courseParticipationId: courseParticipation.id,
@@ -327,6 +329,7 @@ describe('NewReferralsCourseParticipationsController', () => {
       await requestHandler(request, response, next)
 
       expect(referralService.getReferral).toHaveBeenCalledWith(username, referralId)
+      expect(personService.getPerson).toHaveBeenCalledWith(username, draftReferral.prisonNumber)
       expect(courseService.getAndPresentParticipationsByPerson).toHaveBeenCalledWith(
         username,
         userToken,
@@ -422,6 +425,7 @@ describe('NewReferralsCourseParticipationsController', () => {
       await requestHandler(request, response, next)
 
       expect(referralService.getReferral).toHaveBeenCalledWith(username, referralId)
+      expect(personService.getPerson).toHaveBeenCalledWith(username, draftReferral.prisonNumber)
       expect(response.render).toHaveBeenCalledWith('referrals/new/courseParticipations/course', {
         action: referPaths.new.programmeHistory.create({ referralId }),
         courseRadioOptions: CourseUtils.courseRadioOptions(courseNames),

--- a/server/controllers/refer/new/courseParticipationsController.ts
+++ b/server/controllers/refer/new/courseParticipationsController.ts
@@ -70,11 +70,7 @@ export default class NewReferralsCourseParticipationsController {
         referralId,
         { change: false, remove: false },
       )
-      const person = await this.personService.getPerson(
-        req.user.username,
-        referral.prisonNumber,
-        res.locals.user.caseloads,
-      )
+      const person = await this.personService.getPerson(req.user.username, referral.prisonNumber)
 
       return res.render('referrals/new/courseParticipations/delete', {
         action: `${referPaths.new.programmeHistory.destroy({ courseParticipationId, referralId })}?_method=DELETE`,
@@ -123,11 +119,7 @@ export default class NewReferralsCourseParticipationsController {
       }
 
       const courseParticipation = await this.courseService.getParticipation(req.user.username, courseParticipationId)
-      const person = await this.personService.getPerson(
-        req.user.username,
-        referral.prisonNumber,
-        res.locals.user.caseloads,
-      )
+      const person = await this.personService.getPerson(req.user.username, referral.prisonNumber)
       const courseNames = await this.courseService.getCourseNames(req.user.username)
 
       FormUtils.setFieldErrors(req, res, ['courseName', 'otherCourseName'])
@@ -161,11 +153,7 @@ export default class NewReferralsCourseParticipationsController {
         return res.redirect(referPaths.new.complete({ referralId }))
       }
 
-      const person = await this.personService.getPerson(
-        req.user.username,
-        referral.prisonNumber,
-        res.locals.user.caseloads,
-      )
+      const person = await this.personService.getPerson(req.user.username, referral.prisonNumber)
 
       const summaryListsOptions = await this.courseService.getAndPresentParticipationsByPerson(
         req.user.username,
@@ -204,11 +192,7 @@ export default class NewReferralsCourseParticipationsController {
       }
 
       const courseNames = await this.courseService.getCourseNames(req.user.username)
-      const person = await this.personService.getPerson(
-        req.user.username,
-        referral.prisonNumber,
-        res.locals.user.caseloads,
-      )
+      const person = await this.personService.getPerson(req.user.username, referral.prisonNumber)
 
       FormUtils.setFieldErrors(req, res, ['courseName', 'otherCourseName'])
 

--- a/server/controllers/refer/new/oasysConfirmationController.test.ts
+++ b/server/controllers/refer/new/oasysConfirmationController.test.ts
@@ -65,6 +65,7 @@ describe('NewReferralsOasysConfirmationController', () => {
       await requestHandler(request, response, next)
 
       expect(referralService.getReferral).toHaveBeenCalledWith(username, referralId)
+      expect(personService.getPerson).toHaveBeenCalledWith(username, draftReferral.prisonNumber)
       expect(response.render).toHaveBeenCalledWith('referrals/new/oasysConfirmation/show', {
         pageHeading: 'Confirm the OASys information',
         person,

--- a/server/controllers/refer/new/oasysConfirmationController.ts
+++ b/server/controllers/refer/new/oasysConfirmationController.ts
@@ -27,11 +27,7 @@ export default class NewReferralsOasysConfirmationController {
         return res.redirect(authPaths.error({}))
       }
 
-      const person = await this.personService.getPerson(
-        req.user.username,
-        referral.prisonNumber,
-        res.locals.user.caseloads,
-      )
+      const person = await this.personService.getPerson(req.user.username, referral.prisonNumber)
 
       FormUtils.setFieldErrors(req, res, ['oasysConfirmed'])
 

--- a/server/controllers/refer/new/referralsController.test.ts
+++ b/server/controllers/refer/new/referralsController.test.ts
@@ -204,6 +204,7 @@ describe('NewReferralsController', () => {
       ;(CourseUtils.presentCourse as jest.Mock).mockReturnValue(coursePresenter)
 
       expect(referralService.getReferral).toHaveBeenCalledWith(username, referralId, { updatePerson: undefined })
+      expect(personService.getPerson).toHaveBeenCalledWith(username, draftReferral.prisonNumber)
       expect(request.session.returnTo).toBeUndefined()
       expect(response.render).toHaveBeenCalledWith('referrals/new/show', {
         course: coursePresenter,
@@ -272,6 +273,7 @@ describe('NewReferralsController', () => {
       await requestHandler(request, response, next)
 
       expect(referralService.getReferral).toHaveBeenCalledWith(username, referralId)
+      expect(personService.getPerson).toHaveBeenCalledWith(username, draftReferral.prisonNumber)
       expect(response.render).toHaveBeenCalledWith('referrals/new/showPerson', {
         pageHeading: "Del Hatton's details",
         person,
@@ -360,6 +362,7 @@ describe('NewReferralsController', () => {
       await requestHandler(request, response, next)
 
       expect(referralService.getReferral).toHaveBeenCalledWith(username, referralId)
+      expect(personService.getPerson).toHaveBeenCalledWith(username, submittableReferral.prisonNumber)
       expect(userService.getFullNameFromUsername).toHaveBeenCalledWith(userToken, submittableReferral.referrerUsername)
       expect(FormUtils.setFieldErrors).toHaveBeenCalledWith(request, response, ['confirmation'])
       expect(courseService.getAndPresentParticipationsByPerson).toHaveBeenCalledWith(

--- a/server/controllers/refer/new/referralsController.ts
+++ b/server/controllers/refer/new/referralsController.ts
@@ -36,7 +36,7 @@ export default class NewReferralsController {
       }
 
       const [person, courseOffering, course, referrerName, referrerEmail] = await Promise.all([
-        this.personService.getPerson(req.user.username, referral.prisonNumber, res.locals.user.caseloads),
+        this.personService.getPerson(req.user.username, referral.prisonNumber),
         this.courseService.getOffering(req.user.token, referral.offeringId),
         this.courseService.getCourseByOffering(req.user.token, referral.offeringId),
         this.userService.getFullNameFromUsername(req.user.token, referral.referrerUsername),
@@ -162,11 +162,7 @@ export default class NewReferralsController {
       const course = await this.courseService.getCourseByOffering(req.user.token, referral.offeringId)
       const courseOffering = await this.courseService.getOffering(req.user.token, referral.offeringId)
       const organisation = await this.organisationService.getOrganisation(req.user.token, courseOffering.organisationId)
-      const person = await this.personService.getPerson(
-        req.user.username,
-        referral.prisonNumber,
-        res.locals.user.caseloads,
-      )
+      const person = await this.personService.getPerson(req.user.username, referral.prisonNumber)
       const coursePresenter = CourseUtils.presentCourse(course)
 
       delete req.session.returnTo
@@ -197,11 +193,7 @@ export default class NewReferralsController {
         return res.redirect(authPaths.error({}))
       }
 
-      const person = await this.personService.getPerson(
-        req.user.username,
-        referral.prisonNumber,
-        res.locals.user.caseloads,
-      )
+      const person = await this.personService.getPerson(req.user.username, referral.prisonNumber)
 
       return res.render('referrals/new/showPerson', {
         pageHeading: `${person.name}'s details`,


### PR DESCRIPTION
## Context

If a user has raised a referral and then no longer has that caseload associated with their account, they would no longer be able to view that particular referral.

## Changes in this PR
Call `PersonService.getPerson` with no caseloads specified so the prisoner details can be retrieved from the prisoner-search endpoint, so the referral can still be viewed.



## Release checklist

[Release process documentation](../doc/how-to/perform-a-release.md)

As part of our continuous deployment strategy we must ensure that this work is
ready to be released once merged.

### Pre-merge

- [ ] There are changes required to the Accredited Programmes API for this change to work...
  - [ ] ... and they have been released to production already

### Post-merge

<!-- The outer checkboxes can be completed pre-merge -->

- [ ] This adds, extends or meaningfully modifies a feature...
  - [ ] ... and I have written or updated an end-to-end test for the happy path in the [Accredited Programmes E2E repo](https://github.com/ministryofjustice/hmpps-accredited-programmes-e2e)
- [ ] This makes new expectations of the API...
  - [ ] ... and I have notified the API developer(s) of changes to the contract tests (Pact), or the API is already compliant
- [ ] [Manually approve](../doc/how-to/perform-a-release.md#releasing-to-the-preprod-environment) release to preprod
- [ ] [Manually approve](../doc/how-to/perform-a-release.md#releasing-to-the-production-environment) release to prod

<!-- Should a release fail at any step, you as the author should now lead the work to
fix it as soon as possible. You can monitor deployment failures in CircleCI
itself and application errors are found in
[Sentry](https://ministryofjustice.sentry.io/projects/hmpps-accredited-programmes-ui/?project=4505330122686464&referrer=sidebar&statsPeriod=24h). -->
