### PR TITLE
(APG-363b) Report dashboard

### DIFF
--- a/server/controllers/index.ts
+++ b/server/controllers/index.ts
@@ -5,13 +5,16 @@ import assessControllers from './assess'
 import DashboardController from './dashboardController'
 import findControllers from './find'
 import referControllers from './refer'
+import ReportsController from './reportsController'
 import sharedControllers from './shared'
 
 export const controllers = (services: Services) => {
   const dashboardController = new DashboardController()
+  const reportsController = new ReportsController(services.statisticsService)
 
   return {
     dashboardController,
+    reportsController,
     ...assessControllers(services),
     ...findControllers(services),
     ...referControllers(services),

--- a/server/controllers/reportsController.test.ts
+++ b/server/controllers/reportsController.test.ts
@@ -1,0 +1,87 @@
+import { type DeepMocked, createMock } from '@golevelup/ts-jest'
+import type { NextFunction, Request, Response } from 'express'
+
+import type { StatisticsService } from '../services'
+import ReportsController from './reportsController'
+import { reportContentFactory } from '../testutils/factories'
+import { StatisticsReportUtils } from '../utils'
+
+jest.mock('../utils/statisticsReportUtils')
+
+const mockStatisticsReportUtils = StatisticsReportUtils as jest.Mocked<typeof StatisticsReportUtils>
+
+describe('ReportsController', () => {
+  const username = 'USERNAME'
+  const mockTodaysDate = new Date('2024-02-14')
+
+  let request: DeepMocked<Request>
+  let response: DeepMocked<Response>
+  const next: DeepMocked<NextFunction> = createMock<NextFunction>({})
+
+  const statisticsService = createMock<StatisticsService>({})
+
+  const reportDataBlock = {
+    date: 'January 2024',
+    testId: 'referral-count',
+    title: 'Total referrals submitted',
+    value: '123',
+  }
+
+  let controller: ReportsController
+
+  beforeEach(() => {
+    mockStatisticsReportUtils.reportContentDataBlock.mockReturnValue(reportDataBlock)
+
+    controller = new ReportsController(statisticsService)
+
+    request = createMock<Request>({
+      user: { username },
+    })
+    response = createMock<Response>()
+
+    jest.useFakeTimers().setSystemTime(mockTodaysDate)
+  })
+
+  afterEach(() => {
+    jest.resetAllMocks()
+    jest.useRealTimers()
+  })
+
+  describe('show', () => {
+    it('should render the reports/show view with the correct data', async () => {
+      statisticsService.getReport.mockResolvedValue(reportContentFactory.build())
+
+      const requestHandler = controller.show()
+      await requestHandler(request, response, next)
+
+      const expectedQuery = {
+        endDate: '2024-01-31',
+        startDate: '2024-01-01',
+      }
+
+      const reportTypes = [
+        'REFERRAL_COUNT',
+        'PROGRAMME_COMPLETE_COUNT',
+        'NOT_ELIGIBLE_COUNT',
+        'WITHDRAWN_COUNT',
+        'DESELECTED_COUNT',
+      ]
+
+      expect(statisticsService.getReport).toHaveBeenCalledTimes(reportTypes.length)
+      reportTypes.forEach(reportType => {
+        expect(statisticsService.getReport).toHaveBeenCalledWith(username, reportType, expectedQuery)
+      })
+
+      expect(StatisticsReportUtils.reportContentDataBlock).toHaveBeenCalledTimes(reportTypes.length)
+      expect(StatisticsReportUtils.reportContentDataBlock).toHaveBeenCalledWith(
+        expect.anything(),
+        new Date(expectedQuery.startDate),
+      )
+
+      expect(response.render).toHaveBeenCalledWith('reports/show', {
+        pageHeading: 'Accredited Programmes data',
+        reportDataBlocks: [reportDataBlock, reportDataBlock, reportDataBlock, reportDataBlock, reportDataBlock],
+      })
+    })
+  })
+})

--- a/server/controllers/reportsController.ts
+++ b/server/controllers/reportsController.ts
@@ -1,0 +1,42 @@
+import type { Request, Response, TypedRequestHandler } from 'express'
+
+import type { StatisticsService } from '../services'
+import { DateUtils, StatisticsReportUtils, TypeUtils } from '../utils'
+
+export default class ReportsController {
+  constructor(private readonly statisticsService: StatisticsService) {}
+
+  show(): TypedRequestHandler<Request, Response> {
+    return async (req: Request, res: Response) => {
+      TypeUtils.assertHasUser(req)
+
+      const now = new Date()
+      const startDateOfLastMonth = new Date(now.getFullYear(), now.getMonth() - 1, 1)
+      const endDateOfLastMonth = new Date(now.getFullYear(), now.getMonth(), 0)
+
+      const reportTypes = [
+        'REFERRAL_COUNT',
+        'PROGRAMME_COMPLETE_COUNT',
+        'NOT_ELIGIBLE_COUNT',
+        'WITHDRAWN_COUNT',
+        'DESELECTED_COUNT',
+      ]
+
+      const reports = await Promise.all(
+        reportTypes.map(reportType =>
+          this.statisticsService.getReport(req.user.username, reportType, {
+            endDate: DateUtils.isoDateOnly(endDateOfLastMonth),
+            startDate: DateUtils.isoDateOnly(startDateOfLastMonth),
+          }),
+        ),
+      )
+
+      res.render('reports/show', {
+        pageHeading: 'Accredited Programmes data',
+        reportDataBlocks: reports.map(report =>
+          StatisticsReportUtils.reportContentDataBlock(report, startDateOfLastMonth),
+        ),
+      })
+    }
+  }
+}

--- a/server/paths/index.ts
+++ b/server/paths/index.ts
@@ -5,6 +5,7 @@ import findPaths from './find'
 import prisonApiPaths from './prisonApi'
 import prisonRegisterApiPaths from './prisonRegisterApi'
 import referPaths, { referPathBase } from './refer'
+import reportsPaths from './reports'
 
 export {
   apiPaths,
@@ -16,4 +17,5 @@ export {
   prisonRegisterApiPaths,
   referPathBase,
   referPaths,
+  reportsPaths,
 }

--- a/server/paths/reports.ts
+++ b/server/paths/reports.ts
@@ -1,0 +1,7 @@
+import { path } from 'static-path'
+
+const reportsPathBase = path('/reports')
+
+export default {
+  show: reportsPathBase,
+}

--- a/server/routes/index.ts
+++ b/server/routes/index.ts
@@ -4,6 +4,7 @@ import assessRoutes from './assess'
 import editorRoutes from './editor'
 import findRoutes from './find'
 import referRoutes from './refer'
+import reportsRoutes from './reports'
 import config from '../config'
 import type { Controllers } from '../controllers'
 import { RouteUtils } from '../utils'
@@ -17,6 +18,7 @@ export default function routes(controllers: Controllers): Router {
 
   editorRoutes(controllers, router)
   findRoutes(controllers, router)
+  reportsRoutes(controllers, router)
   if (config.flags.referEnabled) {
     assessRoutes(controllers, router)
     referRoutes(controllers, router)

--- a/server/routes/reports.ts
+++ b/server/routes/reports.ts
@@ -1,0 +1,14 @@
+import type { Router } from 'express'
+
+import type { Controllers } from '../controllers'
+import { reportsPaths } from '../paths'
+import { RouteUtils } from '../utils'
+
+export default function routes(controllers: Controllers, router: Router): Router {
+  const { get } = RouteUtils.actions(router)
+  const { reportsController } = controllers
+
+  get(reportsPaths.show.pattern, reportsController.show())
+
+  return router
+}

--- a/server/utils/dateUtils.test.ts
+++ b/server/utils/dateUtils.test.ts
@@ -30,6 +30,13 @@ describe('DateUtils', () => {
     })
   })
 
+  describe('isoDateOnly', () => {
+    it('returns a date string in the format YYYY-MM-DD', () => {
+      const mockDate = new Date('2001-06-03')
+      expect(DateUtils.isoDateOnly(mockDate)).toEqual('2001-06-03')
+    })
+  })
+
   describe('removeTimezoneOffset', () => {
     describe('for a date before British Summer Time (BST)', () => {
       it('returns an unchanged ISO date string', () => {

--- a/server/utils/dateUtils.ts
+++ b/server/utils/dateUtils.ts
@@ -30,6 +30,17 @@ export default class DateUtils {
     })
   }
 
+  /**
+   * Uses en-GB locale to format a date. If we used toISOString() and then split() the string at T,
+   * this could sometimes return the wrong date if the date is in a different timezone.
+   * @param date
+   * @returns A date string in the format YYYY-MM-DD
+   *
+   */
+  static isoDateOnly(date: Date): string {
+    return date.toLocaleDateString('en-GB').split('/').reverse().join('-')
+  }
+
   static removeTimezoneOffset(dateString: string): string {
     const date = new Date(dateString)
     const serverTimezoneOffset = date.getTimezoneOffset() * 60000

--- a/server/utils/index.ts
+++ b/server/utils/index.ts
@@ -32,6 +32,7 @@ import RoshAnalysisUtils from './risksAndNeeds/roshAnalysisUtils'
 import ThinkingAndBehavingUtils from './risksAndNeeds/thinkingAndBehavingUtils'
 import RouteUtils from './routeUtils'
 import SentenceInformationUtils from './sentenceInformationUtils'
+import StatisticsReportUtils from './statisticsReportUtils'
 import StringUtils from './stringUtils'
 import TypeUtils from './typeUtils'
 import UserUtils from './userUtils'
@@ -65,6 +66,7 @@ export {
   SentenceInformationUtils,
   ShowReferralUtils,
   ShowRisksAndNeedsUtils,
+  StatisticsReportUtils,
   StringUtils,
   ThinkingAndBehavingUtils,
   TypeUtils,

--- a/server/utils/statisticsReportUtils.test.ts
+++ b/server/utils/statisticsReportUtils.test.ts
@@ -1,0 +1,76 @@
+import StatisticsReportUtils from './statisticsReportUtils'
+import type { ReportContent } from '@accredited-programmes-api'
+
+describe('StatisticsReportUtils', () => {
+  describe('reportContentDataBlock', () => {
+    const reportContent: ReportContent = {
+      content: {
+        count: 1,
+        courseCounts: [
+          {
+            audience: 'audience',
+            count: 1,
+            name: 'name',
+          },
+        ],
+      },
+      parameters: {
+        endDate: '2022-01-01',
+        startDate: '2022-01-31',
+      },
+      reportType: 'REFERRAL_COUNT',
+    }
+    it('returns the report content data block', () => {
+      expect(StatisticsReportUtils.reportContentDataBlock(reportContent, new Date('2022-01-01'))).toEqual({
+        date: 'January 2022',
+        testId: 'referral-count',
+        title: 'Total referrals submitted',
+        value: '1',
+      })
+    })
+
+    describe('when report content is `null`', () => {
+      it('returns the correct values', () => {
+        expect(StatisticsReportUtils.reportContentDataBlock(null, new Date('2022-01-01'))).toEqual(
+          expect.objectContaining({
+            testId: 'unknown',
+            value: '0',
+          }),
+        )
+      })
+    })
+
+    describe('when there is no count value', () => {
+      it('returns the correct values', () => {
+        reportContent.content.count = undefined
+        expect(StatisticsReportUtils.reportContentDataBlock(reportContent, new Date('2022-01-01'))).toEqual(
+          expect.objectContaining({
+            value: '0',
+          }),
+        )
+      })
+    })
+  })
+
+  describe('reportContentTitle', () => {
+    it('returns the title for the given report type', () => {
+      expect(StatisticsReportUtils.reportContentTitle('REFERRAL_COUNT')).toEqual('Total referrals submitted')
+      expect(StatisticsReportUtils.reportContentTitle('PROGRAMME_COMPLETE_COUNT')).toEqual('Total programmes completed')
+      expect(StatisticsReportUtils.reportContentTitle('NOT_ELIGIBLE_COUNT')).toEqual('Total referrals not eligible')
+      expect(StatisticsReportUtils.reportContentTitle('WITHDRAWN_COUNT')).toEqual('Total referrals withdrawn')
+      expect(StatisticsReportUtils.reportContentTitle('DESELECTED_COUNT')).toEqual('Total referrals deselected')
+    })
+
+    describe('when the report type is unknown', () => {
+      it('returns "Unknown"', () => {
+        expect(StatisticsReportUtils.reportContentTitle('UNKNOWN')).toEqual('Unknown')
+      })
+    })
+
+    describe('when the report type is undefined', () => {
+      it('returns "Unknown"', () => {
+        expect(StatisticsReportUtils.reportContentTitle(undefined)).toEqual('Unknown')
+      })
+    })
+  })
+})

--- a/server/utils/statisticsReportUtils.ts
+++ b/server/utils/statisticsReportUtils.ts
@@ -1,0 +1,38 @@
+import type { ReportContent } from '@accredited-programmes-api'
+
+interface ReportContentDataBlock {
+  date: string
+  testId: string
+  title: string
+  value: string
+}
+
+export default class StatisticsReportUtils {
+  static reportContentDataBlock(reportContent: ReportContent | null, date: Date): ReportContentDataBlock {
+    const monthAndYear = date.toLocaleDateString('en-GB', { month: 'long', year: 'numeric' })
+
+    return {
+      date: monthAndYear,
+      testId: reportContent?.reportType.replace(/_/g, '-').toLowerCase() || 'unknown',
+      title: this.reportContentTitle(reportContent?.reportType),
+      value: reportContent?.content.count?.toString() || '0',
+    }
+  }
+
+  static reportContentTitle(reportType?: ReportContent['reportType']): string {
+    switch (reportType) {
+      case 'REFERRAL_COUNT':
+        return 'Total referrals submitted'
+      case 'PROGRAMME_COMPLETE_COUNT':
+        return 'Total programmes completed'
+      case 'NOT_ELIGIBLE_COUNT':
+        return 'Total referrals not eligible'
+      case 'WITHDRAWN_COUNT':
+        return 'Total referrals withdrawn'
+      case 'DESELECTED_COUNT':
+        return 'Total referrals deselected'
+      default:
+        return 'Unknown'
+    }
+  }
+}

--- a/server/views/reports/_reportDataBlock.njk
+++ b/server/views/reports/_reportDataBlock.njk
@@ -1,0 +1,8 @@
+{% macro reportDataBlock(data) %}
+  <div data-testid={{ data.testId }}>
+    <h3 class="govuk-heading-s">{{ data.title }}</h3>
+    <p class="govuk-body">
+      <span class="govuk-heading-xl govuk-!-display-inline">{{ data.value }}</span> in {{ data.date }}
+    </p>
+  </div>
+{% endmacro %}

--- a/server/views/reports/show.njk
+++ b/server/views/reports/show.njk
@@ -1,0 +1,31 @@
+{% from "govuk/components/back-link/macro.njk" import govukBackLink %}
+{% from "./_reportDataBlock.njk" import reportDataBlock %}
+
+{% extends "../partials/layout.njk" %}
+
+{% block backLink %}
+  {{ govukBackLink({
+    text: "Back",
+    href: "/"
+  }) }}
+{% endblock backLink %}
+
+{% block content %}
+  <h1 class="govuk-heading-l">{{ pageHeading }}</h1>
+
+  <div class="govuk-grid-row">
+    <div class="govuk-grid-column-two-thirds">
+      {% if reportDataBlocks | length %}
+        {% for items in reportDataBlocks | slice(2) %}
+          <div class="govuk-grid-row govuk-!-margin-bottom-6">
+            {% for item in items %}
+              <div class="govuk-grid-column-one-third">
+                {{ reportDataBlock(item) }}
+              </div>
+            {% endfor %}
+          </div>
+        {% endfor %}
+      {% endif %}
+    </div>
+  </div>
+{% endblock content %}


### PR DESCRIPTION
## Context

To support the ability for service stakeholders to be able to self-serve when it comes to AcP data reporting, we need to build the dashboard for Accredited Programmes.



## Changes in this PR
Add new controller and page to fetch and display statistics for the previous full month.


## Screenshots of UI changes

![image](https://github.com/user-attachments/assets/a9b59b46-4f98-4033-a205-c39764ec3f1b)



## Release checklist

[Release process documentation](../doc/how-to/perform-a-release.md)

As part of our continuous deployment strategy we must ensure that this work is
ready to be released once merged.

### Pre-merge

- [ ] There are changes required to the Accredited Programmes API for this change to work...
  - [ ] ... and they have been released to production already

### Post-merge

<!-- The outer checkboxes can be completed pre-merge -->

- [ ] This adds, extends or meaningfully modifies a feature...
  - [ ] ... and I have written or updated an end-to-end test for the happy path in the [Accredited Programmes E2E repo](https://github.com/ministryofjustice/hmpps-accredited-programmes-e2e)
- [ ] This makes new expectations of the API...
  - [ ] ... and I have notified the API developer(s) of changes to the contract tests (Pact), or the API is already compliant
- [ ] [Manually approve](../doc/how-to/perform-a-release.md#releasing-to-the-preprod-environment) release to preprod
- [ ] [Manually approve](../doc/how-to/perform-a-release.md#releasing-to-the-production-environment) release to prod

<!-- Should a release fail at any step, you as the author should now lead the work to
fix it as soon as possible. You can monitor deployment failures in CircleCI
itself and application errors are found in
[Sentry](https://ministryofjustice.sentry.io/projects/hmpps-accredited-programmes-ui/?project=4505330122686464&referrer=sidebar&statsPeriod=24h). -->
