### PR TITLE
(APG-241) OASys assessment date on confirmation screen

### DIFF
--- a/integration_tests/e2e/refer/new/confirmOasys.cy.ts
+++ b/integration_tests/e2e/refer/new/confirmOasys.cy.ts
@@ -42,6 +42,11 @@ context('OASys confirmation', () => {
   })
 
   it('Shows the confirm OASys form page', () => {
+    cy.task('stubAssessmentDateInfo', {
+      assessmentDateInfo: { hasOpenAssessment: true, recentCompletedAssessmentDate: '2023-12-19' },
+      prisonNumber: person.prisonNumber,
+    })
+
     const path = referPaths.new.confirmOasys.show({ referralId: referral.id })
     cy.visit(path)
 
@@ -49,12 +54,45 @@ context('OASys confirmation', () => {
     confirmOasysPage.shouldHavePersonDetails(person)
     confirmOasysPage.shouldContainBackLink(referPaths.new.show({ referralId: referral.id }))
     confirmOasysPage.shouldContainHomeLink()
-    confirmOasysPage.shouldContainOasysAccessParagraph()
-    confirmOasysPage.shouldContainWarningText(
-      'You must confirm that the OASys information is accurate before submitting your application.',
+    confirmOasysPage.shouldContainOasysInformationParagraph(
+      'The latest approved layer 3 assessment for Del Hatton was completed on 19 December 2023. A newer assessment exists, but is incomplete, so will not be shown in the referral.',
     )
     confirmOasysPage.shouldContainConfirmationCheckbox()
     confirmOasysPage.shouldContainContinueButton()
+  })
+
+  describe('when there a completed assessment date but no open assessment', () => {
+    it('displays the correct message', () => {
+      cy.task('stubAssessmentDateInfo', {
+        assessmentDateInfo: { hasOpenAssessment: false, recentCompletedAssessmentDate: '2023-12-19' },
+        prisonNumber: person.prisonNumber,
+      })
+
+      const path = referPaths.new.confirmOasys.show({ referralId: referral.id })
+      cy.visit(path)
+
+      const confirmOasysPage = Page.verifyOnPage(NewReferralConfirmOasysPage, { person, referral })
+      confirmOasysPage.shouldContainOasysInformationParagraph(
+        'The latest approved layer 3 assessment for Del Hatton was completed on 19 December 2023.',
+      )
+    })
+  })
+
+  describe('when there is no assessment information', () => {
+    it('displays the correct message', () => {
+      cy.task('stubAssessmentDateInfo', {
+        assessmentDateInfo: {},
+        prisonNumber: person.prisonNumber,
+      })
+
+      const path = referPaths.new.confirmOasys.show({ referralId: referral.id })
+      cy.visit(path)
+
+      const confirmOasysPage = Page.verifyOnPage(NewReferralConfirmOasysPage, { person, referral })
+      confirmOasysPage.shouldContainOasysInformationParagraph(
+        'There is no completed and approved layer 3 assessment for Del Hatton.',
+      )
+    })
   })
 
   describe('When confirming OASys information', () => {

--- a/integration_tests/mockApis/oasys.ts
+++ b/integration_tests/mockApis/oasys.ts
@@ -3,6 +3,7 @@ import type { SuperAgentRequest } from 'superagent'
 import { apiPaths } from '../../server/paths'
 import { stubFor } from '../../wiremock'
 import type {
+  AssessmentDateInfo,
   Attitude,
   Behaviour,
   DrugAlcoholDetail,
@@ -18,6 +19,22 @@ import type {
 } from '@accredited-programmes/models'
 
 export default {
+  stubAssessmentDateInfo: (args: {
+    assessmentDateInfo: AssessmentDateInfo
+    prisonNumber: Referral['prisonNumber']
+  }): SuperAgentRequest =>
+    stubFor({
+      request: {
+        method: 'GET',
+        url: apiPaths.oasys.assessmentDate({ prisonNumber: args.prisonNumber }),
+      },
+      response: {
+        headers: { 'Content-Type': 'application/json;charset=UTF-8' },
+        jsonBody: args.assessmentDateInfo,
+        status: 200,
+      },
+    }),
+
   stubAttitude: (args: { attitude: Attitude; prisonNumber: Referral['prisonNumber'] }): SuperAgentRequest =>
     stubFor({
       request: {

--- a/integration_tests/pages/refer/new/confirmOasys.ts
+++ b/integration_tests/pages/refer/new/confirmOasys.ts
@@ -7,7 +7,7 @@ export default class NewReferralConfirmOasysPage extends Page {
   referral: Referral
 
   constructor(args: { person: Person; referral: Referral }) {
-    super('Confirm the OASys information')
+    super('Check risks and needs information (OASys)')
 
     const { person, referral } = args
     this.person = person
@@ -30,10 +30,7 @@ export default class NewReferralConfirmOasysPage extends Page {
     this.shouldContainButton('Continue')
   }
 
-  shouldContainOasysAccessParagraph() {
-    cy.get('[data-testid="oasys-access-paragraph"]').should(
-      'have.text',
-      'The programme team will need to access the full OASys Layer 3 to assess this referral.',
-    )
+  shouldContainOasysInformationParagraph(text: string) {
+    cy.get('[data-testid="oasys-information-paragraph"]').should('contain.text', text)
   }
 }

--- a/server/@types/models/AssessmentDateInfo.ts
+++ b/server/@types/models/AssessmentDateInfo.ts
@@ -1,0 +1,4 @@
+export interface AssessmentDateInfo {
+  hasOpenAssessment?: boolean
+  recentCompletedAssessmentDate?: string | null
+}

--- a/server/@types/models/index.d.ts
+++ b/server/@types/models/index.d.ts
@@ -1,3 +1,4 @@
+import type { AssessmentDateInfo } from './AssessmentDateInfo'
 import type { Attitude } from './Attitude'
 import type { Behaviour } from './Behaviour'
 import type { Course } from './Course'
@@ -41,6 +42,7 @@ import type { RoshAnalysis } from './RoshAnalysis'
 
 export type {
   Alert,
+  AssessmentDateInfo,
   Attitude,
   Behaviour,
   ConfirmationFields,

--- a/server/controllers/refer/new/index.ts
+++ b/server/controllers/refer/new/index.ts
@@ -27,6 +27,7 @@ const controllers = (services: Services) => {
     services.referralService,
   )
   const newReferralsOasysConfirmationController = new NewReferralsOasysConfirmationController(
+    services.oasysService,
     services.personService,
     services.referralService,
   )

--- a/server/data/accreditedProgrammesApi/oasysClient.ts
+++ b/server/data/accreditedProgrammesApi/oasysClient.ts
@@ -3,6 +3,7 @@ import config, { type ApiConfig } from '../../config'
 import { apiPaths } from '../../paths'
 import RestClient from '../restClient'
 import type {
+  AssessmentDateInfo,
   Attitude,
   Behaviour,
   DrugAlcoholDetail,
@@ -23,6 +24,12 @@ export default class OasysClient {
 
   constructor(systemToken: SystemToken) {
     this.restClient = new RestClient('oasysClient', config.apis.accreditedProgrammesApi as ApiConfig, systemToken)
+  }
+
+  async findAssessmentDateInfo(prisonNumber: Referral['prisonNumber']): Promise<AssessmentDateInfo> {
+    return (await this.restClient.get({
+      path: apiPaths.oasys.assessmentDate({ prisonNumber }),
+    })) as AssessmentDateInfo
   }
 
   async findAttitude(prisonNumber: Referral['prisonNumber']): Promise<Attitude> {

--- a/server/paths/api.ts
+++ b/server/paths/api.ts
@@ -45,6 +45,7 @@ export default {
     show: coursePath,
   },
   oasys: {
+    assessmentDate: oasysBasePath.path('assessment_date'),
     attitude: oasysBasePath.path('attitude'),
     behaviour: oasysBasePath.path('behaviour'),
     drugAndAlcoholDetails: oasysBasePath.path('drug-and-alcohol-details'),

--- a/server/testutils/factories/assessmentDateInfo.ts
+++ b/server/testutils/factories/assessmentDateInfo.ts
@@ -1,0 +1,12 @@
+import { faker } from '@faker-js/faker'
+import { Factory } from 'fishery'
+
+import FactoryHelpers from './factoryHelpers'
+import type { AssessmentDateInfo } from '@accredited-programmes/models'
+
+export default Factory.define<AssessmentDateInfo>(() => {
+  return {
+    hasOpenAssessment: FactoryHelpers.optionalArrayElement(faker.datatype.boolean()),
+    recentCompletedAssessmentDate: FactoryHelpers.optionalArrayElement(faker.date.recent().toISOString()),
+  }
+})

--- a/server/testutils/factories/index.ts
+++ b/server/testutils/factories/index.ts
@@ -1,3 +1,4 @@
+import assessmentDateInfoFactory from './assessmentDateInfo'
 import attitudeFactory from './attitude'
 import behaviourFactory from './behaviour'
 import caseloadFactory from './caseload'
@@ -39,6 +40,7 @@ import sentenceDetailsFactory from './sentenceDetails'
 import userFactory from './user'
 
 export {
+  assessmentDateInfoFactory,
   attitudeFactory,
   behaviourFactory,
   caseloadFactory,

--- a/server/views/referrals/new/oasysConfirmation/show.njk
+++ b/server/views/referrals/new/oasysConfirmation/show.njk
@@ -2,9 +2,18 @@
 {% from "govuk/components/button/macro.njk" import govukButton %}
 {% from "govuk/components/checkboxes/macro.njk" import govukCheckboxes %}
 {% from "govuk/components/error-summary/macro.njk" import govukErrorSummary %}
-{% from "govuk/components/warning-text/macro.njk" import govukWarningText %}
 
 {% extends "../../../partials/layout.njk" %}
+
+{% set assessmentInfoString = 'There is no completed and approved layer 3 assessment for ' + person.name + '.' %}
+
+{% if recentCompletedAssessmentDate %}
+  {% set assessmentInfoString = 'The latest approved layer 3 assessment for ' + person.name + ' was completed on <strong>' + recentCompletedAssessmentDate + '</strong>.' %}
+
+  {% if hasOpenAssessment %}
+    {% set assessmentInfoString = assessmentInfoString + ' A newer assessment exists, but is incomplete, so will not be shown in the referral.' %}
+  {% endif %}
+{% endif %}
 
 {% block personBanner %}
   {% include "../../_personBanner.njk" %}
@@ -33,12 +42,18 @@
 
   <div class="govuk-grid-row">
     <div class="govuk-grid-column-two-thirds">
-      <p class="govuk-body" data-testid="oasys-access-paragraph">The programme team will need to access the full OASys Layer 3 to assess this referral.</p>
+      <p class="govuk-body">Scores and supporting information from the latest approved risks and needs assessment will be pulled into this referral. The programme team will use this to assess the referral.</p>
 
-      {{ govukWarningText({
-        text: "You must confirm that the OASys information is accurate before submitting your application.",
-        iconFallbackText: "Warning"
-      }) }}
+      <p class="govuk-body" data-testid="oasys-information-paragraph">
+        {{ assessmentInfoString | safe }}
+      </p>
+
+      <p class="govuk-body">Before you submit the referral, check that:</p>
+
+      <ul class="govuk-list govuk-list--bullet">
+        <li>all layer 3 information is complete</li>
+        <li>the information is up to date</li>
+      </ul>
 
       <form action="{{ referPaths.new.confirmOasys.update({ referralId: referral.id }) }}?_method=PUT" method="post">
         <input type="hidden" name="_csrf" value="{{ csrfToken }}"/>


### PR DESCRIPTION
## Context

The designs have been updated to give users more information about the OASys record and what will pull through, before they submit the referral.

## Changes in this PR
- Call OASys `/assessment_date` endpoint
- Display assessment date information on OASys confirmation screen, if available.


## Screenshots of UI changes

With assessment date and incomplete assessment:
<img width="587" alt="image" src="https://github.com/user-attachments/assets/a0c5263b-adfb-47e5-b901-2467f2662382">

With assessment date only:
<img width="535" alt="image" src="https://github.com/user-attachments/assets/ed484e41-a9c5-4bc7-a03b-239a21e9199c">

With no assessment information:
<img width="490" alt="image" src="https://github.com/user-attachments/assets/6e006bfb-05ac-4a12-982a-979a8685338f">



## Release checklist

[Release process documentation](../doc/how-to/perform-a-release.md)

As part of our continuous deployment strategy we must ensure that this work is
ready to be released once merged.

### Pre-merge

- [x] There are changes required to the Accredited Programmes API for this change to work...
  - [x] ... and they have been released to production already

### Post-merge

<!-- The outer checkboxes can be completed pre-merge -->

- [x] This adds, extends or meaningfully modifies a feature...
  - [x] ... and I have written or updated an end-to-end test for the happy path in the [Accredited Programmes E2E repo](https://github.com/ministryofjustice/hmpps-accredited-programmes-e2e)
- [ ] This makes new expectations of the API...
  - [ ] ... and I have notified the API developer(s) of changes to the contract tests (Pact), or the API is already compliant
- [ ] [Manually approve](../doc/how-to/perform-a-release.md#releasing-to-the-preprod-environment) release to preprod
- [ ] [Manually approve](../doc/how-to/perform-a-release.md#releasing-to-the-production-environment) release to prod

<!-- Should a release fail at any step, you as the author should now lead the work to
fix it as soon as possible. You can monitor deployment failures in CircleCI
itself and application errors are found in
[Sentry](https://ministryofjustice.sentry.io/projects/hmpps-accredited-programmes-ui/?project=4505330122686464&referrer=sidebar&statsPeriod=24h). -->
