### PR TITLE
(APG-250a) Add Course/Programme client methods

### DIFF
--- a/server/@types/models/Course.ts
+++ b/server/@types/models/Course.ts
@@ -4,7 +4,7 @@ import type { TagColour } from '@accredited-programmes/ui'
 
 export type Course = {
   id: string // eslint-disable-next-line @typescript-eslint/member-ordering
-  alternateName: string | null
+  alternateName?: string
   audience: CourseAudience
   audienceColour: TagColour
   coursePrerequisites: Array<CoursePrerequisite>

--- a/server/@types/models/CourseAudience.ts
+++ b/server/@types/models/CourseAudience.ts
@@ -1,7 +1,16 @@
-export type CourseAudience =
+type Audience = {
+  id: string // eslint-disable-next-line @typescript-eslint/member-ordering
+  colour: string
+  name: CourseAudience
+}
+
+type CourseAudience =
+  | 'All offences'
   | 'Extremism offence'
   | 'Gang offence'
   | 'General offence'
   | 'General violence offence'
   | 'Intimate partner violence offence'
   | 'Sexual offence'
+
+export type { Audience, CourseAudience }

--- a/server/@types/models/CourseCreateRequest.ts
+++ b/server/@types/models/CourseCreateRequest.ts
@@ -1,0 +1,7 @@
+export interface CourseCreateRequest {
+  audienceId: string
+  description: string
+  name: string
+  withdrawn: boolean
+  alternateName?: string
+}

--- a/server/@types/models/index.d.ts
+++ b/server/@types/models/index.d.ts
@@ -2,7 +2,8 @@ import type { AssessmentDateInfo } from './AssessmentDateInfo'
 import type { Attitude } from './Attitude'
 import type { Behaviour } from './Behaviour'
 import type { Course } from './Course'
-import type { CourseAudience } from './CourseAudience'
+import type { Audience, CourseAudience } from './CourseAudience'
+import type { CourseCreateRequest } from './CourseCreateRequest'
 import type { CourseOffering } from './CourseOffering'
 import type {
   CourseParticipation,
@@ -44,10 +45,12 @@ export type {
   Alert,
   AssessmentDateInfo,
   Attitude,
+  Audience,
   Behaviour,
   ConfirmationFields,
   Course,
   CourseAudience,
+  CourseCreateRequest,
   CourseOffering,
   CourseParticipation,
   CourseParticipationOutcome,

--- a/server/data/accreditedProgrammesApi/courseClient.ts
+++ b/server/data/accreditedProgrammesApi/courseClient.ts
@@ -3,7 +3,9 @@ import config from '../../config'
 import { apiPaths } from '../../paths'
 import RestClient from '../restClient'
 import type {
+  Audience,
   Course,
+  CourseCreateRequest,
   CourseOffering,
   CourseParticipation,
   CourseParticipationUpdate,
@@ -20,6 +22,13 @@ export default class CourseClient {
 
   async all(): Promise<Array<Course>> {
     return (await this.restClient.get({ path: apiPaths.courses.index({}) })) as Array<Course>
+  }
+
+  async createCourse(courseCreateRequest: CourseCreateRequest): Promise<Course> {
+    return (await this.restClient.post({
+      data: { ...courseCreateRequest },
+      path: apiPaths.courses.create({}),
+    })) as Course
   }
 
   async createParticipation(
@@ -40,6 +49,12 @@ export default class CourseClient {
 
   async find(courseId: Course['id']): Promise<Course> {
     return (await this.restClient.get({ path: apiPaths.courses.show({ courseId }) })) as Course
+  }
+
+  async findCourseAudiences(): Promise<Array<Audience>> {
+    return (await this.restClient.get({
+      path: apiPaths.courses.audiences({}),
+    })) as Array<Audience>
   }
 
   async findCourseByOffering(courseOfferingId: CourseOffering['id']): Promise<Course> {

--- a/server/paths/api.ts
+++ b/server/paths/api.ts
@@ -39,6 +39,8 @@ const referralStatusCodeReasonsPath = referralStatusCodeCategoriesPath.path(':ca
 
 export default {
   courses: {
+    audiences: coursesPath.path('audiences'),
+    create: coursesPath,
     index: coursesPath,
     names: courseNamesPath,
     offerings: offeringsByCoursePath,

--- a/server/testutils/factories/audience.ts
+++ b/server/testutils/factories/audience.ts
@@ -1,0 +1,22 @@
+import { faker } from '@faker-js/faker/locale/en_GB'
+import { Factory } from 'fishery'
+
+import courseAudienceFactory from './courseAudience'
+import type { Audience } from '@accredited-programmes/models'
+
+export default Factory.define<Audience>(() => ({
+  id: faker.string.uuid(), // eslint-disable-next-line sort-keys
+  colour: faker.helpers.arrayElement([
+    'blue',
+    'green',
+    'grey',
+    'light-blue',
+    'orange',
+    'pink',
+    'purple',
+    'red',
+    'turquoise',
+    'yellow',
+  ]),
+  name: courseAudienceFactory.build(),
+}))

--- a/server/testutils/factories/courseAudience.ts
+++ b/server/testutils/factories/courseAudience.ts
@@ -5,6 +5,7 @@ import type { CourseAudience } from '@accredited-programmes/models'
 
 export default Factory.define<CourseAudience>(() =>
   faker.helpers.arrayElement([
+    'All offences',
     'Extremism offence',
     'Gang offence',
     'General offence',

--- a/server/testutils/factories/index.ts
+++ b/server/testutils/factories/index.ts
@@ -1,5 +1,6 @@
 import assessmentDateInfoFactory from './assessmentDateInfo'
 import attitudeFactory from './attitude'
+import audienceFactory from './audience'
 import behaviourFactory from './behaviour'
 import caseloadFactory from './caseload'
 import confirmationFieldsFactory from './confirmationFields'
@@ -42,6 +43,7 @@ import userFactory from './user'
 export {
   assessmentDateInfoFactory,
   attitudeFactory,
+  audienceFactory,
   behaviourFactory,
   caseloadFactory,
   confirmationFieldsFactory,


### PR DESCRIPTION
## Context

We need an easier way to update the content in FIND to ensure it is accurate.

## Changes in this PR
- Add some new types to support adding a new Course/Programme
- Add `createCourse` and `findCourseAudiences` methods to `CourseClient`

## Release checklist

[Release process documentation](../doc/how-to/perform-a-release.md)

As part of our continuous deployment strategy we must ensure that this work is
ready to be released once merged.

### Pre-merge

- [ ] There are changes required to the Accredited Programmes API for this change to work...
  - [ ] ... and they have been released to production already

### Post-merge

<!-- The outer checkboxes can be completed pre-merge -->

- [ ] This adds, extends or meaningfully modifies a feature...
  - [ ] ... and I have written or updated an end-to-end test for the happy path in the [Accredited Programmes E2E repo](https://github.com/ministryofjustice/hmpps-accredited-programmes-e2e)
- [ ] This makes new expectations of the API...
  - [ ] ... and I have notified the API developer(s) of changes to the contract tests (Pact), or the API is already compliant
- [ ] [Manually approve](../doc/how-to/perform-a-release.md#releasing-to-the-preprod-environment) release to preprod
- [ ] [Manually approve](../doc/how-to/perform-a-release.md#releasing-to-the-production-environment) release to prod

<!-- Should a release fail at any step, you as the author should now lead the work to
fix it as soon as possible. You can monitor deployment failures in CircleCI
itself and application errors are found in
[Sentry](https://ministryofjustice.sentry.io/projects/hmpps-accredited-programmes-ui/?project=4505330122686464&referrer=sidebar&statsPeriod=24h). -->
