### PR TITLE
(APG-365) Prevent duplicate referrals

### DIFF
--- a/integration_tests/mockApis/referrals.ts
+++ b/integration_tests/mockApis/referrals.ts
@@ -61,7 +61,7 @@ export default {
       },
     }),
 
-  stubCreateReferral: (referral: Referral): SuperAgentRequest =>
+  stubCreateReferral: (args: { referral: Referral; status?: number }): SuperAgentRequest =>
     stubFor({
       request: {
         method: 'POST',
@@ -69,8 +69,8 @@ export default {
       },
       response: {
         headers: { 'Content-Type': 'application/json;charset=UTF-8' },
-        jsonBody: referral,
-        status: 201,
+        jsonBody: args.referral,
+        status: args.status || 201,
       },
     }),
 

--- a/integration_tests/mockApis/referrals.ts
+++ b/integration_tests/mockApis/referrals.ts
@@ -69,7 +69,7 @@ export default {
       },
       response: {
         headers: { 'Content-Type': 'application/json;charset=UTF-8' },
-        jsonBody: { referralId: referral.id },
+        jsonBody: referral,
         status: 201,
       },
     }),

--- a/integration_tests/pages/refer/index.ts
+++ b/integration_tests/pages/refer/index.ts
@@ -5,6 +5,7 @@ import NewReferralConfirmOasysPage from './new/confirmOasys'
 import NewReferralConfirmPersonPage from './new/confirmPerson'
 import NewReferralDeletePage from './new/delete'
 import NewReferralDeleteProgrammeHistoryPage from './new/deleteProgrammeHistory'
+import NewReferralDuplicatePage from './new/duplicate'
 import NewReferralFindPersonPage from './new/findPerson'
 import NewReferralProgrammeHistoryPage from './new/programmeHistory'
 import NewReferralProgrammeHistoryDetailsPage from './new/programmeHistoryDetails'
@@ -21,6 +22,7 @@ export {
   NewReferralConfirmPersonPage,
   NewReferralDeletePage,
   NewReferralDeleteProgrammeHistoryPage,
+  NewReferralDuplicatePage,
   NewReferralFindPersonPage,
   NewReferralProgrammeHistoryDetailsPage,
   NewReferralProgrammeHistoryPage,

--- a/integration_tests/pages/refer/new/duplicate.ts
+++ b/integration_tests/pages/refer/new/duplicate.ts
@@ -1,0 +1,64 @@
+import { CourseUtils, ShowReferralUtils } from '../../../../server/utils'
+import Page from '../../page'
+import type { Course, CourseOffering, Organisation, Person, Referral } from '@accredited-programmes/models'
+import type { CoursePresenter } from '@accredited-programmes/ui'
+import type { User } from '@manage-users-api'
+
+export default class NewReferralDuplicatePage extends Page {
+  course: CoursePresenter
+
+  courseOffering: CourseOffering
+
+  organisation: Organisation
+
+  person: Person
+
+  referral: Referral
+
+  constructor(args: {
+    course: Course
+    courseOffering: CourseOffering
+    organisation: Organisation
+    person: Person
+    referral: Referral
+  }) {
+    super('Duplicate referral found')
+
+    const { course, courseOffering, organisation, person, referral } = args
+    this.course = CourseUtils.presentCourse(course)
+    this.courseOffering = courseOffering
+    this.organisation = organisation
+    this.person = person
+    this.referral = referral
+  }
+
+  shouldContainCourseOfferingSummaryList() {
+    cy.get('[data-testid="course-offering-summary-list"]').then(summaryListElement => {
+      this.shouldContainSummaryListRows(
+        ShowReferralUtils.courseOfferingSummaryListRows(
+          this.person.name,
+          this.course,
+          this.courseOffering.contactEmail,
+          this.organisation.name,
+        ),
+        summaryListElement,
+      )
+    })
+  }
+
+  shouldContainReferralExistsText() {
+    cy.get('[data-testid="referral-exists-text"]').should(
+      'have.text',
+      `A referral already exists for ${this.person.name} to ${this.course.displayName} at ${this.organisation.name}.`,
+    )
+  }
+
+  shouldContainSubmissionSummaryList(referrerName: User['name'], referrerEmail: CourseOffering['contactEmail']): void {
+    cy.get('[data-testid="submission-summary-list"]').then(summaryListElement => {
+      this.shouldContainSummaryListRows(
+        ShowReferralUtils.submissionSummaryListRows(this.referral.submittedOn, referrerName, referrerEmail),
+        summaryListElement,
+      )
+    })
+  }
+}

--- a/server/@types/models/Referral.ts
+++ b/server/@types/models/Referral.ts
@@ -50,10 +50,6 @@ type Referral = {
   submittedOn?: string
 }
 
-type CreatedReferralResponse = {
-  referralId: Referral['id']
-}
-
 type ReferralUpdate = {
   hasReviewedProgrammeHistory: Referral['hasReviewedProgrammeHistory']
   oasysConfirmed: Referral['oasysConfirmed']
@@ -132,7 +128,6 @@ export { referralStatusGroups, referralStatuses }
 
 export type {
   ConfirmationFields,
-  CreatedReferralResponse,
   Referral,
   ReferralStatus,
   ReferralStatusCategory,

--- a/server/@types/models/index.d.ts
+++ b/server/@types/models/index.d.ts
@@ -20,7 +20,6 @@ import type { Paginated } from './Paginated'
 import type { KeyDates, Person, SentenceDetails } from './Person'
 import type {
   ConfirmationFields,
-  CreatedReferralResponse,
   Referral,
   ReferralStatus,
   ReferralStatusCategory,
@@ -49,7 +48,6 @@ export type {
   CourseParticipationSetting,
   CourseParticipationUpdate,
   CoursePrerequisite,
-  CreatedReferralResponse,
   DrugAlcoholDetail,
   Health,
   KeyDates,

--- a/server/@types/ui/index.d.ts
+++ b/server/@types/ui/index.d.ts
@@ -106,8 +106,10 @@ type OrganisationWithOfferingEmailsPresenter = Organisation & {
 
 type ReferralSharedPageData = {
   buttons: Array<GovukFrontendButton>
+  course: Course
   courseOfferingSummaryListRows: Array<GovukFrontendSummaryListRowWithKeyAndValue>
   navigationItems: Array<MojFrontendNavigationItem>
+  organisation: Organisation
   pageHeading: string
   pageSubHeading: string
   person: Person

--- a/server/controllers/shared/referralsController.test.ts
+++ b/server/controllers/shared/referralsController.test.ts
@@ -4,7 +4,7 @@ import type { NextFunction, Request, Response } from 'express'
 import createError from 'http-errors'
 
 import SubmittedReferralsController from './referralsController'
-import { assessPaths, referPathBase, referPaths } from '../../paths'
+import { assessPaths, findPaths, referPathBase, referPaths } from '../../paths'
 import type { CourseService, OrganisationService, PersonService, ReferralService, UserService } from '../../services'
 import {
   courseFactory,
@@ -83,6 +83,7 @@ describe('ReferralsController', () => {
 
     sharedPageData = {
       buttons,
+      course,
       courseOfferingSummaryListRows: ShowReferralUtils.courseOfferingSummaryListRows(
         person.name,
         coursePresenter,
@@ -90,6 +91,7 @@ describe('ReferralsController', () => {
         organisation.name,
       ),
       navigationItems,
+      organisation,
       pageHeading: `Referral to ${coursePresenter.displayName}`,
       pageSubHeading: 'Referral summary',
       person,
@@ -172,6 +174,28 @@ describe('ReferralsController', () => {
           ...sharedPageData,
           submittedText: `Submitted in referral on ${DateUtils.govukFormattedFullDateString(referral.submittedOn)}.`,
         })
+      })
+    })
+  })
+
+  describe('duplicate', () => {
+    it('renders the duplicate template with the correct response locals', async () => {
+      request.path = referPaths.show.duplicate({ referralId: referral.id })
+
+      const requestHandler = controller.duplicate()
+      await requestHandler(request, response, next)
+
+      assertSharedDataServicesAreCalledWithExpectedArguments(request.path)
+
+      expect(response.render).toHaveBeenCalledWith('referrals/show/duplicate', {
+        ...sharedPageData,
+        backLinkHref: referPaths.new.people.show({
+          courseOfferingId: sharedPageData.course.id,
+          prisonNumber: sharedPageData.person.prisonNumber,
+        }),
+        pageHeading: 'Duplicate referral found',
+        programmeListHref: findPaths.index({}),
+        summaryText: `A referral already exists for ${sharedPageData.person.name} to ${sharedPageData.course.displayName} at ${sharedPageData.organisation.name}.`,
       })
     })
   })

--- a/server/controllers/shared/referralsController.ts
+++ b/server/controllers/shared/referralsController.ts
@@ -1,7 +1,7 @@
 import type { Request, Response, TypedRequestHandler } from 'express'
 import createError from 'http-errors'
 
-import { referPathBase } from '../../paths'
+import { findPaths, referPathBase, referPaths } from '../../paths'
 import type { CourseService, OrganisationService, PersonService, ReferralService, UserService } from '../../services'
 import {
   CourseUtils,
@@ -37,6 +37,25 @@ export default class ReferralsController {
       return res.render('referrals/show/additionalInformation', {
         ...sharedPageData,
         submittedText: `Submitted in referral on ${DateUtils.govukFormattedFullDateString(referral.submittedOn)}.`,
+      })
+    }
+  }
+
+  duplicate(): TypedRequestHandler<Request, Response> {
+    return async (req: Request, res: Response) => {
+      TypeUtils.assertHasUser(req)
+
+      const sharedPageData = await this.sharedPageData(req, res)
+
+      return res.render('referrals/show/duplicate', {
+        ...sharedPageData,
+        backLinkHref: referPaths.new.people.show({
+          courseOfferingId: sharedPageData.course.id,
+          prisonNumber: sharedPageData.person.prisonNumber,
+        }),
+        pageHeading: 'Duplicate referral found',
+        programmeListHref: findPaths.index({}),
+        summaryText: `A referral already exists for ${sharedPageData.person.name} to ${sharedPageData.course.displayName} at ${sharedPageData.organisation.name}.`,
       })
     }
   }
@@ -193,6 +212,7 @@ export default class ReferralsController {
         referral,
         statusTransitions,
       ),
+      course,
       courseOfferingSummaryListRows: ShowReferralUtils.courseOfferingSummaryListRows(
         person.name,
         coursePresenter,
@@ -200,6 +220,7 @@ export default class ReferralsController {
         organisation.name,
       ),
       navigationItems: ShowReferralUtils.viewReferralNavigationItems(req.path, referral.id),
+      organisation,
       pageHeading: `Referral to ${coursePresenter.displayName}`,
       pageSubHeading: 'Referral summary',
       person,

--- a/server/data/accreditedProgrammesApi/referralClient.test.ts
+++ b/server/data/accreditedProgrammesApi/referralClient.test.ts
@@ -1,4 +1,3 @@
-import { faker } from '@faker-js/faker/locale/en_GB'
 import { Matchers } from '@pact-foundation/pact'
 import { pactWith } from 'jest-pact'
 
@@ -8,7 +7,6 @@ import { apiPaths } from '../../paths'
 import { referralFactory, referralViewFactory } from '../../testutils/factories'
 import FactoryHelpers from '../../testutils/factories/factoryHelpers'
 import type { Paginated, ReferralUpdate, ReferralView } from '@accredited-programmes/models'
-import type { Referral } from '@accredited-programmes-api'
 
 pactWith({ consumer: 'Accredited Programmes UI', provider: 'Accredited Programmes API' }, provider => {
   let referralClient: ReferralClient
@@ -21,7 +19,7 @@ pactWith({ consumer: 'Accredited Programmes UI', provider: 'Accredited Programme
   })
 
   describe('create', () => {
-    const createdReferralResponse: Partial<Referral> = { id: faker.string.uuid() }
+    const createdReferralResponse = referralFactory.started().build()
     const prisonNumber = 'A1234AA'
 
     beforeEach(() => {

--- a/server/data/accreditedProgrammesApi/referralClient.ts
+++ b/server/data/accreditedProgrammesApi/referralClient.ts
@@ -6,7 +6,6 @@ import { apiPaths } from '../../paths'
 import RestClient from '../restClient'
 import type {
   ConfirmationFields,
-  CreatedReferralResponse,
   Paginated,
   Referral,
   ReferralStatusGroup,
@@ -26,14 +25,11 @@ export default class ReferralClient {
     this.restClient = new RestClient('referralClient', config.apis.accreditedProgrammesApi as ApiConfig, systemToken)
   }
 
-  async create(
-    courseOfferingId: Referral['offeringId'],
-    prisonNumber: Referral['prisonNumber'],
-  ): Promise<CreatedReferralResponse> {
+  async create(courseOfferingId: Referral['offeringId'], prisonNumber: Referral['prisonNumber']): Promise<Referral> {
     return (await this.restClient.post({
       data: { offeringId: courseOfferingId, prisonNumber },
       path: apiPaths.referrals.create({}),
-    })) as CreatedReferralResponse
+    })) as Referral
   }
 
   async deleteReferral(referralId: Referral['id']): Promise<void> {

--- a/server/paths/refer.ts
+++ b/server/paths/refer.ts
@@ -74,6 +74,7 @@ export default {
   },
   show: {
     additionalInformation: referralShowPathBase.path('additional-information'),
+    duplicate: referralShowPathBase.path('duplicate'),
     offenceHistory: referralShowPathBase.path('offence-history'),
     personalDetails: referralShowPathBase.path('personal-details'),
     programmeHistory: referralShowPathBase.path('programme-history'),

--- a/server/routes/refer.ts
+++ b/server/routes/refer.ts
@@ -108,5 +108,7 @@ export default function routes(controllers: Controllers, router: Router): Router
   get(referPaths.manageHold.pattern, updateStatusActionController.manageHold())
   get(referPaths.withdraw.pattern, updateStatusActionController.withdraw())
 
+  get(referPaths.show.duplicate.pattern, referralsController.duplicate())
+
   return router
 }

--- a/server/sanitisedError.test.ts
+++ b/server/sanitisedError.test.ts
@@ -1,5 +1,5 @@
 import type { SanitisedError, UnsanitisedError } from './sanitisedError'
-import sanitiseError from './sanitisedError'
+import sanitiseError, { isErrorWithData } from './sanitisedError'
 
 describe('sanitiseError', () => {
   it('returns an error without the request headers', () => {
@@ -52,5 +52,26 @@ describe('sanitiseError', () => {
 
       expect(sanitiseError(error)).toEqual(sanitisedError)
     })
+  })
+})
+
+describe('isErrorWithData', () => {
+  it('returns true if the error has data', () => {
+    const error = {
+      data: 'data',
+      message: 'message',
+      stack: 'stack',
+    } as SanitisedError
+
+    expect(isErrorWithData(error)).toBe(true)
+  })
+
+  it('returns false if the error does not have data', () => {
+    const error = {
+      message: 'message',
+      stack: 'stack',
+    } as SanitisedError
+
+    expect(isErrorWithData(error)).toBe(false)
   })
 })

--- a/server/sanitisedError.ts
+++ b/server/sanitisedError.ts
@@ -26,4 +26,8 @@ export default function sanitiseError(error: UnsanitisedError): SanitisedError {
   return sanitisedError
 }
 
+export function isErrorWithData<T>(error: unknown): error is SanitisedError & { data: T } {
+  return (error as SanitisedError).data !== undefined
+}
+
 export type { SanitisedError, UnsanitisedError }

--- a/server/services/referralService.test.ts
+++ b/server/services/referralService.test.ts
@@ -13,12 +13,7 @@ import {
   referralStatusRefDataFactory,
   referralViewFactory,
 } from '../testutils/factories'
-import type {
-  CreatedReferralResponse,
-  ReferralStatusGroup,
-  ReferralStatusUpdate,
-  ReferralUpdate,
-} from '@accredited-programmes/models'
+import type { ReferralStatusGroup, ReferralStatusUpdate, ReferralUpdate } from '@accredited-programmes/models'
 
 jest.mock('../data/accreditedProgrammesApi/referralClient')
 jest.mock('../data/hmppsAuthClient')
@@ -51,15 +46,12 @@ describe('ReferralService', () => {
   describe('createReferral', () => {
     it('returns a created referral', async () => {
       const referral = referralFactory.started().build()
-      const createdReferralResponse: CreatedReferralResponse = { referralId: referral.id }
 
-      when(referralClient.create)
-        .calledWith(referral.offeringId, referral.prisonNumber)
-        .mockResolvedValue(createdReferralResponse)
+      when(referralClient.create).calledWith(referral.offeringId, referral.prisonNumber).mockResolvedValue(referral)
 
       const result = await service.createReferral(username, referral.offeringId, referral.prisonNumber)
 
-      expect(result).toEqual(createdReferralResponse)
+      expect(result).toEqual(referral)
 
       expect(hmppsAuthClientBuilder).toHaveBeenCalled()
       expect(hmppsAuthClient.getSystemClientToken).toHaveBeenCalledWith(username)

--- a/server/services/referralService.ts
+++ b/server/services/referralService.ts
@@ -3,7 +3,6 @@ import logger from '../../logger'
 import type { HmppsAuthClient, ReferralClient, RestClientBuilder, RestClientBuilderWithoutToken } from '../data'
 import type {
   ConfirmationFields,
-  CreatedReferralResponse,
   Organisation,
   Paginated,
   Referral,
@@ -28,7 +27,7 @@ export default class ReferralService {
     username: Express.User['username'],
     courseOfferingId: Referral['offeringId'],
     prisonNumber: Referral['prisonNumber'],
-  ): Promise<CreatedReferralResponse> {
+  ): Promise<Referral> {
     const hmppsAuthClient = this.hmppsAuthClientBuilder()
     const systemToken = await hmppsAuthClient.getSystemClientToken(username)
     const referralClient = this.referralClientBuilder(systemToken)

--- a/server/views/referrals/show/duplicate.njk
+++ b/server/views/referrals/show/duplicate.njk
@@ -17,7 +17,7 @@
     <div class="govuk-grid-column-two-thirds">
       <h1 class="govuk-heading-l">{{ pageHeading }}</h1>
 
-      <p>{{ summaryText }}</p>
+      <p data-testid="referral-exists-text">{{ summaryText }}</p>
 
       <h2 class="govuk-heading-m">Duplicate referral summary</h2>
 

--- a/server/views/referrals/show/duplicate.njk
+++ b/server/views/referrals/show/duplicate.njk
@@ -1,0 +1,54 @@
+{% from "govuk/components/back-link/macro.njk" import govukBackLink %}
+{% from "govuk/components/button/macro.njk" import govukButton %}
+{% from "govuk/components/summary-list/macro.njk" import govukSummaryList %}
+{% from "govuk/components/warning-text/macro.njk" import govukWarningText %}
+
+{% extends "../../partials/layout.njk" %}
+
+{% block backLink %}
+  {{ govukBackLink({
+    text: "Back",
+    href: backLinkHref
+  }) }}
+{% endblock backLink %}
+
+{% block content %}
+  <div class="govuk-grid-row">
+    <div class="govuk-grid-column-two-thirds">
+      <h1 class="govuk-heading-l">{{ pageHeading }}</h1>
+
+      <p>{{ summaryText }}</p>
+
+      <h2 class="govuk-heading-m">Duplicate referral summary</h2>
+
+      {{ govukSummaryList({
+        classes: 'govuk-summary-list--no-border',
+        rows: courseOfferingSummaryListRows,
+        attributes: {
+          "data-testid": "course-offering-summary-list"
+        }
+      }) }}
+
+      {{ govukSummaryList({
+        classes: 'govuk-summary-list--no-border govuk-!-margin-bottom-6',
+        rows: submissionSummaryListRows,
+        attributes: {
+          "data-testid": "submission-summary-list"
+        }
+      }) }}
+
+      {{ govukWarningText({
+        text: "You cannot create this referral while a duplicate referral is open.",
+        iconFallbackText: "Warning"
+      }) }}
+
+      {{ govukButton({
+        text: "Return to programme list",
+        href: programmeListHref,
+        attributes: {
+          "data-testid": "programme-list-link"
+        }
+      }) }}
+    </div>
+  </div>
+{% endblock content %}


### PR DESCRIPTION
## Context

In the current service its possible for a duplicate referral to be made for the same person, to the same offering at the same location.

For example, Del Hatton could be referred twice to Kaizen at Stocken.

We think it would be sensible to stop this from happening for open referrals only.

## Changes in this PR
- Add `isErrorWithData` type guard so we can confidently return the data to the front end if it is received as part of a http error.
- Add new controller method and page tempate to display duplicate referral information
- Update create referral controller method to check if 409 with referral data and redirect to the new page
- Add related integration tests


## Screenshots of UI changes
![image](https://github.com/user-attachments/assets/2952d9d7-2f5d-409c-975c-650356a111e7)



## Release checklist

[Release process documentation](../doc/how-to/perform-a-release.md)

As part of our continuous deployment strategy we must ensure that this work is
ready to be released once merged.

### Pre-merge

- [x] There are changes required to the Accredited Programmes API for this change to work...
  - [ ] ... and they have been released to production already

### Post-merge

<!-- The outer checkboxes can be completed pre-merge -->

- [ ] This adds, extends or meaningfully modifies a feature...
  - [ ] ... and I have written or updated an end-to-end test for the happy path in the [Accredited Programmes E2E repo](https://github.com/ministryofjustice/hmpps-accredited-programmes-e2e)
- [ ] This makes new expectations of the API...
  - [ ] ... and I have notified the API developer(s) of changes to the contract tests (Pact), or the API is already compliant
- [ ] [Manually approve](../doc/how-to/perform-a-release.md#releasing-to-the-preprod-environment) release to preprod
- [ ] [Manually approve](../doc/how-to/perform-a-release.md#releasing-to-the-production-environment) release to prod

<!-- Should a release fail at any step, you as the author should now lead the work to
fix it as soon as possible. You can monitor deployment failures in CircleCI
itself and application errors are found in
[Sentry](https://ministryofjustice.sentry.io/projects/hmpps-accredited-programmes-ui/?project=4505330122686464&referrer=sidebar&statsPeriod=24h). -->
