### PR TITLE
(APG-254) Add the ability the delete a course offering

### DIFF
--- a/integration_tests/pages/find/courseOffering.ts
+++ b/integration_tests/pages/find/courseOffering.ts
@@ -41,7 +41,7 @@ export default class CourseOfferingPage extends Page {
   }
 
   shouldNotContainMakeAReferralButtonLink() {
-    this.shouldNotContainButtonLink()
+    cy.get('.govuk-button').contains('Make a referral').should('not.exist')
   }
 
   shouldNotContainSecondaryContactEmailSummaryListItem() {

--- a/server/controllers/find/courseOfferingsController.ts
+++ b/server/controllers/find/courseOfferingsController.ts
@@ -1,5 +1,6 @@
 import type { Request, Response, TypedRequestHandler } from 'express'
 
+import { findPaths } from '../../paths'
 import type { CourseService, OrganisationService } from '../../services'
 import { CourseUtils, OrganisationUtils, TypeUtils } from '../../utils'
 import type { CourseOffering, Organisation } from '@accredited-programmes/models'
@@ -9,6 +10,18 @@ export default class CourseOfferingsController {
     private readonly courseService: CourseService,
     private readonly organisationService: OrganisationService,
   ) {}
+
+  delete(): TypedRequestHandler<Request, Response> {
+    return async (req: Request, res: Response) => {
+      TypeUtils.assertHasUser(req)
+
+      const { courseId, courseOfferingId } = req.params
+
+      await this.courseService.deleteOffering(req.user.token, courseId, courseOfferingId)
+
+      res.redirect(findPaths.show({ courseId }))
+    }
+  }
 
   show(): TypedRequestHandler<Request, Response> {
     return async (req: Request, res: Response) => {
@@ -31,6 +44,7 @@ export default class CourseOfferingsController {
       res.render('courses/offerings/show', {
         course: coursePresenter,
         courseOffering,
+        deleteOfferingAction: `${findPaths.offerings.delete({ courseId: course.id, courseOfferingId: courseOffering.id })}?_method=DELETE`,
         organisation: OrganisationUtils.presentOrganisationWithOfferingEmails(
           organisation,
           courseOffering,

--- a/server/data/accreditedProgrammesApi/courseClient.ts
+++ b/server/data/accreditedProgrammesApi/courseClient.ts
@@ -53,6 +53,13 @@ export default class CourseClient {
     })) as CourseParticipation
   }
 
+  /* istanbul ignore next */
+  async destroyOffering(courseId: Course['id'], courseOfferingId: CourseOffering['id']): Promise<void> {
+    await this.restClient.delete({
+      path: apiPaths.courses.offering({ courseId, courseOfferingId }),
+    })
+  }
+
   async destroyParticipation(courseParticipationId: CourseParticipation['id']): Promise<void> {
     await this.restClient.delete({
       path: apiPaths.participations.delete({ courseParticipationId }),

--- a/server/paths/api.ts
+++ b/server/paths/api.ts
@@ -43,6 +43,7 @@ export default {
     create: coursesPath,
     index: coursesPath,
     names: courseNamesPath,
+    offering: offeringsByCoursePath.path(':courseOfferingId'),
     offerings: offeringsByCoursePath,
     prerequisites: coursePath.path('prerequisites'),
     show: coursePath,

--- a/server/paths/find.ts
+++ b/server/paths/find.ts
@@ -7,6 +7,7 @@ const coursePath = coursesPath.path(':courseId')
 const addCoursePath = coursesPath.path('/add')
 
 const addCourseOfferingPath = coursePath.path('/offerings/add')
+const deleteCourseOfferingPath = coursePath.path('/offerings/:courseOfferingId/delete')
 const courseOfferingPath = findPathBase.path('/offerings/:courseOfferingId')
 
 export default {
@@ -22,6 +23,7 @@ export default {
       create: addCourseOfferingPath,
       show: addCourseOfferingPath,
     },
+    delete: deleteCourseOfferingPath,
     show: courseOfferingPath,
   },
   show: coursePath,

--- a/server/routes/find.ts
+++ b/server/routes/find.ts
@@ -5,12 +5,13 @@ import { findPaths } from '../paths'
 import { RouteUtils } from '../utils'
 
 export default function routes(controllers: Controllers, router: Router): Router {
-  const { get } = RouteUtils.actions(router)
+  const { delete: deleteAction, get } = RouteUtils.actions(router)
   const { coursesController, courseOfferingsController } = controllers
 
   get(findPaths.index.pattern, coursesController.index())
   get(findPaths.show.pattern, coursesController.show())
   get(findPaths.offerings.show.pattern, courseOfferingsController.show())
+  deleteAction(findPaths.offerings.delete.pattern, courseOfferingsController.delete())
 
   return router
 }

--- a/server/services/courseService.test.ts
+++ b/server/services/courseService.test.ts
@@ -112,6 +112,18 @@ describe('CourseService', () => {
     })
   })
 
+  describe('deleteOffering', () => {
+    it('asks the client to delete a course offering', async () => {
+      const courseId = 'COURSE-ID'
+      const courseOfferingId = 'COURSE-OFFERING-ID'
+
+      await service.deleteOffering(username, courseId, courseOfferingId)
+
+      expect(courseClientBuilder).toHaveBeenCalledWith(systemToken)
+      expect(courseClient.destroyOffering).toHaveBeenCalledWith(courseId, courseOfferingId)
+    })
+  })
+
   describe('deleteParticipation', () => {
     it('asks the client to delete a course participation', async () => {
       const courseParticipation = courseParticipationFactory.build()

--- a/server/services/courseService.ts
+++ b/server/services/courseService.ts
@@ -57,6 +57,18 @@ export default class CourseService {
     return courseClient.createParticipation(prisonNumber, courseName)
   }
 
+  async deleteOffering(
+    username: Express.User['username'],
+    courseId: Course['id'],
+    courseOfferingId: CourseOffering['id'],
+  ): Promise<void> {
+    const hmppsAuthClient = this.hmppsAuthClientBuilder()
+    const systemToken = await hmppsAuthClient.getSystemClientToken(username)
+    const courseClient = this.courseClientBuilder(systemToken)
+
+    return courseClient.destroyOffering(courseId, courseOfferingId)
+  }
+
   async deleteParticipation(
     username: Express.User['username'],
     courseParticipationId: CourseParticipation['id'],

--- a/server/views/courses/offerings/show.njk
+++ b/server/views/courses/offerings/show.njk
@@ -16,7 +16,23 @@
 {% endblock backLink %}
 
 {% block content %}
-  <h1 class="govuk-heading-l">{{ pageHeading }}</h1>
+  <div class="header-with-actions">
+    <h1 class="header-with-actions__title govuk-heading-l">{{ pageHeading }}</h1>
+
+    <form action="{{ deleteOfferingAction }}" method="post">
+      <input type="hidden" name="_csrf" value="{{ csrfToken }}"/>
+
+      <div class="govuk-button-group">
+        {{ govukButton({
+          text: "Delete",
+          classes: "govuk-button--warning",
+          attributes: {
+          "data-testid": "delete-programme-offering-link"
+          }
+        }) }}
+      </div>
+    </form>
+  </div>
 
   <div class="govuk-grid-row">
     <div class="govuk-grid-column-two-thirds">


### PR DESCRIPTION
## Context

We need an easier way to update the content in FIND to ensure it is accurate

## Changes in this PR
Added Delete button to course offering page.

Note: The API only allows offerings to be deleted if there are no associated referrals. 


## Screenshots of UI changes

![image](https://github.com/user-attachments/assets/e31da7f5-e935-4fe1-b919-39da7c301e78)



## Release checklist

[Release process documentation](../doc/how-to/perform-a-release.md)

As part of our continuous deployment strategy we must ensure that this work is
ready to be released once merged.

### Pre-merge

- [ ] There are changes required to the Accredited Programmes API for this change to work...
  - [ ] ... and they have been released to production already

### Post-merge

<!-- The outer checkboxes can be completed pre-merge -->

- [ ] This adds, extends or meaningfully modifies a feature...
  - [ ] ... and I have written or updated an end-to-end test for the happy path in the [Accredited Programmes E2E repo](https://github.com/ministryofjustice/hmpps-accredited-programmes-e2e)
- [ ] This makes new expectations of the API...
  - [ ] ... and I have notified the API developer(s) of changes to the contract tests (Pact), or the API is already compliant
- [ ] [Manually approve](../doc/how-to/perform-a-release.md#releasing-to-the-preprod-environment) release to preprod
- [ ] [Manually approve](../doc/how-to/perform-a-release.md#releasing-to-the-production-environment) release to prod

<!-- Should a release fail at any step, you as the author should now lead the work to
fix it as soon as possible. You can monitor deployment failures in CircleCI
itself and application errors are found in
[Sentry](https://ministryofjustice.sentry.io/projects/hmpps-accredited-programmes-ui/?project=4505330122686464&referrer=sidebar&statsPeriod=24h). -->
