### PR TITLE
(APG-375) Update `PniService.getPni` to return null when there is a 400

### DIFF
--- a/server/services/pniService.test.ts
+++ b/server/services/pniService.test.ts
@@ -48,6 +48,20 @@ describe('PniService', () => {
     })
 
     describe('when the PNI client throws an error', () => {
+      it('returns null when the error status is 400', async () => {
+        const clientError = createError(400)
+        pniClient.findPni.mockRejectedValue(clientError)
+
+        const result = await service.getPni(username, prisonNumber)
+
+        expect(result).toBeNull()
+
+        expect(hmppsAuthClientBuilder).toHaveBeenCalled()
+        expect(hmppsAuthClient.getSystemClientToken).toHaveBeenCalledWith(username)
+        expect(pniClientBuilder).toHaveBeenCalledWith(systemToken)
+        expect(pniClient.findPni).toHaveBeenCalledWith(prisonNumber)
+      })
+
       it('returns null when the error status is 404', async () => {
         const clientError = createError(404)
         pniClient.findPni.mockRejectedValue(clientError)

--- a/server/services/pniService.ts
+++ b/server/services/pniService.ts
@@ -23,7 +23,7 @@ export default class PniService {
     } catch (error) {
       const knownError = error as ResponseError
 
-      if (knownError.status === 404) {
+      if (knownError.status === 400 || knownError.status === 404) {
         return null
       }
 


### PR DESCRIPTION
## Context

Business exceptions throw a 400 so we want to return null when this happens so the Information missing message can be displayed.

## Changes in this PR
Return null in getPni service method when there is a 400 error.


## Release checklist

[Release process documentation](../doc/how-to/perform-a-release.md)

As part of our continuous deployment strategy we must ensure that this work is
ready to be released once merged.

### Pre-merge

- [ ] There are changes required to the Accredited Programmes API for this change to work...
  - [ ] ... and they have been released to production already

### Post-merge

<!-- The outer checkboxes can be completed pre-merge -->

- [ ] This adds, extends or meaningfully modifies a feature...
  - [ ] ... and I have written or updated an end-to-end test for the happy path in the [Accredited Programmes E2E repo](https://github.com/ministryofjustice/hmpps-accredited-programmes-e2e)
- [ ] This makes new expectations of the API...
  - [ ] ... and I have notified the API developer(s) of changes to the contract tests (Pact), or the API is already compliant
- [ ] [Manually approve](../doc/how-to/perform-a-release.md#releasing-to-the-preprod-environment) release to preprod
- [ ] [Manually approve](../doc/how-to/perform-a-release.md#releasing-to-the-production-environment) release to prod

<!-- Should a release fail at any step, you as the author should now lead the work to
fix it as soon as possible. You can monitor deployment failures in CircleCI
itself and application errors are found in
[Sentry](https://ministryofjustice.sentry.io/projects/hmpps-accredited-programmes-ui/?project=4505330122686464&referrer=sidebar&statsPeriod=24h). -->
