### PR TITLE
(APG-255) Add Location column to PT case list

### DIFF
--- a/integration_tests/e2e/assess/caseList.cy.ts
+++ b/integration_tests/e2e/assess/caseList.cy.ts
@@ -26,6 +26,7 @@ context('Referral case lists', () => {
 
   const columnHeaders: Array<CaseListColumnHeader> = [
     'Name and prison number',
+    'Location',
     'Earliest release date',
     'Programme strand',
     'Sentence type',

--- a/server/@types/models/Referral.ts
+++ b/server/@types/models/Referral.ts
@@ -125,6 +125,7 @@ type ReferralView = {
   earliestReleaseDateType?: string
   forename?: string
   listDisplayName?: string
+  location?: string
   nonDtoReleaseDateType?: Prisoner['nonDtoReleaseDateType']
   organisationId?: Organisation['id']
   organisationName?: Organisation['name']

--- a/server/@types/ui/index.d.ts
+++ b/server/@types/ui/index.d.ts
@@ -64,6 +64,7 @@ type TagColour =
 type CaseListColumnHeader =
   | 'Date referred'
   | 'Earliest release date'
+  | 'Location'
   | 'Name and prison number'
   | 'Programme location'
   | 'Programme name'
@@ -196,6 +197,7 @@ type SortableCaseListColumnKey =
   | 'audience'
   | 'earliestReleaseDate'
   | 'listDisplayName'
+  | 'location'
   | 'organisationName'
   | 'sentenceType'
   | 'status'

--- a/server/controllers/assess/caseListController.test.ts
+++ b/server/controllers/assess/caseListController.test.ts
@@ -134,6 +134,7 @@ describe('AssessCaseListController', () => {
     const tableHeadings = 'fff' as unknown as jest.Mocked<Array<GovukFrontendTableHeadElement>>
     const columnsToInclude: Array<CaseListColumnHeader> = [
       'Name and prison number',
+      'Location',
       'Earliest release date',
       'Programme strand',
       'Sentence type',
@@ -235,6 +236,7 @@ describe('AssessCaseListController', () => {
           {
             audience: 'Programme strand',
             earliestReleaseDate: 'Earliest release date',
+            location: 'Location',
             sentenceType: 'Sentence type',
             status: 'Referral status',
             surname: 'Name and prison number',
@@ -313,6 +315,7 @@ describe('AssessCaseListController', () => {
             {
               audience: 'Programme strand',
               earliestReleaseDate: 'Earliest release date',
+              location: 'Location',
               sentenceType: 'Sentence type',
               status: 'Referral status',
               surname: 'Name and prison number',
@@ -391,6 +394,7 @@ describe('AssessCaseListController', () => {
           {
             audience: 'Programme strand',
             earliestReleaseDate: 'Earliest release date',
+            location: 'Location',
             sentenceType: 'Sentence type',
             status: 'Referral status',
             surname: 'Name and prison number',

--- a/server/controllers/assess/caseListController.ts
+++ b/server/controllers/assess/caseListController.ts
@@ -110,6 +110,7 @@ export default class AssessCaseListController {
       /* eslint-disable sort-keys */
       const caseListColumns: Partial<Record<SortableCaseListColumnKey, CaseListColumnHeader>> = {
         surname: 'Name and prison number',
+        location: 'Location',
         earliestReleaseDate: 'Earliest release date',
         audience: 'Programme strand',
         sentenceType: 'Sentence type',

--- a/server/testutils/factories/referralView.ts
+++ b/server/testutils/factories/referralView.ts
@@ -37,6 +37,7 @@ export default ReferralViewFactory.define(({ params, transientParams }) => {
     ]),
     forename: faker.person.firstName(),
     listDisplayName: `${courseName}: ${audience}`,
+    location: `${faker.location.county()} (HMP)`,
     nonDtoReleaseDateType: faker.helpers.arrayElement(['ARD', 'CRD', 'NPD', 'PRRD']),
     organisationId: faker.string.alpha({ casing: 'upper', length: 3 }),
     organisationName: `${faker.location.county()} (HMP)`,

--- a/server/utils/referrals/caseListUtils.test.ts
+++ b/server/utils/referrals/caseListUtils.test.ts
@@ -381,6 +381,7 @@ describe('CaseListUtils', () => {
       earliestReleaseDateType: 'Home detention curfew eligibility date',
       forename: 'Del',
       id: 'referral-123',
+      location: 'Whatton (HMP)',
       nonDtoReleaseDateType: 'ARD',
       organisationName: 'Whatton (HMP)',
       paroleEligibilityDate: new Date('2022-01-01T00:00:00.000000').toISOString(),
@@ -418,6 +419,18 @@ describe('CaseListUtils', () => {
           expect(
             CaseListUtils.tableRowContent({ ...referralView, earliestReleaseDate: undefined }, 'Earliest release date'),
           ).toEqual('N/A')
+        })
+      })
+    })
+
+    describe('Location', () => {
+      it('returns the location', () => {
+        expect(CaseListUtils.tableRowContent(referralView, 'Location')).toEqual('Whatton (HMP)')
+      })
+
+      describe('when `location` is `undefined`', () => {
+        it('returns "N/A"', () => {
+          expect(CaseListUtils.tableRowContent({ ...referralView, location: undefined }, 'Location')).toEqual('N/A')
         })
       })
     })
@@ -600,6 +613,7 @@ describe('CaseListUtils', () => {
       const columnsToInclude: Array<CaseListColumnHeader> = [
         'Date referred',
         'Earliest release date',
+        'Location',
         'Name and prison number',
         'Programme location',
         'Programme name',
@@ -613,6 +627,7 @@ describe('CaseListUtils', () => {
         [
           { text: CaseListUtils.tableRowContent(referralViews[0], 'Date referred') },
           { html: CaseListUtils.tableRowContent(referralViews[0], 'Earliest release date') },
+          { text: CaseListUtils.tableRowContent(referralViews[0], 'Location') },
           { html: CaseListUtils.tableRowContent(referralViews[0], 'Name and prison number') },
           { text: CaseListUtils.tableRowContent(referralViews[0], 'Programme location') },
           { text: CaseListUtils.tableRowContent(referralViews[0], 'Programme name') },
@@ -624,6 +639,7 @@ describe('CaseListUtils', () => {
         [
           { text: CaseListUtils.tableRowContent(referralViews[1], 'Date referred') },
           { html: CaseListUtils.tableRowContent(referralViews[1], 'Earliest release date') },
+          { text: CaseListUtils.tableRowContent(referralViews[1], 'Location') },
           { html: CaseListUtils.tableRowContent(referralViews[1], 'Name and prison number') },
           { text: CaseListUtils.tableRowContent(referralViews[1], 'Programme location') },
           { text: CaseListUtils.tableRowContent(referralViews[1], 'Programme name') },

--- a/server/utils/referrals/caseListUtils.ts
+++ b/server/utils/referrals/caseListUtils.ts
@@ -170,6 +170,8 @@ export default class CaseListUtils {
         return referralView.earliestReleaseDate
           ? `${DateUtils.govukFormattedFullDateString(referralView.earliestReleaseDate)}<br>${referralView.earliestReleaseDateType}`
           : 'N/A'
+      case 'Location':
+        return referralView.location || 'N/A'
       case 'Name and prison number':
         return CaseListUtils.nameAndPrisonNumberHtml(referralView, paths)
       case 'Programme location':
@@ -207,6 +209,11 @@ export default class CaseListUtils {
           case 'Earliest release date':
             row.push({
               html: CaseListUtils.tableRowContent(view, 'Earliest release date'),
+            })
+            break
+          case 'Location':
+            row.push({
+              text: CaseListUtils.tableRowContent(view, 'Location'),
             })
             break
           case 'Name and prison number':


### PR DESCRIPTION
## Context

There’s a need for PTs to see whether prisoners are at their site or external, as some early referral stages, like the assessment, can only be done once they have been transferred. Being able to sort by this in the case list view helps them to see which referrals they can progress now, and which require a transfer.



## Changes in this PR
Display `location` from the dashboard `ReferralView` in a new Location column.


## Screenshots of UI changes

![image](https://github.com/user-attachments/assets/39629cd2-d787-4cd0-b145-b0af5f74e824)



## Release checklist

[Release process documentation](../doc/how-to/perform-a-release.md)

As part of our continuous deployment strategy we must ensure that this work is
ready to be released once merged.

### Pre-merge

- [ ] There are changes required to the Accredited Programmes API for this change to work...
  - [ ] ... and they have been released to production already

### Post-merge

<!-- The outer checkboxes can be completed pre-merge -->

- [ ] This adds, extends or meaningfully modifies a feature...
  - [ ] ... and I have written or updated an end-to-end test for the happy path in the [Accredited Programmes E2E repo](https://github.com/ministryofjustice/hmpps-accredited-programmes-e2e)
- [ ] This makes new expectations of the API...
  - [ ] ... and I have notified the API developer(s) of changes to the contract tests (Pact), or the API is already compliant
- [ ] [Manually approve](../doc/how-to/perform-a-release.md#releasing-to-the-preprod-environment) release to preprod
- [ ] [Manually approve](../doc/how-to/perform-a-release.md#releasing-to-the-production-environment) release to prod

<!-- Should a release fail at any step, you as the author should now lead the work to
fix it as soon as possible. You can monitor deployment failures in CircleCI
itself and application errors are found in
[Sentry](https://ministryofjustice.sentry.io/projects/hmpps-accredited-programmes-ui/?project=4505330122686464&referrer=sidebar&statsPeriod=24h). -->
