### PR TITLE
(APG-51) Add last assessment date to top of Risks and needs pages

### DIFF
--- a/integration_tests/pages/page.ts
+++ b/integration_tests/pages/page.ts
@@ -95,6 +95,10 @@ export default abstract class Page {
     })
   }
 
+  shouldContainAssessmentCompletedText(date: string): void {
+    cy.get('[data-testid="last-assessment-date-text"]').should('contain.text', `Assessment completed ${date}`)
+  }
+
   shouldContainAudienceTag(audienceTag: CoursePresenter['audienceTag']) {
     cy.get('[data-testid="audience-tag"]').then(tagElement => {
       this.shouldContainTag(audienceTag, tagElement)

--- a/integration_tests/support/sharedTests.ts
+++ b/integration_tests/support/sharedTests.ts
@@ -96,6 +96,8 @@ const defaultPerson = personFactory.build({
   setting: 'Custody',
   tariffDate: defaultPrisoner.tariffDate,
 })
+const recentCompletedAssessmentDate = '2023-12-19'
+const recentCompletedAssessmentDateString = '19 December 2023'
 let referral: Referral
 let referringUser: User
 const organisation = OrganisationUtils.organisationFromPrison(prison)
@@ -560,9 +562,16 @@ const sharedTests = {
     },
   },
   risksAndNeeds: {
+    beforeEach: (): void => {
+      cy.task('stubAssessmentDateInfo', {
+        assessmentDateInfo: { recentCompletedAssessmentDate },
+        prisonNumber: person.prisonNumber,
+      })
+    },
     showsAlcoholMisusePageWithData: (role: ApplicationRole): void => {
       const drugAndAlcoholDetails = drugAlcoholDetailFactory.build()
       sharedTests.referrals.beforeEach(role)
+      sharedTests.risksAndNeeds.beforeEach()
 
       cy.task('stubDrugAndAlcoholDetails', {
         drugAndAlcoholDetails,
@@ -583,11 +592,12 @@ const sharedTests = {
       alcoholMisusePage.shouldContainShowReferralSubHeading('Risks and needs')
       alcoholMisusePage.shouldContainRisksAndNeedsOasysMessage()
       alcoholMisusePage.shouldContainRisksAndNeedsSideNavigation(path, referral.id)
-      alcoholMisusePage.shouldContainImportedFromText('OASys')
+      alcoholMisusePage.shouldContainAssessmentCompletedText(recentCompletedAssessmentDateString)
       alcoholMisusePage.shouldContainAlcoholMisuseSummaryList()
     },
     showsAlcoholMisusePageWithoutData: (role: ApplicationRole): void => {
       sharedTests.referrals.beforeEach(role)
+      sharedTests.risksAndNeeds.beforeEach()
 
       cy.task('stubDrugAndAlcoholDetails', {
         drugAndAlcoholDetails: null,
@@ -613,6 +623,7 @@ const sharedTests = {
     showsAttitudesPageWithData: (role: ApplicationRole): void => {
       const attitude = attitudeFactory.build()
       sharedTests.referrals.beforeEach(role)
+      sharedTests.risksAndNeeds.beforeEach()
 
       cy.task('stubAttitude', {
         attitude,
@@ -633,11 +644,12 @@ const sharedTests = {
       attitudePage.shouldContainShowReferralSubHeading('Risks and needs')
       attitudePage.shouldContainRisksAndNeedsOasysMessage()
       attitudePage.shouldContainRisksAndNeedsSideNavigation(path, referral.id)
-      attitudePage.shouldContainImportedFromText('OASys')
+      attitudePage.shouldContainAssessmentCompletedText(recentCompletedAssessmentDateString)
       attitudePage.shouldContainAttitudesSummaryList()
     },
     showsAttitudesPageWithoutData: (role: ApplicationRole): void => {
       sharedTests.referrals.beforeEach(role)
+      sharedTests.risksAndNeeds.beforeEach()
 
       cy.task('stubAttitude', {
         attitude: null,
@@ -663,6 +675,7 @@ const sharedTests = {
     showsDrugMisusePageWithData: (role: ApplicationRole): void => {
       const drugAndAlcoholDetails = drugAlcoholDetailFactory.build()
       sharedTests.referrals.beforeEach(role)
+      sharedTests.risksAndNeeds.beforeEach()
 
       cy.task('stubDrugAndAlcoholDetails', {
         drugAndAlcoholDetails,
@@ -683,7 +696,7 @@ const sharedTests = {
       drugMisusePage.shouldContainShowReferralSubHeading('Risks and needs')
       drugMisusePage.shouldContainRisksAndNeedsOasysMessage()
       drugMisusePage.shouldContainRisksAndNeedsSideNavigation(path, referral.id)
-      drugMisusePage.shouldContainImportedFromText('OASys')
+      drugMisusePage.shouldContainAssessmentCompletedText(recentCompletedAssessmentDateString)
       drugMisusePage.shouldContainDrugMisuseSummaryList()
     },
     showsDrugMisusePageWithoutData: (role: ApplicationRole): void => {
@@ -713,6 +726,7 @@ const sharedTests = {
     showsEmotionalWellbeingPageWithData: (role: ApplicationRole): void => {
       const psychiatric = psychiatricFactory.build()
       sharedTests.referrals.beforeEach(role)
+      sharedTests.risksAndNeeds.beforeEach()
 
       cy.task('stubPsychiatric', {
         prisonNumber: prisoner.prisonerNumber,
@@ -733,7 +747,7 @@ const sharedTests = {
       emotionalWellbeingPage.shouldContainShowReferralSubHeading('Risks and needs')
       emotionalWellbeingPage.shouldContainRisksAndNeedsOasysMessage()
       emotionalWellbeingPage.shouldContainRisksAndNeedsSideNavigation(path, referral.id)
-      emotionalWellbeingPage.shouldContainImportedFromText('OASys')
+      emotionalWellbeingPage.shouldContainAssessmentCompletedText(recentCompletedAssessmentDateString)
       emotionalWellbeingPage.shouldContainPsychiatricProblemsSummaryList()
     },
     showsEmotionalWellbeingPageWithoutData: (role: ApplicationRole): void => {
@@ -763,6 +777,7 @@ const sharedTests = {
     showsHealthPageWithData: (role: ApplicationRole): void => {
       const health = healthFactory.build()
       sharedTests.referrals.beforeEach(role)
+      sharedTests.risksAndNeeds.beforeEach()
 
       cy.task('stubHealth', {
         health,
@@ -783,7 +798,7 @@ const sharedTests = {
       healthPage.shouldContainShowReferralSubHeading('Risks and needs')
       healthPage.shouldContainRisksAndNeedsOasysMessage()
       healthPage.shouldContainRisksAndNeedsSideNavigation(path, referral.id)
-      healthPage.shouldContainImportedFromText('OASys')
+      healthPage.shouldContainAssessmentCompletedText(recentCompletedAssessmentDateString)
       healthPage.shouldContainHealthSummaryList()
     },
     showsHealthPageWithoutData: (role: ApplicationRole): void => {
@@ -812,6 +827,7 @@ const sharedTests = {
     showsLearningNeedsPageWithData: (role: ApplicationRole): void => {
       const learningNeeds = learningNeedsFactory.build()
       sharedTests.referrals.beforeEach(role)
+      sharedTests.risksAndNeeds.beforeEach()
 
       cy.task('stubLearningNeeds', {
         learningNeeds,
@@ -832,7 +848,7 @@ const sharedTests = {
       learningNeedsPage.shouldContainShowReferralSubHeading('Risks and needs')
       learningNeedsPage.shouldContainRisksAndNeedsOasysMessage()
       learningNeedsPage.shouldContainRisksAndNeedsSideNavigation(path, referral.id)
-      learningNeedsPage.shouldContainImportedFromText('OASys')
+      learningNeedsPage.shouldContainAssessmentCompletedText(recentCompletedAssessmentDateString)
       learningNeedsPage.shouldContainInformationSummaryList()
       learningNeedsPage.shouldContainScoreSummaryList()
     },
@@ -863,6 +879,7 @@ const sharedTests = {
     showsLifestyleAndAssociatesPageWithData: (role: ApplicationRole): void => {
       const lifestyle = lifestyleFactory.build()
       sharedTests.referrals.beforeEach(role)
+      sharedTests.risksAndNeeds.beforeEach()
 
       cy.task('stubLifestyle', {
         lifestyle,
@@ -883,7 +900,7 @@ const sharedTests = {
       lifestyleAndAssociatesPage.shouldContainShowReferralSubHeading('Risks and needs')
       lifestyleAndAssociatesPage.shouldContainRisksAndNeedsOasysMessage()
       lifestyleAndAssociatesPage.shouldContainRisksAndNeedsSideNavigation(path, referral.id)
-      lifestyleAndAssociatesPage.shouldContainImportedFromText('OASys')
+      lifestyleAndAssociatesPage.shouldContainAssessmentCompletedText(recentCompletedAssessmentDateString)
       lifestyleAndAssociatesPage.shouldContainReoffendingSummaryList()
       lifestyleAndAssociatesPage.shouldContainLifestyleIssuesSummaryCard()
     },
@@ -914,6 +931,7 @@ const sharedTests = {
     showsOffenceAnalysisPageWithData: (role: ApplicationRole): void => {
       const offenceDetail = offenceDetailFactory.build()
       sharedTests.referrals.beforeEach(role)
+      sharedTests.risksAndNeeds.beforeEach()
 
       cy.task('stubOffenceDetails', {
         offenceDetail,
@@ -934,7 +952,7 @@ const sharedTests = {
       offenceAnalysisPage.shouldContainShowReferralSubHeading('Risks and needs')
       offenceAnalysisPage.shouldContainRisksAndNeedsOasysMessage()
       offenceAnalysisPage.shouldContainRisksAndNeedsSideNavigation(path, referral.id)
-      offenceAnalysisPage.shouldContainImportedFromText('OASys')
+      offenceAnalysisPage.shouldContainAssessmentCompletedText(recentCompletedAssessmentDateString)
       offenceAnalysisPage.shouldContainBriefOffenceDetailsSummaryCard()
       offenceAnalysisPage.shouldContainVictimsAndPartnersSummaryList()
       offenceAnalysisPage.shouldContainImpactAndConsequencesSummaryList()
@@ -969,6 +987,7 @@ const sharedTests = {
     showsRelationshipsPageWithData: (role: ApplicationRole): void => {
       const relationships = relationshipsFactory.build()
       sharedTests.referrals.beforeEach(role)
+      sharedTests.risksAndNeeds.beforeEach()
 
       cy.task('stubRelationships', {
         prisonNumber: prisoner.prisonerNumber,
@@ -989,7 +1008,7 @@ const sharedTests = {
       relationshipsPage.shouldContainShowReferralSubHeading('Risks and needs')
       relationshipsPage.shouldContainRisksAndNeedsOasysMessage()
       relationshipsPage.shouldContainRisksAndNeedsSideNavigation(path, referral.id)
-      relationshipsPage.shouldContainImportedFromText('OASys')
+      relationshipsPage.shouldContainAssessmentCompletedText(recentCompletedAssessmentDateString)
       relationshipsPage.shouldContainDomesticViolenceSummaryList()
       relationshipsPage.shouldContainRelationshipIssuesSummaryCard()
     },
@@ -1044,6 +1063,7 @@ const sharedTests = {
     showsRisksAndAlertsPageWithData: (role: ApplicationRole): void => {
       const risksAndAlerts = risksAndAlertsFactory.build()
       sharedTests.referrals.beforeEach(role)
+      sharedTests.risksAndNeeds.beforeEach()
 
       cy.task('stubRisksAndAlerts', {
         prisonNumber: prisoner.prisonerNumber,
@@ -1064,7 +1084,7 @@ const sharedTests = {
       risksAndAlertsPage.shouldContainShowReferralSubHeading('Risks and needs')
       risksAndAlertsPage.shouldContainRisksAndNeedsOasysMessage()
       risksAndAlertsPage.shouldContainRisksAndNeedsSideNavigation(path, referral.id)
-      risksAndAlertsPage.shouldContainImportedFromText('OASys', 'imported-from-text')
+      risksAndAlertsPage.shouldContainAssessmentCompletedText(recentCompletedAssessmentDateString)
       risksAndAlertsPage.shouldHaveOgrsInformation()
       risksAndAlertsPage.shouldHaveOvpInformation()
       risksAndAlertsPage.shouldHaveSaraInformation()
@@ -1099,6 +1119,7 @@ const sharedTests = {
     showsRoshAnalysisPageWithData: (role: ApplicationRole): void => {
       const roshAnalysis = roshAnalysisFactory.build()
       sharedTests.referrals.beforeEach(role)
+      sharedTests.risksAndNeeds.beforeEach()
 
       cy.task('stubRoshAnalysis', {
         prisonNumber: prisoner.prisonerNumber,
@@ -1119,7 +1140,7 @@ const sharedTests = {
       roshAnalysisPage.shouldContainShowReferralSubHeading('Risks and needs')
       roshAnalysisPage.shouldContainRisksAndNeedsOasysMessage()
       roshAnalysisPage.shouldContainRisksAndNeedsSideNavigation(path, referral.id)
-      roshAnalysisPage.shouldContainImportedFromText('OASys')
+      roshAnalysisPage.shouldContainAssessmentCompletedText(recentCompletedAssessmentDateString)
       roshAnalysisPage.shouldContainPreviousBehaviourSummaryList()
     },
     showsRoshAnalysisPageWithoutData: (role: ApplicationRole): void => {
@@ -1148,6 +1169,7 @@ const sharedTests = {
     showsThinkingAndBehavingPageWithData: (role: ApplicationRole): void => {
       const behaviour = behaviourFactory.build()
       sharedTests.referrals.beforeEach(role)
+      sharedTests.risksAndNeeds.beforeEach()
 
       cy.task('stubBehaviour', {
         behaviour,
@@ -1168,7 +1190,7 @@ const sharedTests = {
       thinkingAndBehavingPage.shouldContainShowReferralSubHeading('Risks and needs')
       thinkingAndBehavingPage.shouldContainRisksAndNeedsOasysMessage()
       thinkingAndBehavingPage.shouldContainRisksAndNeedsSideNavigation(path, referral.id)
-      thinkingAndBehavingPage.shouldContainImportedFromText('OASys')
+      thinkingAndBehavingPage.shouldContainAssessmentCompletedText(recentCompletedAssessmentDateString)
       thinkingAndBehavingPage.shouldContainThinkingAndBehavingSummaryList()
     },
     showsThinkingAndBehavingPageWithoutData: (role: ApplicationRole): void => {

--- a/server/@types/ui/index.d.ts
+++ b/server/@types/ui/index.d.ts
@@ -157,6 +157,7 @@ type RisksAndNeedsSharedPageData = {
   person: Person
   referral: Referral
   subNavigationItems: Array<MojFrontendNavigationItem>
+  recentCompletedAssessmentDate?: string
 }
 
 type ReferralTaskListSection = {

--- a/server/controllers/shared/risksAndNeedsController.test.ts
+++ b/server/controllers/shared/risksAndNeedsController.test.ts
@@ -97,7 +97,8 @@ describe('RisksAndNeedsController', () => {
   const coursePresenter = CourseUtils.presentCourse(course)
   const organisation = organisationFactory.build()
   const courseOffering = courseOfferingFactory.build({ organisationId: organisation.id })
-  const importedFromDate = '10 January 2024'
+  const recentCompletedAssessmentDate = '2023-12-19'
+  const recentCompletedAssessmentDateString = '19 December 2023'
   const navigationItems = [{ active: true, href: 'nav-href', text: 'Nav Item' }]
   const subNavigationItems = [{ active: true, href: 'sub-nav-href', text: 'Sub Nav Item' }]
   const buttons = [{ href: 'button-href', text: 'Button' }]
@@ -112,7 +113,7 @@ describe('RisksAndNeedsController', () => {
   beforeEach(() => {
     person = personFactory.build()
     referral = referralFactory.submitted().build({ offeringId: courseOffering.id, prisonNumber: person.prisonNumber })
-    mockDateUtils.govukFormattedFullDateString.mockReturnValue(importedFromDate)
+    mockDateUtils.govukFormattedFullDateString.mockReturnValue(recentCompletedAssessmentDateString)
     mockShowRisksAndNeedsUtils.navigationItems.mockReturnValue(navigationItems)
     mockShowReferralUtils.subNavigationItems.mockReturnValue(subNavigationItems)
     mockShowReferralUtils.buttons.mockReturnValue(buttons)
@@ -123,6 +124,7 @@ describe('RisksAndNeedsController', () => {
       pageHeading: `Referral to ${coursePresenter.displayName}`,
       pageSubHeading: 'Risks and needs',
       person,
+      recentCompletedAssessmentDate: recentCompletedAssessmentDateString,
       referral,
       subNavigationItems,
     }
@@ -130,6 +132,7 @@ describe('RisksAndNeedsController', () => {
 
     courseService.getCourseByOffering.mockResolvedValue(course)
     courseService.getOffering.mockResolvedValue(courseOffering)
+    oasysService.getAssessmentDateInfo.mockResolvedValue({ hasOpenAssessment: false, recentCompletedAssessmentDate })
     personService.getPerson.mockResolvedValue(person)
     referralService.getReferral.mockResolvedValue(referral)
     referralService.getStatusTransitions.mockResolvedValue(statusTransitions)
@@ -170,13 +173,13 @@ describe('RisksAndNeedsController', () => {
         ...sharedPageData,
         alcoholMisuseSummaryListRows,
         hasData: true,
-        importedFromText: `Imported from OASys on ${importedFromDate}.`,
       })
     })
 
     describe('when the oasys service returns `null`', () => {
       it('renders the alcohol misuse page with the correct response locals', async () => {
         when(oasysService.getDrugAndAlcoholDetails).calledWith(username, person.prisonNumber).mockResolvedValue(null)
+        when(oasysService.getAssessmentDateInfo).calledWith(username, person.prisonNumber).mockResolvedValue(null)
 
         request.path = referPaths.show.risksAndNeeds.alcoholMisuse({ referralId: referral.id })
 
@@ -188,6 +191,7 @@ describe('RisksAndNeedsController', () => {
         expect(response.render).toHaveBeenCalledWith('referrals/show/risksAndNeeds/alcoholMisuse', {
           ...sharedPageData,
           hasData: false,
+          recentCompletedAssessmentDate: undefined,
         })
       })
     })
@@ -213,7 +217,7 @@ describe('RisksAndNeedsController', () => {
         ...sharedPageData,
         attitudesSummaryListRows,
         hasData: true,
-        importedFromText: `Imported from OASys on ${importedFromDate}.`,
+
         navigationItems,
         subNavigationItems,
       })
@@ -302,7 +306,6 @@ describe('RisksAndNeedsController', () => {
         ...sharedPageData,
         drugMisuseSummaryListRows,
         hasData: true,
-        importedFromText: `Imported from OASys on ${importedFromDate}.`,
       })
     })
 
@@ -344,7 +347,7 @@ describe('RisksAndNeedsController', () => {
       expect(response.render).toHaveBeenCalledWith('referrals/show/risksAndNeeds/emotionalWellbeing', {
         ...sharedPageData,
         hasData: true,
-        importedFromText: `Imported from OASys on ${importedFromDate}.`,
+
         navigationItems,
         psychiatricSummaryListRows,
         subNavigationItems,
@@ -393,7 +396,7 @@ describe('RisksAndNeedsController', () => {
       expect(response.render).toHaveBeenCalledWith('referrals/show/risksAndNeeds/learningNeeds', {
         ...sharedPageData,
         hasData: true,
-        importedFromText: `Imported from OASys on ${importedFromDate}.`,
+
         informationSummaryListRows,
         navigationItems,
         scoreSummaryListRows,
@@ -442,7 +445,7 @@ describe('RisksAndNeedsController', () => {
         ...sharedPageData,
         hasData: true,
         healthSummaryListRows,
-        importedFromText: `Imported from OASys on ${importedFromDate}.`,
+
         navigationItems,
         subNavigationItems,
       })
@@ -491,7 +494,7 @@ describe('RisksAndNeedsController', () => {
       expect(response.render).toHaveBeenCalledWith('referrals/show/risksAndNeeds/lifestyleAndAssociates', {
         ...sharedPageData,
         hasData: true,
-        importedFromText: `Imported from OASys on ${importedFromDate}.`,
+
         lifestyleIssues,
         navigationItems,
         reoffendingSummaryListRows,
@@ -562,7 +565,7 @@ describe('RisksAndNeedsController', () => {
         ...sharedPageData,
         hasData: true,
         impactAndConsequencesSummaryListRows,
-        importedFromText: `Imported from OASys on ${importedFromDate}.`,
+
         motivationAndTriggersText,
         navigationItems,
         offenceDetailsText,
@@ -620,7 +623,7 @@ describe('RisksAndNeedsController', () => {
         ...sharedPageData,
         domesticViolenceSummaryListRows,
         hasData: true,
-        importedFromText: `Imported from OASys on ${importedFromDate}.`,
+
         navigationItems,
         relIssuesDetails,
         subNavigationItems,
@@ -760,8 +763,7 @@ describe('RisksAndNeedsController', () => {
         ...sharedPageData,
         alertsGroupTables,
         hasData: true,
-        importedFromNomisText: `Imported from NOMIS on ${importedFromDate}.`,
-        importedFromText: `Imported from OASys on ${importedFromDate}.`,
+        importedFromNomisText: `Imported from NOMIS on ${recentCompletedAssessmentDateString}.`,
         navigationItems,
         ogrsYear1Box,
         ogrsYear2Box,
@@ -818,7 +820,7 @@ describe('RisksAndNeedsController', () => {
       expect(response.render).toHaveBeenCalledWith('referrals/show/risksAndNeeds/roshAnalysis', {
         ...sharedPageData,
         hasData: true,
-        importedFromText: `Imported from OASys on ${importedFromDate}.`,
+
         navigationItems,
         previousBehaviourSummaryListRows,
         subNavigationItems,
@@ -867,7 +869,7 @@ describe('RisksAndNeedsController', () => {
       expect(response.render).toHaveBeenCalledWith('referrals/show/risksAndNeeds/thinkingAndBehaving', {
         ...sharedPageData,
         hasData: true,
-        importedFromText: `Imported from OASys on ${importedFromDate}.`,
+
         navigationItems,
         subNavigationItems,
         thinkingAndBehavingSummaryListRows,
@@ -898,6 +900,7 @@ describe('RisksAndNeedsController', () => {
   function assertSharedDataServicesAreCalledWithExpectedArguments(path?: Request['path']) {
     const isRefer = path?.startsWith(referPathBase.pattern)
 
+    expect(oasysService.getAssessmentDateInfo).toHaveBeenCalledWith(username, person.prisonNumber)
     expect(referralService.getReferral).toHaveBeenCalledWith(username, referral.id)
     expect(courseService.getCourseByOffering).toHaveBeenCalledWith(username, referral.offeringId)
     expect(personService.getPerson).toHaveBeenCalledWith(username, person.prisonNumber)

--- a/server/controllers/shared/risksAndNeedsController.ts
+++ b/server/controllers/shared/risksAndNeedsController.ts
@@ -46,7 +46,6 @@ export default class RisksAndNeedsController {
         ? {
             alcoholMisuseSummaryListRows: AlcoholMisuseUtils.summaryListRows(drugAlcoholDetail.alcohol),
             hasData: true,
-            importedFromText: `Imported from OASys on ${DateUtils.govukFormattedFullDateString()}.`,
           }
         : {
             hasData: false,
@@ -71,7 +70,6 @@ export default class RisksAndNeedsController {
         ? {
             attitudesSummaryListRows: AttitudesUtils.attitudesSummaryListRows(attitude),
             hasData: true,
-            importedFromText: `Imported from OASys on ${DateUtils.govukFormattedFullDateString()}.`,
           }
         : {
             hasData: false,
@@ -96,7 +94,6 @@ export default class RisksAndNeedsController {
         ? {
             drugMisuseSummaryListRows: DrugMisuseUtils.summaryListRows(drugAlcoholDetail.drug),
             hasData: true,
-            importedFromText: `Imported from OASys on ${DateUtils.govukFormattedFullDateString()}.`,
           }
         : {
             hasData: false,
@@ -120,7 +117,6 @@ export default class RisksAndNeedsController {
       const templateLocals = psychiatric
         ? {
             hasData: true,
-            importedFromText: `Imported from OASys on ${DateUtils.govukFormattedFullDateString()}.`,
             psychiatricSummaryListRows: EmotionalWellbeingUtils.psychiatricSummaryListRows(psychiatric),
           }
         : {
@@ -149,7 +145,6 @@ export default class RisksAndNeedsController {
         ? {
             hasData: true,
             healthSummaryListRows: HealthUtils.healthSummaryListRows(health),
-            importedFromText: `Imported from OASys on ${DateUtils.govukFormattedFullDateString()}.`,
           }
         : {
             hasData: false,
@@ -173,7 +168,6 @@ export default class RisksAndNeedsController {
       const templateLocals = learningNeeds
         ? {
             hasData: true,
-            importedFromText: `Imported from OASys on ${DateUtils.govukFormattedFullDateString()}.`,
             informationSummaryListRows: LearningNeedsUtils.informationSummaryListRows(learningNeeds),
             scoreSummaryListRows: LearningNeedsUtils.scoreSummaryListRows(learningNeeds),
           }
@@ -202,7 +196,6 @@ export default class RisksAndNeedsController {
       const templateLocals = lifestyle
         ? {
             hasData: true,
-            importedFromText: `Imported from OASys on ${DateUtils.govukFormattedFullDateString()}.`,
             lifestyleIssues: ShowRisksAndNeedsUtils.textValue(lifestyle.lifestyleIssues),
             reoffendingSummaryListRows: LifestyleAndAssociatesUtils.reoffendingSummaryListRows(lifestyle),
           }
@@ -233,7 +226,6 @@ export default class RisksAndNeedsController {
             hasData: true,
             impactAndConsequencesSummaryListRows:
               OffenceAnalysisUtils.impactAndConsequencesSummaryListRows(offenceDetails),
-            importedFromText: `Imported from OASys on ${DateUtils.govukFormattedFullDateString()}.`,
             motivationAndTriggersText: ShowRisksAndNeedsUtils.textValue(offenceDetails.motivationAndTriggers),
             offenceDetailsText: ShowRisksAndNeedsUtils.textValue(offenceDetails.offenceDetails),
             otherOffendersAndInfluencesSummaryListRows:
@@ -268,7 +260,6 @@ export default class RisksAndNeedsController {
         ? {
             domesticViolenceSummaryListRows: RelationshipsUtils.domesticViolenceSummaryListRows(relationships),
             hasData: true,
-            importedFromText: `Imported from OASys on ${DateUtils.govukFormattedFullDateString()}.`,
             relIssuesDetails: ShowRisksAndNeedsUtils.textValue(relationships.relIssuesDetails),
           }
         : {
@@ -298,7 +289,6 @@ export default class RisksAndNeedsController {
             alertsGroupTables: RisksAndAlertsUtils.alertsGroupTables(risksAndAlerts.alerts),
             hasData: true,
             importedFromNomisText: `Imported from NOMIS on ${DateUtils.govukFormattedFullDateString()}.`,
-            importedFromText: `Imported from OASys on ${DateUtils.govukFormattedFullDateString()}.`,
             ogrsYear1Box: RisksAndAlertsUtils.riskBox(
               'OGRS Year 1',
               risksAndAlerts.ogrsRisk,
@@ -359,7 +349,6 @@ export default class RisksAndNeedsController {
       const templateLocals = roshAnalysis
         ? {
             hasData: true,
-            importedFromText: `Imported from OASys on ${DateUtils.govukFormattedFullDateString()}.`,
             previousBehaviourSummaryListRows: RoshAnalysisUtils.previousBehaviourSummaryListRows(roshAnalysis),
           }
         : {
@@ -387,7 +376,6 @@ export default class RisksAndNeedsController {
       const templateLocals = behaviour
         ? {
             hasData: true,
-            importedFromText: `Imported from OASys on ${DateUtils.govukFormattedFullDateString()}.`,
             thinkingAndBehavingSummaryListRows: ThinkingAndBehavingUtils.thinkingAndBehavingSummaryListRows(behaviour),
           }
         : {
@@ -410,7 +398,8 @@ export default class RisksAndNeedsController {
 
     const referral = await this.referralService.getReferral(username, referralId)
 
-    const [course, person, statusTransitions] = await Promise.all([
+    const [assessmentDateInfo, course, person, statusTransitions] = await Promise.all([
+      this.oasysService.getAssessmentDateInfo(username, referral.prisonNumber),
       this.courseService.getCourseByOffering(username, referral.offeringId),
       this.personService.getPerson(username, referral.prisonNumber),
       isRefer ? this.referralService.getStatusTransitions(username, referral.id) : undefined,
@@ -428,6 +417,9 @@ export default class RisksAndNeedsController {
       pageHeading: `Referral to ${coursePresenter.displayName}`,
       pageSubHeading: 'Risks and needs',
       person,
+      recentCompletedAssessmentDate: assessmentDateInfo?.recentCompletedAssessmentDate
+        ? DateUtils.govukFormattedFullDateString(assessmentDateInfo.recentCompletedAssessmentDate)
+        : undefined,
       referral,
       subNavigationItems: ShowReferralUtils.subNavigationItems(req.path, 'risksAndNeeds', referral.id),
     }

--- a/server/views/referrals/show/partials/risksAndNeedsLayout.njk
+++ b/server/views/referrals/show/partials/risksAndNeedsLayout.njk
@@ -7,12 +7,12 @@
 {% endblock supportingContent %}
 
 {% block primaryContent %}
-  {% if hasData %}
+  {% if hasData and recentCompletedAssessmentDate %}
     {{ govukInsetText({
       classes: "govuk-!-margin-top-0",
-      text: importedFromText,
+      text: 'Assessment completed ' + recentCompletedAssessmentDate,
       attributes: {
-        "data-testid": "imported-from-text"
+        "data-testid": "last-assessment-date-text"
       }
     }) }}
   {% elseif oasysNomisErrorMessage %}


### PR DESCRIPTION
## Context

In the Risk and Needs section of the referral, where we show OASys data we should also say when OASys was last updated.

## Changes in this PR
Get the `recentCompletedAssessmentDate` from `/assessment_date` and display at the top of of the Risks and needs pages.


## Screenshots of UI changes

### Before
![image](https://github.com/user-attachments/assets/89ac746b-3917-4c47-966f-e479f36367e8)


### After
![image](https://github.com/user-attachments/assets/245b4dda-18e3-4539-ad49-c2eca172ee74)


## Release checklist

[Release process documentation](../doc/how-to/perform-a-release.md)

As part of our continuous deployment strategy we must ensure that this work is
ready to be released once merged.

### Pre-merge

- [ ] There are changes required to the Accredited Programmes API for this change to work...
  - [ ] ... and they have been released to production already

### Post-merge

<!-- The outer checkboxes can be completed pre-merge -->

- [ ] This adds, extends or meaningfully modifies a feature...
  - [ ] ... and I have written or updated an end-to-end test for the happy path in the [Accredited Programmes E2E repo](https://github.com/ministryofjustice/hmpps-accredited-programmes-e2e)
- [ ] This makes new expectations of the API...
  - [ ] ... and I have notified the API developer(s) of changes to the contract tests (Pact), or the API is already compliant
- [ ] [Manually approve](../doc/how-to/perform-a-release.md#releasing-to-the-preprod-environment) release to preprod
- [ ] [Manually approve](../doc/how-to/perform-a-release.md#releasing-to-the-production-environment) release to prod

<!-- Should a release fail at any step, you as the author should now lead the work to
fix it as soon as possible. You can monitor deployment failures in CircleCI
itself and application errors are found in
[Sentry](https://ministryofjustice.sentry.io/projects/hmpps-accredited-programmes-ui/?project=4505330122686464&referrer=sidebar&statsPeriod=24h). -->
