### PR TITLE
(APG-245) Only allow content update related content and routes to be visible with role

### DIFF
--- a/integration_tests/e2e/find.cy.ts
+++ b/integration_tests/e2e/find.cy.ts
@@ -60,6 +60,7 @@ context('Find', () => {
       coursePage.shouldContainBackLink(findPaths.index({}))
       coursePage.shouldContainHomeLink()
       coursePage.shouldHaveCourse()
+      coursePage.shouldNotContainUpdateProgrammeLink()
       coursePage.shouldNotContainAddCourseOfferingLink()
       coursePage.shouldContainOfferingsText()
       coursePage.shouldHaveOrganisations(organisationsWithOfferingIds)
@@ -147,28 +148,56 @@ context('Find', () => {
       cy.signIn()
     })
 
-    it('shows the "Add a new programme" button', () => {
-      cy.task('stubCourses', courses)
+    describe('when viewing all programmes', () => {
+      it('shows the "Add a new programme" button', () => {
+        cy.task('stubCourses', courses)
 
-      const path = findPaths.index({})
-      cy.visit(path)
+        const path = findPaths.index({})
+        cy.visit(path)
 
-      const coursesPage = Page.verifyOnPage(CoursesPage)
-      coursesPage.shouldContainAddNewProgrammeLink()
+        const coursesPage = Page.verifyOnPage(CoursesPage)
+        coursesPage.shouldContainAddNewProgrammeLink()
+      })
     })
 
-    it('shows the "Add a new location" link', () => {
-      cy.task('stubCourse', courses[0])
+    describe('when viewing an individual programme', () => {
+      it('shows the "Add a new location" and "Update programme" links', () => {
+        cy.task('stubCourse', courses[0])
 
-      const courseOfferings: Array<CourseOffering> = []
+        const courseOfferings: Array<CourseOffering> = []
 
-      cy.task('stubOfferingsByCourse', { courseId: courses[0].id, courseOfferings })
+        cy.task('stubOfferingsByCourse', { courseId: courses[0].id, courseOfferings })
 
-      const path = findPaths.show({ courseId: courses[0].id })
-      cy.visit(path)
+        const path = findPaths.show({ courseId: courses[0].id })
+        cy.visit(path)
 
-      const coursePage = Page.verifyOnPage(CoursePage, courses[0])
-      coursePage.shouldContainAddCourseOfferingLink()
+        const coursePage = Page.verifyOnPage(CoursePage, courses[0])
+        coursePage.shouldContainUpdateProgrammeLink()
+        coursePage.shouldContainAddCourseOfferingLink()
+      })
+    })
+
+    describe('when viewing an individual offering', () => {
+      it('shows contain update and delete buttons ', () => {
+        const courseOffering = courseOfferingFactory.build({ referable: true })
+        cy.task('stubOffering', { courseOffering })
+        cy.task('stubCourseByOffering', { course: courses[0], courseOfferingId: courseOffering.id })
+
+        const prison = prisonFactory.build({ prisonId: courseOffering.organisationId })
+        const organisation = OrganisationUtils.organisationFromPrison(prison)
+        cy.task('stubPrison', prison)
+
+        const path = findPaths.offerings.show({ courseOfferingId: courseOffering.id })
+        cy.visit(path)
+
+        const courseOfferingPage = Page.verifyOnPage(CourseOfferingPage, {
+          course: courses[0],
+          courseOffering,
+          organisation,
+        })
+        courseOfferingPage.shouldContainUpdateCourseOfferingLink()
+        courseOfferingPage.shouldContainDeleteOfferingButton()
+      })
     })
   })
 
@@ -210,6 +239,8 @@ context('Find', () => {
             organisation,
           })
           courseOfferingPage.shouldContainMakeAReferralButtonLink()
+          courseOfferingPage.shouldNotContainUpdateCourseOfferingLink()
+          courseOfferingPage.shouldNotContainDeleteOfferingButton()
         })
       })
 
@@ -231,6 +262,8 @@ context('Find', () => {
             organisation,
           })
           courseOfferingPage.shouldNotContainMakeAReferralButtonLink()
+          courseOfferingPage.shouldNotContainUpdateCourseOfferingLink()
+          courseOfferingPage.shouldNotContainDeleteOfferingButton()
         })
       })
     })
@@ -252,6 +285,8 @@ context('Find', () => {
           organisation,
         })
         courseOfferingPage.shouldNotContainMakeAReferralButtonLink()
+        courseOfferingPage.shouldNotContainUpdateCourseOfferingLink()
+        courseOfferingPage.shouldNotContainDeleteOfferingButton()
       })
     })
   })

--- a/integration_tests/pages/find/course.ts
+++ b/integration_tests/pages/find/course.ts
@@ -35,6 +35,12 @@ export default class CoursePage extends Page {
     )
   }
 
+  shouldContainUpdateProgrammeLink() {
+    cy.get('[data-testid="update-programme-link"]')
+      .should('contain.text', 'Update programme')
+      .and('have.attr', 'href', findPaths.course.update.show({ courseId: this.course.id }))
+  }
+
   shouldHaveCourse() {
     this.shouldContainAudienceTag(this.course.audienceTag)
 
@@ -70,5 +76,9 @@ export default class CoursePage extends Page {
 
   shouldNotContainAddCourseOfferingLink() {
     cy.get('[data-testid="add-programme-offering-link"]').should('not.exist')
+  }
+
+  shouldNotContainUpdateProgrammeLink() {
+    cy.get('[data-testid="update-programme-link"]').should('not.exist')
   }
 }

--- a/integration_tests/pages/find/courseOffering.ts
+++ b/integration_tests/pages/find/courseOffering.ts
@@ -1,4 +1,4 @@
-import { referPaths } from '../../../server/paths'
+import { findPaths, referPaths } from '../../../server/paths'
 import { CourseUtils, OrganisationUtils } from '../../../server/utils'
 import Page from '../page'
 import type { Course, CourseOffering, Organisation } from '@accredited-programmes/models'
@@ -28,8 +28,18 @@ export default class CourseOfferingPage extends Page {
     )
   }
 
+  shouldContainDeleteOfferingButton() {
+    cy.get('[data-testid="delete-programme-offering-button"]').should('contain.text', 'Delete')
+  }
+
   shouldContainMakeAReferralButtonLink() {
     this.shouldContainButtonLink('Make a referral', referPaths.new.start({ courseOfferingId: this.courseOffering.id }))
+  }
+
+  shouldContainUpdateCourseOfferingLink() {
+    cy.get('[data-testid="update-programme-offering-link"]')
+      .should('contain.text', 'Update')
+      .and('have.attr', 'href', findPaths.offerings.update.show({ courseOfferingId: this.courseOffering.id }))
   }
 
   shouldHaveOrganisationWithOfferingEmails() {
@@ -40,11 +50,19 @@ export default class CourseOfferingPage extends Page {
     })
   }
 
+  shouldNotContainDeleteOfferingButton() {
+    cy.get('[data-testid="delete-programme-offering-button"]').should('not.exist')
+  }
+
   shouldNotContainMakeAReferralButtonLink() {
-    cy.get('.govuk-button').contains('Make a referral').should('not.exist')
+    cy.get('[data-testid="make-referral-link"]').should('not.exist')
   }
 
   shouldNotContainSecondaryContactEmailSummaryListItem() {
     cy.get('.govuk-summary-list').should('not.contain', 'Secondary email address')
+  }
+
+  shouldNotContainUpdateCourseOfferingLink() {
+    cy.get('[data-testid="update-programme-offering-link"]').should('not.exist')
   }
 }

--- a/server/routes/editor.ts
+++ b/server/routes/editor.ts
@@ -6,14 +6,32 @@ import { findPaths } from '../paths'
 import { RouteUtils } from '../utils'
 
 export default function routes(controllers: Controllers, router: Router): Router {
-  const { get, post } = RouteUtils.actions(router, { allowedRoles: [ApplicationRoles.ACP_EDITOR] })
-  const { addCourseController, addCourseOfferingController } = controllers
+  const {
+    delete: deleteAction,
+    get,
+    post,
+    put,
+  } = RouteUtils.actions(router, { allowedRoles: [ApplicationRoles.ACP_EDITOR] })
+  const {
+    addCourseController,
+    addCourseOfferingController,
+    courseOfferingsController,
+    updateCourseController,
+    updateCourseOfferingController,
+  } = controllers
 
   get(findPaths.course.add.show.pattern, addCourseController.show())
   post(findPaths.course.add.create.pattern, addCourseController.submit())
 
+  get(findPaths.course.update.show.pattern, updateCourseController.show())
+  put(findPaths.course.update.submit.pattern, updateCourseController.submit())
+
   get(findPaths.offerings.add.show.pattern, addCourseOfferingController.show())
   post(findPaths.offerings.add.create.pattern, addCourseOfferingController.submit())
+
+  get(findPaths.offerings.update.show.pattern, updateCourseOfferingController.show())
+  put(findPaths.offerings.update.submit.pattern, updateCourseOfferingController.submit())
+  deleteAction(findPaths.offerings.delete.pattern, courseOfferingsController.delete())
 
   return router
 }

--- a/server/routes/find.ts
+++ b/server/routes/find.ts
@@ -5,20 +5,12 @@ import { findPaths } from '../paths'
 import { RouteUtils } from '../utils'
 
 export default function routes(controllers: Controllers, router: Router): Router {
-  const { delete: deleteAction, get, put } = RouteUtils.actions(router)
-  const { coursesController, courseOfferingsController, updateCourseController, updateCourseOfferingController } =
-    controllers
+  const { get } = RouteUtils.actions(router)
+  const { coursesController, courseOfferingsController } = controllers
 
   get(findPaths.index.pattern, coursesController.index())
   get(findPaths.show.pattern, coursesController.show())
   get(findPaths.offerings.show.pattern, courseOfferingsController.show())
-  deleteAction(findPaths.offerings.delete.pattern, courseOfferingsController.delete())
-
-  get(findPaths.course.update.show.pattern, updateCourseController.show())
-  put(findPaths.course.update.submit.pattern, updateCourseController.submit())
-
-  get(findPaths.offerings.update.show.pattern, updateCourseOfferingController.show())
-  put(findPaths.offerings.update.submit.pattern, updateCourseOfferingController.submit())
 
   return router
 }

--- a/server/views/courses/offerings/show.njk
+++ b/server/views/courses/offerings/show.njk
@@ -19,29 +19,31 @@
   <div class="header-with-actions">
     <h1 class="header-with-actions__title govuk-heading-l">{{ pageHeading }}</h1>
 
-    <form action="{{ deleteOfferingAction }}" method="post">
-      <input type="hidden" name="_csrf" value="{{ csrfToken }}"/>
+    {% if 'ROLE_ACP_EDITOR' in user.roles %}
+      <form action="{{ deleteOfferingAction }}" method="post">
+        <input type="hidden" name="_csrf" value="{{ csrfToken }}"/>
 
-      <div class="govuk-button-group">
-        {{ govukButton({
-          type: "button",
-          text: "Update",
-          href: updateOfferingPath,
-          classes: "govuk-button--secondary",
-          attributes: {
-          "data-testid": "update-programme-offering-link"
-          }
-        }) }}
+        <div class="govuk-button-group">
+          {{ govukButton({
+            type: "button",
+            text: "Update",
+            href: updateOfferingPath,
+            classes: "govuk-button--secondary",
+            attributes: {
+            "data-testid": "update-programme-offering-link"
+            }
+          }) }}
 
-        {{ govukButton({
-          text: "Delete",
-          classes: "govuk-button--warning",
-          attributes: {
-          "data-testid": "delete-programme-offering-link"
-          }
-        }) }}
-      </div>
-    </form>
+          {{ govukButton({
+            text: "Delete",
+            classes: "govuk-button--warning",
+            attributes: {
+            "data-testid": "delete-programme-offering-button"
+            }
+          }) }}
+        </div>
+      </form>
+    {% endif %}
   </div>
 
   <div class="govuk-grid-row">
@@ -58,7 +60,10 @@
       {% if referEnabled and user.hasReferrerRole and courseOffering.referable and courseOffering.organisationEnabled %}
         {{ govukButton({
             text: "Make a referral",
-            href: referPaths.new.start({ courseOfferingId: courseOffering.id })
+            href: referPaths.new.start({ courseOfferingId: courseOffering.id }),
+            attributes: {
+              "data-testid": "make-referral-link"
+            }
         }) }}
       {% endif %}
     </div>

--- a/server/views/courses/show.njk
+++ b/server/views/courses/show.njk
@@ -17,14 +17,16 @@
   <div class="header-with-actions">
     <h1 class="header-with-actions__title govuk-heading-l">{{ pageHeading }}</h1>
 
-    {{ govukButton({
-      text: "Update programme",
-      href: updateProgrammePath,
-      classes: "govuk-button--secondary",
-      attributes: {
-        "data-testid": "update-programme-link"
-      }
-    }) }}
+    {% if 'ROLE_ACP_EDITOR' in user.roles %}
+      {{ govukButton({
+        text: "Update programme",
+        href: updateProgrammePath,
+        classes: "govuk-button--secondary",
+        attributes: {
+          "data-testid": "update-programme-link"
+        }
+      }) }}
+    {% endif %}
   </div>
 
   <div class="govuk-grid-row">


### PR DESCRIPTION

## Context

We need an easier way to update the content in FIND to ensure it is accurate



## Changes in this PR
Hidden new buttons and routes for editing content behind `ROLE_ACP_EDITOR` role.


## Release checklist

[Release process documentation](../doc/how-to/perform-a-release.md)

As part of our continuous deployment strategy we must ensure that this work is
ready to be released once merged.

### Pre-merge

- [ ] There are changes required to the Accredited Programmes API for this change to work...
  - [ ] ... and they have been released to production already

### Post-merge

<!-- The outer checkboxes can be completed pre-merge -->

- [ ] This adds, extends or meaningfully modifies a feature...
  - [ ] ... and I have written or updated an end-to-end test for the happy path in the [Accredited Programmes E2E repo](https://github.com/ministryofjustice/hmpps-accredited-programmes-e2e)
- [ ] This makes new expectations of the API...
  - [ ] ... and I have notified the API developer(s) of changes to the contract tests (Pact), or the API is already compliant
- [ ] [Manually approve](../doc/how-to/perform-a-release.md#releasing-to-the-preprod-environment) release to preprod
- [ ] [Manually approve](../doc/how-to/perform-a-release.md#releasing-to-the-production-environment) release to prod

<!-- Should a release fail at any step, you as the author should now lead the work to
fix it as soon as possible. You can monitor deployment failures in CircleCI
itself and application errors are found in
[Sentry](https://ministryofjustice.sentry.io/projects/hmpps-accredited-programmes-ui/?project=4505330122686464&referrer=sidebar&statsPeriod=24h). -->
