### PR TITLE
(APG-253) Add client methods to help with adding a course offering

### DIFF
--- a/integration_tests/e2e/find.cy.ts
+++ b/integration_tests/e2e/find.cy.ts
@@ -84,7 +84,7 @@ context('Find', () => {
     describe('Viewing a single offering', () => {
       it('shows a single offering with no secondary email address', () => {
         const courseOffering = courseOfferingFactory.build({
-          secondaryContactEmail: null,
+          secondaryContactEmail: undefined,
         })
         cy.task('stubOffering', { courseOffering })
         cy.task('stubCourseByOffering', { course: courses[0], courseOfferingId: courseOffering.id })

--- a/integration_tests/e2eReferDisabled/find.cy.ts
+++ b/integration_tests/e2eReferDisabled/find.cy.ts
@@ -13,7 +13,7 @@ context('Find', () => {
 
     const course = courseFactory.build()
     const courseOffering = courseOfferingFactory.build({
-      secondaryContactEmail: null,
+      secondaryContactEmail: undefined,
     })
     cy.task('stubOffering', { courseOffering })
     cy.task('stubCourseByOffering', { course, courseOfferingId: courseOffering.id })

--- a/server/@types/models/CourseOffering.ts
+++ b/server/@types/models/CourseOffering.ts
@@ -1,8 +1,9 @@
 export type CourseOffering = {
   id: string // eslint-disable-next-line @typescript-eslint/member-ordering
   contactEmail: string
-  organisationEnabled: boolean
   organisationId: string
   referable: boolean
-  secondaryContactEmail: string | null
+  organisationEnabled?: boolean
+  secondaryContactEmail?: string
+  withdrawn?: boolean
 }

--- a/server/data/accreditedProgrammesApi/courseClient.ts
+++ b/server/data/accreditedProgrammesApi/courseClient.ts
@@ -20,6 +20,16 @@ export default class CourseClient {
     this.restClient = new RestClient('courseClient', config.apis.accreditedProgrammesApi as ApiConfig, systemToken)
   }
 
+  async addCourseOffering(
+    courseId: Course['id'],
+    courseOffering: Omit<CourseOffering, 'id' | 'organisationEnabled'>,
+  ): Promise<CourseOffering> {
+    return (await this.restClient.put({
+      data: courseOffering,
+      path: apiPaths.offerings.create({ courseId }),
+    })) as CourseOffering
+  }
+
   async all(): Promise<Array<Course>> {
     return (await this.restClient.get({ path: apiPaths.courses.index({}) })) as Array<Course>
   }

--- a/server/data/prisonRegisterApiClient.test.ts
+++ b/server/data/prisonRegisterApiClient.test.ts
@@ -25,6 +25,17 @@ describe('PrisonRegisterApiClient', () => {
     nock.cleanAll()
   })
 
+  describe('all', () => {
+    const prisons: Array<Prison> = prisonFactory.buildList(3)
+
+    it('fetches all prisons', async () => {
+      fakePrisonRegisterApi.get('/prisons').matchHeader('authorization', `Bearer ${userToken}`).reply(200, prisons)
+
+      const output = await prisonRegisterApiClient.all()
+      expect(output).toEqual(prisons)
+    })
+  })
+
   describe('find', () => {
     const prison: Prison = prisonFactory.build()
 

--- a/server/data/prisonRegisterApiClient.ts
+++ b/server/data/prisonRegisterApiClient.ts
@@ -11,6 +11,10 @@ export default class PrisonRegisterApiClient {
     this.restClient = new RestClient('prisonRegisterApiClient', config.apis.prisonRegisterApi as ApiConfig, userToken)
   }
 
+  async all(): Promise<Array<Prison>> {
+    return (await this.restClient.get({ path: prisonRegisterApiPaths.prisons.all({}) })) as Array<Prison>
+  }
+
   async find(prisonId: string): Promise<Prison> {
     return (await this.restClient.get({ path: prisonRegisterApiPaths.prisons.show({ prisonId }) })) as Prison
   }

--- a/server/paths/api.ts
+++ b/server/paths/api.ts
@@ -62,6 +62,7 @@ export default {
   },
   offerings: {
     course: courseByOfferingPath,
+    create: offeringsByCoursePath,
     show: offeringPath,
   },
   organisations: {

--- a/server/paths/prisonRegisterApi.ts
+++ b/server/paths/prisonRegisterApi.ts
@@ -1,9 +1,11 @@
 import { path } from 'static-path'
 
-const prisonPath = path('/prisons/id/:prisonId')
+const prisonsBasePath = path('/prisons')
+const prisonPath = prisonsBasePath.path('id/:prisonId')
 
 export default {
   prisons: {
+    all: prisonsBasePath,
     show: prisonPath,
   },
 }

--- a/server/services/organisationService.test.ts
+++ b/server/services/organisationService.test.ts
@@ -21,6 +21,33 @@ describe('OrganisationService', () => {
     prisonRegisterApiClientBuilder.mockReturnValue(prisonRegisterApiClient)
   })
 
+  describe('getAllOrganisations', () => {
+    it('returns all organisations', async () => {
+      const prisons = prisonFactory.buildList(3)
+      prisonRegisterApiClient.all.mockResolvedValue(prisons)
+
+      const result = await service.getAllOrganisations(userToken)
+
+      expect(result).toEqual(prisons)
+
+      expect(prisonRegisterApiClientBuilder).toHaveBeenCalledWith(userToken)
+      expect(prisonRegisterApiClient.all).toHaveBeenCalled()
+    })
+
+    describe('when the prison client throws an error', () => {
+      it('re-throws the error', async () => {
+        const clientError = createError(500)
+        prisonRegisterApiClient.all.mockRejectedValue(clientError)
+
+        const expectedError = createError(500, 'Error fetching organisations.')
+        expect(() => service.getAllOrganisations(userToken)).rejects.toThrowError(expectedError)
+
+        expect(prisonRegisterApiClientBuilder).toHaveBeenCalledWith(userToken)
+        expect(prisonRegisterApiClient.all).toHaveBeenCalled()
+      })
+    })
+  })
+
   describe('getOrganisation', () => {
     describe('when the prison client finds the corresponding prison', () => {
       describe("and it's active", () => {

--- a/server/services/organisationService.ts
+++ b/server/services/organisationService.ts
@@ -9,6 +9,16 @@ import type { Prison } from '@prison-register-api'
 export default class OrganisationService {
   constructor(private readonly prisonRegisterApiClientBuilder: RestClientBuilder<PrisonRegisterApiClient>) {}
 
+  async getAllOrganisations(userToken: Express.User['token']): Promise<Array<Prison>> {
+    const prisonRegisterApiClient = this.prisonRegisterApiClientBuilder(userToken)
+
+    try {
+      return await prisonRegisterApiClient.all()
+    } catch (error) {
+      throw createError(500, 'Error fetching organisations.')
+    }
+  }
+
   async getOrganisation(userToken: Express.User['token'], organisationId: Organisation['id']): Promise<Organisation> {
     const prisonRegisterApiClient = this.prisonRegisterApiClientBuilder(userToken)
 

--- a/server/testutils/factories/courseOffering.ts
+++ b/server/testutils/factories/courseOffering.ts
@@ -9,12 +9,13 @@ export default Factory.define<CourseOffering>(({ params }) => {
   return {
     id: faker.string.uuid(), // eslint-disable-next-line sort-keys
     contactEmail: `nobody-${organisationId.toLowerCase()}@digital.justice.gov.uk`,
-    organisationEnabled: faker.datatype.boolean(),
+    organisationEnabled: faker.helpers.arrayElement([faker.datatype.boolean()]),
     organisationId,
     referable: faker.datatype.boolean(),
     secondaryContactEmail: faker.helpers.arrayElement([
       `nobody2-${organisationId.toLowerCase()}@digital.justice.gov.uk`,
-      null,
+      undefined,
     ]),
+    withdrawn: faker.helpers.arrayElement([faker.datatype.boolean(), undefined]),
   }
 })

--- a/server/utils/organisationUtils.test.ts
+++ b/server/utils/organisationUtils.test.ts
@@ -206,7 +206,7 @@ describe('OrganisationUtils', () => {
       it('does not include a secondary email address field', () => {
         const offeringWithNoSecondaryContactEmail = courseOfferingFactory.build({
           contactEmail: 'nobody-hmp-what@digital.justice.gov.uk',
-          secondaryContactEmail: null,
+          secondaryContactEmail: undefined,
         })
 
         expect(


### PR DESCRIPTION
## Context

We need an easier way to update the content in FIND to ensure it is accurate.


## Changes in this PR
- Add prison register client methods for getting all available prisons.  This is so we can show a list of available prisons/locations to select from on the form.
- Add `addCourseOffering` method to CourseClient and update `CourseOffering` type.  Will add associated PACT test to API.



## Release checklist

[Release process documentation](../doc/how-to/perform-a-release.md)

As part of our continuous deployment strategy we must ensure that this work is
ready to be released once merged.

### Pre-merge

- [ ] There are changes required to the Accredited Programmes API for this change to work...
  - [ ] ... and they have been released to production already

### Post-merge

<!-- The outer checkboxes can be completed pre-merge -->

- [ ] This adds, extends or meaningfully modifies a feature...
  - [ ] ... and I have written or updated an end-to-end test for the happy path in the [Accredited Programmes E2E repo](https://github.com/ministryofjustice/hmpps-accredited-programmes-e2e)
- [ ] This makes new expectations of the API...
  - [ ] ... and I have notified the API developer(s) of changes to the contract tests (Pact), or the API is already compliant
- [ ] [Manually approve](../doc/how-to/perform-a-release.md#releasing-to-the-preprod-environment) release to preprod
- [ ] [Manually approve](../doc/how-to/perform-a-release.md#releasing-to-the-production-environment) release to prod

<!-- Should a release fail at any step, you as the author should now lead the work to
fix it as soon as possible. You can monitor deployment failures in CircleCI
itself and application errors are found in
[Sentry](https://ministryofjustice.sentry.io/projects/hmpps-accredited-programmes-ui/?project=4505330122686464&referrer=sidebar&statsPeriod=24h). -->
