### PR TITLE
(APG-36) Add Cancel button to status update pages

### DIFF
--- a/integration_tests/e2e/refer/withdraw.cy.ts
+++ b/integration_tests/e2e/refer/withdraw.cy.ts
@@ -110,6 +110,7 @@ context('Withdraw referral', () => {
       withdrawCategoryPage.shouldContainBackLink(referPaths.show.statusHistory({ referralId: referral.id }))
       withdrawCategoryPage.shouldContainCurrentStatusTimelineItem(presentedStatusHistory)
       withdrawCategoryPage.shouldContainWithdrawalCategoryRadioItems(referralStatusCategories)
+      withdrawCategoryPage.shouldContainLink('Cancel', referPaths.show.statusHistory({ referralId: referral.id }))
     })
 
     describe('when submitting without selecting a category', () => {
@@ -142,6 +143,7 @@ context('Withdraw referral', () => {
       withdrawReasonPage.shouldContainBackLink(referPaths.show.statusHistory({ referralId: referral.id }))
       withdrawReasonPage.shouldContainCurrentStatusTimelineItem(presentedStatusHistory)
       withdrawReasonPage.shouldContainWithdrawalReasonRadioItems(referralStatusReasons)
+      withdrawReasonPage.shouldContainLink('Cancel', referPaths.show.statusHistory({ referralId: referral.id }))
     })
 
     describe('when submitting without selecting a reason', () => {
@@ -171,6 +173,10 @@ context('Withdraw referral', () => {
       withdrawConfirmSelectionPage.shouldHavePersonDetails(person)
       withdrawConfirmSelectionPage.shouldContainBackLink(referPaths.show.statusHistory({ referralId: referral.id }))
       withdrawConfirmSelectionPage.shouldContainCurrentStatusTimelineItem(presentedStatusHistory)
+      withdrawConfirmSelectionPage.shouldContainLink(
+        'Cancel',
+        referPaths.show.statusHistory({ referralId: referral.id }),
+      )
     })
 
     describe('when submitting without entering a reason', () => {

--- a/server/views/referrals/updateStatus/category/show.njk
+++ b/server/views/referrals/updateStatus/category/show.njk
@@ -23,8 +23,12 @@
       }
     }) }}
 
-    {{ govukButton({
-      text: "Continue"
-    }) }}
+    <div class="govuk-button-group">
+      {{ govukButton({
+        text: "Continue"
+      }) }}
+
+      <a class="govuk-link" href={{ backLinkHref }}>Cancel</a>
+    </div>
   </form>
 {% endblock statusAction %}

--- a/server/views/referrals/updateStatus/decision/show.njk
+++ b/server/views/referrals/updateStatus/decision/show.njk
@@ -26,8 +26,12 @@
       }
     }) }}
 
-    {{ govukButton({
-      text: "Continue"
-    }) }}
+    <div class="govuk-button-group">
+      {{ govukButton({
+        text: "Continue"
+      }) }}
+
+      <a class="govuk-link" href={{ backLinkHref }}>Cancel</a>
+    </div>
   </form>
 {% endblock statusAction %}

--- a/server/views/referrals/updateStatus/reason/show.njk
+++ b/server/views/referrals/updateStatus/reason/show.njk
@@ -23,8 +23,12 @@
       }
     }) }}
 
-    {{ govukButton({
-      text: "Continue"
-    }) }}
+    <div class="govuk-button-group">
+      {{ govukButton({
+        text: "Continue"
+      }) }}
+
+      <a class="govuk-link" href={{ backLinkHref }}>Cancel</a>
+    </div>
   </form>
 {% endblock statusAction %}

--- a/server/views/referrals/updateStatus/selection/show.njk
+++ b/server/views/referrals/updateStatus/selection/show.njk
@@ -54,7 +54,7 @@
         text: "Submit"
       }) }}
 
-      <a href={{ backLinkHref }}>Cancel</a>
+      <a class="govuk-link" href={{ backLinkHref }}>Cancel</a>
     </div>
   </form>
 {% endblock statusAction %}


### PR DESCRIPTION
## Context

The cancel link is missing on several of the update status screens.

## Changes in this PR
Added the cancel link to all update status related pages.




## Release checklist

[Release process documentation](../doc/how-to/perform-a-release.md)

As part of our continuous deployment strategy we must ensure that this work is
ready to be released once merged.

### Pre-merge

- [ ] There are changes required to the Accredited Programmes API for this change to work...
  - [ ] ... and they have been released to production already

### Post-merge

<!-- The outer checkboxes can be completed pre-merge -->

- [ ] This adds, extends or meaningfully modifies a feature...
  - [ ] ... and I have written or updated an end-to-end test for the happy path in the [Accredited Programmes E2E repo](https://github.com/ministryofjustice/hmpps-accredited-programmes-e2e)
- [ ] This makes new expectations of the API...
  - [ ] ... and I have notified the API developer(s) of changes to the contract tests (Pact), or the API is already compliant
- [ ] [Manually approve](../doc/how-to/perform-a-release.md#releasing-to-the-preprod-environment) release to preprod
- [ ] [Manually approve](../doc/how-to/perform-a-release.md#releasing-to-the-production-environment) release to prod

<!-- Should a release fail at any step, you as the author should now lead the work to
fix it as soon as possible. You can monitor deployment failures in CircleCI
itself and application errors are found in
[Sentry](https://ministryofjustice.sentry.io/projects/hmpps-accredited-programmes-ui/?project=4505330122686464&referrer=sidebar&statsPeriod=24h). -->
