### PR TITLE
(APG-253) Add Course offering form page

### DIFF
--- a/integration_tests/e2e/find.cy.ts
+++ b/integration_tests/e2e/find.cy.ts
@@ -60,6 +60,7 @@ context('Find', () => {
       coursePage.shouldContainBackLink(findPaths.index({}))
       coursePage.shouldContainHomeLink()
       coursePage.shouldHaveCourse()
+      coursePage.shouldNotContainAddCourseOfferingLink()
       coursePage.shouldContainOfferingsText()
       coursePage.shouldHaveOrganisations(organisationsWithOfferingIds)
     })
@@ -138,12 +139,15 @@ context('Find', () => {
   })
 
   describe('For a user with the `ROLE_ACP_EDITOR` role', () => {
-    it('should show the "Add a new programme" button', () => {
+    beforeEach(() => {
       cy.task('reset')
       cy.task('stubSignIn', { authorities: [ApplicationRoles.ACP_EDITOR] })
       cy.task('stubAuthUser')
       cy.task('stubDefaultCaseloads')
       cy.signIn()
+    })
+
+    it('shows the "Add a new programme" button', () => {
       cy.task('stubCourses', courses)
 
       const path = findPaths.index({})
@@ -151,6 +155,20 @@ context('Find', () => {
 
       const coursesPage = Page.verifyOnPage(CoursesPage)
       coursesPage.shouldContainAddNewProgrammeLink()
+    })
+
+    it('shows the "Add a new location" link', () => {
+      cy.task('stubCourse', courses[0])
+
+      const courseOfferings: Array<CourseOffering> = []
+
+      cy.task('stubOfferingsByCourse', { courseId: courses[0].id, courseOfferings })
+
+      const path = findPaths.show({ courseId: courses[0].id })
+      cy.visit(path)
+
+      const coursePage = Page.verifyOnPage(CoursePage, courses[0])
+      coursePage.shouldContainAddCourseOfferingLink()
     })
   })
 

--- a/integration_tests/pages/find/course.ts
+++ b/integration_tests/pages/find/course.ts
@@ -15,6 +15,12 @@ export default class CoursePage extends Page {
     this.course = coursePresenter
   }
 
+  shouldContainAddCourseOfferingLink() {
+    cy.get('[data-testid="add-programme-offering-link"]')
+      .should('contain.text', 'Add a new location')
+      .and('have.attr', 'href', findPaths.offerings.add.show({ courseId: this.course.id }))
+  }
+
   shouldContainNoOfferingsText() {
     cy.get('[data-testid="no-offerings-text"]').should(
       'have.text',
@@ -60,5 +66,9 @@ export default class CoursePage extends Page {
         })
       })
     })
+  }
+
+  shouldNotContainAddCourseOfferingLink() {
+    cy.get('[data-testid="add-programme-offering-link"]').should('not.exist')
   }
 }

--- a/server/controllers/find/addCourseOfferingController.test.ts
+++ b/server/controllers/find/addCourseOfferingController.test.ts
@@ -1,0 +1,96 @@
+import type { DeepMocked } from '@golevelup/ts-jest'
+import { createMock } from '@golevelup/ts-jest'
+import type { NextFunction, Request, Response } from 'express'
+
+import AddCourseOfferingController from './addCourseOfferingController'
+import { findPaths } from '../../paths'
+import type { CourseService, OrganisationService } from '../../services'
+import { courseOfferingFactory, prisonFactory } from '../../testutils/factories'
+import { OrganisationUtils } from '../../utils'
+import type { GovukFrontendSelectItem } from '@govuk-frontend'
+
+jest.mock('../../utils/organisationUtils')
+
+const mockOrganisationUtils = OrganisationUtils as jest.Mocked<typeof OrganisationUtils>
+
+describe('AddCourseController', () => {
+  let controller: AddCourseOfferingController
+  let request: Request
+  let response: Response
+
+  const username = 'SOME_USERNAME'
+  const userToken = 'USER_TOKEN'
+  const courseService = createMock<CourseService>({})
+  const organisationService = createMock<OrganisationService>({})
+  const courseId = 'course-id'
+  const next: DeepMocked<NextFunction> = createMock<NextFunction>({})
+
+  beforeEach(() => {
+    controller = new AddCourseOfferingController(courseService, organisationService)
+    request = createMock<Request>({ params: { courseId }, user: { token: userToken, username } })
+    response = createMock<Response>()
+  })
+
+  describe('show', () => {
+    const organisationSelectItems: Array<GovukFrontendSelectItem> = [
+      { text: 'Organisation 1', value: '1' },
+      { text: 'Organisation 2', value: '2' },
+      { text: 'Organisation 3', value: '3' },
+    ]
+
+    beforeEach(() => {
+      mockOrganisationUtils.organisationSelectItems.mockReturnValue(organisationSelectItems)
+    })
+
+    it('renders the create course offering form template with organisation select items', async () => {
+      const organisations = prisonFactory.buildList(3)
+      organisationService.getAllOrganisations.mockResolvedValue(organisations)
+
+      const requestHandler = controller.show()
+      await requestHandler(request, response, next)
+
+      expect(organisationService.getAllOrganisations).toHaveBeenCalledWith(userToken)
+
+      expect(response.render).toHaveBeenCalledWith('courses/offerings/form/show', {
+        action: '/find/programmes/course-id/offerings/add',
+        backLinkHref: '/find/programmes/course-id',
+        organisationSelectItems,
+        pageHeading: 'Add a Location',
+      })
+      expect(OrganisationUtils.organisationSelectItems).toHaveBeenCalledWith(organisations)
+    })
+  })
+
+  describe('submit', () => {
+    it('creates a course offering and redirects back to the course page', async () => {
+      const newCourseOfferingBody: Record<string, string> = {
+        contactEmail: 'contact-email@test.com',
+        organisationId: 'organisation-id',
+        referable: 'true',
+        secondaryContactEmail: 'secondary-contact-email@test.com',
+        withdrawn: 'false',
+      }
+      const courseOffering = courseOfferingFactory.build({
+        contactEmail: newCourseOfferingBody.contactEmail,
+        organisationId: newCourseOfferingBody.organisationId,
+        referable: true,
+        secondaryContactEmail: newCourseOfferingBody.secondaryContactEmail,
+        withdrawn: false,
+      })
+
+      courseService.addCourseOffering.mockResolvedValue(courseOffering)
+
+      request.body = newCourseOfferingBody
+
+      const requestHandler = controller.submit()
+      await requestHandler(request, response, next)
+
+      expect(courseService.addCourseOffering).toHaveBeenCalledWith(username, courseId, {
+        ...newCourseOfferingBody,
+        referable: true,
+        withdrawn: false,
+      })
+      expect(response.redirect).toHaveBeenCalledWith(findPaths.offerings.show({ courseOfferingId: courseOffering.id }))
+    })
+  })
+})

--- a/server/controllers/find/addCourseOfferingController.ts
+++ b/server/controllers/find/addCourseOfferingController.ts
@@ -1,0 +1,53 @@
+import type { Request, Response, TypedRequestHandler } from 'express'
+
+import { findPaths } from '../../paths'
+import type { CourseService, OrganisationService } from '../../services'
+import { OrganisationUtils, TypeUtils } from '../../utils'
+
+export default class AddCourseOfferingController {
+  constructor(
+    private readonly courseService: CourseService,
+    private readonly organisationService: OrganisationService,
+  ) {}
+
+  show(): TypedRequestHandler<Request, Response> {
+    return async (req: Request, res: Response) => {
+      TypeUtils.assertHasUser(req)
+
+      const { courseId } = req.params
+
+      const organisations = await this.organisationService.getAllOrganisations(req.user.token)
+
+      const organisationSelectItems = OrganisationUtils.organisationSelectItems(organisations)
+
+      res.render('courses/offerings/form/show', {
+        action: findPaths.offerings.add.create({ courseId }),
+        backLinkHref: findPaths.show({ courseId }),
+        organisationSelectItems,
+        pageHeading: 'Add a Location',
+      })
+    }
+  }
+
+  submit(): TypedRequestHandler<Request, Response> {
+    return async (req: Request, res: Response) => {
+      TypeUtils.assertHasUser(req)
+
+      const { courseId } = req.params
+      const { contactEmail, organisationId, referable, secondaryContactEmail, withdrawn } = req.body as Record<
+        string,
+        string
+      >
+
+      const offering = await this.courseService.addCourseOffering(req.user.username, courseId, {
+        contactEmail,
+        organisationId,
+        referable: referable === 'true',
+        secondaryContactEmail,
+        withdrawn: withdrawn ? withdrawn === 'true' : undefined,
+      })
+
+      res.redirect(findPaths.offerings.show({ courseOfferingId: offering.id }))
+    }
+  }
+}

--- a/server/controllers/find/coursesController.test.ts
+++ b/server/controllers/find/coursesController.test.ts
@@ -80,6 +80,7 @@ describe('CoursesController', () => {
 
         const coursePresenter = CourseUtils.presentCourse(course)
         expect(response.render).toHaveBeenCalledWith('courses/show', {
+          addOfferingPath: `/find/programmes/${course.id}/offerings/add`,
           course: coursePresenter,
           organisationsTableData: OrganisationUtils.organisationTableRows(organisationsWithOfferingIds),
           pageHeading: coursePresenter.displayName,
@@ -119,6 +120,7 @@ describe('CoursesController', () => {
 
         const coursePresenter = CourseUtils.presentCourse(course)
         expect(response.render).toHaveBeenCalledWith('courses/show', {
+          addOfferingPath: `/find/programmes/${course.id}/offerings/add`,
           course: coursePresenter,
           organisationsTableData: OrganisationUtils.organisationTableRows(existingOrganisationsWithOfferingIds),
           pageHeading: coursePresenter.displayName,

--- a/server/controllers/find/coursesController.ts
+++ b/server/controllers/find/coursesController.ts
@@ -47,6 +47,7 @@ export default class CoursesController {
       const coursePresenter = CourseUtils.presentCourse(course)
 
       res.render('courses/show', {
+        addOfferingPath: findPaths.offerings.add.create({ courseId: course.id }),
         course: coursePresenter,
         organisationsTableData,
         pageHeading: coursePresenter.displayName,

--- a/server/controllers/find/index.ts
+++ b/server/controllers/find/index.ts
@@ -1,17 +1,23 @@
 /* istanbul ignore file */
 
 import AddCourseController from './addCourseController'
+import AddCourseOfferingController from './addCourseOfferingController'
 import CourseOfferingsController from './courseOfferingsController'
 import CoursesController from './coursesController'
 import type { Services } from '../../services'
 
 const controllers = (services: Services) => {
   const addCourseController = new AddCourseController(services.courseService)
+  const addCourseOfferingController = new AddCourseOfferingController(
+    services.courseService,
+    services.organisationService,
+  )
   const coursesController = new CoursesController(services.courseService, services.organisationService)
   const courseOfferingsController = new CourseOfferingsController(services.courseService, services.organisationService)
 
   return {
     addCourseController,
+    addCourseOfferingController,
     courseOfferingsController,
     coursesController,
   }

--- a/server/data/accreditedProgrammesApi/courseClient.test.ts
+++ b/server/data/accreditedProgrammesApi/courseClient.test.ts
@@ -23,7 +23,7 @@ pactWith({ consumer: 'Accredited Programmes UI', provider: 'Accredited Programme
     config.apis.accreditedProgrammesApi.url = provider.mockService.baseUrl
   })
 
-  describe('addCourseOffering', () => {
+  describe.skip('addCourseOffering', () => {
     const course = courseFactory.build({ id: 'd3abc217-75ee-46e9-a010-368f30282367' })
 
     const courseOffering = courseOfferingFactory.build({

--- a/server/data/accreditedProgrammesApi/courseClient.ts
+++ b/server/data/accreditedProgrammesApi/courseClient.ts
@@ -20,6 +20,7 @@ export default class CourseClient {
     this.restClient = new RestClient('courseClient', config.apis.accreditedProgrammesApi as ApiConfig, systemToken)
   }
 
+  /* istanbul ignore next */
   async addCourseOffering(
     courseId: Course['id'],
     courseOffering: Omit<CourseOffering, 'id' | 'organisationEnabled'>,

--- a/server/paths/find.ts
+++ b/server/paths/find.ts
@@ -6,6 +6,7 @@ const coursePath = coursesPath.path(':courseId')
 
 const addCoursePath = coursesPath.path('/add')
 
+const addCourseOfferingPath = coursePath.path('/offerings/add')
 const courseOfferingPath = findPathBase.path('/offerings/:courseOfferingId')
 
 export default {
@@ -17,6 +18,10 @@ export default {
   },
   index: coursesPath,
   offerings: {
+    add: {
+      create: addCourseOfferingPath,
+      show: addCourseOfferingPath,
+    },
     show: courseOfferingPath,
   },
   show: coursePath,

--- a/server/routes/editor.ts
+++ b/server/routes/editor.ts
@@ -7,10 +7,13 @@ import { RouteUtils } from '../utils'
 
 export default function routes(controllers: Controllers, router: Router): Router {
   const { get, post } = RouteUtils.actions(router, { allowedRoles: [ApplicationRoles.ACP_EDITOR] })
-  const { addCourseController } = controllers
+  const { addCourseController, addCourseOfferingController } = controllers
 
   get(findPaths.course.add.show.pattern, addCourseController.show())
   post(findPaths.course.add.create.pattern, addCourseController.submit())
+
+  get(findPaths.offerings.add.show.pattern, addCourseOfferingController.show())
+  post(findPaths.offerings.add.create.pattern, addCourseOfferingController.submit())
 
   return router
 }

--- a/server/services/courseService.test.ts
+++ b/server/services/courseService.test.ts
@@ -16,7 +16,7 @@ import {
   userFactory,
 } from '../testutils/factories'
 import { CourseParticipationUtils, StringUtils } from '../utils'
-import type { CourseCreateRequest, CourseParticipationUpdate } from '@accredited-programmes/models'
+import type { CourseCreateRequest, CourseOffering, CourseParticipationUpdate } from '@accredited-programmes/models'
 
 jest.mock('../data/accreditedProgrammesApi/courseClient')
 jest.mock('../data/hmppsAuthClient')
@@ -45,6 +45,29 @@ describe('CourseService', () => {
     courseClientBuilder.mockReturnValue(courseClient)
     hmppsAuthClientBuilder.mockReturnValue(hmppsAuthClient)
     hmppsAuthClient.getSystemClientToken.mockResolvedValue(systemToken)
+  })
+
+  describe('addCourseOffering', () => {
+    it('adds a course offering using the `courseOfferingRequest` values', async () => {
+      const courseId = courseFactory.build().id
+      const courseOffering = courseOfferingFactory.build({})
+      const courseOfferingRequest: Omit<CourseOffering, 'id' | 'organisationEnabled'> = {
+        contactEmail: courseOffering.contactEmail,
+        organisationId: courseOffering.organisationId,
+        referable: courseOffering.referable,
+        secondaryContactEmail: courseOffering.secondaryContactEmail,
+        withdrawn: courseOffering.withdrawn,
+      }
+
+      when(courseClient.addCourseOffering).calledWith(courseId, courseOfferingRequest).mockResolvedValue(courseOffering)
+
+      const result = await service.addCourseOffering(username, courseId, courseOfferingRequest)
+
+      expect(result).toEqual(courseOffering)
+
+      expect(courseClientBuilder).toHaveBeenCalledWith(systemToken)
+      expect(courseClient.addCourseOffering).toHaveBeenCalledWith(courseId, courseOfferingRequest)
+    })
   })
 
   describe('createCourse', () => {

--- a/server/services/courseService.ts
+++ b/server/services/courseService.ts
@@ -24,6 +24,18 @@ export default class CourseService {
     private readonly userService: UserService,
   ) {}
 
+  async addCourseOffering(
+    username: Express.User['username'],
+    courseId: Course['id'],
+    courseOffering: Omit<CourseOffering, 'id' | 'organisationEnabled'>,
+  ): Promise<CourseOffering> {
+    const hmppsAuthClient = this.hmppsAuthClientBuilder()
+    const systemToken = await hmppsAuthClient.getSystemClientToken(username)
+    const courseClient = this.courseClientBuilder(systemToken)
+
+    return courseClient.addCourseOffering(courseId, courseOffering)
+  }
+
   async createCourse(username: Express.User['username'], courseCreateRequest: CourseCreateRequest): Promise<Course> {
     const hmppsAuthClient = this.hmppsAuthClientBuilder()
     const systemToken = await hmppsAuthClient.getSystemClientToken(username)

--- a/server/utils/organisationUtils.test.ts
+++ b/server/utils/organisationUtils.test.ts
@@ -32,6 +32,20 @@ describe('OrganisationUtils', () => {
     })
   })
 
+  describe('organisationSelectItems', () => {
+    it('returns an array of `GovukFrontendSelectItem` objects from an array of prisons', () => {
+      const prisons = [
+        prisonFactory.build({ prisonId: 'an-ID-1', prisonName: 'Prison 1' }),
+        prisonFactory.build({ prisonId: 'an-ID-2', prisonName: 'Prison 2' }),
+      ]
+
+      expect(OrganisationUtils.organisationSelectItems(prisons)).toEqual([
+        { text: prisons[0].prisonName, value: prisons[0].prisonId },
+        { text: prisons[1].prisonName, value: prisons[1].prisonId },
+      ])
+    })
+  })
+
   describe('organisationTableRows', () => {
     let organisationsWithOfferingIds: Array<OrganisationWithOfferingId>
 

--- a/server/utils/organisationUtils.ts
+++ b/server/utils/organisationUtils.ts
@@ -5,7 +5,7 @@ import type {
   OrganisationWithOfferingEmailsPresenter,
   OrganisationWithOfferingId,
 } from '@accredited-programmes/ui'
-import type { GovukFrontendTableRow } from '@govuk-frontend'
+import type { GovukFrontendSelectItem, GovukFrontendTableRow } from '@govuk-frontend'
 import type { Prison } from '@prison-register-api'
 
 export default class OrganisationUtils {
@@ -19,6 +19,15 @@ export default class OrganisationUtils {
       category: categories,
       name: prison.prisonName,
     }
+  }
+
+  static organisationSelectItems(organisations: Array<Prison>): Array<GovukFrontendSelectItem> {
+    return organisations.map(organisation => {
+      return {
+        text: organisation.prisonName,
+        value: organisation.prisonId,
+      }
+    })
   }
 
   static organisationTableRows(organisations: Array<OrganisationWithOfferingId>): Array<GovukFrontendTableRow> {

--- a/server/views/courses/offerings/form/show.njk
+++ b/server/views/courses/offerings/form/show.njk
@@ -1,0 +1,98 @@
+{% from "govuk/components/back-link/macro.njk" import govukBackLink %}
+{% from "govuk/components/button/macro.njk" import govukButton %}
+{% from "govuk/components/input/macro.njk" import govukInput %}
+{% from "govuk/components/radios/macro.njk" import govukRadios %}
+{% from "govuk/components/select/macro.njk" import govukSelect %}
+{% from "govuk/components/textarea/macro.njk" import govukTextarea %}
+
+{% extends "../../../partials/layout.njk" %}
+
+{% block backLink %}
+  {{ govukBackLink({
+    text: "Back",
+    href: backLinkHref
+  }) }}
+{% endblock backLink %}
+
+{% block content %}
+  <h1 class="govuk-heading-l">{{ pageHeading }}</h1>
+
+  <div class="govuk-grid-row">
+    <div class="govuk-grid-column-two-thirds">
+      <form action="{{ action }}" method="post">
+        <input type="hidden" name="_csrf" value="{{ csrfToken }}"/>
+
+        {{ govukSelect({
+          id: "location-organisation-id",
+          name: "organisationId",
+          label: {
+            text: "Organisation"
+          },
+          items: organisationSelectItems,
+            attributes: {
+            "data-testid": "organisation-select"
+          },
+          errorMessage: errors.messages.organisationId
+        }) }}
+
+        {{ govukInput({
+          label: {
+            text: "Contact email"
+          },
+          id: "location-contact-email",
+          name: "contactEmail",
+          errorMessage: errors.messages.contactEmail
+        }) }}
+
+        {{ govukInput({
+          label: {
+            text: "Secondary contact email"
+          },
+          id: "location-secondary-contact-email",
+          name: "secondaryContactEmail",
+          errorMessage: errors.messages.secondaryContactEmail
+        }) }}
+
+        {{ govukRadios({
+          name: "referable",
+          fieldset: {
+            legend: {
+              text: "Referable"
+            }
+          },
+          items: [
+            {
+              value: "true",
+              text: "Yes"
+            },
+            {
+              value: "false",
+              text: "No"
+            }
+          ]
+        }) }}
+
+        {{ govukRadios({
+          name: "withdrawn",
+          fieldset: {
+            legend: {
+              text: "Withdrawn"
+            }
+          },
+          items: [
+            {
+              value: "true",
+              text: "Yes"
+            },
+            {
+              value: "false",
+              text: "No"
+            }
+          ]
+        }) }}
+
+        {{ govukButton({ text: "Submit" }) }}
+      </form>
+    </div>
+  </div>
+{% endblock content %}

--- a/server/views/courses/show.njk
+++ b/server/views/courses/show.njk
@@ -1,4 +1,5 @@
 {% from "govuk/components/back-link/macro.njk" import govukBackLink %}
+{% from "govuk/components/button/macro.njk" import govukButton %}
 {% from "govuk/components/summary-list/macro.njk" import govukSummaryList %}
 
 {% from "../partials/audienceTag.njk" import audienceTag %}
@@ -30,7 +31,20 @@
 
       <p class="govuk-body" data-testid="description-paragraph">{{ course.description }}</p>
 
-      <h2 class="govuk-heading-m">Locations</h2>
+      <div class="header-with-actions">
+        <h2 class="header-with-actions__title govuk-heading-m">Locations</h2>
+
+        {% if 'ROLE_ACP_EDITOR' in user.roles %}
+          {{ govukButton({
+            text: "Add a new location",
+            href: addOfferingPath,
+            classes: "govuk-button--secondary",
+            attributes: {
+              "data-testid": "add-programme-offering-link"
+            }
+          }) }}
+        {% endif %}
+      </div>
 
       {% if organisationsTableData | length %}
         <p data-testid="offerings-text">Select a prison to contact the programme team or make a referral. Online referrals are not yet available at all sites.</p>


### PR DESCRIPTION
## Context

We need to be able to add offerings/locations for a course/programme.



## Changes in this PR
Add new `AddCourseOfferingController` for displaying and submitting new form.


## Screenshots of UI changes
![image](https://github.com/user-attachments/assets/04f7bd94-8a09-402d-9293-7ffbed80c8f7)

![image](https://github.com/user-attachments/assets/f9712b0a-eb8a-459f-a17e-bd401796993b)



## Release checklist

[Release process documentation](../doc/how-to/perform-a-release.md)

As part of our continuous deployment strategy we must ensure that this work is
ready to be released once merged.

### Pre-merge

- [ ] There are changes required to the Accredited Programmes API for this change to work...
  - [ ] ... and they have been released to production already

### Post-merge

<!-- The outer checkboxes can be completed pre-merge -->

- [ ] This adds, extends or meaningfully modifies a feature...
  - [ ] ... and I have written or updated an end-to-end test for the happy path in the [Accredited Programmes E2E repo](https://github.com/ministryofjustice/hmpps-accredited-programmes-e2e)
- [ ] This makes new expectations of the API...
  - [ ] ... and I have notified the API developer(s) of changes to the contract tests (Pact), or the API is already compliant
- [ ] [Manually approve](../doc/how-to/perform-a-release.md#releasing-to-the-preprod-environment) release to preprod
- [ ] [Manually approve](../doc/how-to/perform-a-release.md#releasing-to-the-production-environment) release to prod

<!-- Should a release fail at any step, you as the author should now lead the work to
fix it as soon as possible. You can monitor deployment failures in CircleCI
itself and application errors are found in
[Sentry](https://ministryofjustice.sentry.io/projects/hmpps-accredited-programmes-ui/?project=4505330122686464&referrer=sidebar&statsPeriod=24h). -->
