### PR TITLE
(APG-375c) Provide gender query param when getting pni information

### DIFF
--- a/server/controllers/assess/pniController.test.ts
+++ b/server/controllers/assess/pniController.test.ts
@@ -117,6 +117,7 @@ describe('PniController', () => {
       referral.id,
       usersActiveCaseLoadId,
     )
+    expect(pniService.getPni).toHaveBeenCalledWith(username, referral.prisonNumber, { gender: person.gender })
   })
 
   describe('when the pni service returns `null`', () => {

--- a/server/controllers/assess/pniController.ts
+++ b/server/controllers/assess/pniController.ts
@@ -21,10 +21,10 @@ export default class PniController {
       const { activeCaseLoadId } = res.locals.user
 
       const referral = await this.referralService.getReferral(username, referralId)
-      const [course, person, pni] = await Promise.all([
+      const person = await this.personService.getPerson(username, referral.prisonNumber)
+      const [course, pni] = await Promise.all([
         this.courseService.getCourseByOffering(username, referral.offeringId),
-        this.personService.getPerson(username, referral.prisonNumber),
-        this.pniService.getPni(username, referral.prisonNumber),
+        this.pniService.getPni(username, referral.prisonNumber, { gender: person.gender }),
       ])
 
       const coursePresenter = CourseUtils.presentCourse(course)

--- a/server/data/accreditedProgrammesApi/pniClient.ts
+++ b/server/data/accreditedProgrammesApi/pniClient.ts
@@ -13,9 +13,17 @@ export default class PniClient {
     this.restClient = new RestClient('pniClient', config.apis.accreditedProgrammesApi as ApiConfig, systemToken)
   }
 
-  async findPni(prisonNumber: Referral['prisonNumber']): Promise<PniScore> {
+  async findPni(
+    prisonNumber: Referral['prisonNumber'],
+    query?: {
+      gender?: string
+    },
+  ): Promise<PniScore> {
     return (await this.restClient.get({
       path: apiPaths.pni.show({ prisonNumber }),
+      query: {
+        ...(query?.gender && { gender: query.gender }),
+      },
     })) as PniScore
   }
 }

--- a/server/services/pniService.test.ts
+++ b/server/services/pniService.test.ts
@@ -32,11 +32,11 @@ describe('PniService', () => {
   })
 
   describe('getPni', () => {
-    it('returns the PNI score for the given prison number', async () => {
-      const pniScore = pniScoreFactory.build()
-
+    const pniScore = pniScoreFactory.build()
+    beforeEach(() => {
       pniClient.findPni.mockResolvedValue(pniScore)
-
+    })
+    it('returns the PNI score for the given prison number', async () => {
       const result = await service.getPni(username, prisonNumber)
 
       expect(result).toEqual(pniScore)
@@ -44,7 +44,15 @@ describe('PniService', () => {
       expect(hmppsAuthClientBuilder).toHaveBeenCalled()
       expect(hmppsAuthClient.getSystemClientToken).toHaveBeenCalledWith(username)
       expect(pniClientBuilder).toHaveBeenCalledWith(systemToken)
-      expect(pniClient.findPni).toHaveBeenCalledWith(prisonNumber)
+      expect(pniClient.findPni).toHaveBeenCalledWith(prisonNumber, undefined)
+    })
+
+    describe('when there are query params', () => {
+      it('passes the query params to the PNI client', async () => {
+        await service.getPni(username, prisonNumber, { gender: 'Male' })
+
+        expect(pniClient.findPni).toHaveBeenCalledWith(prisonNumber, { gender: 'Male' })
+      })
     })
 
     describe('when the PNI client throws an error', () => {
@@ -59,7 +67,7 @@ describe('PniService', () => {
         expect(hmppsAuthClientBuilder).toHaveBeenCalled()
         expect(hmppsAuthClient.getSystemClientToken).toHaveBeenCalledWith(username)
         expect(pniClientBuilder).toHaveBeenCalledWith(systemToken)
-        expect(pniClient.findPni).toHaveBeenCalledWith(prisonNumber)
+        expect(pniClient.findPni).toHaveBeenCalledWith(prisonNumber, undefined)
       })
 
       it('returns null when the error status is 404', async () => {
@@ -73,7 +81,7 @@ describe('PniService', () => {
         expect(hmppsAuthClientBuilder).toHaveBeenCalled()
         expect(hmppsAuthClient.getSystemClientToken).toHaveBeenCalledWith(username)
         expect(pniClientBuilder).toHaveBeenCalledWith(systemToken)
-        expect(pniClient.findPni).toHaveBeenCalledWith(prisonNumber)
+        expect(pniClient.findPni).toHaveBeenCalledWith(prisonNumber, undefined)
       })
 
       it('re-throws the error when the status is not 404', async () => {
@@ -86,7 +94,7 @@ describe('PniService', () => {
         expect(hmppsAuthClientBuilder).toHaveBeenCalled()
         expect(hmppsAuthClient.getSystemClientToken).toHaveBeenCalledWith(username)
         expect(pniClientBuilder).toHaveBeenCalledWith(systemToken)
-        expect(pniClient.findPni).toHaveBeenCalledWith(prisonNumber)
+        expect(pniClient.findPni).toHaveBeenCalledWith(prisonNumber, undefined)
       })
     })
   })

--- a/server/services/pniService.ts
+++ b/server/services/pniService.ts
@@ -11,13 +11,17 @@ export default class PniService {
     private readonly pniClientBuilder: RestClientBuilder<PniClient>,
   ) {}
 
-  async getPni(username: Express.User['username'], prisonNumber: Referral['prisonNumber']): Promise<PniScore | null> {
+  async getPni(
+    username: Express.User['username'],
+    prisonNumber: Referral['prisonNumber'],
+    query?: { gender?: string },
+  ): Promise<PniScore | null> {
     const hmppsAuthClient = this.hmppsAuthClientBuilder()
     const systemToken = await hmppsAuthClient.getSystemClientToken(username)
     const pniClient = this.pniClientBuilder(systemToken)
 
     try {
-      const pni = await pniClient.findPni(prisonNumber)
+      const pni = await pniClient.findPni(prisonNumber, query)
 
       return pni
     } catch (error) {


### PR DESCRIPTION
## Context

The PNI endpoint will be quicker if we provide `gender`



## Changes in this PR
Pass the persons gender to the pni call.




## Release checklist

[Release process documentation](../doc/how-to/perform-a-release.md)

As part of our continuous deployment strategy we must ensure that this work is
ready to be released once merged.

### Pre-merge

- [ ] There are changes required to the Accredited Programmes API for this change to work...
  - [ ] ... and they have been released to production already

### Post-merge

<!-- The outer checkboxes can be completed pre-merge -->

- [ ] This adds, extends or meaningfully modifies a feature...
  - [ ] ... and I have written or updated an end-to-end test for the happy path in the [Accredited Programmes E2E repo](https://github.com/ministryofjustice/hmpps-accredited-programmes-e2e)
- [ ] This makes new expectations of the API...
  - [ ] ... and I have notified the API developer(s) of changes to the contract tests (Pact), or the API is already compliant
- [ ] [Manually approve](../doc/how-to/perform-a-release.md#releasing-to-the-preprod-environment) release to preprod
- [ ] [Manually approve](../doc/how-to/perform-a-release.md#releasing-to-the-production-environment) release to prod

<!-- Should a release fail at any step, you as the author should now lead the work to
fix it as soon as possible. You can monitor deployment failures in CircleCI
itself and application errors are found in
[Sentry](https://ministryofjustice.sentry.io/projects/hmpps-accredited-programmes-ui/?project=4505330122686464&referrer=sidebar&statsPeriod=24h). -->
