### PR TITLE
(APG-252) Update offering

### DIFF
--- a/server/controllers/find/courseOfferingsController.test.ts
+++ b/server/controllers/find/courseOfferingsController.test.ts
@@ -63,6 +63,7 @@ describe('CoursesOfferingsController', () => {
           course.name,
         ),
         pageHeading: coursePresenter.displayName,
+        updateOfferingPath: `/find/offerings/${courseOffering.id}/update`,
       })
     })
   })

--- a/server/controllers/find/courseOfferingsController.ts
+++ b/server/controllers/find/courseOfferingsController.ts
@@ -51,6 +51,9 @@ export default class CourseOfferingsController {
           course.name,
         ),
         pageHeading: coursePresenter.displayName,
+        updateOfferingPath: findPaths.offerings.update.show({
+          courseOfferingId: courseOffering.id,
+        }),
       })
     }
   }

--- a/server/controllers/find/index.ts
+++ b/server/controllers/find/index.ts
@@ -5,6 +5,7 @@ import AddCourseOfferingController from './addCourseOfferingController'
 import CourseOfferingsController from './courseOfferingsController'
 import CoursesController from './coursesController'
 import UpdateCourseController from './updateCourseController'
+import UpdateCourseOfferingController from './updateCourseOfferingController'
 import type { Services } from '../../services'
 
 const controllers = (services: Services) => {
@@ -16,6 +17,10 @@ const controllers = (services: Services) => {
   const coursesController = new CoursesController(services.courseService, services.organisationService)
   const courseOfferingsController = new CourseOfferingsController(services.courseService, services.organisationService)
   const updateCourseController = new UpdateCourseController(services.courseService)
+  const updateCourseOfferingController = new UpdateCourseOfferingController(
+    services.courseService,
+    services.organisationService,
+  )
 
   return {
     addCourseController,
@@ -23,6 +28,7 @@ const controllers = (services: Services) => {
     courseOfferingsController,
     coursesController,
     updateCourseController,
+    updateCourseOfferingController,
   }
 }
 

--- a/server/controllers/find/updateCourseOfferingController.test.ts
+++ b/server/controllers/find/updateCourseOfferingController.test.ts
@@ -1,0 +1,102 @@
+import type { DeepMocked } from '@golevelup/ts-jest'
+import { createMock } from '@golevelup/ts-jest'
+import type { NextFunction, Request, Response } from 'express'
+import { when } from 'jest-when'
+
+import UpdateCourseOfferingController from './updateCourseOfferingController'
+import { findPaths } from '../../paths'
+import type { CourseService, OrganisationService } from '../../services'
+import { courseFactory, courseOfferingFactory, prisonFactory } from '../../testutils/factories'
+import { OrganisationUtils } from '../../utils'
+import type { GovukFrontendSelectItem } from '@govuk-frontend'
+
+jest.mock('../../utils/organisationUtils')
+
+const mockOrganisationUtils = OrganisationUtils as jest.Mocked<typeof OrganisationUtils>
+
+describe('UpdateCourseOfferingController', () => {
+  let controller: UpdateCourseOfferingController
+  let request: Request
+  let response: Response
+
+  const username = 'SOME_USERNAME'
+  const userToken = 'USER_TOKEN'
+  const courseService = createMock<CourseService>({})
+  const organisationService = createMock<OrganisationService>({})
+  const courseOffering = courseOfferingFactory.build({})
+  const next: DeepMocked<NextFunction> = createMock<NextFunction>({})
+
+  beforeEach(() => {
+    controller = new UpdateCourseOfferingController(courseService, organisationService)
+    request = createMock<Request>({
+      params: { courseOfferingId: courseOffering.id },
+      user: { token: userToken, username },
+    })
+    response = createMock<Response>()
+  })
+
+  describe('show', () => {
+    const organisationSelectItems: Array<GovukFrontendSelectItem> = [
+      { text: 'Organisation 1', value: '1' },
+      { text: 'Organisation 2', value: '2' },
+      { text: 'Organisation 3', value: '3' },
+    ]
+
+    beforeEach(() => {
+      mockOrganisationUtils.organisationSelectItems.mockReturnValue(organisationSelectItems)
+      when(courseService.getOffering).calledWith(userToken, courseOffering.id).mockResolvedValue(courseOffering)
+    })
+
+    it('renders the update course offering form template with organisation select items', async () => {
+      const organisations = prisonFactory.buildList(3)
+      organisationService.getAllOrganisations.mockResolvedValue(organisations)
+
+      const requestHandler = controller.show()
+      await requestHandler(request, response, next)
+
+      expect(organisationService.getAllOrganisations).toHaveBeenCalledWith(userToken)
+
+      expect(response.render).toHaveBeenCalledWith('courses/offerings/form/show', {
+        action: `/find/offerings/${courseOffering.id}/update?_method=PUT`,
+        backLinkHref: `/find/offerings/${courseOffering.id}`,
+        offering: courseOffering,
+        organisationSelectItems,
+        pageHeading: 'Update location',
+      })
+      expect(OrganisationUtils.organisationSelectItems).toHaveBeenCalledWith(organisations)
+    })
+  })
+
+  describe('submit', () => {
+    const course = courseFactory.build({})
+
+    beforeEach(() => {
+      when(courseService.getCourseByOffering).calledWith(userToken, courseOffering.id).mockResolvedValue(course)
+    })
+
+    it('updates a course offering and redirects back to the offering page', async () => {
+      const updatedCourseOfferingBody: Record<string, string> = {
+        contactEmail: 'contact-email@test.com',
+        organisationId: 'organisation-id',
+        referable: 'true',
+        secondaryContactEmail: 'secondary-contact-email@test.com',
+        withdrawn: 'false',
+      }
+
+      courseService.updateCourseOffering.mockResolvedValue(courseOffering)
+
+      request.body = updatedCourseOfferingBody
+
+      const requestHandler = controller.submit()
+      await requestHandler(request, response, next)
+
+      expect(courseService.updateCourseOffering).toHaveBeenCalledWith(username, course.id, {
+        ...updatedCourseOfferingBody,
+        id: courseOffering.id,
+        referable: true,
+        withdrawn: false,
+      })
+      expect(response.redirect).toHaveBeenCalledWith(findPaths.offerings.show({ courseOfferingId: courseOffering.id }))
+    })
+  })
+})

--- a/server/controllers/find/updateCourseOfferingController.ts
+++ b/server/controllers/find/updateCourseOfferingController.ts
@@ -1,0 +1,60 @@
+import type { Request, Response, TypedRequestHandler } from 'express'
+
+import { findPaths } from '../../paths'
+import type { CourseService, OrganisationService } from '../../services'
+import { OrganisationUtils, TypeUtils } from '../../utils'
+
+export default class UpdateCourseOfferingController {
+  constructor(
+    private readonly courseService: CourseService,
+    private readonly organisationService: OrganisationService,
+  ) {}
+
+  show(): TypedRequestHandler<Request, Response> {
+    return async (req: Request, res: Response) => {
+      TypeUtils.assertHasUser(req)
+
+      const { courseOfferingId } = req.params
+
+      const [offering, organisations] = await Promise.all([
+        this.courseService.getOffering(req.user.token, courseOfferingId),
+        this.organisationService.getAllOrganisations(req.user.token),
+      ])
+
+      const organisationSelectItems = OrganisationUtils.organisationSelectItems(organisations)
+
+      res.render('courses/offerings/form/show', {
+        action: `${findPaths.offerings.update.submit({ courseOfferingId })}?_method=PUT`,
+        backLinkHref: findPaths.offerings.show({ courseOfferingId }),
+        offering,
+        organisationSelectItems,
+        pageHeading: 'Update location',
+      })
+    }
+  }
+
+  submit(): TypedRequestHandler<Request, Response> {
+    return async (req: Request, res: Response) => {
+      TypeUtils.assertHasUser(req)
+
+      const { courseOfferingId } = req.params
+      const { contactEmail, organisationId, referable, secondaryContactEmail, withdrawn } = req.body as Record<
+        string,
+        string
+      >
+
+      const course = await this.courseService.getCourseByOffering(req.user.token, courseOfferingId)
+
+      await this.courseService.updateCourseOffering(req.user.username, course.id, {
+        contactEmail,
+        id: courseOfferingId,
+        organisationId,
+        referable: referable === 'true',
+        secondaryContactEmail,
+        withdrawn: withdrawn ? withdrawn === 'true' : undefined,
+      })
+
+      res.redirect(findPaths.offerings.show({ courseOfferingId }))
+    }
+  }
+}

--- a/server/data/accreditedProgrammesApi/courseClient.ts
+++ b/server/data/accreditedProgrammesApi/courseClient.ts
@@ -127,6 +127,17 @@ export default class CourseClient {
   }
 
   /* istanbul ignore next */
+  async updateCourseOffering(
+    courseId: Course['id'],
+    courseOffering: Omit<CourseOffering, 'organisationEnabled'>,
+  ): Promise<CourseOffering> {
+    return (await this.restClient.put({
+      data: courseOffering,
+      path: apiPaths.offerings.update({ courseId }),
+    })) as CourseOffering
+  }
+
+  /* istanbul ignore next */
   async updateCoursePrerequisites(
     courseId: Course['id'],
     coursePrerequisites: Array<CoursePrerequisite>,

--- a/server/paths/api.ts
+++ b/server/paths/api.ts
@@ -67,6 +67,7 @@ export default {
     course: courseByOfferingPath,
     create: offeringsByCoursePath,
     show: offeringPath,
+    update: offeringsByCoursePath,
   },
   organisations: {
     courses: coursesByOrganisationPath,

--- a/server/paths/find.ts
+++ b/server/paths/find.ts
@@ -1,15 +1,16 @@
 import { path } from 'static-path'
 
 const findPathBase = path('/find')
-const coursesPath = findPathBase.path('/programmes')
+const coursesPath = findPathBase.path('programmes')
 const coursePath = coursesPath.path(':courseId')
 
-const addCoursePath = coursesPath.path('/add')
-const updateCoursePath = coursePath.path('/update')
+const addCoursePath = coursesPath.path('add')
+const updateCoursePath = coursePath.path('update')
 
-const addCourseOfferingPath = coursePath.path('/offerings/add')
-const deleteCourseOfferingPath = coursePath.path('/offerings/:courseOfferingId/delete')
-const courseOfferingPath = findPathBase.path('/offerings/:courseOfferingId')
+const addCourseOfferingPath = coursePath.path('offerings/add')
+const deleteCourseOfferingPath = coursePath.path('offerings/:courseOfferingId/delete')
+const courseOfferingPath = findPathBase.path('offerings/:courseOfferingId')
+const updateCourseOfferingPath = courseOfferingPath.path('update')
 
 export default {
   course: {
@@ -30,6 +31,10 @@ export default {
     },
     delete: deleteCourseOfferingPath,
     show: courseOfferingPath,
+    update: {
+      show: updateCourseOfferingPath,
+      submit: updateCourseOfferingPath,
+    },
   },
   show: coursePath,
 }

--- a/server/routes/find.ts
+++ b/server/routes/find.ts
@@ -6,7 +6,8 @@ import { RouteUtils } from '../utils'
 
 export default function routes(controllers: Controllers, router: Router): Router {
   const { delete: deleteAction, get, put } = RouteUtils.actions(router)
-  const { coursesController, courseOfferingsController, updateCourseController } = controllers
+  const { coursesController, courseOfferingsController, updateCourseController, updateCourseOfferingController } =
+    controllers
 
   get(findPaths.index.pattern, coursesController.index())
   get(findPaths.show.pattern, coursesController.show())
@@ -15,6 +16,9 @@ export default function routes(controllers: Controllers, router: Router): Router
 
   get(findPaths.course.update.show.pattern, updateCourseController.show())
   put(findPaths.course.update.submit.pattern, updateCourseController.submit())
+
+  get(findPaths.offerings.update.show.pattern, updateCourseOfferingController.show())
+  put(findPaths.offerings.update.submit.pattern, updateCourseOfferingController.submit())
 
   return router
 }

--- a/server/services/courseService.test.ts
+++ b/server/services/courseService.test.ts
@@ -461,6 +461,32 @@ describe('CourseService', () => {
     })
   })
 
+  describe('updateCourseOffering', () => {
+    it('updates a course offering using the `courseOfferingRequest` values', async () => {
+      const course = courseFactory.build()
+      const courseOffering = courseOfferingFactory.build()
+      const courseOfferingRequest: Omit<CourseOffering, 'organisationEnabled'> = {
+        contactEmail: 'contact-email-1@test.com',
+        id: courseOffering.id,
+        organisationId: 'MDI',
+        referable: true,
+        secondaryContactEmail: 'contact-email-2@test.com',
+        withdrawn: false,
+      }
+
+      when(courseClient.updateCourseOffering)
+        .calledWith(course.id, courseOfferingRequest)
+        .mockResolvedValue(courseOffering)
+
+      const result = await service.updateCourseOffering(username, course.id, courseOfferingRequest)
+
+      expect(result).toEqual(courseOffering)
+
+      expect(courseClientBuilder).toHaveBeenCalledWith(systemToken)
+      expect(courseClient.updateCourseOffering).toHaveBeenCalledWith(course.id, courseOfferingRequest)
+    })
+  })
+
   describe('updateCoursePrerequisites', () => {
     it('asks the client to update course prerequisites', async () => {
       const courseId = 'COURSE_ID'

--- a/server/services/courseService.ts
+++ b/server/services/courseService.ts
@@ -239,6 +239,18 @@ export default class CourseService {
     return courseClient.updateCourse(courseId, courseUpdate)
   }
 
+  async updateCourseOffering(
+    username: Express.User['username'],
+    courseId: Course['id'],
+    courseOffering: Omit<CourseOffering, 'organisationEnabled'>,
+  ): Promise<CourseOffering> {
+    const hmppsAuthClient = this.hmppsAuthClientBuilder()
+    const systemToken = await hmppsAuthClient.getSystemClientToken(username)
+    const courseClient = this.courseClientBuilder(systemToken)
+
+    return courseClient.updateCourseOffering(courseId, courseOffering)
+  }
+
   async updateCoursePrerequisites(
     username: Express.User['username'],
     courseId: Course['id'],

--- a/server/views/courses/offerings/form/show.njk
+++ b/server/views/courses/offerings/form/show.njk
@@ -32,7 +32,8 @@
             attributes: {
             "data-testid": "organisation-select"
           },
-          errorMessage: errors.messages.organisationId
+          errorMessage: errors.messages.organisationId,
+          value: offering.organisationId
         }) }}
 
         {{ govukInput({
@@ -41,7 +42,8 @@
           },
           id: "location-contact-email",
           name: "contactEmail",
-          errorMessage: errors.messages.contactEmail
+          errorMessage: errors.messages.contactEmail,
+          value: offering.contactEmail
         }) }}
 
         {{ govukInput({
@@ -50,7 +52,8 @@
           },
           id: "location-secondary-contact-email",
           name: "secondaryContactEmail",
-          errorMessage: errors.messages.secondaryContactEmail
+          errorMessage: errors.messages.secondaryContactEmail,
+          value: offering.secondaryContactEmail
         }) }}
 
         {{ govukRadios({
@@ -63,11 +66,13 @@
           items: [
             {
               value: "true",
-              text: "Yes"
+              text: "Yes",
+              checked: offering.referable === true
             },
             {
               value: "false",
-              text: "No"
+              text: "No",
+              checked: offering.referable === false
             }
           ]
         }) }}
@@ -82,11 +87,13 @@
           items: [
             {
               value: "true",
-              text: "Yes"
+              text: "Yes",
+              checked: offering.withdrawn === true
             },
             {
               value: "false",
-              text: "No"
+              text: "No",
+              checked: offering.withdrawn === false
             }
           ]
         }) }}

--- a/server/views/courses/offerings/show.njk
+++ b/server/views/courses/offerings/show.njk
@@ -24,6 +24,16 @@
 
       <div class="govuk-button-group">
         {{ govukButton({
+          type: "button",
+          text: "Update",
+          href: updateOfferingPath,
+          classes: "govuk-button--secondary",
+          attributes: {
+          "data-testid": "update-programme-offering-link"
+          }
+        }) }}
+
+        {{ govukButton({
           text: "Delete",
           classes: "govuk-button--warning",
           attributes: {


### PR DESCRIPTION
## Context

We need an easier way to update the content in FIND to ensure it is accurate



## Changes in this PR
- Add `UpdateCourseOfferingController` 
- Update course offering form to pre-fill inputs with passed in values



## Screenshots of UI changes
Update button link
![image](https://github.com/user-attachments/assets/47129038-72a8-43c5-bbbc-c707909aa4d4)

Offering form with values pre-filled
![image](https://github.com/user-attachments/assets/c0a25efe-c307-4a1c-8bc3-ebbccafcc389)




## Release checklist

[Release process documentation](../doc/how-to/perform-a-release.md)

As part of our continuous deployment strategy we must ensure that this work is
ready to be released once merged.

### Pre-merge

- [ ] There are changes required to the Accredited Programmes API for this change to work...
  - [ ] ... and they have been released to production already

### Post-merge

<!-- The outer checkboxes can be completed pre-merge -->

- [ ] This adds, extends or meaningfully modifies a feature...
  - [ ] ... and I have written or updated an end-to-end test for the happy path in the [Accredited Programmes E2E repo](https://github.com/ministryofjustice/hmpps-accredited-programmes-e2e)
- [ ] This makes new expectations of the API...
  - [ ] ... and I have notified the API developer(s) of changes to the contract tests (Pact), or the API is already compliant
- [ ] [Manually approve](../doc/how-to/perform-a-release.md#releasing-to-the-preprod-environment) release to preprod
- [ ] [Manually approve](../doc/how-to/perform-a-release.md#releasing-to-the-production-environment) release to prod

<!-- Should a release fail at any step, you as the author should now lead the work to
fix it as soon as possible. You can monitor deployment failures in CircleCI
itself and application errors are found in
[Sentry](https://ministryofjustice.sentry.io/projects/hmpps-accredited-programmes-ui/?project=4505330122686464&referrer=sidebar&statsPeriod=24h). -->
