### PR TITLE
(APG-429) Enable PNI page for Drake Hall and Whatton

### DIFF
--- a/helm_deploy/values-prod.yaml
+++ b/helm_deploy/values-prod.yaml
@@ -25,6 +25,7 @@ generic-service:
     PRISON_REGISTER_API_URL: 'https://prison-register.hmpps.service.justice.gov.uk'
     REFER_ENABLED: true
     CASE_TRANSFER_ENABLED: true
+    PNI_ENABLED_ORGANISATIONS: 'DHI,WTI'
 
   allowlist:
     groups:


### PR DESCRIPTION
## Context

PNI has been released, it just needs enabling when we're ready.



## Changes in this PR
Add `DHI` and `WTI` to `PNI_ENABLED_ORGANISATIONS`





## Release checklist

[Release process documentation](../doc/how-to/perform-a-release.md)

As part of our continuous deployment strategy we must ensure that this work is
ready to be released once merged.

### Pre-merge

- [ ] There are changes required to the Accredited Programmes API for this change to work...
  - [ ] ... and they have been released to production already

### Post-merge

<!-- The outer checkboxes can be completed pre-merge -->

- [ ] This adds, extends or meaningfully modifies a feature...
  - [ ] ... and I have written or updated an end-to-end test for the happy path in the [Accredited Programmes E2E repo](https://github.com/ministryofjustice/hmpps-accredited-programmes-e2e)
- [ ] This makes new expectations of the API...
  - [ ] ... and I have notified the API developer(s) of changes to the contract tests (Pact), or the API is already compliant
- [ ] [Manually approve](../doc/how-to/perform-a-release.md#releasing-to-the-preprod-environment) release to preprod
- [ ] [Manually approve](../doc/how-to/perform-a-release.md#releasing-to-the-production-environment) release to prod

<!-- Should a release fail at any step, you as the author should now lead the work to
fix it as soon as possible. You can monitor deployment failures in CircleCI
itself and application errors are found in
[Sentry](https://ministryofjustice.sentry.io/projects/hmpps-accredited-programmes-ui/?project=4505330122686464&referrer=sidebar&statsPeriod=24h). -->
