### PR TITLE
(APG-364) Add `PNI_ENABLED_ORGANISATIONS` env value

### DIFF
--- a/helm_deploy/values-dev.yaml
+++ b/helm_deploy/values-dev.yaml
@@ -27,6 +27,7 @@ generic-service:
     PRISON_REGISTER_API_URL: 'https://prison-register-dev.hmpps.service.justice.gov.uk'
     REFER_ENABLED: true
     CASE_TRANSFER_ENABLED: true
+    PNI_ENABLED_ORGANISATIONS: 'DHI,WTI'
 
 generic-prometheus-alerts:
   alertSeverity: digital-prison-service-dev

--- a/helm_deploy/values-preprod.yaml
+++ b/helm_deploy/values-preprod.yaml
@@ -25,6 +25,7 @@ generic-service:
     PRISON_REGISTER_API_URL: 'https://prison-register-preprod.hmpps.service.justice.gov.uk'
     REFER_ENABLED: true
     CASE_TRANSFER_ENABLED: true
+    PNI_ENABLED_ORGANISATIONS: 'DHI,WTI'
 
   allowlist:
     groups:

--- a/server/config.ts
+++ b/server/config.ts
@@ -92,6 +92,7 @@ export default {
   environment: process.env.ENVIRONMENT || 'local',
   flags: {
     caseTransferEnabled: get('CASE_TRANSFER_ENABLED', 'false') === 'true',
+    pniEnabledOrganisations: get('PNI_ENABLED_ORGANISATIONS', '').split(','),
     referEnabled: get('REFER_ENABLED', 'false') === 'true',
   },
   https: production,


### PR DESCRIPTION
## Context

We only want to show the upcoming PNI page to selected organisations.

## Changes in this PR
Created new `PNI_ENABLED_ORGANISATIONS` env var and added the following organisations to dev and pre prod:
- Drake Hall
- Whatton

Prod will be done in a future PR after the feature is completed.


## Release checklist

[Release process documentation](../doc/how-to/perform-a-release.md)

As part of our continuous deployment strategy we must ensure that this work is
ready to be released once merged.

### Pre-merge

- [ ] There are changes required to the Accredited Programmes API for this change to work...
  - [ ] ... and they have been released to production already

### Post-merge

<!-- The outer checkboxes can be completed pre-merge -->

- [ ] This adds, extends or meaningfully modifies a feature...
  - [ ] ... and I have written or updated an end-to-end test for the happy path in the [Accredited Programmes E2E repo](https://github.com/ministryofjustice/hmpps-accredited-programmes-e2e)
- [ ] This makes new expectations of the API...
  - [ ] ... and I have notified the API developer(s) of changes to the contract tests (Pact), or the API is already compliant
- [ ] [Manually approve](../doc/how-to/perform-a-release.md#releasing-to-the-preprod-environment) release to preprod
- [ ] [Manually approve](../doc/how-to/perform-a-release.md#releasing-to-the-production-environment) release to prod

<!-- Should a release fail at any step, you as the author should now lead the work to
fix it as soon as possible. You can monitor deployment failures in CircleCI
itself and application errors are found in
[Sentry](https://ministryofjustice.sentry.io/projects/hmpps-accredited-programmes-ui/?project=4505330122686464&referrer=sidebar&statsPeriod=24h). -->
