### PR TITLE
(APG-56) Add link to DPS on homepage and update related integration tests

### DIFF
--- a/integration.env
+++ b/integration.env
@@ -14,3 +14,4 @@ PRISON_API_URL=http://localhost:9199
 PRISON_REGISTER_API_URL=http://localhost:9199
 INTEGRATION_ENV=true
 REFER_ENABLED=true
+DPS_URL=http://dps-url

--- a/integration_tests/e2e/app.cy.ts
+++ b/integration_tests/e2e/app.cy.ts
@@ -36,17 +36,7 @@ context('App', () => {
       })
     })
 
-    it('does not show navigation on the index page', () => {
-      const indexPage = Page.verifyOnPage(IndexPage)
-      indexPage.shouldNotContainNavigation()
-    })
-
-    it('does not show the home link on the index page', () => {
-      const indexPage = Page.verifyOnPage(IndexPage)
-      indexPage.shouldNotContainHomeLink()
-    })
-
-    it('shows a notification banner on the index page', () => {
+    it('Shows a notification banner on the index page', () => {
       const bannerInnerHTML = `
         <h3 class="govuk-notification-banner__heading">Rolling out the referral service</h3>
         <p class="govuk-body">This is a new service. While we're rolling it out, referrers can only use it to refer people to Accredited Programmes at a few prisons. At the moment, you can refer to:</p>
@@ -59,6 +49,13 @@ context('App', () => {
       `
       const indexPage = Page.verifyOnPage(IndexPage)
       indexPage.shouldContainNotificationBanner('Important', bannerInnerHTML)
+    })
+
+    it('Shows the correct navigation elements', () => {
+      const indexPage = Page.verifyOnPage(IndexPage)
+      indexPage.shouldNotContainNavigation()
+      indexPage.shouldContainBackLink('http://dps-url')
+      indexPage.shouldNotContainHomeLink()
     })
   })
 

--- a/server/views/dashboard/index.njk
+++ b/server/views/dashboard/index.njk
@@ -1,3 +1,5 @@
+{% from "govuk/components/back-link/macro.njk" import govukBackLink %}
+
 {% extends "../partials/layout.njk" %}
 
 {% set customPageTitleEnd = "Home" %}
@@ -6,6 +8,13 @@
 {% block notificationBanner %}
   {% include "./_notificationBanner.njk" %}
 {% endblock notificationBanner %}
+
+{% block backLink %}
+  {{ govukBackLink({
+    text: "Digital Prison Services",
+    href: dpsUrl
+  }) }}
+{% endblock backLink %}
 
 {% block homeLink %}{% endblock homeLink %}
 


### PR DESCRIPTION
## Context

The live service is missing a link back to DPS on the AcP homepage, as per screen shot off prototype:



## Changes in this PR
Add back link to Digital Prison Services to service homepage.


## Screenshots of UI changes

![image](https://github.com/ministryofjustice/hmpps-accredited-programmes-ui/assets/1067537/e8ecd1b6-309e-49c0-a52c-e9cc0c7379b4)


## Release checklist

[Release process documentation](../doc/how-to/perform-a-release.md)

As part of our continuous deployment strategy we must ensure that this work is
ready to be released once merged.

### Pre-merge

- [ ] There are changes required to the Accredited Programmes API for this change to work...
  - [ ] ... and they have been released to production already

### Post-merge

<!-- The outer checkboxes can be completed pre-merge -->

- [ ] This adds, extends or meaningfully modifies a feature...
  - [ ] ... and I have written or updated an end-to-end test for the happy path in the [Accredited Programmes E2E repo](https://github.com/ministryofjustice/hmpps-accredited-programmes-e2e)
- [ ] This makes new expectations of the API...
  - [ ] ... and I have notified the API developer(s) of changes to the contract tests (Pact), or the API is already compliant
- [ ] [Manually approve](../doc/how-to/perform-a-release.md#releasing-to-the-preprod-environment) release to preprod
- [ ] [Manually approve](../doc/how-to/perform-a-release.md#releasing-to-the-production-environment) release to prod

<!-- Should a release fail at any step, you as the author should now lead the work to
fix it as soon as possible. You can monitor deployment failures in CircleCI
itself and application errors are found in
[Sentry](https://ministryofjustice.sentry.io/projects/hmpps-accredited-programmes-ui/?project=4505330122686464&referrer=sidebar&statsPeriod=24h). -->
