### PR TITLE
(APG-375) Set `savePNI` query parameter to true when getting PNI

### DIFF
--- a/server/controllers/assess/pniController.test.ts
+++ b/server/controllers/assess/pniController.test.ts
@@ -117,7 +117,10 @@ describe('PniController', () => {
       referral.id,
       usersActiveCaseLoadId,
     )
-    expect(pniService.getPni).toHaveBeenCalledWith(username, referral.prisonNumber, { gender: person.gender })
+    expect(pniService.getPni).toHaveBeenCalledWith(username, referral.prisonNumber, {
+      gender: person.gender,
+      savePNI: true,
+    })
   })
 
   describe('when the pni service returns `null`', () => {

--- a/server/controllers/assess/pniController.ts
+++ b/server/controllers/assess/pniController.ts
@@ -24,7 +24,7 @@ export default class PniController {
       const person = await this.personService.getPerson(username, referral.prisonNumber)
       const [course, pni] = await Promise.all([
         this.courseService.getCourseByOffering(username, referral.offeringId),
-        this.pniService.getPni(username, referral.prisonNumber, { gender: person.gender }),
+        this.pniService.getPni(username, referral.prisonNumber, { gender: person.gender, savePNI: true }),
       ])
 
       const coursePresenter = CourseUtils.presentCourse(course)

--- a/server/data/accreditedProgrammesApi/pniClient.ts
+++ b/server/data/accreditedProgrammesApi/pniClient.ts
@@ -17,12 +17,14 @@ export default class PniClient {
     prisonNumber: Referral['prisonNumber'],
     query?: {
       gender?: string
+      savePNI?: boolean
     },
   ): Promise<PniScore> {
     return (await this.restClient.get({
       path: apiPaths.pni.show({ prisonNumber }),
       query: {
         ...(query?.gender && { gender: query.gender }),
+        ...(query?.savePNI && { savePNI: 'true' }),
       },
     })) as PniScore
   }

--- a/server/services/pniService.test.ts
+++ b/server/services/pniService.test.ts
@@ -49,9 +49,9 @@ describe('PniService', () => {
 
     describe('when there are query params', () => {
       it('passes the query params to the PNI client', async () => {
-        await service.getPni(username, prisonNumber, { gender: 'Male' })
+        await service.getPni(username, prisonNumber, { gender: 'Male', savePNI: true })
 
-        expect(pniClient.findPni).toHaveBeenCalledWith(prisonNumber, { gender: 'Male' })
+        expect(pniClient.findPni).toHaveBeenCalledWith(prisonNumber, { gender: 'Male', savePNI: true })
       })
     })
 

--- a/server/services/pniService.ts
+++ b/server/services/pniService.ts
@@ -14,7 +14,7 @@ export default class PniService {
   async getPni(
     username: Express.User['username'],
     prisonNumber: Referral['prisonNumber'],
-    query?: { gender?: string },
+    query?: { gender?: string; savePNI?: boolean },
   ): Promise<PniScore | null> {
     const hmppsAuthClient = this.hmppsAuthClientBuilder()
     const systemToken = await hmppsAuthClient.getSystemClientToken(username)


### PR DESCRIPTION
## Context

We need to make sure we get and use the latest PNI result when displaying it.



## Changes in this PR
Set `savePNI` to `true` when calling the api.




## Release checklist

[Release process documentation](../doc/how-to/perform-a-release.md)

As part of our continuous deployment strategy we must ensure that this work is
ready to be released once merged.

### Pre-merge

- [ ] There are changes required to the Accredited Programmes API for this change to work...
  - [ ] ... and they have been released to production already

### Post-merge

<!-- The outer checkboxes can be completed pre-merge -->

- [ ] This adds, extends or meaningfully modifies a feature...
  - [ ] ... and I have written or updated an end-to-end test for the happy path in the [Accredited Programmes E2E repo](https://github.com/ministryofjustice/hmpps-accredited-programmes-e2e)
- [ ] This makes new expectations of the API...
  - [ ] ... and I have notified the API developer(s) of changes to the contract tests (Pact), or the API is already compliant
- [ ] [Manually approve](../doc/how-to/perform-a-release.md#releasing-to-the-preprod-environment) release to preprod
- [ ] [Manually approve](../doc/how-to/perform-a-release.md#releasing-to-the-production-environment) release to prod

<!-- Should a release fail at any step, you as the author should now lead the work to
fix it as soon as possible. You can monitor deployment failures in CircleCI
itself and application errors are found in
[Sentry](https://ministryofjustice.sentry.io/projects/hmpps-accredited-programmes-ui/?project=4505330122686464&referrer=sidebar&statsPeriod=24h). -->
