### PR TITLE
(APG-250) Add 'Add a new programme' button link to find index

### DIFF
--- a/integration_tests/e2e/find.cy.ts
+++ b/integration_tests/e2e/find.cy.ts
@@ -30,6 +30,7 @@ context('Find', () => {
       const sortedCourses = [...courses].sort((courseA, courseB) => courseA.name.localeCompare(courseB.name))
 
       coursesPage.shouldHaveCourses(sortedCourses)
+      coursesPage.shouldNotContainAddNewProgrammeLink()
     })
 
     it('Shows a single course and its offerings', () => {
@@ -133,6 +134,23 @@ context('Find', () => {
         courseOfferingPage.shouldHaveOrganisationWithOfferingEmails()
         courseOfferingPage.shouldNotContainMakeAReferralButtonLink()
       })
+    })
+  })
+
+  describe('For a user with the `ROLE_ACP_EDITOR` role', () => {
+    it('should show the "Add a new programme" button', () => {
+      cy.task('reset')
+      cy.task('stubSignIn', { authorities: [ApplicationRoles.ACP_EDITOR] })
+      cy.task('stubAuthUser')
+      cy.task('stubDefaultCaseloads')
+      cy.signIn()
+      cy.task('stubCourses', courses)
+
+      const path = findPaths.index({})
+      cy.visit(path)
+
+      const coursesPage = Page.verifyOnPage(CoursesPage)
+      coursesPage.shouldContainAddNewProgrammeLink()
     })
   })
 

--- a/integration_tests/pages/find/courses.ts
+++ b/integration_tests/pages/find/courses.ts
@@ -8,6 +8,12 @@ export default class CoursesPage extends Page {
     super('Find an Accredited Programme')
   }
 
+  shouldContainAddNewProgrammeLink() {
+    cy.get('[data-testid="add-programme-link"]')
+      .should('contain.text', 'Add a new programme')
+      .and('have.attr', 'href', findPaths.course.add.show({}))
+  }
+
   shouldHaveCourses(courses: Array<Course>) {
     cy.get('div[role=listitem]').each((courseElement, courseElementIndex) => {
       cy.wrap(courseElement).within(() => {
@@ -27,5 +33,9 @@ export default class CoursesPage extends Page {
         })
       })
     })
+  }
+
+  shouldNotContainAddNewProgrammeLink() {
+    cy.get('[data-testid="add-programme-link"]').should('not.exist')
   }
 }

--- a/server/controllers/find/coursesController.test.ts
+++ b/server/controllers/find/coursesController.test.ts
@@ -3,6 +3,7 @@ import { createMock } from '@golevelup/ts-jest'
 import type { NextFunction, Request, Response } from 'express'
 
 import CoursesController from './coursesController'
+import { findPaths } from '../../paths'
 import type { CourseService, OrganisationService } from '../../services'
 import { courseFactory, courseOfferingFactory, organisationFactory } from '../../testutils/factories'
 import { CourseUtils, OrganisationUtils } from '../../utils'
@@ -38,6 +39,7 @@ describe('CoursesController', () => {
       await requestHandler(request, response, next)
 
       expect(response.render).toHaveBeenCalledWith('courses/index', {
+        addProgrammePath: findPaths.course.add.show({}),
         courses: sortedCourses.map(course => CourseUtils.presentCourse(course)),
         pageHeading: 'Find an Accredited Programme',
       })

--- a/server/controllers/find/coursesController.ts
+++ b/server/controllers/find/coursesController.ts
@@ -1,5 +1,6 @@
 import type { Request, Response, TypedRequestHandler } from 'express'
 
+import { findPaths } from '../../paths'
 import type { CourseService, OrganisationService } from '../../services'
 import { CourseUtils, OrganisationUtils, TypeUtils } from '../../utils'
 import type { CourseOffering } from '@accredited-programmes/models'
@@ -17,6 +18,7 @@ export default class CoursesController {
       const courses = await this.courseService.getCourses(req.user.token)
 
       res.render('courses/index', {
+        addProgrammePath: findPaths.course.add.show({}),
         courses: courses
           .sort((courseA, courseB) => courseA.name.localeCompare(courseB.name))
           .map(course => CourseUtils.presentCourse(course)),

--- a/server/views/courses/form/show.njk
+++ b/server/views/courses/form/show.njk
@@ -1,3 +1,4 @@
+{% from "govuk/components/back-link/macro.njk" import govukBackLink %}
 {% from "govuk/components/button/macro.njk" import govukButton %}
 {% from "govuk/components/input/macro.njk" import govukInput %}
 {% from "govuk/components/radios/macro.njk" import govukRadios %}
@@ -5,6 +6,13 @@
 {% from "govuk/components/textarea/macro.njk" import govukTextarea %}
 
 {% extends "../../partials/layout.njk" %}
+
+{% block backLink %}
+  {{ govukBackLink({
+    text: "Back",
+    href: findPaths.index({})
+  }) }}
+{% endblock backLink %}
 
 {% block content %}
   <h1 class="govuk-heading-l">{{ pageHeading }}</h1>

--- a/server/views/courses/index.njk
+++ b/server/views/courses/index.njk
@@ -1,9 +1,24 @@
+{% from "govuk/components/button/macro.njk" import govukButton %}
+
 {% from "./_indexCourseSummary.njk" import indexCourseSummary %}
 
 {% extends "../partials/layout.njk" %}
 
 {% block content %}
-  <h1 class="govuk-heading-l">{{ pageHeading }}</h1>
+  <div class="header-with-actions">
+    <h1 class="header-with-actions__title govuk-heading-l">{{ pageHeading }}</h1>
+
+    {% if 'ROLE_ACP_EDITOR' in user.roles %}
+      {{ govukButton({
+        text: "Add a new programme",
+        href: addProgrammePath,
+        classes: "govuk-button--secondary",
+        attributes: {
+          "data-testid": "add-programme-link"
+        }
+      }) }}
+    {% endif %}
+  </div>
 
   <div role="list">
     {% for course in courses %}


### PR DESCRIPTION
## Changes in this PR
Add button link to Add a new programme form page, for users with `ROLE_ACP_EDITOR` role.


## Screenshots of UI changes

![image](https://github.com/user-attachments/assets/ddb10ad6-f2c8-4bbe-9074-e07a2c91d774)



## Release checklist

[Release process documentation](../doc/how-to/perform-a-release.md)

As part of our continuous deployment strategy we must ensure that this work is
ready to be released once merged.

### Pre-merge

- [ ] There are changes required to the Accredited Programmes API for this change to work...
  - [ ] ... and they have been released to production already

### Post-merge

<!-- The outer checkboxes can be completed pre-merge -->

- [ ] This adds, extends or meaningfully modifies a feature...
  - [ ] ... and I have written or updated an end-to-end test for the happy path in the [Accredited Programmes E2E repo](https://github.com/ministryofjustice/hmpps-accredited-programmes-e2e)
- [ ] This makes new expectations of the API...
  - [ ] ... and I have notified the API developer(s) of changes to the contract tests (Pact), or the API is already compliant
- [ ] [Manually approve](../doc/how-to/perform-a-release.md#releasing-to-the-preprod-environment) release to preprod
- [ ] [Manually approve](../doc/how-to/perform-a-release.md#releasing-to-the-production-environment) release to prod

<!-- Should a release fail at any step, you as the author should now lead the work to
fix it as soon as possible. You can monitor deployment failures in CircleCI
itself and application errors are found in
[Sentry](https://ministryofjustice.sentry.io/projects/hmpps-accredited-programmes-ui/?project=4505330122686464&referrer=sidebar&statsPeriod=24h). -->
