### PR TITLE
(APG-165) Add `recentCaseListPath` to session to be used when navigating between case lists and referrals

### DIFF
--- a/integration_tests/pages/page.ts
+++ b/integration_tests/pages/page.ts
@@ -348,7 +348,7 @@ export default abstract class Page {
       : referPathBase.pattern
 
     cy.get('[data-testid="show-referral-buttons"]').then(buttonsElement => {
-      const buttons = ShowReferralUtils.buttons(currentBasePath, referral, statusTransitions)
+      const buttons = ShowReferralUtils.buttons({ currentPath: currentBasePath }, referral, statusTransitions)
 
       cy.wrap(buttonsElement).within(() => {
         buttons.forEach((button, buttonIndex) => {

--- a/server/@types/express/index.d.ts
+++ b/server/@types/express/index.d.ts
@@ -9,6 +9,7 @@ declare module 'express-session' {
   // Declare that the session will potentially contain these additional fields
   interface SessionData {
     nowInMinutes: number
+    recentCaseListPath: string
     referralStatusUpdateData: ReferralStatusUpdateSessionData
     returnTo: string
     user: UserDetails

--- a/server/controllers/assess/caseListController.test.ts
+++ b/server/controllers/assess/caseListController.test.ts
@@ -27,6 +27,7 @@ const mockCaseListUtils = CaseListUtils as jest.Mocked<typeof CaseListUtils>
 describe('AssessCaseListController', () => {
   const username = 'USERNAME'
   const activeCaseLoadId = 'MDI'
+  const originalUrl = '/original-url'
   const referralStatusGroup = 'open'
   const pathWithQuery = 'path-with-query'
   const queryParamsExcludingPage: Array<QueryParam> = []
@@ -49,7 +50,7 @@ describe('AssessCaseListController', () => {
   beforeEach(() => {
     controller = new AssessCaseListController(courseService, referralService, referenceDataService)
 
-    request = createMock<Request>({ user: { username } })
+    request = createMock<Request>({ originalUrl, user: { username } })
     response = createMock<Response>({ locals: { user: { activeCaseLoadId, username } } })
   })
 
@@ -185,9 +186,12 @@ describe('AssessCaseListController', () => {
       })
 
       it('renders the show template with the correct response locals', async () => {
+        expect(request.session.recentCaseListPath).toBeUndefined()
+
         const requestHandler = controller.show()
         await requestHandler(request, response, next)
 
+        expect(request.session.recentCaseListPath).toBe(originalUrl)
         expect(response.render).toHaveBeenCalledWith('referrals/caseList/assess/show', {
           action: assessPaths.caseList.filter({ courseId: limeCourse.id, referralStatusGroup }),
           audienceSelectItems,

--- a/server/controllers/assess/caseListController.ts
+++ b/server/controllers/assess/caseListController.ts
@@ -117,6 +117,8 @@ export default class AssessCaseListController {
       }
       /* eslint-enable sort-keys */
 
+      req.session.recentCaseListPath = req.originalUrl
+
       return res.render('referrals/caseList/assess/show', {
         action: assessPaths.caseList.filter({ courseId, referralStatusGroup }),
         audienceSelectItems: CaseListUtils.audienceSelectItems(audience),

--- a/server/controllers/refer/caseListController.test.ts
+++ b/server/controllers/refer/caseListController.test.ts
@@ -25,6 +25,7 @@ jest.mock('../../utils/referrals/caseListUtils')
 describe('ReferCaseListController', () => {
   const username = 'USERNAME'
   const activeCaseLoadId = 'MDI'
+  const originalUrl = '/original-url'
   const pathWithQuery = 'path-with-query'
   const queryParamsExcludingPage: Array<QueryParam> = []
   const queryParamsExcludingSort: Array<QueryParam> = []
@@ -40,7 +41,7 @@ describe('ReferCaseListController', () => {
   beforeEach(() => {
     controller = new ReferCaseListController(referralService)
 
-    request = createMock<Request>({ flash: jest.fn().mockReturnValue([]), user: { username } })
+    request = createMock<Request>({ flash: jest.fn().mockReturnValue([]), originalUrl, user: { username } })
     response = createMock<Response>({ locals: { user: { activeCaseLoadId, username } } })
   })
 
@@ -92,9 +93,12 @@ describe('ReferCaseListController', () => {
       })
 
       it('renders the show template with the correct response locals', async () => {
+        expect(request.session.recentCaseListPath).toBeUndefined()
+
         const requestHandler = controller.show()
         await requestHandler(request, response, next)
 
+        expect(request.session.recentCaseListPath).toBe(originalUrl)
         expect(response.render).toHaveBeenCalledWith('referrals/caseList/refer/show', {
           isMyReferralsPage: true,
           pageHeading: 'My referrals',

--- a/server/controllers/refer/caseListController.ts
+++ b/server/controllers/refer/caseListController.ts
@@ -77,6 +77,8 @@ export default class ReferCaseListController {
         sortableCaseListColumns.status = 'Referral status'
       }
 
+      req.session.recentCaseListPath = req.originalUrl
+
       return res.render('referrals/caseList/refer/show', {
         draftReferralDeletedMessage: req.flash('draftReferralDeletedMessage')[0],
         isMyReferralsPage: true,

--- a/server/controllers/shared/referralsController.test.ts
+++ b/server/controllers/shared/referralsController.test.ts
@@ -63,6 +63,7 @@ describe('ReferralsController', () => {
   const subNavigationItems = [{ active: true, href: 'sub-nav-href', text: 'Sub Nav Item' }]
   const buttons = [{ href: 'button-href', text: 'Button' }]
   const referrerEmail = 'referrer.email@test-email.co.uk'
+  const recentCaseListPath = '/case-list-path'
   let person: Person
   let referral: Referral
   let referringUser: User
@@ -117,7 +118,11 @@ describe('ReferralsController', () => {
       userService,
     )
 
-    request = createMock<Request>({ params: { referralId: referral.id }, user: { token: userToken, username } })
+    request = createMock<Request>({
+      params: { referralId: referral.id },
+      session: { recentCaseListPath },
+      user: { token: userToken, username },
+    })
     response = Helpers.createMockResponseWithCaseloads()
   })
 
@@ -409,7 +414,11 @@ describe('ReferralsController', () => {
     expect(courseService.getOffering).toHaveBeenCalledWith(username, referral.offeringId)
     expect(personService.getPerson).toHaveBeenCalledWith(username, person.prisonNumber)
     expect(organisationService.getOrganisation).toHaveBeenCalledWith(userToken, organisation.id)
-    expect(mockShowReferralUtils.buttons).toHaveBeenCalledWith(path, referral, isRefer ? statusTransitions : undefined)
+    expect(mockShowReferralUtils.buttons).toHaveBeenCalledWith(
+      { currentPath: path, recentCaseListPath },
+      referral,
+      isRefer ? statusTransitions : undefined,
+    )
     expect(mockShowReferralUtils.viewReferralNavigationItems).toHaveBeenCalledWith(path, referral.id)
     expect(mockShowReferralUtils.subNavigationItems).toHaveBeenCalledWith(path, 'referral', referral.id)
 

--- a/server/controllers/shared/referralsController.ts
+++ b/server/controllers/shared/referralsController.ts
@@ -187,7 +187,11 @@ export default class ReferralsController {
     const coursePresenter = CourseUtils.presentCourse(course)
 
     return {
-      buttons: ShowReferralUtils.buttons(req.path, referral, statusTransitions),
+      buttons: ShowReferralUtils.buttons(
+        { currentPath: req.path, recentCaseListPath: req.session.recentCaseListPath },
+        referral,
+        statusTransitions,
+      ),
       courseOfferingSummaryListRows: ShowReferralUtils.courseOfferingSummaryListRows(
         person.name,
         coursePresenter,

--- a/server/controllers/shared/risksAndNeedsController.test.ts
+++ b/server/controllers/shared/risksAndNeedsController.test.ts
@@ -101,6 +101,7 @@ describe('RisksAndNeedsController', () => {
   const navigationItems = [{ active: true, href: 'nav-href', text: 'Nav Item' }]
   const subNavigationItems = [{ active: true, href: 'sub-nav-href', text: 'Sub Nav Item' }]
   const buttons = [{ href: 'button-href', text: 'Button' }]
+  const recentCaseListPath = '/case-list-path'
   let person: Person
   let referral: Referral
   let sharedPageData: RisksAndNeedsSharedPageData
@@ -135,7 +136,11 @@ describe('RisksAndNeedsController', () => {
 
     controller = new RisksAndNeedsController(courseService, oasysService, personService, referralService)
 
-    request = createMock<Request>({ params: { referralId: referral.id }, user: { token: userToken, username } })
+    request = createMock<Request>({
+      params: { referralId: referral.id },
+      session: { recentCaseListPath },
+      user: { token: userToken, username },
+    })
     response = Helpers.createMockResponseWithCaseloads()
   })
 
@@ -896,7 +901,11 @@ describe('RisksAndNeedsController', () => {
     expect(referralService.getReferral).toHaveBeenCalledWith(username, referral.id)
     expect(courseService.getCourseByOffering).toHaveBeenCalledWith(username, referral.offeringId)
     expect(personService.getPerson).toHaveBeenCalledWith(username, person.prisonNumber)
-    expect(mockShowReferralUtils.buttons).toHaveBeenCalledWith(path, referral, isRefer ? statusTransitions : undefined)
+    expect(mockShowReferralUtils.buttons).toHaveBeenCalledWith(
+      { currentPath: path, recentCaseListPath },
+      referral,
+      isRefer ? statusTransitions : undefined,
+    )
 
     if (isRefer) {
       expect(referralService.getStatusTransitions).toHaveBeenCalledWith(username, referral.id)

--- a/server/controllers/shared/risksAndNeedsController.ts
+++ b/server/controllers/shared/risksAndNeedsController.ts
@@ -419,7 +419,11 @@ export default class RisksAndNeedsController {
     const coursePresenter = CourseUtils.presentCourse(course)
 
     return {
-      buttons: ShowReferralUtils.buttons(req.path, referral, statusTransitions),
+      buttons: ShowReferralUtils.buttons(
+        { currentPath: req.path, recentCaseListPath: req.session.recentCaseListPath },
+        referral,
+        statusTransitions,
+      ),
       navigationItems: ShowRisksAndNeedsUtils.navigationItems(req.path, referral.id),
       pageHeading: `Referral to ${coursePresenter.displayName}`,
       pageSubHeading: 'Risks and needs',

--- a/server/controllers/shared/statusHistoryController.test.ts
+++ b/server/controllers/shared/statusHistoryController.test.ts
@@ -49,6 +49,7 @@ describe('StatusHistoryController', () => {
       label: { text: 'Referral submitted' },
     },
   ]
+  const recentCaseListPath = '/case-list-path'
   let person: Person
   let referral: Referral
   let referralStatusHistory: Array<ReferralStatusHistoryPresenter>
@@ -77,6 +78,7 @@ describe('StatusHistoryController', () => {
     request = createMock<Request>({
       params: { referralId: referral.id },
       path: referPaths.show.statusHistory({ referralId: referral.id }),
+      session: { recentCaseListPath },
       user: { token: userToken, username },
     })
     response = Helpers.createMockResponseWithCaseloads()
@@ -111,7 +113,11 @@ describe('StatusHistoryController', () => {
         'statusHistory',
         referral.id,
       )
-      expect(mockShowReferralUtils.buttons).toHaveBeenCalledWith(request.path, referral, statusTransitions)
+      expect(mockShowReferralUtils.buttons).toHaveBeenCalledWith(
+        { currentPath: request.path, recentCaseListPath },
+        referral,
+        statusTransitions,
+      )
       expect(mockShowReferralUtils.statusHistoryTimelineItems).toHaveBeenCalledWith(referralStatusHistory)
     })
 
@@ -144,7 +150,11 @@ describe('StatusHistoryController', () => {
         await requestHandler(request, response, next)
 
         expect(referralService.getStatusTransitions).not.toHaveBeenCalled()
-        expect(mockShowReferralUtils.buttons).toHaveBeenCalledWith(request.path, referral, undefined)
+        expect(mockShowReferralUtils.buttons).toHaveBeenCalledWith(
+          { currentPath: request.path, recentCaseListPath },
+          referral,
+          undefined,
+        )
       })
     })
   })

--- a/server/controllers/shared/statusHistoryController.ts
+++ b/server/controllers/shared/statusHistoryController.ts
@@ -34,7 +34,11 @@ export default class StatusHistoryController {
       const coursePresenter = CourseUtils.presentCourse(course)
 
       return res.render('referrals/show/statusHistory/show', {
-        buttons: ShowReferralUtils.buttons(req.path, referral, statusTransitions),
+        buttons: ShowReferralUtils.buttons(
+          { currentPath: req.path, recentCaseListPath: req.session.recentCaseListPath },
+          referral,
+          statusTransitions,
+        ),
         pageHeading: `Referral to ${coursePresenter.displayName}`,
         pageSubHeading: 'Status history',
         person,

--- a/server/utils/referrals/showReferralUtils.test.ts
+++ b/server/utils/referrals/showReferralUtils.test.ts
@@ -23,7 +23,7 @@ describe('ShowReferralUtils', () => {
       it('contains the "Back to referrals" and "Update status" buttons with the corect hrefs', () => {
         expect(
           ShowReferralUtils.buttons(
-            assessPaths.show.statusHistory({ referralId: submittedReferral.id }),
+            { currentPath: assessPaths.show.statusHistory({ referralId: submittedReferral.id }) },
             submittedReferral,
           ),
         ).toEqual([
@@ -46,7 +46,7 @@ describe('ShowReferralUtils', () => {
 
           expect(
             ShowReferralUtils.buttons(
-              assessPaths.show.statusHistory({ referralId: closedReferral.id }),
+              { currentPath: assessPaths.show.statusHistory({ referralId: closedReferral.id }) },
               closedReferral,
             ),
           ).toEqual(
@@ -61,13 +61,36 @@ describe('ShowReferralUtils', () => {
           )
         })
       })
+
+      describe('and there is a `recentCaseListPath` value', () => {
+        it('contains the "Back to referrals" button with the correct href', () => {
+          const recentCaseListPath = '/assess/referrals/case-list'
+
+          expect(
+            ShowReferralUtils.buttons(
+              {
+                currentPath: assessPaths.show.statusHistory({ referralId: submittedReferral.id }),
+                recentCaseListPath,
+              },
+              submittedReferral,
+            ),
+          ).toEqual(
+            expect.arrayContaining([
+              {
+                href: recentCaseListPath,
+                text: 'Back to referrals',
+              },
+            ]),
+          )
+        })
+      })
     })
 
     describe('when on the refer journey', () => {
       it('contains the correct buttons, with the "Withdraw referral" and "Hold" buttons in a disabled state', () => {
         expect(
           ShowReferralUtils.buttons(
-            referPaths.show.statusHistory({ referralId: submittedReferral.id }),
+            { currentPath: referPaths.show.statusHistory({ referralId: submittedReferral.id }) },
             submittedReferral,
           ),
         ).toEqual([
@@ -93,7 +116,10 @@ describe('ShowReferralUtils', () => {
           const closedReferral = referralFactory.closed().build()
 
           expect(
-            ShowReferralUtils.buttons(referPaths.show.statusHistory({ referralId: closedReferral.id }), closedReferral),
+            ShowReferralUtils.buttons(
+              { currentPath: referPaths.show.statusHistory({ referralId: closedReferral.id }) },
+              closedReferral,
+            ),
           ).toEqual(
             expect.arrayContaining([
               {
@@ -123,7 +149,7 @@ describe('ShowReferralUtils', () => {
           it('contains the "Put on hold" button with the correct href', () => {
             expect(
               ShowReferralUtils.buttons(
-                referPaths.show.statusHistory({ referralId: submittedReferral.id }),
+                { currentPath: referPaths.show.statusHistory({ referralId: submittedReferral.id }) },
                 submittedReferral,
                 statusTransitions,
               ),
@@ -149,7 +175,7 @@ describe('ShowReferralUtils', () => {
           it('contains the "Remove hold" button with the correct href', () => {
             expect(
               ShowReferralUtils.buttons(
-                referPaths.show.statusHistory({ referralId: submittedReferral.id }),
+                { currentPath: referPaths.show.statusHistory({ referralId: submittedReferral.id }) },
                 submittedReferral,
                 statusTransitions,
               ),
@@ -172,7 +198,7 @@ describe('ShowReferralUtils', () => {
           it('contains the "Withdraw referral" button with the correct href', () => {
             expect(
               ShowReferralUtils.buttons(
-                referPaths.show.statusHistory({ referralId: submittedReferral.id }),
+                { currentPath: referPaths.show.statusHistory({ referralId: submittedReferral.id }) },
                 submittedReferral,
                 statusTransitions,
               ),

--- a/server/utils/referrals/showReferralUtils.ts
+++ b/server/utils/referrals/showReferralUtils.ts
@@ -16,17 +16,20 @@ import type { User, UserEmail } from '@manage-users-api'
 
 export default class ShowReferralUtils {
   static buttons(
-    currentPath: Request['path'],
+    referencePaths: {
+      currentPath: Request['path']
+      recentCaseListPath?: string
+    },
     referral: Referral,
     statusTransitions?: Array<ReferralStatusRefData>,
   ): Array<GovukFrontendButton> {
-    const isAssess = currentPath.startsWith(assessPathBase.pattern)
+    const isAssess = referencePaths.currentPath.startsWith(assessPathBase.pattern)
     const paths = isAssess ? assessPaths : referPaths
     const { closed } = referral
 
     const buttons: Array<GovukFrontendButton> = [
       {
-        href: paths.caseList.index({}),
+        href: referencePaths.recentCaseListPath || paths.caseList.index({}),
         text: 'Back to referrals',
       },
     ]


### PR DESCRIPTION
## Context

Currently, when viewing a referral, the Back to referrals button link takes the user back to the course index which is always the first course.  This could be confusing and a tedious experience because it is possible that the user may have been viewing another course, with filters selected, on another page number other than 1.

## Changes in this PR
Store recently viewed case list path in session and update Back to referrals button to use that value.




## Release checklist

[Release process documentation](../doc/how-to/perform-a-release.md)

As part of our continuous deployment strategy we must ensure that this work is
ready to be released once merged.

### Pre-merge

- [ ] There are changes required to the Accredited Programmes API for this change to work...
  - [ ] ... and they have been released to production already

### Post-merge

<!-- The outer checkboxes can be completed pre-merge -->

- [ ] This adds, extends or meaningfully modifies a feature...
  - [ ] ... and I have written or updated an end-to-end test for the happy path in the [Accredited Programmes E2E repo](https://github.com/ministryofjustice/hmpps-accredited-programmes-e2e)
- [ ] This makes new expectations of the API...
  - [ ] ... and I have notified the API developer(s) of changes to the contract tests (Pact), or the API is already compliant
- [ ] [Manually approve](../doc/how-to/perform-a-release.md#releasing-to-the-preprod-environment) release to preprod
- [ ] [Manually approve](../doc/how-to/perform-a-release.md#releasing-to-the-production-environment) release to prod

<!-- Should a release fail at any step, you as the author should now lead the work to
fix it as soon as possible. You can monitor deployment failures in CircleCI
itself and application errors are found in
[Sentry](https://ministryofjustice.sentry.io/projects/hmpps-accredited-programmes-ui/?project=4505330122686464&referrer=sidebar&statsPeriod=24h). -->
