### PR TITLE
(APG-251) Add course prerequisites

### DIFF
--- a/assets/js/fieldRepeater.js
+++ b/assets/js/fieldRepeater.js
@@ -1,0 +1,21 @@
+$('.js-repeater-button').on('click', function () {
+  const $lastDiv = $('div[id^="js-repeater-section-"]:last')
+
+  const num = parseInt($lastDiv.prop('id').match(/\d+/g), 10) + 1
+
+  const $clone = $lastDiv.clone().prop('id', `js-repeater-section-${num}`)
+
+  $clone.find('label').each(function () {
+    const inputLabel = parseInt(this.htmlFor.match(/\d+/), 10) + 1
+    this.htmlFor = this.htmlFor.replace(/\d+/, inputLabel)
+  })
+
+  $clone.find('input').each(function () {
+    this.value = ''
+    const inputNumber = parseInt(this.name.match(/\d+/), 10) + 1
+    this.name = this.name.replace(/\d+/, inputNumber)
+    this.id = this.id.replace(/\d+/, inputNumber)
+  })
+
+  $lastDiv.after($clone)
+})

--- a/server/data/accreditedProgrammesApi/courseClient.ts
+++ b/server/data/accreditedProgrammesApi/courseClient.ts
@@ -117,7 +117,7 @@ export default class CourseClient {
     coursePrerequisites: Array<CoursePrerequisite>,
   ): Promise<Array<CoursePrerequisite>> {
     return (await this.restClient.put({
-      data: coursePrerequisites,
+      data: { prerequisites: coursePrerequisites },
       path: apiPaths.courses.prerequisites({ courseId }),
     })) as Array<CoursePrerequisite>
   }

--- a/server/services/courseService.test.ts
+++ b/server/services/courseService.test.ts
@@ -12,6 +12,7 @@ import {
   courseFactory,
   courseOfferingFactory,
   courseParticipationFactory,
+  coursePrerequisiteFactory,
   personFactory,
   userFactory,
 } from '../testutils/factories'
@@ -423,6 +424,22 @@ describe('CourseService', () => {
       const result = await service.presentCourseParticipation(userToken, courseParticipation, referralId)
 
       expect(result).toEqual('course participation 1 options')
+    })
+  })
+
+  describe('updateCoursePrerequisites', () => {
+    it('asks the client to update course prerequisites', async () => {
+      const courseId = 'COURSE_ID'
+      const prerequisites = coursePrerequisiteFactory.buildList(3)
+
+      when(courseClient.updateCoursePrerequisites).calledWith(courseId, prerequisites).mockResolvedValue(prerequisites)
+
+      const result = await service.updateCoursePrerequisites(username, courseId, prerequisites)
+
+      expect(result).toEqual(prerequisites)
+
+      expect(courseClientBuilder).toHaveBeenCalledWith(systemToken)
+      expect(courseClient.updateCoursePrerequisites).toHaveBeenCalledWith(courseId, prerequisites)
     })
   })
 

--- a/server/services/courseService.ts
+++ b/server/services/courseService.ts
@@ -11,6 +11,7 @@ import type {
   CourseOffering,
   CourseParticipation,
   CourseParticipationUpdate,
+  CoursePrerequisite,
   Person,
   Referral,
 } from '@accredited-programmes/models'
@@ -212,6 +213,18 @@ export default class CourseService {
     }
 
     return CourseParticipationUtils.summaryListOptions(courseParticipationPresenter, referralId, withActions)
+  }
+
+  async updateCoursePrerequisites(
+    username: Express.User['username'],
+    courseId: Course['id'],
+    prerequisites: Array<CoursePrerequisite>,
+  ): Promise<Array<CoursePrerequisite>> {
+    const hmppsAuthClient = this.hmppsAuthClientBuilder()
+    const systemToken = await hmppsAuthClient.getSystemClientToken(username)
+    const courseClient = this.courseClientBuilder(systemToken)
+
+    return courseClient.updateCoursePrerequisites(courseId, prerequisites)
   }
 
   async updateParticipation(

--- a/server/views/courses/form/show.njk
+++ b/server/views/courses/form/show.njk
@@ -1,5 +1,6 @@
 {% from "govuk/components/back-link/macro.njk" import govukBackLink %}
 {% from "govuk/components/button/macro.njk" import govukButton %}
+{% from "govuk/components/fieldset/macro.njk" import govukFieldset %}
 {% from "govuk/components/input/macro.njk" import govukInput %}
 {% from "govuk/components/radios/macro.njk" import govukRadios %}
 {% from "govuk/components/select/macro.njk" import govukSelect %}
@@ -65,6 +66,48 @@
           }
         }) }}
 
+        <hr class="govuk-section-break govuk-section-break--xl govuk-section-break--visible">
+
+        {% call govukFieldset({
+          legend: {
+            text: "Programme criteria",
+            classes: "govuk-fieldset__legend--m"
+          }
+        }) %}
+
+        <div id="js-repeater-section-1" class="govuk-grid-row">
+          {{ govukInput({
+              label: {
+                text: "Name"
+              },
+              id: "prerequisites[1][name]",
+              name: "prerequisites[1][name]",
+              formGroup: {
+                classes: "govuk-grid-column-one-third"
+              }
+            }) }}
+
+          {{ govukInput({
+              label: {
+                text: "Description"
+              },
+              id: "prerequisites[1][description]",
+              name: "prerequisites[1][description]",
+              formGroup: {
+                classes: "govuk-grid-column-two-thirds"
+              }
+            }) }}
+        </div>
+        {% endcall %}
+
+        {{ govukButton({
+          type: "button",
+          text: "Add more criteria",
+          classes: "govuk-button--secondary js-repeater-button govuk-!-margin-bottom-0"
+        }) }}
+
+        <hr class="govuk-section-break govuk-section-break--xl govuk-section-break--visible">
+
         {{ govukRadios({
           name: "withdrawn",
           fieldset: {
@@ -89,3 +132,8 @@
     </div>
   </div>
 {% endblock content %}
+
+{% block bodyEnd %}
+  {{ super() }}
+  <script src="/assets/fieldRepeater.js"></script>
+{% endblock bodyEnd %}


### PR DESCRIPTION
## Context

We need an easier way to update the content in FIND to ensure it is accurate.

## Changes in this PR
- Added some client side JS for `fieldRepeater` so more fields can be added to allow for multiple values of a similar name.
- Used the above and added some fields to add course prerequisites when adding a new course


## Screenshots of UI changes

![image](https://github.com/user-attachments/assets/d2c890bd-f221-45eb-acd5-2896f89edf29)



## Release checklist

[Release process documentation](../doc/how-to/perform-a-release.md)

As part of our continuous deployment strategy we must ensure that this work is
ready to be released once merged.

### Pre-merge

- [ ] There are changes required to the Accredited Programmes API for this change to work...
  - [ ] ... and they have been released to production already

### Post-merge

<!-- The outer checkboxes can be completed pre-merge -->

- [ ] This adds, extends or meaningfully modifies a feature...
  - [ ] ... and I have written or updated an end-to-end test for the happy path in the [Accredited Programmes E2E repo](https://github.com/ministryofjustice/hmpps-accredited-programmes-e2e)
- [ ] This makes new expectations of the API...
  - [ ] ... and I have notified the API developer(s) of changes to the contract tests (Pact), or the API is already compliant
- [ ] [Manually approve](../doc/how-to/perform-a-release.md#releasing-to-the-preprod-environment) release to preprod
- [ ] [Manually approve](../doc/how-to/perform-a-release.md#releasing-to-the-production-environment) release to prod

<!-- Should a release fail at any step, you as the author should now lead the work to
fix it as soon as possible. You can monitor deployment failures in CircleCI
itself and application errors are found in
[Sentry](https://ministryofjustice.sentry.io/projects/hmpps-accredited-programmes-ui/?project=4505330122686464&referrer=sidebar&statsPeriod=24h). -->
