### PR TITLE
(APG-363a) Client and Service for reporting dashboard

### DIFF
--- a/server/data/accreditedProgrammesApi/statisticsClient.ts
+++ b/server/data/accreditedProgrammesApi/statisticsClient.ts
@@ -1,0 +1,30 @@
+/* istanbul ignore file */
+import config, { type ApiConfig } from '../../config'
+import { apiPaths } from '../../paths'
+import RestClient from '../restClient'
+import type { ReportContent } from '@accredited-programmes-api'
+import type { SystemToken } from '@hmpps-auth'
+
+export default class StatisticsClient {
+  restClient: RestClient
+
+  constructor(systemToken: SystemToken) {
+    this.restClient = new RestClient('statistics', config.apis.accreditedProgrammesApi as ApiConfig, systemToken)
+  }
+
+  async findReport(
+    reportType: ReportContent['reportType'],
+    query: {
+      startDate: string
+      endDate?: string
+    },
+  ): Promise<ReportContent> {
+    return (await this.restClient.get({
+      path: apiPaths.statistics.report({ reportType }),
+      query: {
+        startDate: query.startDate,
+        ...(query.endDate && { endDate: query.endDate }),
+      },
+    })) as ReportContent
+  }
+}

--- a/server/data/index.ts
+++ b/server/data/index.ts
@@ -19,6 +19,7 @@ import PersonClient from './accreditedProgrammesApi/personClient'
 import PniClient from './accreditedProgrammesApi/pniClient'
 import ReferenceDataClient from './accreditedProgrammesApi/referenceDataClient'
 import ReferralClient from './accreditedProgrammesApi/referralClient'
+import StatisticsClient from './accreditedProgrammesApi/statisticsClient'
 import { serviceCheckFactory } from './healthCheck'
 import HmppsAuthClient from './hmppsAuthClient'
 import HmppsManageUsersClient from './hmppsManageUsersClient'
@@ -48,6 +49,8 @@ const referenceDataClientBuilder: RestClientBuilder<ReferenceDataClient> = (syst
   new ReferenceDataClient(systemToken)
 const referralClientBuilder: RestClientBuilder<ReferralClient> = (userToken: Express.User['token']) =>
   new ReferralClient(userToken)
+const statisticsClientBuilder: RestClientBuilder<StatisticsClient> = (systemToken: SystemToken) =>
+  new StatisticsClient(systemToken)
 const prisonApiClientBuilder: RestClientBuilder<PrisonApiClient> = (systemToken: SystemToken) =>
   new PrisonApiClient(systemToken)
 
@@ -62,6 +65,7 @@ export {
   PrisonRegisterApiClient,
   ReferenceDataClient,
   ReferralClient,
+  StatisticsClient,
   TokenStore,
   courseClientBuilder,
   createRedisClient,
@@ -75,6 +79,7 @@ export {
   referenceDataClientBuilder,
   referralClientBuilder,
   serviceCheckFactory,
+  statisticsClientBuilder,
   verifyToken,
 }
 

--- a/server/paths/api.ts
+++ b/server/paths/api.ts
@@ -12,6 +12,8 @@ const oasysBasePath = path('/oasys/:prisonNumber')
 
 const pniPathBasePath = path('/PNI')
 
+const statisticsBasePath = path('/statistics')
+
 const referralsPath = path('/referrals')
 const referralPath = referralsPath.path(':referralId')
 const updateStatusPath = referralPath.path('status')
@@ -110,5 +112,8 @@ export default {
     submit: submitPath,
     update: referralPath,
     updateStatus: updateStatusPath,
+  },
+  statistics: {
+    report: statisticsBasePath.path('report/:reportType'),
   },
 }

--- a/server/services/index.ts
+++ b/server/services/index.ts
@@ -7,6 +7,7 @@ import OrganisationService from './organisationService'
 import PersonService from './personService'
 import ReferenceDataService from './referenceDataService'
 import ReferralService from './referralService'
+import StatisticsService from './statisticsService'
 import UserService from './userService'
 import {
   courseClientBuilder,
@@ -19,6 +20,7 @@ import {
   prisonRegisterApiClientBuilder,
   referenceDataClientBuilder,
   referralClientBuilder,
+  statisticsClientBuilder,
 } from '../data'
 import PniService from './pniService'
 
@@ -31,6 +33,7 @@ const services = () => {
   const referralService = new ReferralService(hmppsAuthClientBuilder, referralClientBuilder, userService)
   const courseService = new CourseService(courseClientBuilder, hmppsAuthClientBuilder, userService)
   const pniService = new PniService(hmppsAuthClientBuilder, pniClientBuilder)
+  const statisticsService = new StatisticsService(hmppsAuthClientBuilder, statisticsClientBuilder)
 
   return {
     courseService,
@@ -40,6 +43,7 @@ const services = () => {
     pniService,
     referenceDataService,
     referralService,
+    statisticsService,
     userService,
   }
 }
@@ -54,6 +58,7 @@ export {
   PniService,
   ReferenceDataService,
   ReferralService,
+  StatisticsService,
   UserService,
   healthCheck,
   services,

--- a/server/services/statisticsService.test.ts
+++ b/server/services/statisticsService.test.ts
@@ -1,0 +1,83 @@
+import { createMock } from '@golevelup/ts-jest'
+import createError from 'http-errors'
+
+import { HmppsAuthClient, type RedisClient, StatisticsClient, TokenStore } from '../data'
+import StatisticsService from './statisticsService'
+import { reportContentFactory } from '../testutils/factories'
+
+jest.mock('../data/accreditedProgrammesApi/statisticsClient')
+jest.mock('../data/hmppsAuthClient')
+
+describe('StatisticsService', () => {
+  const redisClient = createMock<RedisClient>({})
+  const tokenStore = new TokenStore(redisClient) as jest.Mocked<TokenStore>
+  const systemToken = 'SYSTEM_TOKEN'
+  const username = 'USERNAME'
+
+  const hmppsAuthClient = new HmppsAuthClient(tokenStore) as jest.Mocked<HmppsAuthClient>
+  const hmppsAuthClientBuilder = jest.fn()
+
+  const statisticsClient = new StatisticsClient(systemToken) as jest.Mocked<StatisticsClient>
+  const statisticsClientBuilder = jest.fn()
+
+  const service = new StatisticsService(hmppsAuthClientBuilder, statisticsClientBuilder)
+
+  beforeEach(() => {
+    jest.resetAllMocks()
+
+    hmppsAuthClientBuilder.mockReturnValue(hmppsAuthClient)
+    statisticsClientBuilder.mockReturnValue(statisticsClient)
+    hmppsAuthClient.getSystemClientToken.mockResolvedValue(systemToken)
+  })
+
+  describe('getReport', () => {
+    const reportContent = reportContentFactory.build()
+
+    beforeEach(() => {
+      statisticsClient.findReport.mockResolvedValue(reportContent)
+    })
+
+    it('returns the report content for the given report type', async () => {
+      const result = await service.getReport(username, reportContent.reportType, {
+        endDate: reportContent.parameters.endDate,
+        startDate: reportContent.parameters.startDate,
+      })
+
+      expect(result).toEqual(reportContent)
+
+      expect(hmppsAuthClientBuilder).toHaveBeenCalled()
+      expect(hmppsAuthClient.getSystemClientToken).toHaveBeenCalledWith(username)
+      expect(statisticsClientBuilder).toHaveBeenCalledWith(systemToken)
+      expect(statisticsClient.findReport).toHaveBeenCalledWith(reportContent.reportType, {
+        endDate: reportContent.parameters.endDate,
+        startDate: reportContent.parameters.startDate,
+      })
+    })
+
+    describe('when the statistics client throws an error', () => {
+      it('returns null when the error status is 400', async () => {
+        const clientError = createError(400)
+        statisticsClient.findReport.mockRejectedValue(clientError)
+
+        const result = await service.getReport(username, reportContent.reportType, {
+          endDate: reportContent.parameters.endDate,
+          startDate: reportContent.parameters.startDate,
+        })
+
+        expect(result).toBeNull()
+      })
+
+      it('throws an error when the error status is not 400', async () => {
+        const clientError = createError(500)
+        statisticsClient.findReport.mockRejectedValue(clientError)
+
+        await expect(
+          service.getReport(username, reportContent.reportType, {
+            endDate: reportContent.parameters.endDate,
+            startDate: reportContent.parameters.startDate,
+          }),
+        ).rejects.toThrow(`Error fetching report data for ${reportContent.reportType}.`)
+      })
+    })
+  })
+})

--- a/server/services/statisticsService.ts
+++ b/server/services/statisticsService.ts
@@ -1,0 +1,39 @@
+import createError from 'http-errors'
+
+import type { HmppsAuthClient, RestClientBuilder, RestClientBuilderWithoutToken, StatisticsClient } from '../data'
+import type { SanitisedError } from '../sanitisedError'
+import type { ReportContent } from '@accredited-programmes-api'
+
+export default class StatisticsService {
+  constructor(
+    private readonly hmppsAuthClientBuilder: RestClientBuilderWithoutToken<HmppsAuthClient>,
+    private readonly statisticsClientBuilder: RestClientBuilder<StatisticsClient>,
+  ) {}
+
+  async getReport(
+    username: Express.User['username'],
+    reportType: ReportContent['reportType'],
+    query: {
+      startDate: string
+      endDate?: string
+    },
+  ): Promise<ReportContent | null> {
+    const hmppsAuthClient = this.hmppsAuthClientBuilder()
+    const systemToken = await hmppsAuthClient.getSystemClientToken(username)
+    const statisticsClient = this.statisticsClientBuilder(systemToken)
+
+    try {
+      const report = await statisticsClient.findReport(reportType, query)
+
+      return report
+    } catch (error) {
+      const knownError = error as SanitisedError
+
+      if (knownError.status === 400) {
+        return null
+      }
+
+      throw createError(knownError.status || 500, `Error fetching report data for ${reportType}.`)
+    }
+  }
+}

--- a/server/testutils/factories/index.ts
+++ b/server/testutils/factories/index.ts
@@ -36,6 +36,7 @@ import referralStatusReasonFactory from './referralStatusReason'
 import referralStatusRefDataFactory from './referralStatusRefData'
 import referralViewFactory from './referralView'
 import relationshipsFactory from './relationships'
+import reportContentFactory from './reportContent'
 import risksAndAlertsFactory from './risksAndAlerts'
 import roshAnalysisFactory from './roshAnalysis'
 import sentenceDetailsFactory from './sentenceDetails'
@@ -80,6 +81,7 @@ export {
   referralStatusRefDataFactory,
   referralViewFactory,
   relationshipsFactory,
+  reportContentFactory,
   risksAndAlertsFactory,
   roshAnalysisFactory,
   sentenceDetailsFactory,

--- a/server/testutils/factories/reportContent.ts
+++ b/server/testutils/factories/reportContent.ts
@@ -1,0 +1,34 @@
+import { faker } from '@faker-js/faker/locale/en_GB'
+import { Factory } from 'fishery'
+
+import type { CourseCount, ReportContent } from '@accredited-programmes-api'
+
+const courseCount = Factory.define<CourseCount>(() => ({
+  audience: faker.lorem.words(2),
+  count: 1,
+  name: faker.lorem.words(),
+}))
+
+export default Factory.define<ReportContent>(() => {
+  const count = faker.number.int({ max: 3 })
+  return {
+    content: {
+      count,
+      courseCounts: courseCount.buildList(count),
+    },
+    parameters: {
+      endDate: faker.date.past().toISOString().split('T')[0],
+      startDate: faker.date.past().toISOString().split('T')[0],
+    },
+    reportType: faker.helpers.arrayElement([
+      'DESELECTED_COUNT',
+      'NOT_ELIGIBLE_COUNT',
+      'NOT_SUITABLE_COUNT',
+      'PNI_PATHWAY_COUNT',
+      'PROGRAMME_COMPLETE_COUNT',
+      'REFERRAL_COUNT_BY_COURSE',
+      'REFERRAL_COUNT',
+      'WITHDRAWN_COUNT',
+    ]),
+  }
+})


### PR DESCRIPTION
## Context
To support the ability for service stakeholders to be able to self-serve when it comes to AcP data reporting, we need to build the dashboard for Accredited Programmes.



## Changes in this PR
Add client and service to call the statistics endpoints.


## Release checklist

[Release process documentation](../doc/how-to/perform-a-release.md)

As part of our continuous deployment strategy we must ensure that this work is
ready to be released once merged.

### Pre-merge

- [ ] There are changes required to the Accredited Programmes API for this change to work...
  - [ ] ... and they have been released to production already

### Post-merge

<!-- The outer checkboxes can be completed pre-merge -->

- [ ] This adds, extends or meaningfully modifies a feature...
  - [ ] ... and I have written or updated an end-to-end test for the happy path in the [Accredited Programmes E2E repo](https://github.com/ministryofjustice/hmpps-accredited-programmes-e2e)
- [ ] This makes new expectations of the API...
  - [ ] ... and I have notified the API developer(s) of changes to the contract tests (Pact), or the API is already compliant
- [ ] [Manually approve](../doc/how-to/perform-a-release.md#releasing-to-the-preprod-environment) release to preprod
- [ ] [Manually approve](../doc/how-to/perform-a-release.md#releasing-to-the-production-environment) release to prod

<!-- Should a release fail at any step, you as the author should now lead the work to
fix it as soon as possible. You can monitor deployment failures in CircleCI
itself and application errors are found in
[Sentry](https://ministryofjustice.sentry.io/projects/hmpps-accredited-programmes-ui/?project=4505330122686464&referrer=sidebar&statsPeriod=24h). -->
