### PR TITLE
(APG-375) Hide calculated section on PNI page for MISSING_INFORMATION

### DIFF
--- a/server/@types/accreditedProgrammesApi/index.d.ts
+++ b/server/@types/accreditedProgrammesApi/index.d.ts
@@ -1234,14 +1234,10 @@ export interface IndividualSexScores {
    * @example 1
    */
   emotionalCongruence?: number
-  isAllValuesPresent: boolean
 }
 
 /**
  * @example "{
- *   "prisonNumber": "A1234BC",
- *   "crn": "X739590",
- *   "assessmentId": 2114584,
  *   "needsScore": {
  *     "overallNeedsScore": 6,
  *     "domainScore": {
@@ -1289,6 +1285,11 @@ export interface NeedsScore {
    * @example 5
    */
   overallNeedsScore: number
+  /**
+   * @format int32
+   * @example 6
+   */
+  basicSkillsScore?: number
   /** @example "High Intensity BC" */
   classification: string
   DomainScore: DomainScore
@@ -1317,7 +1318,6 @@ export interface RelationshipDomainScore {
   /** @format int32 */
   overallRelationshipDomainScore: number
   individualRelationshipScores: IndividualRelationshipScores
-  isAllValuesPresent: string[]
 }
 
 /**
@@ -1342,7 +1342,6 @@ export interface SelfManagementDomainScore {
   /** @format int32 */
   overallSelfManagementDomainScore: number
   individualSelfManagementScores: IndividualSelfManagementScores
-  isAllValuesPresent: string[]
 }
 
 /** @example 1 */
@@ -1360,5 +1359,4 @@ export interface ThinkingDomainScore {
   /** @format int32 */
   overallThinkingDomainScore: number
   individualThinkingScores: IndividualCognitiveScores
-  isAllValuesPresent: string[]
 }

--- a/server/controllers/assess/pniController.test.ts
+++ b/server/controllers/assess/pniController.test.ts
@@ -90,7 +90,7 @@ describe('PniController', () => {
   })
 
   it('renders the show pni page with the correct response locals', async () => {
-    pniService.getPni.mockResolvedValue(pniScoreFactory.build())
+    pniService.getPni.mockResolvedValue(pniScoreFactory.build({ programmePathway: 'HIGH_INTENSITY_BC' }))
 
     const requestHandler = controller.show()
     await requestHandler(request, response, next)
@@ -98,6 +98,7 @@ describe('PniController', () => {
     expect(response.render).toHaveBeenCalledWith('referrals/show/pni/show', {
       buttons,
       hasData: true,
+      missingInformation: false,
       pageHeading: `Referral to ${coursePresenter.displayName}`,
       pageSubHeading: 'Programme needs identifier',
       pathwayContent,
@@ -120,6 +121,23 @@ describe('PniController', () => {
     expect(pniService.getPni).toHaveBeenCalledWith(username, referral.prisonNumber, {
       gender: person.gender,
       savePNI: true,
+    })
+  })
+
+  describe('when the pni service returns `MISSING_INFORMATION`', () => {
+    it('renders the show pni page with the correct response locals', async () => {
+      pniService.getPni.mockResolvedValue(pniScoreFactory.build({ programmePathway: 'MISSING_INFORMATION' }))
+
+      const requestHandler = controller.show()
+      await requestHandler(request, response, next)
+
+      expect(response.render).toHaveBeenCalledWith(
+        'referrals/show/pni/show',
+        expect.objectContaining({
+          hasData: true,
+          missingInformation: true,
+        }),
+      )
     })
   })
 

--- a/server/controllers/assess/pniController.ts
+++ b/server/controllers/assess/pniController.ts
@@ -42,6 +42,7 @@ export default class PniController {
 
         templateLocals = {
           hasData: true,
+          missingInformation: pni?.programmePathway === 'MISSING_INFORMATION',
           relationshipsSummaryListRows: PniUtils.relationshipsSummaryListRows(RelationshipDomainScore),
           selfManagementSummaryListRows: PniUtils.selfManagementSummaryListRows(SelfManagementDomainScore),
           sexSummaryListRows: PniUtils.sexSummaryListRows(SexDomainScore),

--- a/server/utils/risksAndNeeds/pniUtils.test.ts
+++ b/server/utils/risksAndNeeds/pniUtils.test.ts
@@ -12,7 +12,6 @@ describe('PniUtils', () => {
             easilyInfluenced: 2,
             prevExpCloseRel: 3,
           },
-          isAllValuesPresent: [],
           overallRelationshipDomainScore: 0,
         },
         SelfManagementDomainScore: {
@@ -22,13 +21,11 @@ describe('PniUtils', () => {
             problemSolvingSkills: 2,
             temperControl: 3,
           },
-          isAllValuesPresent: [],
           overallSelfManagementDomainScore: 1,
         },
         SexDomainScore: {
           individualSexScores: {
             emotionalCongruence: 0,
-            isAllValuesPresent: true,
             offenceRelatedSexualInterests: 1,
             sexualPreOccupation: 2,
           },
@@ -39,7 +36,6 @@ describe('PniUtils', () => {
             hostileOrientation: 1,
             proCriminalAttitudes: 2,
           },
-          isAllValuesPresent: [],
           overallThinkingDomainScore: 1,
         },
       },

--- a/server/views/referrals/show/pni/show.njk
+++ b/server/views/referrals/show/pni/show.njk
@@ -3,12 +3,14 @@
 
 {% extends "../partials/rootLayout.njk" %}
 
+{% set showCalculatedData = hasData and not missingInformation %}
+
 {% block supportingContent %}
   <p data-testid="programme-needs-identifier-message">This is the recommended Accredited Programmes pathway. It is based on the person's risks and needs.</p>
 
   {% include "./_pathway.njk" %}
 
-  {% if hasData %}
+  {% if showCalculatedData %}
     <hr class="govuk-section-break govuk-section-break--xl govuk-section-break--visible">
   {% endif %}
 {% endblock supportingContent %}
@@ -16,7 +18,7 @@
 {% block content %}
   {{ super() }}
 
-  {% if hasData %}
+  {% if showCalculatedData %}
     <div id="content" class="govuk-grid-row">
       <div class="govuk-grid-column-three-quarters">
         <h2 class="govuk-heading-m" data-testid="calculated-sub-heading">How is this calculated?</h2>


### PR DESCRIPTION
## Context
API has recently been updated to return `MISSING_INFORMATION` for `programmePathway`



## Changes in this PR
- Update ACP API types
- Update controller and template to hide calculated content when `programmePathway` is `MISSING_INFORMATION`.





## Release checklist

[Release process documentation](../doc/how-to/perform-a-release.md)

As part of our continuous deployment strategy we must ensure that this work is
ready to be released once merged.

### Pre-merge

- [ ] There are changes required to the Accredited Programmes API for this change to work...
  - [ ] ... and they have been released to production already

### Post-merge

<!-- The outer checkboxes can be completed pre-merge -->

- [ ] This adds, extends or meaningfully modifies a feature...
  - [ ] ... and I have written or updated an end-to-end test for the happy path in the [Accredited Programmes E2E repo](https://github.com/ministryofjustice/hmpps-accredited-programmes-e2e)
- [ ] This makes new expectations of the API...
  - [ ] ... and I have notified the API developer(s) of changes to the contract tests (Pact), or the API is already compliant
- [ ] [Manually approve](../doc/how-to/perform-a-release.md#releasing-to-the-preprod-environment) release to preprod
- [ ] [Manually approve](../doc/how-to/perform-a-release.md#releasing-to-the-production-environment) release to prod

<!-- Should a release fail at any step, you as the author should now lead the work to
fix it as soon as possible. You can monitor deployment failures in CircleCI
itself and application errors are found in
[Sentry](https://ministryofjustice.sentry.io/projects/hmpps-accredited-programmes-ui/?project=4505330122686464&referrer=sidebar&statsPeriod=24h). -->
