### PR TITLE
(APG-250b) CourseService and CourseUtils methods needed for adding a course

### DIFF
--- a/server/services/courseService.ts
+++ b/server/services/courseService.ts
@@ -5,7 +5,9 @@ import type UserService from './userService'
 import type { CourseClient, HmppsAuthClient, RestClientBuilder, RestClientBuilderWithoutToken } from '../data'
 import { CourseParticipationUtils } from '../utils'
 import type {
+  Audience,
   Course,
+  CourseCreateRequest,
   CourseOffering,
   CourseParticipation,
   CourseParticipationUpdate,
@@ -21,6 +23,14 @@ export default class CourseService {
     private readonly hmppsAuthClientBuilder: RestClientBuilderWithoutToken<HmppsAuthClient>,
     private readonly userService: UserService,
   ) {}
+
+  async createCourse(username: Express.User['username'], courseCreateRequest: CourseCreateRequest): Promise<Course> {
+    const hmppsAuthClient = this.hmppsAuthClientBuilder()
+    const systemToken = await hmppsAuthClient.getSystemClientToken(username)
+    const courseClient = this.courseClientBuilder(systemToken)
+
+    return courseClient.createCourse(courseCreateRequest)
+  }
 
   async createParticipation(
     username: Express.User['username'],
@@ -72,6 +82,14 @@ export default class CourseService {
     const courseClient = this.courseClientBuilder(systemToken)
 
     return courseClient.find(courseId)
+  }
+
+  async getCourseAudiences(username: Express.User['username']): Promise<Array<Audience>> {
+    const hmppsAuthClient = this.hmppsAuthClientBuilder()
+    const systemToken = await hmppsAuthClient.getSystemClientToken(username)
+    const courseClient = this.courseClientBuilder(systemToken)
+
+    return courseClient.findCourseAudiences()
   }
 
   async getCourseByOffering(username: Express.User['username'], courseOfferingId: CourseOffering['id']) {

--- a/server/utils/courseUtils.test.ts
+++ b/server/utils/courseUtils.test.ts
@@ -1,7 +1,18 @@
 import CourseUtils from './courseUtils'
-import { courseFactory, coursePrerequisiteFactory } from '../testutils/factories'
+import { audienceFactory, courseFactory, coursePrerequisiteFactory } from '../testutils/factories'
 
 describe('CourseUtils', () => {
+  describe('audienceSelectItems', () => {
+    it('returns a formatted array of audiences to use with UI selects', () => {
+      const audiences = audienceFactory.buildList(2)
+
+      expect(CourseUtils.audienceSelectItems(audiences)).toEqual([
+        { text: audiences[0].name, value: audiences[0].id },
+        { text: audiences[1].name, value: audiences[1].id },
+      ])
+    })
+  })
+
   describe('courseRadioOptions', () => {
     it('returns a formatted array of courses to use with UI radios', () => {
       const courses = courseFactory.buildList(2)

--- a/server/utils/courseUtils.ts
+++ b/server/utils/courseUtils.ts
@@ -1,13 +1,23 @@
 import { findPaths } from '../paths'
-import type { Course, CoursePrerequisite } from '@accredited-programmes/models'
+import type { Audience, Course, CoursePrerequisite } from '@accredited-programmes/models'
 import type {
   CoursePresenter,
   GovukFrontendSummaryListRowWithKeyAndValue,
   GovukFrontendTagWithText,
   HasHtmlString,
 } from '@accredited-programmes/ui'
+import type { GovukFrontendSelectItem } from '@govuk-frontend'
 
 export default class CourseUtils {
+  static audienceSelectItems(audiences: Array<Audience>): Array<GovukFrontendSelectItem> {
+    return audiences.map(audience => {
+      return {
+        text: audience.name,
+        value: audience.id,
+      }
+    })
+  }
+
   static courseRadioOptions(courseNames: Array<Course['name']>): Array<GovukFrontendTagWithText> {
     return courseNames.map(courseName => {
       return {


### PR DESCRIPTION
## Context
Follows #688 

## Changes in this PR
- Add `createCourse` and `getCourseAudiences` methods to `CourseService`
- Add `audienceSelectItems` to `CourseUtils`

## Release checklist

[Release process documentation](../doc/how-to/perform-a-release.md)

As part of our continuous deployment strategy we must ensure that this work is
ready to be released once merged.

### Pre-merge

- [ ] There are changes required to the Accredited Programmes API for this change to work...
  - [ ] ... and they have been released to production already

### Post-merge

<!-- The outer checkboxes can be completed pre-merge -->

- [ ] This adds, extends or meaningfully modifies a feature...
  - [ ] ... and I have written or updated an end-to-end test for the happy path in the [Accredited Programmes E2E repo](https://github.com/ministryofjustice/hmpps-accredited-programmes-e2e)
- [ ] This makes new expectations of the API...
  - [ ] ... and I have notified the API developer(s) of changes to the contract tests (Pact), or the API is already compliant
- [ ] [Manually approve](../doc/how-to/perform-a-release.md#releasing-to-the-preprod-environment) release to preprod
- [ ] [Manually approve](../doc/how-to/perform-a-release.md#releasing-to-the-production-environment) release to prod

<!-- Should a release fail at any step, you as the author should now lead the work to
fix it as soon as possible. You can monitor deployment failures in CircleCI
itself and application errors are found in
[Sentry](https://ministryofjustice.sentry.io/projects/hmpps-accredited-programmes-ui/?project=4505330122686464&referrer=sidebar&statsPeriod=24h). -->
