### PR TITLE
(APG-251) Add `updateCoursePrerequisites` method to `CourseClient`

### DIFF
--- a/server/data/accreditedProgrammesApi/courseClient.test.ts
+++ b/server/data/accreditedProgrammesApi/courseClient.test.ts
@@ -479,6 +479,39 @@ pactWith({ consumer: 'Accredited Programmes UI', provider: 'Accredited Programme
     })
   })
 
+  describe('updateCoursePrerequisites', () => {
+    const course = courseFactory.build({ id: 'd3abc217-75ee-46e9-a010-368f30282367' })
+
+    beforeEach(() => {
+      provider.addInteraction({
+        state: 'Course prerequisites for d3abc217-75ee-46e9-a010-368f30282367 can be updated',
+        uponReceiving: 'A request to update course prerequisites for d3abc217-75ee-46e9-a010-368f30282367',
+        willRespondWith: {
+          body: Matchers.like(course),
+          status: 200,
+        },
+        withRequest: {
+          headers: {
+            authorization: `Bearer ${systemToken}`,
+          },
+          method: 'PUT',
+          path: apiPaths.courses.prerequisites({ courseId: course.id }),
+        },
+      })
+    })
+
+    it('updates the course with the given course prerequisites', async () => {
+      const result = await courseClient.updateCoursePrerequisites(course.id, [
+        {
+          description: 'Male',
+          name: 'Gender',
+        },
+      ])
+
+      expect(result).toEqual(course)
+    })
+  })
+
   describe('updateParticipation', () => {
     const courseParticipation = courseParticipationFactory.build({
       id: 'cc8eb19e-050a-4aa9-92e0-c654e5cfe281',

--- a/server/data/accreditedProgrammesApi/courseClient.ts
+++ b/server/data/accreditedProgrammesApi/courseClient.ts
@@ -9,6 +9,7 @@ import type {
   CourseOffering,
   CourseParticipation,
   CourseParticipationUpdate,
+  CoursePrerequisite,
   Person,
 } from '@accredited-programmes/models'
 import type { SystemToken } from '@hmpps-auth'
@@ -108,6 +109,16 @@ export default class CourseClient {
     return (await this.restClient.get({
       path: apiPaths.people.participations({ prisonNumber }),
     })) as Array<CourseParticipation>
+  }
+
+  async updateCoursePrerequisites(
+    courseId: Course['id'],
+    coursePrerequisites: Array<CoursePrerequisite>,
+  ): Promise<Array<CoursePrerequisite>> {
+    return (await this.restClient.put({
+      data: coursePrerequisites,
+      path: apiPaths.courses.prerequisites({ courseId }),
+    })) as Array<CoursePrerequisite>
   }
 
   async updateParticipation(

--- a/server/data/restClient.ts
+++ b/server/data/restClient.ts
@@ -22,7 +22,7 @@ interface GetRequest {
 interface DeleteRequest extends GetRequest {}
 
 interface PostRequest {
-  data?: Record<string, unknown>
+  data?: Array<Record<string, unknown>> | Record<string, unknown>
   headers?: Record<string, string>
   path?: string
   raw?: boolean

--- a/server/paths/api.ts
+++ b/server/paths/api.ts
@@ -44,6 +44,7 @@ export default {
     index: coursesPath,
     names: courseNamesPath,
     offerings: offeringsByCoursePath,
+    prerequisites: coursePath.path('prerequisites'),
     show: coursePath,
   },
   oasys: {


### PR DESCRIPTION
## Context

We need to be able to update the prerequisites for a course.



## Changes in this PR
Add new client method for `/courses/:id/prerequisites`



## Release checklist

[Release process documentation](../doc/how-to/perform-a-release.md)

As part of our continuous deployment strategy we must ensure that this work is
ready to be released once merged.

### Pre-merge

- [ ] There are changes required to the Accredited Programmes API for this change to work...
  - [ ] ... and they have been released to production already

### Post-merge

<!-- The outer checkboxes can be completed pre-merge -->

- [ ] This adds, extends or meaningfully modifies a feature...
  - [ ] ... and I have written or updated an end-to-end test for the happy path in the [Accredited Programmes E2E repo](https://github.com/ministryofjustice/hmpps-accredited-programmes-e2e)
- [ ] This makes new expectations of the API...
  - [ ] ... and I have notified the API developer(s) of changes to the contract tests (Pact), or the API is already compliant
- [ ] [Manually approve](../doc/how-to/perform-a-release.md#releasing-to-the-preprod-environment) release to preprod
- [ ] [Manually approve](../doc/how-to/perform-a-release.md#releasing-to-the-production-environment) release to prod

<!-- Should a release fail at any step, you as the author should now lead the work to
fix it as soon as possible. You can monitor deployment failures in CircleCI
itself and application errors are found in
[Sentry](https://ministryofjustice.sentry.io/projects/hmpps-accredited-programmes-ui/?project=4505330122686464&referrer=sidebar&statsPeriod=24h). -->
