### PR TITLE
(APG-140) Move Release dates to new specific sub page under Referral details

### DIFF
--- a/integration_tests/e2e/assess/show.cy.ts
+++ b/integration_tests/e2e/assess/show.cy.ts
@@ -42,9 +42,21 @@ context('Viewing a submitted referral', () => {
         sharedTests.referrals.showsSentenceInformationPageWithAllData(ApplicationRoles.ACP_PROGRAMME_TEAM)
       })
 
-      describe('and there are no sentence details and no release dates for that person', () => {
-        it('shows the correct information, including a message for the missing sentence details and a message for the missing release dates', () => {
+      describe('and there are no sentence details for that person', () => {
+        it('shows the correct information, including a message for the missing sentence details', () => {
           sharedTests.referrals.showsSentenceInformationPageWithoutAllData(ApplicationRoles.ACP_PROGRAMME_TEAM)
+        })
+      })
+    })
+
+    describe('When reviewing release dates', () => {
+      it('shows the correct information', () => {
+        sharedTests.referrals.showsReleaseDatesPageWithAllData(ApplicationRoles.ACP_PROGRAMME_TEAM)
+      })
+
+      describe('and there are no release dates for that person', () => {
+        it('shows the correct information, including a message for the missing release dates', () => {
+          sharedTests.referrals.showsReleaseDatesPageWithoutAllData(ApplicationRoles.ACP_PROGRAMME_TEAM)
         })
       })
     })

--- a/integration_tests/pages/shared/index.ts
+++ b/integration_tests/pages/shared/index.ts
@@ -3,6 +3,7 @@ import AdditionalInformationPage from './showReferral/additionalInformation'
 import OffenceHistoryPage from './showReferral/offenceHistory'
 import PersonalDetailsPage from './showReferral/personalDetails'
 import ProgrammeHistoryPage from './showReferral/programmeHistory'
+import ReleaseDatesPage from './showReferral/releaseDates'
 import AttitudesPage from './showReferral/risksAndNeeds/attitudes'
 import EmotionalWellbeingPage from './showReferral/risksAndNeeds/emotionalWellbeing'
 import HealthPage from './showReferral/risksAndNeeds/health'
@@ -32,6 +33,7 @@ export {
   PersonalDetailsPage,
   ProgrammeHistoryPage,
   RelationshipsPage,
+  ReleaseDatesPage,
   RisksAndAlertsPage,
   RoshAnalysisPage,
   SentenceInformationPage,

--- a/integration_tests/pages/shared/showReferral/releaseDates.ts
+++ b/integration_tests/pages/shared/showReferral/releaseDates.ts
@@ -1,0 +1,40 @@
+import { CourseUtils, PersonUtils } from '../../../../server/utils'
+import Page from '../../page'
+import type { Course, Person, SentenceDetails } from '@accredited-programmes/models'
+
+export default class SentenceInformationPage extends Page {
+  person: Person
+
+  sentenceDetails: SentenceDetails
+
+  constructor(args: { course: Course; person: Person; sentenceDetails: SentenceDetails }) {
+    const { course, person, sentenceDetails } = args
+    const coursePresenter = CourseUtils.presentCourse(course)
+
+    super(`Referral to ${coursePresenter.displayName}`)
+
+    this.person = person
+    this.sentenceDetails = sentenceDetails
+  }
+
+  shouldContainNoReleaseDatesSummaryCard(): void {
+    cy.get('[data-testid="no-release-dates-summary-card"]').then(summaryCardElement => {
+      this.shouldContainKeylessSummaryCard(
+        'Release dates',
+        'There are no release dates for this person.',
+        summaryCardElement,
+      )
+    })
+  }
+
+  shouldContainReleaseDatesSummaryCard(): void {
+    cy.get('[data-testid="release-dates-summary-card"]').then(summaryCardElement => {
+      this.shouldContainSummaryCard(
+        'Release dates',
+        [],
+        PersonUtils.releaseDatesSummaryListRows(this.sentenceDetails.keyDates),
+        summaryCardElement,
+      )
+    })
+  }
+}

--- a/integration_tests/pages/shared/showReferral/sentenceInformation.ts
+++ b/integration_tests/pages/shared/showReferral/sentenceInformation.ts
@@ -1,4 +1,4 @@
-import { CourseUtils, PersonUtils, SentenceInformationUtils } from '../../../../server/utils'
+import { CourseUtils, SentenceInformationUtils } from '../../../../server/utils'
 import Page from '../../page'
 import type { Course, Person, SentenceDetails } from '@accredited-programmes/models'
 
@@ -17,32 +17,11 @@ export default class SentenceInformationPage extends Page {
     this.sentenceDetails = sentenceDetails
   }
 
-  shouldContainNoReleaseDatesSummaryCard(): void {
-    cy.get('[data-testid="no-release-dates-summary-card"]').then(summaryCardElement => {
-      this.shouldContainKeylessSummaryCard(
-        'Release dates',
-        'There are no release dates for this person.',
-        summaryCardElement,
-      )
-    })
-  }
-
   shouldContainNoSentenceDetailsSummaryCard(): void {
     cy.get('[data-testid="no-sentence-information-summary-card"]').then(summaryCardElement => {
       this.shouldContainKeylessSummaryCard(
         'Sentence details',
         'There are no sentence details for this person.',
-        summaryCardElement,
-      )
-    })
-  }
-
-  shouldContainReleaseDatesSummaryCard(): void {
-    cy.get('[data-testid="release-dates-summary-card"]').then(summaryCardElement => {
-      this.shouldContainSummaryCard(
-        'Release dates',
-        [],
-        PersonUtils.releaseDatesSummaryListRows(this.sentenceDetails.keyDates),
         summaryCardElement,
       )
     })

--- a/integration_tests/support/sharedTests.ts
+++ b/integration_tests/support/sharedTests.ts
@@ -42,6 +42,7 @@ import {
   PersonalDetailsPage,
   ProgrammeHistoryPage,
   RelationshipsPage,
+  ReleaseDatesPage,
   RisksAndAlertsPage,
   RoshAnalysisPage,
   SentenceInformationPage,
@@ -407,6 +408,80 @@ const sharedTests = {
       })
     },
 
+    showsReleaseDatesPageWithAllData: (role: ApplicationRole): void => {
+      sharedTests.referrals.beforeEach(role)
+      const sentenceDetails = sentenceDetailsFactory.withData(2).build()
+      cy.task('stubSentenceDetails', { prisonNumber: prisoner.prisonerNumber, sentenceDetails })
+
+      const path = pathsByRole(role).show.releaseDates({ referralId: referral.id })
+      cy.visit(path)
+
+      const releaseDatesPage = Page.verifyOnPage(ReleaseDatesPage, {
+        course,
+        person,
+        sentenceDetails,
+      })
+      releaseDatesPage.shouldHavePersonDetails(person)
+      releaseDatesPage.shouldContainHomeLink()
+      releaseDatesPage.shouldContainShowReferralButtons(path, referral, statusTransitions)
+      releaseDatesPage.shouldContainShowReferralSubNavigation(path, 'referral', referral.id)
+      releaseDatesPage.shouldContainCourseOfferingSummaryList(
+        person.name,
+        coursePresenter,
+        courseOffering.contactEmail,
+        organisation.name,
+      )
+      releaseDatesPage.shouldContainSubmissionSummaryList(
+        referral.submittedOn,
+        referringUser.name,
+        addedByUser1Email.email,
+      )
+      releaseDatesPage.shouldContainSubmittedReferralSideNavigation(path, referral.id)
+      releaseDatesPage.shouldContainImportedFromText('NOMIS')
+      releaseDatesPage.shouldContainReleaseDatesSummaryCard()
+    },
+
+    showsReleaseDatesPageWithoutAllData: (role: ApplicationRole): void => {
+      let undefinedReleaseDates = {}
+      releaseDateFields.forEach(date => {
+        undefinedReleaseDates = { ...undefinedReleaseDates, [date]: undefined }
+      })
+
+      sharedTests.referrals.beforeEach(role, {
+        person: { ...defaultPerson, sentenceStartDate: undefined, ...undefinedReleaseDates },
+        prisoner: { ...defaultPrisoner, sentenceStartDate: undefined, ...undefinedReleaseDates },
+      })
+      const sentenceDetails: SentenceDetails = { keyDates: [], sentences: [] }
+      cy.task('stubSentenceDetails', { prisonNumber: prisoner.prisonerNumber, sentenceDetails })
+
+      const path = pathsByRole(role).show.releaseDates({ referralId: referral.id })
+      cy.visit(path)
+
+      const releaseDatesPage = Page.verifyOnPage(ReleaseDatesPage, {
+        course,
+        person,
+        sentenceDetails,
+      })
+      releaseDatesPage.shouldHavePersonDetails(person)
+      releaseDatesPage.shouldContainHomeLink()
+      releaseDatesPage.shouldContainShowReferralButtons(path, referral, statusTransitions)
+      releaseDatesPage.shouldContainShowReferralSubNavigation(path, 'referral', referral.id)
+      releaseDatesPage.shouldContainCourseOfferingSummaryList(
+        person.name,
+        coursePresenter,
+        courseOffering.contactEmail,
+        organisation.name,
+      )
+      releaseDatesPage.shouldContainSubmissionSummaryList(
+        referral.submittedOn,
+        referringUser.name,
+        addedByUser1Email.email,
+      )
+      releaseDatesPage.shouldContainSubmittedReferralSideNavigation(path, referral.id)
+      releaseDatesPage.shouldContainImportedFromText('NOMIS')
+      releaseDatesPage.shouldContainNoReleaseDatesSummaryCard()
+    },
+
     showsSentenceInformationPageWithAllData: (role: ApplicationRole): void => {
       sharedTests.referrals.beforeEach(role)
       const sentenceDetails = sentenceDetailsFactory.withData(2).build()
@@ -436,9 +511,8 @@ const sharedTests = {
         addedByUser1Email.email,
       )
       sentenceInformationPage.shouldContainSubmittedReferralSideNavigation(path, referral.id)
-      sentenceInformationPage.shouldContainImportedFromText('OASys')
+      sentenceInformationPage.shouldContainImportedFromText('NOMIS')
       sentenceInformationPage.shouldContainSentenceDetailsSummaryCards()
-      sentenceInformationPage.shouldContainReleaseDatesSummaryCard()
     },
 
     showsSentenceInformationPageWithoutAllData: (role: ApplicationRole): void => {
@@ -478,9 +552,8 @@ const sharedTests = {
         addedByUser1Email.email,
       )
       sentenceInformationPage.shouldContainSubmittedReferralSideNavigation(path, referral.id)
-      sentenceInformationPage.shouldContainImportedFromText('OASys')
+      sentenceInformationPage.shouldContainImportedFromText('NOMIS')
       sentenceInformationPage.shouldContainNoSentenceDetailsSummaryCard()
-      sentenceInformationPage.shouldContainNoReleaseDatesSummaryCard()
     },
   },
   risksAndNeeds: {

--- a/server/controllers/shared/referralsController.ts
+++ b/server/controllers/shared/referralsController.ts
@@ -115,6 +115,30 @@ export default class ReferralsController {
     }
   }
 
+  releaseDates(): TypedRequestHandler<Request, Response> {
+    return async (req: Request, res: Response) => {
+      TypeUtils.assertHasUser(req)
+
+      const sharedPageData = await this.sharedPageData(req, res)
+      const { referral } = sharedPageData
+
+      if (referral.status === 'referral_started') {
+        throw createError(400, 'Referral has not been submitted.')
+      }
+
+      const sentenceDetails = await this.personService.getSentenceDetails(
+        req.user.username,
+        sharedPageData.person.prisonNumber,
+      )
+
+      return res.render('referrals/show/releaseDates', {
+        ...sharedPageData,
+        importedFromText: `Imported from NOMIS on ${DateUtils.govukFormattedFullDateString()}.`,
+        releaseDatesSummaryListRows: PersonUtils.releaseDatesSummaryListRows(sentenceDetails.keyDates),
+      })
+    }
+  }
+
   sentenceInformation(): TypedRequestHandler<Request, Response> {
     return async (req: Request, res: Response) => {
       TypeUtils.assertHasUser(req)
@@ -133,8 +157,7 @@ export default class ReferralsController {
 
       return res.render('referrals/show/sentenceInformation', {
         ...sharedPageData,
-        importedFromText: `Imported from OASys on ${DateUtils.govukFormattedFullDateString()}.`,
-        releaseDatesSummaryListRows: PersonUtils.releaseDatesSummaryListRows(sentenceDetails.keyDates),
+        importedFromText: `Imported from NOMIS on ${DateUtils.govukFormattedFullDateString()}.`,
         sentencesSummaryLists: SentenceInformationUtils.summaryLists(sentenceDetails),
       })
     }

--- a/server/paths/assess.ts
+++ b/server/paths/assess.ts
@@ -24,6 +24,7 @@ export default {
     offenceHistory: referralShowPathBase.path('offence-history'),
     personalDetails: referralShowPathBase.path('personal-details'),
     programmeHistory: referralShowPathBase.path('programme-history'),
+    releaseDates: referralShowPathBase.path('release-dates'),
     risksAndNeeds: {
       attitudes: risksAndNeedsPathBase.path('attitudes'),
       emotionalWellbeing: risksAndNeedsPathBase.path('emotional-wellbeing'),

--- a/server/paths/refer.ts
+++ b/server/paths/refer.ts
@@ -77,6 +77,7 @@ export default {
     offenceHistory: referralShowPathBase.path('offence-history'),
     personalDetails: referralShowPathBase.path('personal-details'),
     programmeHistory: referralShowPathBase.path('programme-history'),
+    releaseDates: referralShowPathBase.path('release-dates'),
     risksAndNeeds: {
       attitudes: risksAndNeedsPathBase.path('attitudes'),
       emotionalWellbeing: risksAndNeedsPathBase.path('emotional-wellbeing'),

--- a/server/routes/assess.ts
+++ b/server/routes/assess.ts
@@ -29,6 +29,7 @@ export default function routes(controllers: Controllers, router: Router): Router
   get(assessPaths.show.offenceHistory.pattern, referralsController.offenceHistory())
   get(assessPaths.show.personalDetails.pattern, referralsController.personalDetails())
   get(assessPaths.show.programmeHistory.pattern, referralsController.programmeHistory())
+  get(assessPaths.show.releaseDates.pattern, referralsController.releaseDates())
   get(assessPaths.show.sentenceInformation.pattern, referralsController.sentenceInformation())
 
   get(assessPaths.show.risksAndNeeds.attitudes.pattern, risksAndNeedsController.attitudes())

--- a/server/routes/refer.ts
+++ b/server/routes/refer.ts
@@ -80,6 +80,7 @@ export default function routes(controllers: Controllers, router: Router): Router
   get(referPaths.show.offenceHistory.pattern, referralsController.offenceHistory())
   get(referPaths.show.personalDetails.pattern, referralsController.personalDetails())
   get(referPaths.show.programmeHistory.pattern, referralsController.programmeHistory())
+  get(referPaths.show.releaseDates.pattern, referralsController.releaseDates())
   get(referPaths.show.sentenceInformation.pattern, referralsController.sentenceInformation())
 
   get(referPaths.show.risksAndNeeds.attitudes.pattern, risksAndNeedsController.attitudes())

--- a/server/utils/referrals/showReferralUtils.test.ts
+++ b/server/utils/referrals/showReferralUtils.test.ts
@@ -493,6 +493,11 @@ describe('ShowReferralUtils', () => {
           },
           {
             active: false,
+            href: referPaths.show.releaseDates({ referralId: mockReferralId }),
+            text: 'Release dates',
+          },
+          {
+            active: false,
             href: referPaths.show.additionalInformation({ referralId: mockReferralId }),
             text: 'Additional information',
           },
@@ -524,6 +529,11 @@ describe('ShowReferralUtils', () => {
             active: false,
             href: assessPaths.show.sentenceInformation({ referralId: mockReferralId }),
             text: 'Sentence information',
+          },
+          {
+            active: false,
+            href: assessPaths.show.releaseDates({ referralId: mockReferralId }),
+            text: 'Release dates',
           },
           {
             active: false,

--- a/server/utils/referrals/showReferralUtils.ts
+++ b/server/utils/referrals/showReferralUtils.ts
@@ -210,6 +210,10 @@ export default class ShowReferralUtils {
         text: 'Sentence information',
       },
       {
+        href: paths.show.releaseDates({ referralId }),
+        text: 'Release dates',
+      },
+      {
         href: paths.show.additionalInformation({ referralId }),
         text: 'Additional information',
       },

--- a/server/views/referrals/show/releaseDates.njk
+++ b/server/views/referrals/show/releaseDates.njk
@@ -14,11 +14,19 @@
     }
   }) }}
 
-  {% if sentencesSummaryLists | length %}
-    {% for sentenceSummaryList in sentencesSummaryLists %}
-      {{ govukSummaryList(sentenceSummaryList) }}
-    {% endfor %}
+  {% if releaseDatesSummaryListRows | length %}
+    {{ govukSummaryList({
+      card: {
+        title: {
+          text: "Release dates"
+        },
+        attributes: {
+          "data-testid": "release-dates-summary-card"
+        }
+      },
+      rows: releaseDatesSummaryListRows
+    }) }}
   {% else %}
-    {{ keylessSummaryCard("Sentence details", bodyText="There are no sentence details for this person.", testId="no-sentence-information-summary-card") }}
+    {{ keylessSummaryCard("Release dates", bodyText="There are no release dates for this person.", testId="no-release-dates-summary-card") }}
   {% endif %}
 {% endblock primaryContent %}


### PR DESCRIPTION
## Context

Based on user feedback since launch and conversations with the ‘calculate a release date’ team, we may not be providing the Earliest Possible Release Date for a person as clearly or as definitively as we could be.

## Changes in this PR

- Moved Release dates summary list from Sentence information page to a new specific Release dates page within Referral details.
- Also replaced Imported from OASys text with Imported from NOMIS on both Sentence Information and the new Release dates page.


## Screenshots of UI changes

![image](https://github.com/ministryofjustice/hmpps-accredited-programmes-ui/assets/1067537/6aa8813f-f994-4cae-9261-e55adcdf7d4e)



## Release checklist

[Release process documentation](../doc/how-to/perform-a-release.md)

As part of our continuous deployment strategy we must ensure that this work is
ready to be released once merged.

### Pre-merge

- [ ] There are changes required to the Accredited Programmes API for this change to work...
  - [ ] ... and they have been released to production already

### Post-merge

<!-- The outer checkboxes can be completed pre-merge -->

- [ ] This adds, extends or meaningfully modifies a feature...
  - [ ] ... and I have written or updated an end-to-end test for the happy path in the [Accredited Programmes E2E repo](https://github.com/ministryofjustice/hmpps-accredited-programmes-e2e)
- [ ] This makes new expectations of the API...
  - [ ] ... and I have notified the API developer(s) of changes to the contract tests (Pact), or the API is already compliant
- [ ] [Manually approve](../doc/how-to/perform-a-release.md#releasing-to-the-preprod-environment) release to preprod
- [ ] [Manually approve](../doc/how-to/perform-a-release.md#releasing-to-the-production-environment) release to prod

<!-- Should a release fail at any step, you as the author should now lead the work to
fix it as soon as possible. You can monitor deployment failures in CircleCI
itself and application errors are found in
[Sentry](https://ministryofjustice.sentry.io/projects/hmpps-accredited-programmes-ui/?project=4505330122686464&referrer=sidebar&statsPeriod=24h). -->
