### PR TITLE
(APG-385a) Statistics report filters

### DIFF
--- a/server/controllers/reportsController.test.ts
+++ b/server/controllers/reportsController.test.ts
@@ -4,15 +4,23 @@ import type { NextFunction, Request, Response } from 'express'
 import type { StatisticsService } from '../services'
 import ReportsController from './reportsController'
 import { reportContentFactory } from '../testutils/factories'
-import { StatisticsReportUtils } from '../utils'
+import { PathUtils, StatisticsReportUtils } from '../utils'
 
 jest.mock('../utils/statisticsReportUtils')
+jest.mock('../utils/pathUtils')
 
 const mockStatisticsReportUtils = StatisticsReportUtils as jest.Mocked<typeof StatisticsReportUtils>
+const mockPathUtils = PathUtils as jest.Mocked<typeof PathUtils>
 
 describe('ReportsController', () => {
   const username = 'USERNAME'
   const mockTodaysDate = new Date('2024-02-14')
+  const lastMonth = {
+    endDate: '2024-01-31',
+    startDate: '2024-01-01',
+  }
+  const queryParams = [{ key: 'period', value: 'lastSixMonths' }]
+  const pathWithQuery = '/reports?period=lastSixMonths'
 
   let request: DeepMocked<Request>
   let response: DeepMocked<Response>
@@ -21,7 +29,6 @@ describe('ReportsController', () => {
   const statisticsService = createMock<StatisticsService>({})
 
   const reportDataBlock = {
-    date: 'January 2024',
     testId: 'referral-count',
     title: 'Total referrals submitted',
     value: '123',
@@ -31,6 +38,9 @@ describe('ReportsController', () => {
 
   beforeEach(() => {
     mockStatisticsReportUtils.reportContentDataBlock.mockReturnValue(reportDataBlock)
+    mockStatisticsReportUtils.filterValuesToApiParams.mockReturnValue(lastMonth)
+    mockStatisticsReportUtils.queryParams.mockReturnValue(queryParams)
+    mockPathUtils.pathWithQuery.mockReturnValue(pathWithQuery)
 
     controller = new ReportsController(statisticsService)
 
@@ -47,40 +57,80 @@ describe('ReportsController', () => {
     jest.useRealTimers()
   })
 
-  describe('show', () => {
-    it('should render the reports/show view with the correct data', async () => {
-      statisticsService.getReport.mockResolvedValue(reportContentFactory.build())
+  describe('filter', () => {
+    it('should redirect to the reports show page with the correct query params', async () => {
+      request.body = { location: 'MDI', period: 'lastSixMonths' }
 
+      const requestHandler = controller.filter()
+      await requestHandler(request, response, next)
+
+      expect(StatisticsReportUtils.queryParams).toHaveBeenCalledWith('lastSixMonths', 'MDI')
+      expect(PathUtils.pathWithQuery).toHaveBeenCalledWith('/reports', queryParams)
+      expect(response.redirect).toHaveBeenCalledWith(pathWithQuery)
+    })
+  })
+
+  describe('show', () => {
+    const reportContent = reportContentFactory.build()
+    const reportTypes = [
+      'REFERRAL_COUNT',
+      'PROGRAMME_COMPLETE_COUNT',
+      'NOT_ELIGIBLE_COUNT',
+      'WITHDRAWN_COUNT',
+      'DESELECTED_COUNT',
+    ]
+
+    beforeEach(() => {
+      statisticsService.getReport.mockResolvedValue(reportContent)
+    })
+
+    it('should render the reports/show view with the correct data', async () => {
       const requestHandler = controller.show()
       await requestHandler(request, response, next)
 
-      const expectedQuery = {
-        endDate: '2024-01-31',
-        startDate: '2024-01-01',
-      }
-
-      const reportTypes = [
-        'REFERRAL_COUNT',
-        'PROGRAMME_COMPLETE_COUNT',
-        'NOT_ELIGIBLE_COUNT',
-        'WITHDRAWN_COUNT',
-        'DESELECTED_COUNT',
-      ]
-
       expect(statisticsService.getReport).toHaveBeenCalledTimes(reportTypes.length)
       reportTypes.forEach(reportType => {
-        expect(statisticsService.getReport).toHaveBeenCalledWith(username, reportType, expectedQuery)
+        expect(statisticsService.getReport).toHaveBeenCalledWith(username, reportType, lastMonth)
       })
 
+      expect(StatisticsReportUtils.filterValuesToApiParams).toHaveBeenCalledTimes(1)
+      expect(StatisticsReportUtils.filterValuesToApiParams).toHaveBeenCalledWith(undefined)
       expect(StatisticsReportUtils.reportContentDataBlock).toHaveBeenCalledTimes(reportTypes.length)
-      expect(StatisticsReportUtils.reportContentDataBlock).toHaveBeenCalledWith(
-        expect.anything(),
-        new Date(expectedQuery.startDate),
-      )
+      expect(StatisticsReportUtils.reportContentDataBlock).toHaveBeenCalledWith(reportContent)
 
       expect(response.render).toHaveBeenCalledWith('reports/show', {
+        filterFormAction: '/reports',
+        filterValues: {},
         pageHeading: 'Accredited Programmes data',
-        reportDataBlocks: [reportDataBlock, reportDataBlock, reportDataBlock, reportDataBlock, reportDataBlock],
+        reportDataBlocks: Array(reportTypes.length).fill(reportDataBlock),
+        subHeading: 'Showing data for 1 January 2024 to 31 January 2024',
+      })
+    })
+
+    describe('with query params', () => {
+      it('should render the reports/show view with the correct data', async () => {
+        request.query = { period: 'lastSixMonths' }
+
+        const requestHandler = controller.show()
+        await requestHandler(request, response, next)
+
+        expect(statisticsService.getReport).toHaveBeenCalledTimes(reportTypes.length)
+        reportTypes.forEach(reportType => {
+          expect(statisticsService.getReport).toHaveBeenCalledWith(username, reportType, lastMonth)
+        })
+
+        expect(StatisticsReportUtils.filterValuesToApiParams).toHaveBeenCalledTimes(1)
+        expect(StatisticsReportUtils.filterValuesToApiParams).toHaveBeenCalledWith('lastSixMonths')
+        expect(StatisticsReportUtils.reportContentDataBlock).toHaveBeenCalledTimes(reportTypes.length)
+        expect(StatisticsReportUtils.reportContentDataBlock).toHaveBeenCalledWith(reportContent)
+
+        expect(response.render).toHaveBeenCalledWith('reports/show', {
+          filterFormAction: '/reports',
+          filterValues: { period: 'lastSixMonths' },
+          pageHeading: 'Accredited Programmes data',
+          reportDataBlocks: Array(reportTypes.length).fill(reportDataBlock),
+          subHeading: 'Showing data for 1 January 2024 to 31 January 2024',
+        })
       })
     })
   })

--- a/server/paths/reports.ts
+++ b/server/paths/reports.ts
@@ -3,5 +3,6 @@ import { path } from 'static-path'
 const reportsPathBase = path('/reports')
 
 export default {
+  filter: reportsPathBase,
   show: reportsPathBase,
 }

--- a/server/routes/reports.ts
+++ b/server/routes/reports.ts
@@ -5,10 +5,11 @@ import { reportsPaths } from '../paths'
 import { RouteUtils } from '../utils'
 
 export default function routes(controllers: Controllers, router: Router): Router {
-  const { get } = RouteUtils.actions(router)
+  const { get, post } = RouteUtils.actions(router)
   const { reportsController } = controllers
 
   get(reportsPaths.show.pattern, reportsController.show())
+  post(reportsPaths.filter.pattern, reportsController.filter())
 
   return router
 }

--- a/server/utils/statisticsReportUtils.test.ts
+++ b/server/utils/statisticsReportUtils.test.ts
@@ -2,6 +2,90 @@ import StatisticsReportUtils from './statisticsReportUtils'
 import type { ReportContent } from '@accredited-programmes-api'
 
 describe('StatisticsReportUtils', () => {
+  afterEach(() => {
+    jest.useRealTimers()
+  })
+
+  describe('filterValuesToApiParams', () => {
+    it.each([
+      // Default is last full month, so July 2024
+      [undefined, { endDate: '2024-07-31', startDate: '2024-07-01' }],
+      // 1 April 2024 to 30 June 2024
+      ['lastQuarter', { endDate: '2024-06-30', startDate: '2024-04-01' }],
+      // 1 February 2024 to 31 July 2024,
+      ['lastSixMonths', { endDate: '2024-07-31', startDate: '2024-02-01' }],
+    ])('returns the correct start and end date for the given period', (period, expected) => {
+      // 15th of August 2024
+      jest.useFakeTimers().setSystemTime(new Date(2024, 7, 15))
+
+      expect(StatisticsReportUtils.filterValuesToApiParams(period)).toEqual(expected)
+    })
+
+    describe('when periods can carry over into the previous year', () => {
+      it('returns the correct last full month by default', () => {
+        // 15th of January 2024
+        jest.useFakeTimers().setSystemTime(new Date(2024, 0, 15))
+
+        // December 2023
+        expect(StatisticsReportUtils.filterValuesToApiParams()).toEqual({
+          endDate: '2023-12-31',
+          startDate: '2023-12-01',
+        })
+      })
+
+      it('returns the correct start and end date for the `lastSixMonths`', () => {
+        // 15th of April 2024
+        jest.useFakeTimers().setSystemTime(new Date(2024, 3, 15))
+
+        // 1st of October 2023 to 31st of March 2024
+        expect(StatisticsReportUtils.filterValuesToApiParams('lastSixMonths')).toEqual({
+          endDate: '2024-03-31',
+          startDate: '2023-10-01',
+        })
+      })
+    })
+  })
+
+  describe('lastFinancialQuarter', () => {
+    it.each([
+      // 1st of January 2022 should be Q3 in 2021
+      [new Date(2022, 0, 1), { endDate: new Date(2021, 11, 31), startDate: new Date(2021, 9, 1) }],
+      // 1st of April 2022 should be Q4 in 2022
+      [new Date(2022, 3, 1), { endDate: new Date(2022, 2, 31), startDate: new Date(2022, 0, 1) }],
+      // 1st of July 2022 should be Q1 in 2022
+      [new Date(2022, 6, 1), { endDate: new Date(2022, 5, 30), startDate: new Date(2022, 3, 1) }],
+      // 1st of October 2022 should be Q2 in 2022
+      [new Date(2022, 9, 1), { endDate: new Date(2022, 8, 30), startDate: new Date(2022, 6, 1) }],
+    ])('return the start end end date of the last full quarter', (now, expected) => {
+      jest.useFakeTimers().setSystemTime(now)
+
+      expect(StatisticsReportUtils.lastFinancialQuarter()).toEqual(expected)
+    })
+  })
+
+  describe('queryParams', () => {
+    it('returns the query params', () => {
+      expect(StatisticsReportUtils.queryParams('lastQuarter', 'MDI')).toEqual([
+        { key: 'period', value: 'lastQuarter' },
+        { key: 'location', value: 'MDI' },
+      ])
+    })
+
+    describe('when period is `undefined`', () => {
+      it('returns the query params without the period key', () => {
+        expect(StatisticsReportUtils.queryParams(undefined, 'MDI')).toEqual([{ key: 'location', value: 'MDI' }])
+      })
+    })
+
+    describe('when location is `undefined`', () => {
+      it('returns the query params without the location key', () => {
+        expect(StatisticsReportUtils.queryParams('lastQuarter', undefined)).toEqual([
+          { key: 'period', value: 'lastQuarter' },
+        ])
+      })
+    })
+  })
+
   describe('reportContentDataBlock', () => {
     const reportContent: ReportContent = {
       content: {
@@ -21,8 +105,7 @@ describe('StatisticsReportUtils', () => {
       reportType: 'REFERRAL_COUNT',
     }
     it('returns the report content data block', () => {
-      expect(StatisticsReportUtils.reportContentDataBlock(reportContent, new Date('2022-01-01'))).toEqual({
-        date: 'January 2022',
+      expect(StatisticsReportUtils.reportContentDataBlock(reportContent)).toEqual({
         testId: 'referral-count',
         title: 'Total referrals submitted',
         value: '1',
@@ -31,7 +114,7 @@ describe('StatisticsReportUtils', () => {
 
     describe('when report content is `null`', () => {
       it('returns the correct values', () => {
-        expect(StatisticsReportUtils.reportContentDataBlock(null, new Date('2022-01-01'))).toEqual(
+        expect(StatisticsReportUtils.reportContentDataBlock(null)).toEqual(
           expect.objectContaining({
             testId: 'unknown',
             value: '0',
@@ -43,7 +126,7 @@ describe('StatisticsReportUtils', () => {
     describe('when there is no count value', () => {
       it('returns the correct values', () => {
         reportContent.content.count = undefined
-        expect(StatisticsReportUtils.reportContentDataBlock(reportContent, new Date('2022-01-01'))).toEqual(
+        expect(StatisticsReportUtils.reportContentDataBlock(reportContent)).toEqual(
           expect.objectContaining({
             value: '0',
           }),

--- a/server/utils/statisticsReportUtils.ts
+++ b/server/utils/statisticsReportUtils.ts
@@ -1,18 +1,83 @@
+import DateUtils from './dateUtils'
+import type { QueryParam } from '@accredited-programmes/ui'
 import type { ReportContent } from '@accredited-programmes-api'
 
 interface ReportContentDataBlock {
-  date: string
   testId: string
   title: string
   value: string
 }
 
 export default class StatisticsReportUtils {
-  static reportContentDataBlock(reportContent: ReportContent | null, date: Date): ReportContentDataBlock {
-    const monthAndYear = date.toLocaleDateString('en-GB', { month: 'long', year: 'numeric' })
+  static filterValuesToApiParams(period?: string): { endDate: string; startDate: string } {
+    const now = new Date()
+    const month = now.getMonth()
+    const year = now.getFullYear()
+
+    let searchEndDate = new Date(year, month, 0)
+    let searchStartDate = new Date(year, month - 1, 1)
+
+    if (period === 'lastQuarter') {
+      const { endDate, startDate } = this.lastFinancialQuarter()
+      searchEndDate = endDate
+      searchStartDate = startDate
+    }
+
+    if (period === 'lastSixMonths') {
+      searchStartDate = new Date(year, month - 6, 1)
+    }
 
     return {
-      date: monthAndYear,
+      endDate: DateUtils.isoDateOnly(searchEndDate),
+      startDate: DateUtils.isoDateOnly(searchStartDate),
+    }
+  }
+
+  static lastFinancialQuarter(): { endDate: Date; startDate: Date } {
+    const now = new Date()
+    const currentMonth = now.getMonth()
+    let currentYear = now.getFullYear()
+
+    const quarters = [
+      /* eslint-disable sort-keys */
+      { start: 0, end: 2 },
+      { start: 3, end: 5 },
+      { start: 6, end: 8 },
+      { start: 9, end: 11 },
+      /* eslint-enable sort-keys */
+    ]
+
+    let quarterIndex = Math.floor(currentMonth / 3)
+
+    if (quarterIndex === 0) {
+      currentYear -= 1
+      quarterIndex = 3
+    } else {
+      quarterIndex -= 1
+    }
+
+    const { start, end } = quarters[quarterIndex]
+    const startDate = new Date(currentYear, start, 1)
+    const endDate = new Date(currentYear, end + 1, 0)
+
+    return { endDate, startDate }
+  }
+
+  static queryParams(period?: string, location?: string): Array<QueryParam> {
+    const queryParams: Array<QueryParam> = []
+
+    if (period) {
+      queryParams.push({ key: 'period', value: period })
+    }
+    if (location) {
+      queryParams.push({ key: 'location', value: location })
+    }
+
+    return queryParams
+  }
+
+  static reportContentDataBlock(reportContent: ReportContent | null): ReportContentDataBlock {
+    return {
       testId: reportContent?.reportType.replace(/_/g, '-').toLowerCase() || 'unknown',
       title: this.reportContentTitle(reportContent?.reportType),
       value: reportContent?.content.count?.toString() || '0',

--- a/server/views/reports/_reportDataBlock.njk
+++ b/server/views/reports/_reportDataBlock.njk
@@ -2,7 +2,7 @@
   <div data-testid={{ data.testId }}>
     <h3 class="govuk-heading-s">{{ data.title }}</h3>
     <p class="govuk-body">
-      <span class="govuk-heading-xl govuk-!-display-inline">{{ data.value }}</span> in {{ data.date }}
+      <span class="govuk-heading-xl govuk-!-display-inline">{{ data.value }}</span>
     </p>
   </div>
 {% endmacro %}

--- a/server/views/reports/show.njk
+++ b/server/views/reports/show.njk
@@ -1,4 +1,7 @@
 {% from "govuk/components/back-link/macro.njk" import govukBackLink %}
+{% from "govuk/components/input/macro.njk" import govukInput %}
+{% from "govuk/components/radios/macro.njk" import govukRadios %}
+{% from "moj/components/filter/macro.njk" import mojFilter %}
 {% from "./_reportDataBlock.njk" import reportDataBlock %}
 
 {% extends "../partials/layout.njk" %}
@@ -10,10 +13,57 @@
   }) }}
 {% endblock backLink %}
 
+{% set filterOptionsHtml %}
+{{ govukRadios({
+  name: "period",
+  classes: "govuk-radios--small",
+  value: filterValues.period or "lastMonth",
+  fieldset: {
+    legend: {
+      text: "Reporting period",
+      classes: "govuk-fieldset__legend--s"
+    }
+  },
+  items: [
+    {
+      value: "lastMonth",
+      text: "last month"
+    },
+    {
+      value: "lastQuarter",
+      text: "last quarter"
+    },
+    {
+      value: "lastSixMonths",
+      text: "last 6 months"
+    }
+  ]
+}) }}
+{% endset %}
+
 {% block content %}
-  <h1 class="govuk-heading-l">{{ pageHeading }}</h1>
+  <h1 class="govuk-heading-l govuk-!-margin-bottom-1">{{ pageHeading }}</h1>
+  <p class="govuk-body govuk-!-font-size-24 govuk-!-margin-bottom-8">{{ subHeading }}</p>
 
   <div class="govuk-grid-row">
+    <div class="govuk-grid-column-one-third">
+      <form action="{{ filterFormAction }}" method="post">
+        <input type="hidden" name="_csrf" value="{{ csrfToken }}"/>
+
+        {{ mojFilter({
+          heading: {
+            text: 'Filters'
+          },
+          submit: {
+            attributes: {
+                "data-test-id": "submit-button"
+            }
+          },
+          optionsHtml: filterOptionsHtml
+        }) }}
+      </form>
+    </div>
+
     <div class="govuk-grid-column-two-thirds">
       {% if reportDataBlocks | length %}
         {% for items in reportDataBlocks | slice(2) %}


### PR DESCRIPTION
## Context

Building on the data reporting dashboard, users will need the ability to filter the data reports by geography and by date.

## Changes in this PR
Add filters which allow the user to filter on the following time periods:

- last full month
- last full quarter
- last full 6 months


## Screenshots of UI changes

![image](https://github.com/user-attachments/assets/c55aa968-0b16-48ea-9af2-a2cfddd5ea60)



## Release checklist

[Release process documentation](../doc/how-to/perform-a-release.md)

As part of our continuous deployment strategy we must ensure that this work is
ready to be released once merged.

### Pre-merge

- [ ] There are changes required to the Accredited Programmes API for this change to work...
  - [ ] ... and they have been released to production already

### Post-merge

<!-- The outer checkboxes can be completed pre-merge -->

- [ ] This adds, extends or meaningfully modifies a feature...
  - [ ] ... and I have written or updated an end-to-end test for the happy path in the [Accredited Programmes E2E repo](https://github.com/ministryofjustice/hmpps-accredited-programmes-e2e)
- [ ] This makes new expectations of the API...
  - [ ] ... and I have notified the API developer(s) of changes to the contract tests (Pact), or the API is already compliant
- [ ] [Manually approve](../doc/how-to/perform-a-release.md#releasing-to-the-preprod-environment) release to preprod
- [ ] [Manually approve](../doc/how-to/perform-a-release.md#releasing-to-the-production-environment) release to prod

<!-- Should a release fail at any step, you as the author should now lead the work to
fix it as soon as possible. You can monitor deployment failures in CircleCI
itself and application errors are found in
[Sentry](https://ministryofjustice.sentry.io/projects/hmpps-accredited-programmes-ui/?project=4505330122686464&referrer=sidebar&statsPeriod=24h). -->
