### PR TITLE
(APG-88) Delete draft referrals

### DIFF
--- a/integration_tests/pages/page.ts
+++ b/integration_tests/pages/page.ts
@@ -261,7 +261,7 @@ export default abstract class Page {
   }): void {
     const { course, organisation } = pageWithOrganisationAndCoursePresenter
 
-    cy.get('.govuk-grid-column-two-thirds > h2:first-child').then(organisationAndCourseHeading => {
+    cy.get('[data-testid="organisation-and-course"]').then(organisationAndCourseHeading => {
       const expectedText = `${organisation.name} | ${course.displayName}`
       const { actual, expected } = Helpers.parseHtml(organisationAndCourseHeading, expectedText)
       expect(actual).to.equal(expected)

--- a/server/controllers/refer/caseListController.test.ts
+++ b/server/controllers/refer/caseListController.test.ts
@@ -40,7 +40,7 @@ describe('ReferCaseListController', () => {
   beforeEach(() => {
     controller = new ReferCaseListController(referralService)
 
-    request = createMock<Request>({ user: { username } })
+    request = createMock<Request>({ flash: jest.fn().mockReturnValue([]), user: { username } })
     response = createMock<Response>({ locals: { user: { activeCaseLoadId, username } } })
   })
 
@@ -220,6 +220,9 @@ describe('ReferCaseListController', () => {
 
     describe('when the referral status group is "draft"', () => {
       it('renders the show template with the correct response locals', async () => {
+        const draftReferralDeletedMessage = 'Draft referral deleted message'
+
+        request.flash = jest.fn().mockReturnValue([draftReferralDeletedMessage])
         request.params = { referralStatusGroup: 'draft' }
 
         when(referralService.getNumberOfTasksCompleted)
@@ -242,6 +245,7 @@ describe('ReferCaseListController', () => {
         await requestHandler(request, response, next)
 
         expect(response.render).toHaveBeenCalledWith('referrals/caseList/refer/show', {
+          draftReferralDeletedMessage,
           isMyReferralsPage: true,
           pageHeading: 'My referrals',
           pagination,

--- a/server/controllers/refer/caseListController.ts
+++ b/server/controllers/refer/caseListController.ts
@@ -79,6 +79,7 @@ export default class ReferCaseListController {
       }
 
       return res.render('referrals/caseList/refer/show', {
+        draftReferralDeletedMessage: req.flash('draftReferralDeletedMessage')[0],
         isMyReferralsPage: true,
         pageHeading: 'My referrals',
         pagination,

--- a/server/controllers/refer/new/deleteReferralController.test.ts
+++ b/server/controllers/refer/new/deleteReferralController.test.ts
@@ -1,0 +1,100 @@
+import type { DeepMocked } from '@golevelup/ts-jest'
+import { createMock } from '@golevelup/ts-jest'
+import type { NextFunction, Request, Response } from 'express'
+
+import NewReferralsDeleteController from './deleteReferralController'
+import type { PersonService, ReferralService } from '../../../services'
+import { courseOfferingFactory, personFactory, referralFactory } from '../../../testutils/factories'
+import Helpers from '../../../testutils/helpers'
+
+describe('NewReferralsDeleteController', () => {
+  const username = 'SOME_USERNAME'
+
+  let request: DeepMocked<Request>
+  let response: DeepMocked<Response>
+  const next: DeepMocked<NextFunction> = createMock<NextFunction>({})
+
+  const personService = createMock<PersonService>({})
+  const referralService = createMock<ReferralService>({})
+
+  const courseOffering = courseOfferingFactory.build()
+  const person = personFactory.build()
+  const referralId = 'A-REFERRAL-ID'
+  const draftReferral = referralFactory.started().build({
+    id: referralId, // eslint-disable-next-line sort-keys
+    additionalInformation: undefined,
+    offeringId: courseOffering.id,
+    prisonNumber: person.prisonNumber,
+    referrerUsername: username,
+  })
+  const submittedReferral = referralFactory.submitted().build({
+    id: referralId, // eslint-disable-next-line sort-keys
+    additionalInformation: undefined,
+    offeringId: courseOffering.id,
+    prisonNumber: person.prisonNumber,
+    referrerUsername: username,
+  })
+
+  let controller: NewReferralsDeleteController
+
+  beforeEach(() => {
+    request = createMock<Request>({ params: { referralId }, user: { username } })
+    response = Helpers.createMockResponseWithCaseloads()
+    controller = new NewReferralsDeleteController(personService, referralService)
+  })
+
+  afterEach(() => {
+    jest.resetAllMocks()
+  })
+
+  describe('show', () => {
+    it('renders the delete draft referral page with the correct response locals', async () => {
+      referralService.getReferral.mockResolvedValue(draftReferral)
+      personService.getPerson.mockResolvedValue(person)
+
+      const requestHandler = controller.show()
+      await requestHandler(request, response, next)
+
+      expect(referralService.getReferral).toHaveBeenCalledWith(username, referralId)
+      expect(personService.getPerson).toHaveBeenCalledWith(username, draftReferral.prisonNumber)
+      expect(response.render).toHaveBeenCalledWith('referrals/new/delete/show', {
+        action: '/refer/referrals/new/A-REFERRAL-ID/delete?_method=DELETE',
+        hrefs: { back: '/refer/referrals/new/A-REFERRAL-ID' },
+        pageHeading: 'Delete draft referral?',
+        person,
+      })
+    })
+
+    describe('when the referral has been submitted', () => {
+      it('redirects to the personal details screen of the subitted referral', async () => {
+        referralService.getReferral.mockResolvedValue(submittedReferral)
+
+        const requestHandler = controller.show()
+        await requestHandler(request, response, next)
+
+        expect(referralService.getReferral).toHaveBeenCalledWith(username, referralId)
+        expect(response.redirect).toHaveBeenCalledWith('/refer/referrals/A-REFERRAL-ID/personal-details')
+        expect(personService.getPerson).not.toHaveBeenCalled()
+      })
+    })
+  })
+
+  describe('submit', () => {
+    it('calls the referral service to delete the draft referral and redirects to the draft case list with a flash message', async () => {
+      referralService.getReferral.mockResolvedValue(draftReferral)
+      personService.getPerson.mockResolvedValue(person)
+
+      const requestHandler = controller.submit()
+      await requestHandler(request, response, next)
+
+      expect(referralService.getReferral).toHaveBeenCalledWith(username, referralId)
+      expect(personService.getPerson).toHaveBeenCalledWith(username, draftReferral.prisonNumber)
+      expect(referralService.deleteReferral).toHaveBeenCalledWith(username, referralId)
+      expect(request.flash).toHaveBeenCalledWith(
+        'draftReferralDeletedMessage',
+        `Draft referral for ${person.name} deleted.`,
+      )
+      expect(response.redirect).toHaveBeenCalledWith('/refer/referrals/case-list/draft')
+    })
+  })
+})

--- a/server/controllers/refer/new/deleteReferralController.ts
+++ b/server/controllers/refer/new/deleteReferralController.ts
@@ -1,0 +1,52 @@
+import type { Request, Response, TypedRequestHandler } from 'express'
+
+import { referPaths } from '../../../paths'
+import type { PersonService, ReferralService } from '../../../services'
+import { TypeUtils } from '../../../utils'
+
+export default class NewReferralsDeleteController {
+  constructor(
+    private readonly personService: PersonService,
+    private readonly referralService: ReferralService,
+  ) {}
+
+  show(): TypedRequestHandler<Request, Response> {
+    return async (req: Request, res: Response) => {
+      TypeUtils.assertHasUser(req)
+
+      const { referralId } = req.params
+
+      const referral = await this.referralService.getReferral(req.user.username, referralId)
+
+      if (referral.status !== 'referral_started') {
+        return res.redirect(referPaths.show.personalDetails({ referralId }))
+      }
+
+      const person = await this.personService.getPerson(req.user.username, referral.prisonNumber)
+
+      return res.render('referrals/new/delete/show', {
+        action: `${referPaths.new.delete({ referralId })}?_method=DELETE`,
+        hrefs: { back: referPaths.new.show({ referralId }) },
+        pageHeading: 'Delete draft referral?',
+        person,
+      })
+    }
+  }
+
+  submit(): TypedRequestHandler<Request, Response> {
+    return async (req: Request, res: Response) => {
+      TypeUtils.assertHasUser(req)
+
+      const { referralId } = req.params
+
+      const referral = await this.referralService.getReferral(req.user.username, referralId)
+      const person = await this.personService.getPerson(req.user.username, referral.prisonNumber)
+
+      await this.referralService.deleteReferral(req.user.username, referralId)
+
+      req.flash('draftReferralDeletedMessage', `Draft referral for ${person.name} deleted.`)
+
+      return res.redirect(referPaths.caseList.show({ referralStatusGroup: 'draft' }))
+    }
+  }
+}

--- a/server/controllers/refer/new/index.ts
+++ b/server/controllers/refer/new/index.ts
@@ -3,6 +3,7 @@
 import NewReferralsAdditionalInformationController from './additionalInformationController'
 import NewReferralsCourseParticipationDetailsController from './courseParticipationDetailsController'
 import NewReferralsCourseParticipationsController from './courseParticipationsController'
+import NewReferralsDeleteController from './deleteReferralController'
 import NewReferralsOasysConfirmationController from './oasysConfirmationController'
 import NewReferralsPeopleController from './peopleController'
 import NewReferralsController from './referralsController'
@@ -15,6 +16,10 @@ const controllers = (services: Services) => {
     services.personService,
     services.referralService,
     services.userService,
+  )
+  const newReferralsDeleteController = new NewReferralsDeleteController(
+    services.personService,
+    services.referralService,
   )
   const newReferralsPeopleController = new NewReferralsPeopleController(services.personService)
   const newReferralsAdditionalInformationController = new NewReferralsAdditionalInformationController(
@@ -41,6 +46,7 @@ const controllers = (services: Services) => {
     newReferralsController,
     newReferralsCourseParticipationDetailsController,
     newReferralsCourseParticipationsController,
+    newReferralsDeleteController,
     newReferralsOasysConfirmationController,
     newReferralsPeopleController,
   }

--- a/server/controllers/refer/new/referralsController.test.ts
+++ b/server/controllers/refer/new/referralsController.test.ts
@@ -208,6 +208,10 @@ describe('NewReferralsController', () => {
       expect(request.session.returnTo).toBeUndefined()
       expect(response.render).toHaveBeenCalledWith('referrals/new/show', {
         course: coursePresenter,
+        hrefs: {
+          delete: '/refer/referrals/new/A-REFERRAL-ID/delete',
+          draftReferrals: '/refer/referrals/case-list/draft',
+        },
         organisation,
         pageHeading: 'Make a referral',
         person,

--- a/server/controllers/refer/new/referralsController.ts
+++ b/server/controllers/refer/new/referralsController.ts
@@ -169,6 +169,10 @@ export default class NewReferralsController {
 
       return res.render('referrals/new/show', {
         course: coursePresenter,
+        hrefs: {
+          delete: referPaths.new.delete({ referralId }),
+          draftReferrals: referPaths.caseList.show({ referralStatusGroup: 'draft' }),
+        },
         organisation,
         pageHeading: 'Make a referral',
         person,

--- a/server/data/accreditedProgrammesApi/referralClient.ts
+++ b/server/data/accreditedProgrammesApi/referralClient.ts
@@ -36,6 +36,12 @@ export default class ReferralClient {
     })) as CreatedReferralResponse
   }
 
+  async deleteReferral(referralId: Referral['id']): Promise<void> {
+    await this.restClient.delete({
+      path: apiPaths.referrals.delete({ referralId }),
+    })
+  }
+
   async find(
     referralId: Referral['id'],
     query?: {

--- a/server/paths/api.ts
+++ b/server/paths/api.ts
@@ -88,6 +88,7 @@ export default {
     confirmationText: confirmationTextPath,
     create: referralsPath,
     dashboard: dashboardPath,
+    delete: referralPath,
     myDashboard: myDashboardPath,
     show: referralPath,
     statusHistory: statusHistoryPath,

--- a/server/paths/refer.ts
+++ b/server/paths/refer.ts
@@ -46,6 +46,7 @@ export default {
       update: newReferralConfirmOasysPath,
     },
     create: newReferralsPath,
+    delete: newReferralShowPath.path('delete'),
     new: offeringReferralPathBase.path('new'),
     people: {
       find: newReferralPeoplePathBase.path('search'),

--- a/server/routes/refer.ts
+++ b/server/routes/refer.ts
@@ -19,6 +19,7 @@ export default function routes(controllers: Controllers, router: Router): Router
     newReferralsCourseParticipationDetailsController,
     newReferralsCourseParticipationsController,
     newReferralsController,
+    newReferralsDeleteController,
     newReferralsPeopleController,
     newReferralsOasysConfirmationController,
     reasonController,
@@ -41,6 +42,9 @@ export default function routes(controllers: Controllers, router: Router): Router
   post(referPaths.new.create.pattern, newReferralsController.create())
   get(referPaths.new.show.pattern, newReferralsController.show())
   get(referPaths.new.showPerson.pattern, newReferralsController.showPerson())
+
+  get(referPaths.new.delete.pattern, newReferralsDeleteController.show())
+  deleteAction(referPaths.new.delete.pattern, newReferralsDeleteController.submit())
 
   get(referPaths.new.confirmOasys.show.pattern, newReferralsOasysConfirmationController.show())
   put(referPaths.new.confirmOasys.update.pattern, newReferralsOasysConfirmationController.update())

--- a/server/services/referralService.test.ts
+++ b/server/services/referralService.test.ts
@@ -69,6 +69,20 @@ describe('ReferralService', () => {
     })
   })
 
+  describe('deleteReferral', () => {
+    it('asks the client to delete a referral', async () => {
+      const referral = referralFactory.started().build()
+
+      await service.deleteReferral(username, referral.id)
+
+      expect(hmppsAuthClientBuilder).toHaveBeenCalled()
+      expect(hmppsAuthClient.getSystemClientToken).toHaveBeenCalledWith(username)
+
+      expect(referralClientBuilder).toHaveBeenCalledWith(systemToken)
+      expect(referralClient.deleteReferral).toHaveBeenCalledWith(referral.id)
+    })
+  })
+
   describe('getConfirmationText', () => {
     const referralId = 'referral-id'
     const chosenStatusCode = 'REFERRAL_SUBMITTED'

--- a/server/services/referralService.ts
+++ b/server/services/referralService.ts
@@ -36,6 +36,14 @@ export default class ReferralService {
     return referralClient.create(courseOfferingId, prisonNumber)
   }
 
+  async deleteReferral(username: Express.User['username'], referralId: Referral['id']): Promise<void> {
+    const hmppsAuthClient = this.hmppsAuthClientBuilder()
+    const systemToken = await hmppsAuthClient.getSystemClientToken(username)
+    const referralClient = this.referralClientBuilder(systemToken)
+
+    return referralClient.deleteReferral(referralId)
+  }
+
   async getConfirmationText(
     username: Express.User['username'],
     referralId: Referral['id'],

--- a/server/views/referrals/caseList/refer/show.njk
+++ b/server/views/referrals/caseList/refer/show.njk
@@ -1,3 +1,4 @@
+{% from "govuk/components/notification-banner/macro.njk" import govukNotificationBanner %}
 {% from "govuk/components/pagination/macro.njk" import govukPagination %}
 {% from "govuk/components/table/macro.njk" import govukTable %}
 {% from "moj/components/sub-navigation/macro.njk" import mojSubNavigation %}
@@ -5,6 +6,15 @@
 {% extends "../../../partials/layout.njk" %}
 
 {% block content %}
+  {% if draftReferralDeletedMessage %}
+    {{ govukNotificationBanner({
+      attributes: { "data-testid": "draft-referral-deleted-message" },
+      text: draftReferralDeletedMessage,
+      titleText: "Draft deleted",
+      type: "success"
+    }) }}
+  {% endif %}
+
   <h1 class="govuk-heading-l">{{ pageHeading }}</h1>
 
   {{ mojSubNavigation({

--- a/server/views/referrals/new/_organisationAndCourse.njk
+++ b/server/views/referrals/new/_organisationAndCourse.njk
@@ -1,3 +1,3 @@
-<h2 class="govuk-heading-m">
+<h2 class="govuk-heading-m" data-testid="organisation-and-course">
   <span class="govuk-!-font-weight-regular">{{ organisation.name }} | </span>{{ course.displayName }}
 </h2>

--- a/server/views/referrals/new/delete/show.njk
+++ b/server/views/referrals/new/delete/show.njk
@@ -1,0 +1,37 @@
+{% from "govuk/components/back-link/macro.njk" import govukBackLink %}
+{% from "govuk/components/button/macro.njk" import govukButton %}
+
+{% extends "../../../partials/layout.njk" %}
+
+{% block personBanner %}
+  {% include "../../_personBanner.njk" %}
+{% endblock personBanner %}
+
+{% block backLink %}
+  {{ govukBackLink({
+    text: "Back",
+    href: hrefs.back
+  }) }}
+{% endblock backLink %}
+
+{% block content %}
+  <div class="govuk-grid-row">
+    <div class="govuk-grid-column-two-thirds">
+      <h1 class="govuk-heading-l govuk-!-margin-bottom-2">{{ pageHeading }}</h1>
+      <p class="govuk-hint govuk-!-margin-bottom-6">This action cannot be undone.</p>
+
+      <form action="{{ action }}" method="post">
+        <input type="hidden" name="_csrf" value="{{ csrfToken }}"/>
+
+        <div class="govuk-button-group">
+          {{ govukButton({
+            text: "Delete draft",
+            classes: "govuk-button--warning"
+          }) }}
+
+          <a href={{ hrefs.back }}>Cancel</a>
+        </div>
+      </form>
+    </div>
+  </div>
+{% endblock content %}

--- a/server/views/referrals/new/people/show.njk
+++ b/server/views/referrals/new/people/show.njk
@@ -40,9 +40,11 @@
           }
         }) }}
         <a href="{{ referPaths.new.new({ courseOfferingId: courseOfferingId }) }}" class="govuk-link">
-        Enter a different identifier
-      </a>
+          Enter a different identifier
+        </a>
       </div>
+
+      <p>This will save a draft referral.</p>
     </div>
   </div>
 

--- a/server/views/referrals/new/show.njk
+++ b/server/views/referrals/new/show.njk
@@ -1,4 +1,5 @@
 {% from "govuk/components/back-link/macro.njk" import govukBackLink %}
+{% from "moj/components/page-header-actions/macro.njk" import mojPageHeaderActions %}
 
 {% from "./_taskListSection.njk" import taskListSection %}
 {% from "../../partials/audienceTag.njk" import audienceTag %}
@@ -10,10 +11,23 @@
 {% endblock personBanner %}
 
 {% block content %}
-  <h1 class="govuk-heading-l">{{ pageHeading }}</h1>
-
   <div class="govuk-grid-row">
     <div class="govuk-grid-column-two-thirds">
+      {{ mojPageHeaderActions({
+        heading: {
+          classes: "govuk-heading-l",
+          text: pageHeading
+        },
+        items: [{
+          attributes: { "data-testid": "draft-referral-delete-button" },
+          classes: 'govuk-button--secondary',
+          href: hrefs.delete,
+          text: "Delete draft referral"
+        }]
+      }) }}
+
+      <p class="govuk-!-margin-bottom-6">Changes you make will be saved. You can leave this page and return to it later in <a href="{{ hrefs.draftReferrals }}">Draft referrals</a>.</p>
+
       {% include "./_organisationAndCourse.njk" %}
 
       {{ audienceTag(course.audienceTag) }}


### PR DESCRIPTION
## Context

There is no way for users to remove draft referrals from their ‘draft referrals’ case list view. They would have to submit and then withdraw the referral to remove it.

Drafts are saved when users click continue on the person’s details confirmation page. At the moment, we don’t tell users that drafts are saved, so they may not even realise that a draft has been created.

## Changes in this PR
- Add message to indicate that a draft referral will be saved
- Add Delete button to task list page which redirects to the new Delete page
- New Delete page where clicking delete is final and redirects to referrers drafts
- Add success message on referrers case list page


## Screenshots of UI changes
![Screenshot 2024-06-04 at 13 29 39](https://github.com/ministryofjustice/hmpps-accredited-programmes-ui/assets/1067537/78178d06-84f9-4e9c-8f6b-f8a38a9db756)

![Screenshot 2024-06-04 at 13 29 50](https://github.com/ministryofjustice/hmpps-accredited-programmes-ui/assets/1067537/9067eb4f-eb61-4c9e-a34c-b9734a2dfd81)

![3  Delete-this-draft-referral](https://github.com/ministryofjustice/hmpps-accredited-programmes-ui/assets/1067537/0f7bad05-5e9e-40c8-bfe3-5541f9c915e5)

![Screenshot 2024-06-04 at 13 30 54](https://github.com/ministryofjustice/hmpps-accredited-programmes-ui/assets/1067537/19d4f14a-db8c-4a06-a22f-27c2883d609d)


## Release checklist

[Release process documentation](../doc/how-to/perform-a-release.md)

As part of our continuous deployment strategy we must ensure that this work is
ready to be released once merged.

### Pre-merge

- [ ] There are changes required to the Accredited Programmes API for this change to work...
  - [ ] ... and they have been released to production already

### Post-merge

<!-- The outer checkboxes can be completed pre-merge -->

- [ ] This adds, extends or meaningfully modifies a feature...
  - [ ] ... and I have written or updated an end-to-end test for the happy path in the [Accredited Programmes E2E repo](https://github.com/ministryofjustice/hmpps-accredited-programmes-e2e)
- [ ] This makes new expectations of the API...
  - [ ] ... and I have notified the API developer(s) of changes to the contract tests (Pact), or the API is already compliant
- [ ] [Manually approve](../doc/how-to/perform-a-release.md#releasing-to-the-preprod-environment) release to preprod
- [ ] [Manually approve](../doc/how-to/perform-a-release.md#releasing-to-the-production-environment) release to prod

<!-- Should a release fail at any step, you as the author should now lead the work to
fix it as soon as possible. You can monitor deployment failures in CircleCI
itself and application errors are found in
[Sentry](https://ministryofjustice.sentry.io/projects/hmpps-accredited-programmes-ui/?project=4505330122686464&referrer=sidebar&statsPeriod=24h). -->
