### PR TITLE
(APG-59) Remove `max-width` on tags within an moj timeline

### DIFF
--- a/assets/scss/application.scss
+++ b/assets/scss/application.scss
@@ -18,3 +18,4 @@ $govuk-page-width: $moj-page-width;
 @import './components/risks-and-alerts';
 @import './components/task-list';
 @import './local';
+@import './overrides';

--- a/assets/scss/local.scss
+++ b/assets/scss/local.scss
@@ -1,7 +1,3 @@
-.govuk-main-wrapper {
-  min-height: 37.5rem;
-}
-
 .maintain-white-space {
   white-space: pre-wrap;
 }

--- a/assets/scss/overrides.scss
+++ b/assets/scss/overrides.scss
@@ -1,0 +1,7 @@
+.govuk-main-wrapper {
+  min-height: 37.5rem;
+}
+
+.moj-timeline .govuk-tag {
+  max-width: none;
+}


### PR DESCRIPTION
Some of the statuses (eg Assessed as suitable) appear to be wrapping when the column width is much wider for the status details. See screen shot below:

## Context

<!-- Is there a Trello ticket you can link to? -->
<!-- Do you need to add any environment variables? -->
<!-- Is an ADR required? An ADR should be added if this PR introduces a change to the architecture. -->



## Changes in this PR
Remove `max-width` on tags within an moj timeline and added to a new overrides.scss file.  Any future moj or govuk overrides should go in here. Will help us keep an eye on if things start getting out of hand.


## Screenshots of UI changes

### Before
![image](https://github.com/ministryofjustice/hmpps-accredited-programmes-ui/assets/1067537/8a86917a-ab14-46f5-9bb5-e6457475fb9f)


### After
![image](https://github.com/ministryofjustice/hmpps-accredited-programmes-ui/assets/1067537/f9c1fb31-221e-4acf-9b6a-561ab7fc09c0)


## Release checklist

[Release process documentation](../doc/how-to/perform-a-release.md)

As part of our continuous deployment strategy we must ensure that this work is
ready to be released once merged.

### Pre-merge

- [ ] There are changes required to the Accredited Programmes API for this change to work...
  - [ ] ... and they have been released to production already

### Post-merge

<!-- The outer checkboxes can be completed pre-merge -->

- [ ] This adds, extends or meaningfully modifies a feature...
  - [ ] ... and I have written or updated an end-to-end test for the happy path in the [Accredited Programmes E2E repo](https://github.com/ministryofjustice/hmpps-accredited-programmes-e2e)
- [ ] This makes new expectations of the API...
  - [ ] ... and I have notified the API developer(s) of changes to the contract tests (Pact), or the API is already compliant
- [ ] [Manually approve](../doc/how-to/perform-a-release.md#releasing-to-the-preprod-environment) release to preprod
- [ ] [Manually approve](../doc/how-to/perform-a-release.md#releasing-to-the-production-environment) release to prod

<!-- Should a release fail at any step, you as the author should now lead the work to
fix it as soon as possible. You can monitor deployment failures in CircleCI
itself and application errors are found in
[Sentry](https://ministryofjustice.sentry.io/projects/hmpps-accredited-programmes-ui/?project=4505330122686464&referrer=sidebar&statsPeriod=24h). -->
