### PR TITLE
(APG-147) Calculate and display a persons age

### DIFF
--- a/server/utils/dateUtils.test.ts
+++ b/server/utils/dateUtils.test.ts
@@ -1,14 +1,26 @@
 import DateUtils from './dateUtils'
 
 describe('DateUtils', () => {
+  afterEach(() => {
+    jest.useRealTimers()
+  })
+
+  describe('calculateAge', () => {
+    it('calculates the age in years and months from a date string', () => {
+      const mockDateOfBirth = '2000-02-01'
+      const mockTodaysDate = new Date('2021-01-01')
+      jest.useFakeTimers().setSystemTime(mockTodaysDate)
+
+      expect(DateUtils.calculateAge(mockDateOfBirth)).toEqual({ months: 11, years: 20 })
+    })
+  })
+
   describe('govukFormattedFullDateString', () => {
     it('returns todays date as a date string in the format specified by the GOV.UK style guide', () => {
       const mockTodaysDate = new Date('2001-06-04')
-      jest.spyOn(global, 'Date').mockImplementation(() => mockTodaysDate)
+      jest.useFakeTimers().setSystemTime(mockTodaysDate)
 
       expect(DateUtils.govukFormattedFullDateString()).toEqual('4 June 2001')
-
-      jest.spyOn(global, 'Date').mockRestore()
     })
 
     describe('when `datestring` is provided', () => {

--- a/server/utils/dateUtils.ts
+++ b/server/utils/dateUtils.ts
@@ -1,4 +1,18 @@
 export default class DateUtils {
+  static calculateAge(dateString: string): { months: number; years: number } {
+    const date = new Date(dateString)
+    const now = new Date()
+    let years = now.getFullYear() - date.getFullYear()
+    let months = now.getMonth() - date.getMonth()
+
+    if (months < 0) {
+      years -= 1
+      months += 12
+    }
+
+    return { months, years }
+  }
+
   /**
    * Formats an ISO8601 datetime string into the format specified by the GOV.UK Style guide
    * e.g. 1 January 2022

--- a/server/utils/personUtils.test.ts
+++ b/server/utils/personUtils.test.ts
@@ -147,6 +147,8 @@ describe('PersonUtils', () => {
     })
 
     it("formats a person's details in the appropriate format for passing to a GOV.UK Summary List nunjucks macro", () => {
+      jest.useFakeTimers().setSystemTime(new Date('2021-01-01'))
+
       expect(PersonUtils.summaryListRows(person)).toEqual([
         {
           key: { text: 'Name' },
@@ -158,7 +160,7 @@ describe('PersonUtils', () => {
         },
         {
           key: { text: 'Date of birth' },
-          value: { text: '5 July 1971' },
+          value: { text: '5 July 1971 (49 years, 6 months)' },
         },
         {
           key: { text: 'Ethnicity' },
@@ -181,6 +183,8 @@ describe('PersonUtils', () => {
           value: { text: 'HMP Hewell' },
         },
       ])
+
+      jest.useRealTimers()
     })
 
     describe('when `currentPrison` is `undefined`', () => {

--- a/server/utils/personUtils.ts
+++ b/server/utils/personUtils.ts
@@ -60,6 +60,8 @@ export default class PersonUtils {
   }
 
   static summaryListRows(person: Person): Array<GovukFrontendSummaryListRowWithKeyAndValue> {
+    const age = DateUtils.calculateAge(person.dateOfBirth)
+
     return [
       {
         key: { text: 'Name' },
@@ -71,7 +73,9 @@ export default class PersonUtils {
       },
       {
         key: { text: 'Date of birth' },
-        value: { text: person.dateOfBirth },
+        value: {
+          text: `${person.dateOfBirth} (${age.years} years, ${age.months} ${StringUtils.pluralise('month', age.months)})`,
+        },
       },
       {
         key: { text: 'Ethnicity' },

--- a/server/utils/stringUtils.test.ts
+++ b/server/utils/stringUtils.test.ts
@@ -44,6 +44,15 @@ describe('StringUtils', () => {
     })
   })
 
+  describe('pluralise', () => {
+    it.each([
+      ['one item', 'item', 1, 'item'],
+      ['multiple items', 'item', 2, 'items'],
+    ])('handles %s: %s -> %s', (_inputType: string, word: string, count: number, expectedOutput: string) => {
+      expect(StringUtils.pluralise(word, count)).toEqual(expectedOutput)
+    })
+  })
+
   describe('properCase', () => {
     it.each([
       ['an empty string', '', ''],

--- a/server/utils/stringUtils.ts
+++ b/server/utils/stringUtils.ts
@@ -20,6 +20,10 @@ export default class StringUtils {
       .join('')
   }
 
+  static pluralise(word: string, count: number): string {
+    return count === 1 ? word : `${word}s`
+  }
+
   static properCase(word: string): string {
     return word.length >= 1 ? word[0].toUpperCase() + word.toLowerCase().slice(1) : word
   }


### PR DESCRIPTION
## Context

We’ve identified that it might be helpful to users if we worked out the age of the person being referred. Currently we only display the DOB.



## Changes in this PR
Add `calculateAge` to `DateUtils`
Add `pluralise` to `StringUtils`
Use `DateUtils.calculateAge` in `PersonUtils.summaryListRows` for Date of birth entry.


## Screenshots of UI changes

![image](https://github.com/ministryofjustice/hmpps-accredited-programmes-ui/assets/1067537/99d9271e-dcab-4abb-a27d-4b75026d8c44)



## Release checklist

[Release process documentation](../doc/how-to/perform-a-release.md)

As part of our continuous deployment strategy we must ensure that this work is
ready to be released once merged.

### Pre-merge

- [ ] There are changes required to the Accredited Programmes API for this change to work...
  - [ ] ... and they have been released to production already

### Post-merge

<!-- The outer checkboxes can be completed pre-merge -->

- [ ] This adds, extends or meaningfully modifies a feature...
  - [ ] ... and I have written or updated an end-to-end test for the happy path in the [Accredited Programmes E2E repo](https://github.com/ministryofjustice/hmpps-accredited-programmes-e2e)
- [ ] This makes new expectations of the API...
  - [ ] ... and I have notified the API developer(s) of changes to the contract tests (Pact), or the API is already compliant
- [ ] [Manually approve](../doc/how-to/perform-a-release.md#releasing-to-the-preprod-environment) release to preprod
- [ ] [Manually approve](../doc/how-to/perform-a-release.md#releasing-to-the-production-environment) release to prod

<!-- Should a release fail at any step, you as the author should now lead the work to
fix it as soon as possible. You can monitor deployment failures in CircleCI
itself and application errors are found in
[Sentry](https://ministryofjustice.sentry.io/projects/hmpps-accredited-programmes-ui/?project=4505330122686464&referrer=sidebar&statsPeriod=24h). -->
