### PR TITLE
(APG-109) Use Key dates for Release dates section

### DIFF
--- a/integration_tests/pages/shared/showReferral/sentenceInformation.ts
+++ b/integration_tests/pages/shared/showReferral/sentenceInformation.ts
@@ -42,7 +42,7 @@ export default class SentenceInformationPage extends Page {
       this.shouldContainSummaryCard(
         'Release dates',
         [],
-        PersonUtils.releaseDatesSummaryListRows(this.person),
+        PersonUtils.releaseDatesSummaryListRows(this.sentenceDetails.keyDates),
         summaryCardElement,
       )
     })

--- a/server/@types/models/Person.ts
+++ b/server/@types/models/Person.ts
@@ -18,8 +18,12 @@ interface Person {
 }
 
 interface KeyDates {
+  code: string
+  type: string
   date?: string
-  type?: string
+  description?: string
+  earliestReleaseDate?: boolean
+  order?: number
 }
 interface Sentence {
   description?: string
@@ -30,4 +34,4 @@ interface SentenceDetails {
   sentences?: Array<Sentence>
 }
 
-export type { Person, SentenceDetails }
+export type { KeyDates, Person, SentenceDetails }

--- a/server/@types/models/index.d.ts
+++ b/server/@types/models/index.d.ts
@@ -17,7 +17,7 @@ import type { OffenceDetail } from './OffenceDetail'
 import type { Organisation } from './Organisation'
 import type { OrganisationAddress } from './OrganisationAddress'
 import type { Paginated } from './Paginated'
-import type { Person, SentenceDetails } from './Person'
+import type { KeyDates, Person, SentenceDetails } from './Person'
 import type { Psychiatric } from './Psychiatric'
 import type {
   ConfirmationFields,
@@ -53,6 +53,7 @@ export type {
   CoursePrerequisite,
   CreatedReferralResponse,
   Health,
+  KeyDates,
   LearningNeeds,
   Lifestyle,
   OffenceDetail,

--- a/server/controllers/shared/referralsController.ts
+++ b/server/controllers/shared/referralsController.ts
@@ -12,7 +12,6 @@ import {
   ShowReferralUtils,
   TypeUtils,
 } from '../../utils'
-import { releaseDateFields } from '../../utils/personUtils'
 import type { ReferralSharedPageData } from '@accredited-programmes/ui'
 
 export default class ReferralsController {
@@ -121,7 +120,7 @@ export default class ReferralsController {
       TypeUtils.assertHasUser(req)
 
       const sharedPageData = await this.sharedPageData(req, res)
-      const { person, referral } = sharedPageData
+      const { referral } = sharedPageData
 
       if (referral.status === 'referral_started') {
         throw createError(400, 'Referral has not been submitted.')
@@ -132,13 +131,10 @@ export default class ReferralsController {
         sharedPageData.person.prisonNumber,
       )
 
-      const hasReleaseDates: boolean = releaseDateFields.some(field => !!person[field])
-
       return res.render('referrals/show/sentenceInformation', {
         ...sharedPageData,
-        hasReleaseDates,
         importedFromText: `Imported from OASys on ${DateUtils.govukFormattedFullDateString()}.`,
-        releaseDatesSummaryListRows: hasReleaseDates ? PersonUtils.releaseDatesSummaryListRows(person) : [],
+        releaseDatesSummaryListRows: PersonUtils.releaseDatesSummaryListRows(sentenceDetails.keyDates),
         sentencesSummaryLists: SentenceInformationUtils.summaryLists(sentenceDetails),
       })
     }

--- a/server/testutils/factories/index.ts
+++ b/server/testutils/factories/index.ts
@@ -10,6 +10,7 @@ import courseParticipationOutcomeFactory from './courseParticipationOutcome'
 import coursePrerequisiteFactory from './coursePrerequisite'
 import healthFactory from './health'
 import inmateDetailFactory from './inmateDetail'
+import keyDatesFactory from './keyDates'
 import learningNeedsFactory from './learningNeeds'
 import lifestyleFactory from './lifestyle'
 import offenceDetailFactory from './offenceDetail'
@@ -49,6 +50,7 @@ export {
   coursePrerequisiteFactory,
   healthFactory,
   inmateDetailFactory,
+  keyDatesFactory,
   learningNeedsFactory,
   lifestyleFactory,
   offenceDetailFactory,

--- a/server/testutils/factories/keyDates.ts
+++ b/server/testutils/factories/keyDates.ts
@@ -1,0 +1,20 @@
+import { faker } from '@faker-js/faker'
+import { Factory } from 'fishery'
+
+import type { KeyDates } from '@accredited-programmes/models'
+
+export default Factory.define<KeyDates>(({ sequence }) => {
+  return {
+    code: faker.string.alpha({ casing: 'upper', length: 3 }),
+    date: faker.date.past().toISOString(),
+    description: faker.lorem.sentence({ max: 4, min: 2 }),
+    earliestReleaseDate: false,
+    order: sequence,
+    type: faker.helpers.arrayElement([
+      'conditionalReleaseDate',
+      'paroleEligibilityDate',
+      'sentenceExpiryDate',
+      'tariffDate',
+    ]),
+  }
+})

--- a/server/testutils/factories/sentenceDetails.ts
+++ b/server/testutils/factories/sentenceDetails.ts
@@ -1,19 +1,8 @@
 import { faker } from '@faker-js/faker'
 import { Factory } from 'fishery'
 
+import keyDatesFactory from './keyDates'
 import type { SentenceDetails } from '@accredited-programmes/models'
-
-const createKeyDates = () => {
-  return {
-    date: faker.date.past().toISOString(),
-    type: faker.helpers.arrayElement([
-      'conditionalReleaseDate',
-      'paroleEligibilityDate',
-      'sentenceExpiryDate',
-      'tariffDate',
-    ]),
-  }
-}
 
 const createSentence = () => {
   return {
@@ -25,9 +14,7 @@ const createSentence = () => {
 class SentenceDetailsFactory extends Factory<SentenceDetails> {
   withData(numberOfSentences?: number, numberOfKeyDates?: number) {
     return this.params({
-      keyDates: faker.helpers.multiple(createKeyDates, {
-        count: { max: numberOfKeyDates || 3, min: numberOfKeyDates || 1 },
-      }),
+      keyDates: keyDatesFactory.buildList(numberOfKeyDates || 3),
       sentences: faker.helpers.multiple(createSentence, {
         count: { max: numberOfSentences || 3, min: numberOfSentences || 1 },
       }),
@@ -37,7 +24,7 @@ class SentenceDetailsFactory extends Factory<SentenceDetails> {
 
 export default SentenceDetailsFactory.define(() => {
   return {
-    keyDates: faker.helpers.multiple(createKeyDates, { count: { max: 3, min: 0 } }),
+    keyDates: keyDatesFactory.buildList(3),
     sentences: faker.helpers.multiple(createSentence, { count: { max: 3, min: 0 } }),
   }
 })

--- a/server/views/referrals/show/sentenceInformation.njk
+++ b/server/views/referrals/show/sentenceInformation.njk
@@ -22,7 +22,7 @@
     {{ keylessSummaryCard("Sentence details", bodyText="There are no sentence details for this person.", testId="no-sentence-information-summary-card") }}
   {% endif %}
 
-  {% if hasReleaseDates %}
+  {% if releaseDatesSummaryListRows | length %}
     {{ govukSummaryList({
       card: {
         title: {


### PR DESCRIPTION
## Context

We need to display the release related dates returned from the AcP API, rather than Prison API on the Sentence Information page.

## Changes in this PR
Use `keyDates` from `/people/{prisonNumber}/sentences` in AcP API, sorted by earliest first and maintaining earliest release date sub label.


## Screenshots of UI changes

![image](https://github.com/ministryofjustice/hmpps-accredited-programmes-ui/assets/1067537/ad31cf89-6565-4b1a-93b9-096ce0d3e42b)



## Release checklist

[Release process documentation](../doc/how-to/perform-a-release.md)

As part of our continuous deployment strategy we must ensure that this work is
ready to be released once merged.

### Pre-merge

- [ ] There are changes required to the Accredited Programmes API for this change to work...
  - [ ] ... and they have been released to production already

### Post-merge

<!-- The outer checkboxes can be completed pre-merge -->

- [ ] This adds, extends or meaningfully modifies a feature...
  - [ ] ... and I have written or updated an end-to-end test for the happy path in the [Accredited Programmes E2E repo](https://github.com/ministryofjustice/hmpps-accredited-programmes-e2e)
- [ ] This makes new expectations of the API...
  - [ ] ... and I have notified the API developer(s) of changes to the contract tests (Pact), or the API is already compliant
- [ ] [Manually approve](../doc/how-to/perform-a-release.md#releasing-to-the-preprod-environment) release to preprod
- [ ] [Manually approve](../doc/how-to/perform-a-release.md#releasing-to-the-production-environment) release to prod

<!-- Should a release fail at any step, you as the author should now lead the work to
fix it as soon as possible. You can monitor deployment failures in CircleCI
itself and application errors are found in
[Sentry](https://ministryofjustice.sentry.io/projects/hmpps-accredited-programmes-ui/?project=4505330122686464&referrer=sidebar&statsPeriod=24h). -->
