### PR TITLE
(APG-164) Update final page of update status journeys to use notes/reason box

### DIFF
--- a/integration_tests/e2e/refer/withdraw.cy.ts
+++ b/integration_tests/e2e/refer/withdraw.cy.ts
@@ -9,6 +9,7 @@ import {
   referralStatusCategoryFactory,
   referralStatusHistoryFactory,
   referralStatusReasonFactory,
+  referralStatusRefDataFactory,
   userFactory,
 } from '../../../server/testutils/factories'
 import auth from '../../mockApis/auth'
@@ -65,6 +66,12 @@ context('Withdraw referral', () => {
   const selectedCategory = referralStatusCategories[0].code
   const selectedReason = referralStatusReasons[0].code
   const reasonInformation = 'Some reason information'
+  const referralStatusCodeData = referralStatusRefDataFactory.build({
+    code: 'WITHDRAWN',
+    hasConfirmation: false,
+    hasNotes: true,
+    notesOptional: false,
+  })
 
   beforeEach(() => {
     cy.task('reset')
@@ -97,6 +104,7 @@ context('Withdraw referral', () => {
       }),
       referralId: referral.id,
     })
+    cy.task('stubReferralStatusCodeData', referralStatusCodeData)
   })
 
   describe('withdrawal category', () => {

--- a/server/@types/models/Referral.ts
+++ b/server/@types/models/Referral.ts
@@ -27,6 +27,7 @@ const referralStatusGroups = ['open', 'draft', 'closed'] as const
 
 interface ConfirmationFields {
   hasConfirmation: boolean
+  notesOptional: boolean
   primaryDescription: string
   primaryHeading: string
   secondaryDescription: string
@@ -111,6 +112,7 @@ type ReferralStatusRefData = {
   hasNotes?: boolean
   hintText?: string
   hold?: boolean
+  notesOptional?: boolean
   release?: boolean
 }
 

--- a/server/controllers/assess/updateStatusDecisionController.test.ts
+++ b/server/controllers/assess/updateStatusDecisionController.test.ts
@@ -15,7 +15,7 @@ import {
 } from '../../testutils/factories'
 import Helpers from '../../testutils/helpers'
 import { FormUtils, ReferralUtils, ShowReferralUtils } from '../../utils'
-import type { Person, Referral, ReferralStatusRefData } from '@accredited-programmes/models'
+import type { ConfirmationFields, Person, Referral, ReferralStatusRefData } from '@accredited-programmes/models'
 import type { MojTimelineItem, ReferralStatusHistoryPresenter } from '@accredited-programmes/ui'
 import type { GovukFrontendRadiosItem } from '@govuk-frontend'
 
@@ -205,8 +205,9 @@ describe('UpdateStatusDecisionController', () => {
 
       describe('and viewing the final decision step of `ASSESSED_SUITABLE`', () => {
         it('should call `getConfirmationText`, call to check the correct radio item and render the template with the correct response locals', async () => {
-          const confirmationText = {
+          const confirmationText: ConfirmationFields = {
             hasConfirmation: false,
+            notesOptional: false,
             primaryDescription:
               'This person cannot complete the programme now. They may be able to join or restart in the future.',
             primaryHeading: 'Deselection: keep referral open',

--- a/server/controllers/shared/index.ts
+++ b/server/controllers/shared/index.ts
@@ -44,6 +44,7 @@ const controllers = (services: Services) => {
 
   const updateStatusSelectionController = new UpdateStatusSelectionController(
     services.personService,
+    services.referenceDataService,
     services.referralService,
   )
 

--- a/server/controllers/shared/updateStatusSelectionController.test.ts
+++ b/server/controllers/shared/updateStatusSelectionController.test.ts
@@ -4,12 +4,13 @@ import type { NextFunction, Request, Response } from 'express'
 
 import UpdateStatusSelectionController from './updateStatusSelectionController'
 import { assessPaths, referPaths } from '../../paths'
-import type { PersonService, ReferralService } from '../../services'
+import type { PersonService, ReferenceDataService, ReferralService } from '../../services'
 import {
   confirmationFieldsFactory,
   personFactory,
   referralFactory,
   referralStatusHistoryFactory,
+  referralStatusRefDataFactory,
 } from '../../testutils/factories'
 import Helpers from '../../testutils/helpers'
 import { FormUtils, ShowReferralUtils } from '../../utils'
@@ -30,6 +31,7 @@ describe('UpdateStatusSelectionController', () => {
   const next: DeepMocked<NextFunction> = createMock<NextFunction>({})
 
   const personService = createMock<PersonService>({})
+  const referenceDataService = createMock<ReferenceDataService>({})
   const referralService = createMock<ReferralService>({})
 
   let person: Person
@@ -65,7 +67,7 @@ describe('UpdateStatusSelectionController', () => {
     referralService.getReferralStatusHistory.mockResolvedValue(referralStatusHistory)
     referralService.getConfirmationText.mockResolvedValue(confirmationText)
 
-    controller = new UpdateStatusSelectionController(personService, referralService)
+    controller = new UpdateStatusSelectionController(personService, referenceDataService, referralService)
 
     request = createMock<Request>({
       params: { referralId: referral.id },
@@ -91,7 +93,7 @@ describe('UpdateStatusSelectionController', () => {
       await requestHandler(request, response, next)
 
       expect(response.render).toHaveBeenCalledWith('referrals/updateStatus/selection/show', {
-        action: assessPaths.updateStatus.selection.confirmation.submit({ referralId: referral.id }),
+        action: assessPaths.updateStatus.selection.reason.submit({ referralId: referral.id }),
         backLinkHref: assessPaths.show.statusHistory({ referralId: referral.id }),
         confirmationText,
         maxLength: 500,
@@ -107,7 +109,8 @@ describe('UpdateStatusSelectionController', () => {
         ptUser: true,
       })
       expect(personService.getPerson).toHaveBeenCalledWith(username, referral.prisonNumber)
-      expect(FormUtils.setFieldErrors).toHaveBeenCalledWith(request, response, ['confirmation'])
+      expect(FormUtils.setFieldErrors).toHaveBeenCalledWith(request, response, ['reason'])
+      expect(FormUtils.setFormValues).toHaveBeenCalledWith(request, response)
     })
 
     describe('when the `initialStatusDecision` is `DESELECTED|OPEN`', () => {
@@ -189,118 +192,34 @@ describe('UpdateStatusSelectionController', () => {
         expect(response.redirect).toHaveBeenCalledWith(assessPaths.show.statusHistory({ referralId: referral.id }))
       })
     })
-
-    describe('when the confirmation text endpoint returns `hasConfirmation: false`', () => {
-      it('should render the template with the correct form action and call the relevant `FormUtils` methods', async () => {
-        confirmationText = confirmationFieldsFactory.build({ hasConfirmation: false })
-        referralService.getConfirmationText.mockResolvedValue(confirmationText)
-
-        const requestHandler = controller.show()
-        await requestHandler(request, response, next)
-
-        expect(response.render).toHaveBeenCalledWith(
-          'referrals/updateStatus/selection/show',
-          expect.objectContaining({
-            action: assessPaths.updateStatus.selection.reason.submit({ referralId: referral.id }),
-          }),
-        )
-
-        expect(FormUtils.setFieldErrors).toHaveBeenCalledWith(request, response, ['reason'])
-        expect(FormUtils.setFormValues).toHaveBeenCalledWith(request, response)
-      })
-    })
-  })
-
-  describe('submitConfirmation', () => {
-    beforeEach(() => {
-      request.body = { confirmation: 'true' }
-    })
-
-    it('should update the referral status, delete `referralStatusUpdateData` and redirect back to the status history page of the referral', async () => {
-      const requestHandler = controller.submitConfirmation()
-      await requestHandler(request, response, next)
-
-      expect(referralService.updateReferralStatus).toHaveBeenCalledWith(username, referral.id, {
-        ptUser: true,
-        status: 'ON_PROGRAMME',
-      })
-      expect(request.session.referralStatusUpdateData).toBeUndefined()
-      expect(response.redirect).toHaveBeenCalledWith(assessPaths.show.statusHistory({ referralId: referral.id }))
-    })
-
-    describe('when `referralStatusUpdateData` is for a different referral', () => {
-      it('should redirect to the status history route', async () => {
-        request.session.referralStatusUpdateData = {
-          finalStatusDecision: 'ON_PROGRAMME',
-          referralId: 'DIFFERENT_REFERRAL_ID',
-        }
-
-        const requestHandler = controller.submitConfirmation()
-        await requestHandler(request, response, next)
-
-        expect(response.redirect).toHaveBeenCalledWith(assessPaths.show.statusHistory({ referralId: referral.id }))
-      })
-    })
-
-    describe('when there is no `referralStatusUpdateData`', () => {
-      it('should redirect to the status history route', async () => {
-        request.session.referralStatusUpdateData = undefined
-
-        const requestHandler = controller.submitConfirmation()
-        await requestHandler(request, response, next)
-
-        expect(response.redirect).toHaveBeenCalledWith(assessPaths.show.statusHistory({ referralId: referral.id }))
-      })
-    })
-
-    describe('when submitting the form on the refer journey', () => {
-      it('should update the referral status, delete `referralStatusUpdateData` and redirect back to the refer status history page of the referral', async () => {
-        request.path = referPaths.updateStatus.selection.show({ referralId: referral.id })
-
-        const requestHandler = controller.submitConfirmation()
-        await requestHandler(request, response, next)
-
-        expect(referralService.updateReferralStatus).toHaveBeenCalledWith(username, referral.id, {
-          ptUser: false,
-          status: 'ON_PROGRAMME',
-        })
-        expect(request.session.referralStatusUpdateData).toBeUndefined()
-        expect(response.redirect).toHaveBeenCalledWith(referPaths.show.statusHistory({ referralId: referral.id }))
-      })
-    })
-
-    describe('when `confirmation` is not present', () => {
-      it('should redirect to the update status selection show page', async () => {
-        request.body = {}
-
-        const requestHandler = controller.submitConfirmation()
-        await requestHandler(request, response, next)
-
-        expect(request.flash).toHaveBeenCalledWith('confirmationError', 'Select confirmation')
-        expect(response.redirect).toHaveBeenCalledWith(
-          assessPaths.updateStatus.selection.show({ referralId: referral.id }),
-        )
-      })
-    })
   })
 
   describe('submitReason', () => {
+    const code = 'NOT_SUITABLE'
     const reason = 'This person is not suitable for the programme.'
 
     beforeEach(() => {
       request.body = { reason }
       request.session.referralStatusUpdateData = {
-        finalStatusDecision: 'NOT_SUITABLE',
+        finalStatusDecision: code,
         referralId: referral.id,
         statusCategoryCode: 'STATUS_CATEGORY_CODE',
         statusReasonCode: 'STATUS_REASON_CODE',
       }
+      referenceDataService.getReferralStatusCodeData.mockResolvedValue(
+        referralStatusRefDataFactory.build({
+          code,
+          hasNotes: true,
+          notesOptional: false,
+        }),
+      )
     })
 
     it('should update the referral status, delete `referralStatusUpdateData` and redirect back to the status history page of the referral', async () => {
       const requestHandler = controller.submitReason()
       await requestHandler(request, response, next)
 
+      expect(referenceDataService.getReferralStatusCodeData).toHaveBeenCalledWith(username, 'NOT_SUITABLE')
       expect(referralService.updateReferralStatus).toHaveBeenCalledWith(username, referral.id, {
         category: 'STATUS_CATEGORY_CODE',
         notes: reason,
@@ -357,16 +276,41 @@ describe('UpdateStatusSelectionController', () => {
     })
 
     describe('when `reason` is not present', () => {
-      it('should redirect to the update status selection show page with a flash message', async () => {
-        request.body = {}
+      describe('and `notesOptional` is `false`', () => {
+        it('should redirect to the update status selection show page with a flash message', async () => {
+          request.body = {}
 
-        const requestHandler = controller.submitReason()
-        await requestHandler(request, response, next)
+          const requestHandler = controller.submitReason()
+          await requestHandler(request, response, next)
 
-        expect(request.flash).toHaveBeenCalledWith('reasonError', 'Enter a reason')
-        expect(response.redirect).toHaveBeenCalledWith(
-          assessPaths.updateStatus.selection.show({ referralId: referral.id }),
-        )
+          expect(request.flash).toHaveBeenCalledWith('reasonError', 'Enter a reason')
+          expect(response.redirect).toHaveBeenCalledWith(
+            assessPaths.updateStatus.selection.show({ referralId: referral.id }),
+          )
+        })
+      })
+
+      describe('and `notesOptional` is `true`', () => {
+        it('should update the referral status, delete `referralStatusUpdateData` and redirect back to the status history page of the referral', async () => {
+          referenceDataService.getReferralStatusCodeData.mockResolvedValue(
+            referralStatusRefDataFactory.build({ code, hasNotes: true, notesOptional: true }),
+          )
+
+          request.body = {}
+
+          const requestHandler = controller.submitReason()
+          await requestHandler(request, response, next)
+
+          expect(referralService.updateReferralStatus).toHaveBeenCalledWith(username, referral.id, {
+            category: 'STATUS_CATEGORY_CODE',
+            notes: undefined,
+            ptUser: true,
+            reason: 'STATUS_REASON_CODE',
+            status: 'NOT_SUITABLE',
+          })
+          expect(request.session.referralStatusUpdateData).toBeUndefined()
+          expect(response.redirect).toHaveBeenCalledWith(assessPaths.show.statusHistory({ referralId: referral.id }))
+        })
       })
     })
 

--- a/server/routes/assess.ts
+++ b/server/routes/assess.ts
@@ -55,10 +55,6 @@ export default function routes(controllers: Controllers, router: Router): Router
   post(assessPaths.updateStatus.reason.submit.pattern, reasonController.submit())
 
   get(assessPaths.updateStatus.selection.show.pattern, updateStatusSelectionController.show())
-  post(
-    assessPaths.updateStatus.selection.confirmation.submit.pattern,
-    updateStatusSelectionController.submitConfirmation(),
-  )
   post(assessPaths.updateStatus.selection.reason.submit.pattern, updateStatusSelectionController.submitReason())
 
   return router

--- a/server/routes/refer.ts
+++ b/server/routes/refer.ts
@@ -103,10 +103,6 @@ export default function routes(controllers: Controllers, router: Router): Router
   post(referPaths.updateStatus.reason.submit.pattern, reasonController.submit())
 
   get(referPaths.updateStatus.selection.show.pattern, updateStatusSelectionController.show())
-  post(
-    referPaths.updateStatus.selection.confirmation.submit.pattern,
-    updateStatusSelectionController.submitConfirmation(),
-  )
   post(referPaths.updateStatus.selection.reason.submit.pattern, updateStatusSelectionController.submitReason())
 
   get(referPaths.manageHold.pattern, updateStatusActionController.manageHold())

--- a/server/testutils/factories/confirmationFields.ts
+++ b/server/testutils/factories/confirmationFields.ts
@@ -6,6 +6,7 @@ import type { ConfirmationFields } from '@accredited-programmes/models'
 export default Factory.define<ConfirmationFields>(() => {
   return {
     hasConfirmation: faker.datatype.boolean(),
+    notesOptional: faker.datatype.boolean(),
     primaryDescription: faker.lorem.sentence(),
     primaryHeading: faker.lorem.words({ max: 4, min: 2 }),
     secondaryDescription: faker.lorem.sentence(),

--- a/server/testutils/factories/referralStatusRefData.ts
+++ b/server/testutils/factories/referralStatusRefData.ts
@@ -27,5 +27,6 @@ export default Factory.define<ReferralStatusRefData>(({ params }) => {
     draft: faker.datatype.boolean(),
     hasConfirmation,
     hasNotes,
+    notesOptional: hasNotes ? faker.datatype.boolean() : false,
   }
 })

--- a/server/views/referrals/updateStatus/selection/show.njk
+++ b/server/views/referrals/updateStatus/selection/show.njk
@@ -14,33 +14,20 @@
 
     <h2 class="govuk-heading-m">{{ confirmationText.secondaryHeading }}</h2>
 
-    {% if confirmationText.hasConfirmation %}
-      {{ govukCheckboxes({
-        name: "confirmation",
-        items: [
-          {
-            value: "true",
-            text: confirmationText.secondaryDescription
-          }
-        ],
-        errorMessage: errors.messages.confirmation
-      }) }}
-    {% else %}
-      <p>{{ confirmationText.secondaryDescription }}</p>
+    <p>{{ confirmationText.secondaryDescription }}</p>
 
-      {{ govukCharacterCount({
-        id: "reason",
-        name: "reason",
-        maxlength: maxLength,
-        label: {
-          text: "Add reason",
-          classes: 'govuk-fieldset__legend--s'
-        },
-        value: formValues.reason,
-        classes: "govuk-!-width-three-quarters",
-        errorMessage: errors.messages.reason
-      }) }}
-    {% endif %}
+    {{ govukCharacterCount({
+      id: "reason",
+      name: "reason",
+      maxlength: maxLength,
+      label: {
+        text: "Add reason" + (" (optional)" if confirmationText.notesOptional),
+        classes: 'govuk-fieldset__legend--s'
+      },
+      value: formValues.reason,
+      classes: "govuk-!-width-three-quarters",
+      errorMessage: errors.messages.reason
+    }) }}
 
     {% if confirmationText.warningText %}
       {{ govukWarningText({


### PR DESCRIPTION
Some status codes will state that the notes can be optional.

## Context

When updating the status of a referral none of the ‘happy path’ journeys allow the user to add additional information. Feedback from user research suggests this creates a user needs gap. We need to add a notes box for all journeys where the status is updated.



## Changes in this PR
Removed confirmation checkbox related code and make all status update journeys have a reason textarea.  On some occasions this can be optional.




## Release checklist

[Release process documentation](../doc/how-to/perform-a-release.md)

As part of our continuous deployment strategy we must ensure that this work is
ready to be released once merged.

### Pre-merge

- [ ] There are changes required to the Accredited Programmes API for this change to work...
  - [ ] ... and they have been released to production already

### Post-merge

<!-- The outer checkboxes can be completed pre-merge -->

- [ ] This adds, extends or meaningfully modifies a feature...
  - [ ] ... and I have written or updated an end-to-end test for the happy path in the [Accredited Programmes E2E repo](https://github.com/ministryofjustice/hmpps-accredited-programmes-e2e)
- [ ] This makes new expectations of the API...
  - [ ] ... and I have notified the API developer(s) of changes to the contract tests (Pact), or the API is already compliant
- [ ] [Manually approve](../doc/how-to/perform-a-release.md#releasing-to-the-preprod-environment) release to preprod
- [ ] [Manually approve](../doc/how-to/perform-a-release.md#releasing-to-the-production-environment) release to prod

<!-- Should a release fail at any step, you as the author should now lead the work to
fix it as soon as possible. You can monitor deployment failures in CircleCI
itself and application errors are found in
[Sentry](https://ministryofjustice.sentry.io/projects/hmpps-accredited-programmes-ui/?project=4505330122686464&referrer=sidebar&statsPeriod=24h). -->
