### PR TITLE
(APG-385b) Location filters on report page

### DIFF
--- a/assets/scss/overrides.scss
+++ b/assets/scss/overrides.scss
@@ -5,3 +5,8 @@
 .moj-timeline .govuk-tag {
   max-width: none;
 }
+
+.scroll-conditional-options .govuk-radios__conditional {
+  max-height: 500px;
+  overflow-y: auto;
+}

--- a/server/controllers/index.ts
+++ b/server/controllers/index.ts
@@ -10,7 +10,7 @@ import sharedControllers from './shared'
 
 export const controllers = (services: Services) => {
   const dashboardController = new DashboardController()
-  const reportsController = new ReportsController(services.statisticsService)
+  const reportsController = new ReportsController(services.organisationService, services.statisticsService)
 
   return {
     dashboardController,

--- a/server/data/accreditedProgrammesApi/statisticsClient.ts
+++ b/server/data/accreditedProgrammesApi/statisticsClient.ts
@@ -17,6 +17,7 @@ export default class StatisticsClient {
     query: {
       startDate: string
       endDate?: string
+      locationCodes?: Array<string>
     },
   ): Promise<ReportContent> {
     return (await this.restClient.get({
@@ -24,6 +25,7 @@ export default class StatisticsClient {
       query: {
         startDate: query.startDate,
         ...(query.endDate && { endDate: query.endDate }),
+        ...(query.locationCodes && { locationCodes: query.locationCodes.join(',') }),
       },
     })) as ReportContent
   }

--- a/server/services/statisticsService.ts
+++ b/server/services/statisticsService.ts
@@ -16,6 +16,7 @@ export default class StatisticsService {
     query: {
       startDate: string
       endDate?: string
+      locationCodes?: Array<string>
     },
   ): Promise<ReportContent | null> {
     const hmppsAuthClient = this.hmppsAuthClientBuilder()

--- a/server/utils/organisationUtils.test.ts
+++ b/server/utils/organisationUtils.test.ts
@@ -32,6 +32,20 @@ describe('OrganisationUtils', () => {
     })
   })
 
+  describe('organisationRadioItems', () => {
+    it('returns an array of `GovukFrontendRadiosItem` objects from an array of prisons, sorted by `prisonName`', () => {
+      const prisons = [
+        prisonFactory.build({ prisonId: 'B', prisonName: 'B Prison' }),
+        prisonFactory.build({ prisonId: 'A', prisonName: 'A Prison' }),
+      ]
+
+      expect(OrganisationUtils.organisationRadioItems(prisons)).toEqual([
+        { text: 'A Prison', value: 'A' },
+        { text: 'B Prison', value: 'B' },
+      ])
+    })
+  })
+
   describe('organisationSelectItems', () => {
     it('returns an array of `GovukFrontendSelectItem` objects from an array of prisons', () => {
       const prisons = [

--- a/server/utils/organisationUtils.ts
+++ b/server/utils/organisationUtils.ts
@@ -5,7 +5,7 @@ import type {
   OrganisationWithOfferingEmailsPresenter,
   OrganisationWithOfferingId,
 } from '@accredited-programmes/ui'
-import type { GovukFrontendSelectItem, GovukFrontendTableRow } from '@govuk-frontend'
+import type { GovukFrontendRadiosItem, GovukFrontendSelectItem, GovukFrontendTableRow } from '@govuk-frontend'
 import type { Prison } from '@prison-register-api'
 
 export default class OrganisationUtils {
@@ -19,6 +19,17 @@ export default class OrganisationUtils {
       category: categories,
       name: prison.prisonName,
     }
+  }
+
+  static organisationRadioItems(organisations: Array<Prison>): Array<GovukFrontendRadiosItem> {
+    return organisations
+      .sort((a, b) => a.prisonName.localeCompare(b.prisonName))
+      .map(organisation => {
+        return {
+          text: organisation.prisonName,
+          value: organisation.prisonId,
+        }
+      })
   }
 
   static organisationSelectItems(organisations: Array<Prison>): Array<GovukFrontendSelectItem> {

--- a/server/utils/statisticsReportUtils.test.ts
+++ b/server/utils/statisticsReportUtils.test.ts
@@ -64,24 +64,30 @@ describe('StatisticsReportUtils', () => {
   })
 
   describe('queryParams', () => {
-    it('returns the query params', () => {
-      expect(StatisticsReportUtils.queryParams('lastQuarter', 'MDI')).toEqual([
+    it('returns all the query params', () => {
+      expect(StatisticsReportUtils.queryParams('lastQuarter', 'MDI', 'prison')).toEqual([
         { key: 'period', value: 'lastQuarter' },
         { key: 'location', value: 'MDI' },
       ])
     })
 
-    describe('when period is `undefined`', () => {
-      it('returns the query params without the period key', () => {
-        expect(StatisticsReportUtils.queryParams(undefined, 'MDI')).toEqual([{ key: 'location', value: 'MDI' }])
+    describe("when `location` is provided on it's own", () => {
+      it('returns no query params', () => {
+        expect(StatisticsReportUtils.queryParams(undefined, 'MDI')).toEqual([])
       })
     })
 
-    describe('when location is `undefined`', () => {
-      it('returns the query params without the location key', () => {
-        expect(StatisticsReportUtils.queryParams('lastQuarter', undefined)).toEqual([
-          { key: 'period', value: 'lastQuarter' },
+    describe('when `location` and `region` are provided', () => {
+      it('returns only the `location` query param', () => {
+        expect(StatisticsReportUtils.queryParams(undefined, 'MDI', 'prison')).toEqual([
+          { key: 'location', value: 'MDI' },
         ])
+      })
+    })
+
+    describe('when only the `period` is provided', () => {
+      it('returns only the `period` key', () => {
+        expect(StatisticsReportUtils.queryParams('lastQuarter')).toEqual([{ key: 'period', value: 'lastQuarter' }])
       })
     })
   })

--- a/server/utils/statisticsReportUtils.ts
+++ b/server/utils/statisticsReportUtils.ts
@@ -63,13 +63,13 @@ export default class StatisticsReportUtils {
     return { endDate, startDate }
   }
 
-  static queryParams(period?: string, location?: string): Array<QueryParam> {
+  static queryParams(period?: string, location?: string, region?: string): Array<QueryParam> {
     const queryParams: Array<QueryParam> = []
 
     if (period) {
       queryParams.push({ key: 'period', value: period })
     }
-    if (location) {
+    if (location && region === 'prison') {
       queryParams.push({ key: 'location', value: location })
     }
 

--- a/server/views/reports/show.njk
+++ b/server/views/reports/show.njk
@@ -13,6 +13,21 @@
   }) }}
 {% endblock backLink %}
 
+{% set locationOptionsHtml %}
+{{ govukRadios({
+  name: "location",
+  classes: "govuk-radios--small",
+  value: filterValues.location,
+  fieldset: {
+    legend: {
+      text: "Select a prison",
+      classes: "govuk-fieldset__legend--s"
+    }
+  },
+  items: prisonLocationOptions
+}) }}
+{% endset %}
+
 {% set filterOptionsHtml %}
 {{ govukRadios({
   name: "period",
@@ -39,6 +54,35 @@
     }
   ]
 }) }}
+
+<hr class="govuk-section-break govuk-section-break--l govuk-section-break--visible">
+
+{{ govukRadios({
+  name: "region",
+  classes: "govuk-radios--small scroll-conditional-options",
+  fieldset: {
+    legend: {
+      text: "Location",
+      classes: "govuk-fieldset__legend--s"
+    }
+  },
+  items: [
+    {
+      value: "national",
+      text: "national data",
+      checked: true if not filterValues.location
+    },
+    {
+      value: "prison",
+      text: "data by prison",
+      checked: true if filterValues.location,
+      conditional: {
+        html: locationOptionsHtml
+      }
+    }
+  ]
+}) }}
+
 {% endset %}
 
 {% block content %}


### PR DESCRIPTION
## Context

Building on the data reporting dashboard, users will need the ability to filter the data reports by geography and by date.


## Changes in this PR
Add filters which allow the user to filter nationally or by each prison location.


## Screenshots of UI changes

![image](https://github.com/user-attachments/assets/f51a6e5e-4b29-419b-8594-b2befdaea224)



## Release checklist

[Release process documentation](../doc/how-to/perform-a-release.md)

As part of our continuous deployment strategy we must ensure that this work is
ready to be released once merged.

### Pre-merge

- [ ] There are changes required to the Accredited Programmes API for this change to work...
  - [ ] ... and they have been released to production already

### Post-merge

<!-- The outer checkboxes can be completed pre-merge -->

- [ ] This adds, extends or meaningfully modifies a feature...
  - [ ] ... and I have written or updated an end-to-end test for the happy path in the [Accredited Programmes E2E repo](https://github.com/ministryofjustice/hmpps-accredited-programmes-e2e)
- [ ] This makes new expectations of the API...
  - [ ] ... and I have notified the API developer(s) of changes to the contract tests (Pact), or the API is already compliant
- [ ] [Manually approve](../doc/how-to/perform-a-release.md#releasing-to-the-preprod-environment) release to preprod
- [ ] [Manually approve](../doc/how-to/perform-a-release.md#releasing-to-the-production-environment) release to prod

<!-- Should a release fail at any step, you as the author should now lead the work to
fix it as soon as possible. You can monitor deployment failures in CircleCI
itself and application errors are found in
[Sentry](https://ministryofjustice.sentry.io/projects/hmpps-accredited-programmes-ui/?project=4505330122686464&referrer=sidebar&statsPeriod=24h). -->
