### PR TITLE
Fix @golevelup/ts-jest version to 0.5.0 in renovate.json

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -45,7 +45,7 @@
         "uuid": "^10.0.0"
       },
       "devDependencies": {
-        "@golevelup/ts-jest": "0.5.0",
+        "@golevelup/ts-jest": "^0.5.0",
         "@pact-foundation/pact": "^12.0.0",
         "@types/bunyan": "^1.8.8",
         "@types/bunyan-format": "^0.2.5",

--- a/package.json
+++ b/package.json
@@ -94,7 +94,7 @@
     "uuid": "^10.0.0"
   },
   "devDependencies": {
-    "@golevelup/ts-jest": "0.5.0",
+    "@golevelup/ts-jest": "^0.5.0",
     "@pact-foundation/pact": "^12.0.0",
     "@types/bunyan": "^1.8.8",
     "@types/bunyan-format": "^0.2.5",

--- a/renovate.json
+++ b/renovate.json
@@ -1,3 +1,9 @@
 {
-  "extends": ["github>ministryofjustice/arn-renovate-config"]
+  "extends": ["github>ministryofjustice/arn-renovate-config"],
+  "packageRules": [
+    {
+      "matchPackageNames": ["@golevelup/ts-jest"],
+      "allowedVersions": "0.5.0"
+    }
+  ]
 }


### PR DESCRIPTION
## Context
Renovate bot is updating package @golevelup/ts-jest which is causing some test failures, so preventing other packages being updated.


## Changes in this PR
Instead of fixing in the package.json, only allow renovate to use 0.5.0.


## Release checklist

[Release process documentation](../doc/how-to/perform-a-release.md)

As part of our continuous deployment strategy we must ensure that this work is
ready to be released once merged.

### Pre-merge

- [ ] There are changes required to the Accredited Programmes API for this change to work...
  - [ ] ... and they have been released to production already

### Post-merge

<!-- The outer checkboxes can be completed pre-merge -->

- [ ] This adds, extends or meaningfully modifies a feature...
  - [ ] ... and I have written or updated an end-to-end test for the happy path in the [Accredited Programmes E2E repo](https://github.com/ministryofjustice/hmpps-accredited-programmes-e2e)
- [ ] This makes new expectations of the API...
  - [ ] ... and I have notified the API developer(s) of changes to the contract tests (Pact), or the API is already compliant
- [ ] [Manually approve](../doc/how-to/perform-a-release.md#releasing-to-the-preprod-environment) release to preprod
- [ ] [Manually approve](../doc/how-to/perform-a-release.md#releasing-to-the-production-environment) release to prod

<!-- Should a release fail at any step, you as the author should now lead the work to
fix it as soon as possible. You can monitor deployment failures in CircleCI
itself and application errors are found in
[Sentry](https://ministryofjustice.sentry.io/projects/hmpps-accredited-programmes-ui/?project=4505330122686464&referrer=sidebar&statsPeriod=24h). -->
