### PR TITLE
(APG-166) Update sub level navigation when viewing a referral

### DIFF
--- a/integration_tests/pages/page.ts
+++ b/integration_tests/pages/page.ts
@@ -329,7 +329,7 @@ export default abstract class Page {
       cy.wrap(navigationItemElement).within(() => {
         cy.get('a').should('have.attr', 'href', href)
 
-        if (currentPath === href) {
+        if (currentPath === href.replace('#content', '')) {
           cy.get('a').should('have.attr', 'aria-current', 'location')
         } else {
           cy.get('a').should('not.have.attr', 'aria-current', 'location')
@@ -435,7 +435,7 @@ export default abstract class Page {
       cy.wrap(navigationItemElement).within(() => {
         cy.get('a').should('have.attr', 'href', href)
 
-        if (currentPath === href) {
+        if (currentPath === href.replace('#content', '')) {
           cy.get('a').should('have.attr', 'aria-current', 'location')
         } else {
           cy.get('a').should('not.have.attr', 'aria-current', 'location')

--- a/server/utils/referrals/showReferralUtils.test.ts
+++ b/server/utils/referrals/showReferralUtils.test.ts
@@ -473,32 +473,32 @@ describe('ShowReferralUtils', () => {
         expect(ShowReferralUtils.viewReferralNavigationItems(currentRequestPath, mockReferralId)).toEqual([
           {
             active: true,
-            href: referPaths.show.personalDetails({ referralId: mockReferralId }),
+            href: `${referPaths.show.personalDetails({ referralId: mockReferralId })}#content`,
             text: 'Personal details',
           },
           {
             active: false,
-            href: referPaths.show.programmeHistory({ referralId: mockReferralId }),
+            href: `${referPaths.show.programmeHistory({ referralId: mockReferralId })}#content`,
             text: 'Programme history',
           },
           {
             active: false,
-            href: referPaths.show.offenceHistory({ referralId: mockReferralId }),
+            href: `${referPaths.show.offenceHistory({ referralId: mockReferralId })}#content`,
             text: 'Offence history',
           },
           {
             active: false,
-            href: referPaths.show.sentenceInformation({ referralId: mockReferralId }),
+            href: `${referPaths.show.sentenceInformation({ referralId: mockReferralId })}#content`,
             text: 'Sentence information',
           },
           {
             active: false,
-            href: referPaths.show.releaseDates({ referralId: mockReferralId }),
+            href: `${referPaths.show.releaseDates({ referralId: mockReferralId })}#content`,
             text: 'Release dates',
           },
           {
             active: false,
-            href: referPaths.show.additionalInformation({ referralId: mockReferralId }),
+            href: `${referPaths.show.additionalInformation({ referralId: mockReferralId })}#content`,
             text: 'Additional information',
           },
         ])
@@ -512,32 +512,32 @@ describe('ShowReferralUtils', () => {
         expect(ShowReferralUtils.viewReferralNavigationItems(currentRequestPath, mockReferralId)).toEqual([
           {
             active: true,
-            href: assessPaths.show.personalDetails({ referralId: mockReferralId }),
+            href: `${assessPaths.show.personalDetails({ referralId: mockReferralId })}#content`,
             text: 'Personal details',
           },
           {
             active: false,
-            href: assessPaths.show.programmeHistory({ referralId: mockReferralId }),
+            href: `${assessPaths.show.programmeHistory({ referralId: mockReferralId })}#content`,
             text: 'Programme history',
           },
           {
             active: false,
-            href: assessPaths.show.offenceHistory({ referralId: mockReferralId }),
+            href: `${assessPaths.show.offenceHistory({ referralId: mockReferralId })}#content`,
             text: 'Offence history',
           },
           {
             active: false,
-            href: assessPaths.show.sentenceInformation({ referralId: mockReferralId }),
+            href: `${assessPaths.show.sentenceInformation({ referralId: mockReferralId })}#content`,
             text: 'Sentence information',
           },
           {
             active: false,
-            href: assessPaths.show.releaseDates({ referralId: mockReferralId }),
+            href: `${assessPaths.show.releaseDates({ referralId: mockReferralId })}#content`,
             text: 'Release dates',
           },
           {
             active: false,
-            href: assessPaths.show.additionalInformation({ referralId: mockReferralId }),
+            href: `${assessPaths.show.additionalInformation({ referralId: mockReferralId })}#content`,
             text: 'Additional information',
           },
         ])

--- a/server/utils/referrals/showReferralUtils.ts
+++ b/server/utils/referrals/showReferralUtils.ts
@@ -222,6 +222,7 @@ export default class ShowReferralUtils {
     return navigationItems.map(item => ({
       ...item,
       active: currentPath === item.href,
+      href: `${item.href}#content`,
     }))
   }
 }

--- a/server/utils/referrals/showRisksAndNeedsUtils.test.ts
+++ b/server/utils/referrals/showRisksAndNeedsUtils.test.ts
@@ -12,62 +12,62 @@ describe('ShowRisksAndNeedsUtils', () => {
         expect(ShowRisksAndNeedsUtils.navigationItems(currentRequestPath, mockReferralId)).toEqual([
           {
             active: false,
-            href: referPaths.show.risksAndNeeds.risksAndAlerts({ referralId: mockReferralId }),
+            href: `${referPaths.show.risksAndNeeds.risksAndAlerts({ referralId: mockReferralId })}#content`,
             text: 'Risks and alerts',
           },
           {
             active: true,
-            href: referPaths.show.risksAndNeeds.offenceAnalysis({ referralId: mockReferralId }),
+            href: `${referPaths.show.risksAndNeeds.offenceAnalysis({ referralId: mockReferralId })}#content`,
             text: 'Section 2 - Offence analysis',
           },
           {
             active: false,
-            href: referPaths.show.risksAndNeeds.relationships({ referralId: mockReferralId }),
+            href: `${referPaths.show.risksAndNeeds.relationships({ referralId: mockReferralId })}#content`,
             text: 'Section 6 - Relationships',
           },
           {
             active: false,
-            href: referPaths.show.risksAndNeeds.lifestyleAndAssociates({ referralId: mockReferralId }),
+            href: `${referPaths.show.risksAndNeeds.lifestyleAndAssociates({ referralId: mockReferralId })}#content`,
             text: 'Section 7 - Lifestyle and associates',
           },
           {
             active: false,
-            href: referPaths.show.risksAndNeeds.drugMisuse({ referralId: mockReferralId }),
+            href: `${referPaths.show.risksAndNeeds.drugMisuse({ referralId: mockReferralId })}#content`,
             text: 'Section 8 - Drug misuse',
           },
           {
             active: false,
-            href: referPaths.show.risksAndNeeds.alcoholMisuse({ referralId: mockReferralId }),
+            href: `${referPaths.show.risksAndNeeds.alcoholMisuse({ referralId: mockReferralId })}#content`,
             text: 'Section 9 - Alcohol misuse',
           },
           {
             active: false,
-            href: referPaths.show.risksAndNeeds.emotionalWellbeing({ referralId: mockReferralId }),
+            href: `${referPaths.show.risksAndNeeds.emotionalWellbeing({ referralId: mockReferralId })}#content`,
             text: 'Section 10 - Emotional wellbeing',
           },
           {
             active: false,
-            href: referPaths.show.risksAndNeeds.thinkingAndBehaving({ referralId: mockReferralId }),
+            href: `${referPaths.show.risksAndNeeds.thinkingAndBehaving({ referralId: mockReferralId })}#content`,
             text: 'Section 11 - Thinking and behaving',
           },
           {
             active: false,
-            href: referPaths.show.risksAndNeeds.attitudes({ referralId: mockReferralId }),
+            href: `${referPaths.show.risksAndNeeds.attitudes({ referralId: mockReferralId })}#content`,
             text: 'Section 12 - Attitudes',
           },
           {
             active: false,
-            href: referPaths.show.risksAndNeeds.health({ referralId: mockReferralId }),
+            href: `${referPaths.show.risksAndNeeds.health({ referralId: mockReferralId })}#content`,
             text: 'Section 13 - Health',
           },
           {
             active: false,
-            href: referPaths.show.risksAndNeeds.learningNeeds({ referralId: mockReferralId }),
+            href: `${referPaths.show.risksAndNeeds.learningNeeds({ referralId: mockReferralId })}#content`,
             text: 'Learning needs',
           },
           {
             active: false,
-            href: referPaths.show.risksAndNeeds.roshAnalysis({ referralId: mockReferralId }),
+            href: `${referPaths.show.risksAndNeeds.roshAnalysis({ referralId: mockReferralId })}#content`,
             text: 'Section R6 - RoSH analysis',
           },
         ])
@@ -81,62 +81,62 @@ describe('ShowRisksAndNeedsUtils', () => {
         expect(ShowRisksAndNeedsUtils.navigationItems(currentRequestPath, mockReferralId)).toEqual([
           {
             active: false,
-            href: assessPaths.show.risksAndNeeds.risksAndAlerts({ referralId: mockReferralId }),
+            href: `${assessPaths.show.risksAndNeeds.risksAndAlerts({ referralId: mockReferralId })}#content`,
             text: 'Risks and alerts',
           },
           {
             active: true,
-            href: assessPaths.show.risksAndNeeds.offenceAnalysis({ referralId: mockReferralId }),
+            href: `${assessPaths.show.risksAndNeeds.offenceAnalysis({ referralId: mockReferralId })}#content`,
             text: 'Section 2 - Offence analysis',
           },
           {
             active: false,
-            href: assessPaths.show.risksAndNeeds.relationships({ referralId: mockReferralId }),
+            href: `${assessPaths.show.risksAndNeeds.relationships({ referralId: mockReferralId })}#content`,
             text: 'Section 6 - Relationships',
           },
           {
             active: false,
-            href: assessPaths.show.risksAndNeeds.lifestyleAndAssociates({ referralId: mockReferralId }),
+            href: `${assessPaths.show.risksAndNeeds.lifestyleAndAssociates({ referralId: mockReferralId })}#content`,
             text: 'Section 7 - Lifestyle and associates',
           },
           {
             active: false,
-            href: assessPaths.show.risksAndNeeds.drugMisuse({ referralId: mockReferralId }),
+            href: `${assessPaths.show.risksAndNeeds.drugMisuse({ referralId: mockReferralId })}#content`,
             text: 'Section 8 - Drug misuse',
           },
           {
             active: false,
-            href: assessPaths.show.risksAndNeeds.alcoholMisuse({ referralId: mockReferralId }),
+            href: `${assessPaths.show.risksAndNeeds.alcoholMisuse({ referralId: mockReferralId })}#content`,
             text: 'Section 9 - Alcohol misuse',
           },
           {
             active: false,
-            href: assessPaths.show.risksAndNeeds.emotionalWellbeing({ referralId: mockReferralId }),
+            href: `${assessPaths.show.risksAndNeeds.emotionalWellbeing({ referralId: mockReferralId })}#content`,
             text: 'Section 10 - Emotional wellbeing',
           },
           {
             active: false,
-            href: assessPaths.show.risksAndNeeds.thinkingAndBehaving({ referralId: mockReferralId }),
+            href: `${assessPaths.show.risksAndNeeds.thinkingAndBehaving({ referralId: mockReferralId })}#content`,
             text: 'Section 11 - Thinking and behaving',
           },
           {
             active: false,
-            href: assessPaths.show.risksAndNeeds.attitudes({ referralId: mockReferralId }),
+            href: `${assessPaths.show.risksAndNeeds.attitudes({ referralId: mockReferralId })}#content`,
             text: 'Section 12 - Attitudes',
           },
           {
             active: false,
-            href: assessPaths.show.risksAndNeeds.health({ referralId: mockReferralId }),
+            href: `${assessPaths.show.risksAndNeeds.health({ referralId: mockReferralId })}#content`,
             text: 'Section 13 - Health',
           },
           {
             active: false,
-            href: assessPaths.show.risksAndNeeds.learningNeeds({ referralId: mockReferralId }),
+            href: `${assessPaths.show.risksAndNeeds.learningNeeds({ referralId: mockReferralId })}#content`,
             text: 'Learning needs',
           },
           {
             active: false,
-            href: assessPaths.show.risksAndNeeds.roshAnalysis({ referralId: mockReferralId }),
+            href: `${assessPaths.show.risksAndNeeds.roshAnalysis({ referralId: mockReferralId })}#content`,
             text: 'Section R6 - RoSH analysis',
           },
         ])

--- a/server/utils/referrals/showRisksAndNeedsUtils.ts
+++ b/server/utils/referrals/showRisksAndNeedsUtils.ts
@@ -62,6 +62,7 @@ export default class ShowRisksAndNeedsUtils {
     return navigationItems.map(item => ({
       ...item,
       active: currentPath === item.href,
+      href: `${item.href}#content`,
     }))
   }
 

--- a/server/views/referrals/show/partials/withNavigationLayout.njk
+++ b/server/views/referrals/show/partials/withNavigationLayout.njk
@@ -5,7 +5,7 @@
 
   <hr class="govuk-section-break govuk-section-break--xl govuk-section-break--visible">
 
-  <div class="govuk-grid-row">
+  <div id="content" class="govuk-grid-row">
     {% if navigationItems | length %}
       <div class="govuk-grid-column-one-quarter">
         {{ mojSideNavigation({


### PR DESCRIPTION
Added a `#content` id to be used by the sub level navigation, so it doesn't scroll back to the top of the page each time.

## Context

The sub navigations when viewing a referral takes the user to the top of the page each time and forces the user to scroll back down to where the content actually is, which isn't a great experience.

## Changes in this PR
- Wrap content in div with `id="content"`
- Update navigation utils hrefs to include `#content`




## Release checklist

[Release process documentation](../doc/how-to/perform-a-release.md)

As part of our continuous deployment strategy we must ensure that this work is
ready to be released once merged.

### Pre-merge

- [ ] There are changes required to the Accredited Programmes API for this change to work...
  - [ ] ... and they have been released to production already

### Post-merge

<!-- The outer checkboxes can be completed pre-merge -->

- [ ] This adds, extends or meaningfully modifies a feature...
  - [ ] ... and I have written or updated an end-to-end test for the happy path in the [Accredited Programmes E2E repo](https://github.com/ministryofjustice/hmpps-accredited-programmes-e2e)
- [ ] This makes new expectations of the API...
  - [ ] ... and I have notified the API developer(s) of changes to the contract tests (Pact), or the API is already compliant
- [ ] [Manually approve](../doc/how-to/perform-a-release.md#releasing-to-the-preprod-environment) release to preprod
- [ ] [Manually approve](../doc/how-to/perform-a-release.md#releasing-to-the-production-environment) release to prod

<!-- Should a release fail at any step, you as the author should now lead the work to
fix it as soon as possible. You can monitor deployment failures in CircleCI
itself and application errors are found in
[Sentry](https://ministryofjustice.sentry.io/projects/hmpps-accredited-programmes-ui/?project=4505330122686464&referrer=sidebar&statsPeriod=24h). -->
