### PR TITLE
(APG-149) Increase character count to 500 on update status selection page

### DIFF
--- a/server/controllers/shared/updateStatusSelectionController.test.ts
+++ b/server/controllers/shared/updateStatusSelectionController.test.ts
@@ -94,7 +94,7 @@ describe('UpdateStatusSelectionController', () => {
         action: assessPaths.updateStatus.selection.confirmation.submit({ referralId: referral.id }),
         backLinkHref: assessPaths.show.statusHistory({ referralId: referral.id }),
         confirmationText,
-        maxLength: 100,
+        maxLength: 500,
         pageHeading: confirmationText.primaryHeading,
         person,
         timelineItems: timelineItems.slice(0, 1),
@@ -372,14 +372,14 @@ describe('UpdateStatusSelectionController', () => {
 
     describe('when `reason` is too long', () => {
       it('should redirect to the update status selection show page with a flash message', async () => {
-        const longReason = 'a'.repeat(101)
+        const longReason = 'a'.repeat(501)
 
         request.body = { reason: longReason }
 
         const requestHandler = controller.submitReason()
         await requestHandler(request, response, next)
 
-        expect(request.flash).toHaveBeenCalledWith('reasonError', 'Reason must be 100 characters or fewer')
+        expect(request.flash).toHaveBeenCalledWith('reasonError', 'Reason must be 500 characters or fewer')
         expect(request.flash).toHaveBeenCalledWith('formValues', [JSON.stringify({ reason: longReason })])
         expect(response.redirect).toHaveBeenCalledWith(
           assessPaths.updateStatus.selection.show({ referralId: referral.id }),

--- a/server/controllers/shared/updateStatusSelectionController.ts
+++ b/server/controllers/shared/updateStatusSelectionController.ts
@@ -5,7 +5,7 @@ import type { PersonService, ReferralService } from '../../services'
 import { FormUtils, ShowReferralUtils, TypeUtils } from '../../utils'
 import type { ReferralStatus, ReferralStatusUppercase } from '@accredited-programmes/models'
 
-const maxLength = 100
+const maxLength = 500
 
 export default class UpdateStatusSelectionController {
   constructor(


### PR DESCRIPTION
## Context

On the update status journey the character limit for reason input has been restricted to 100 characters.

User research has highlighted that 100 characters is not enough.

We’d like to increase the character limit to 500 as this should allow for approximately 2 paragraphs of text to be added.


## Changes in this PR
Increase max length to 500 from 100.

## Screenshots of UI changes

![image](https://github.com/ministryofjustice/hmpps-accredited-programmes-ui/assets/1067537/2f300f00-a61b-479c-954e-3b38339069b4)



## Release checklist

[Release process documentation](../doc/how-to/perform-a-release.md)

As part of our continuous deployment strategy we must ensure that this work is
ready to be released once merged.

### Pre-merge

- [ ] There are changes required to the Accredited Programmes API for this change to work...
  - [ ] ... and they have been released to production already

### Post-merge

<!-- The outer checkboxes can be completed pre-merge -->

- [ ] This adds, extends or meaningfully modifies a feature...
  - [ ] ... and I have written or updated an end-to-end test for the happy path in the [Accredited Programmes E2E repo](https://github.com/ministryofjustice/hmpps-accredited-programmes-e2e)
- [ ] This makes new expectations of the API...
  - [ ] ... and I have notified the API developer(s) of changes to the contract tests (Pact), or the API is already compliant
- [ ] [Manually approve](../doc/how-to/perform-a-release.md#releasing-to-the-preprod-environment) release to preprod
- [ ] [Manually approve](../doc/how-to/perform-a-release.md#releasing-to-the-production-environment) release to prod

<!-- Should a release fail at any step, you as the author should now lead the work to
fix it as soon as possible. You can monitor deployment failures in CircleCI
itself and application errors are found in
[Sentry](https://ministryofjustice.sentry.io/projects/hmpps-accredited-programmes-ui/?project=4505330122686464&referrer=sidebar&statsPeriod=24h). -->
