### PR TITLE
(APG-385c) Custom dates filters

### DIFF
--- a/server/utils/dateUtils.test.ts
+++ b/server/utils/dateUtils.test.ts
@@ -15,6 +15,12 @@ describe('DateUtils', () => {
     })
   })
 
+  describe('convertStringToDate', () => {
+    it('converts a date string in the format DD/MM/YYYY to a Date object', () => {
+      expect(DateUtils.convertStringToDate('01/02/2000')).toEqual(new Date('2000-02-01'))
+    })
+  })
+
   describe('govukFormattedFullDateString', () => {
     it('returns todays date as a date string in the format specified by the GOV.UK style guide', () => {
       const mockTodaysDate = new Date('2001-06-04')

--- a/server/utils/dateUtils.ts
+++ b/server/utils/dateUtils.ts
@@ -13,6 +13,11 @@ export default class DateUtils {
     return { months, years }
   }
 
+  static convertStringToDate(dateString: string): Date {
+    const dateParts = dateString.split('/').map(Number)
+    return new Date(dateParts[2], dateParts[1] - 1, dateParts[0])
+  }
+
   /**
    * Formats an ISO8601 datetime string into the format specified by the GOV.UK Style guide
    * e.g. 1 January 2022

--- a/server/views/reports/show.njk
+++ b/server/views/reports/show.njk
@@ -1,6 +1,7 @@
 {% from "govuk/components/back-link/macro.njk" import govukBackLink %}
 {% from "govuk/components/input/macro.njk" import govukInput %}
 {% from "govuk/components/radios/macro.njk" import govukRadios %}
+{% from "moj/components/date-picker/macro.njk" import mojDatePicker %}
 {% from "moj/components/filter/macro.njk" import mojFilter %}
 {% from "./_reportDataBlock.njk" import reportDataBlock %}
 
@@ -13,10 +14,39 @@
   }) }}
 {% endblock backLink %}
 
+{% set customDatesHtml %}
+{{ mojDatePicker({
+  id: "date-from",
+  name: "dateFrom",
+  value: filterValues.dateFrom,
+  classes: "govuk-!-margin-bottom-3",
+  errorMessage: errorMessages.dateFrom,
+  label: {
+    text: "Date from"
+  },
+  hint: {
+    text: "For example, 17/5/2024."
+  }
+}) }}
+{{ mojDatePicker({
+  id: "date-to",
+  name: "dateTo",
+  value: filterValues.dateTo,
+  errorMessage: errorMessages.dateTo,
+  label: {
+    text: "Date to"
+  },
+  hint: {
+    text: "For example, 17/5/2024."
+  }
+}) }}
+{% endset %}
+
 {% set locationOptionsHtml %}
 {{ govukRadios({
   name: "location",
   classes: "govuk-radios--small",
+  errorMessage: errorMessages.location,
   value: filterValues.location,
   fieldset: {
     legend: {
@@ -51,6 +81,16 @@
     {
       value: "lastSixMonths",
       text: "last 6 months"
+    },
+    {
+      divider: "or"
+    },
+    {
+      value: "custom",
+      text: "custom dates",
+      conditional: {
+        html: customDatesHtml
+      }
     }
   ]
 }) }}
@@ -60,6 +100,7 @@
 {{ govukRadios({
   name: "region",
   classes: "govuk-radios--small scroll-conditional-options",
+  value: filterValues.region or "national",
   fieldset: {
     legend: {
       text: "Location",
@@ -69,13 +110,11 @@
   items: [
     {
       value: "national",
-      text: "national data",
-      checked: true if not filterValues.location
+      text: "national data"
     },
     {
       value: "prison",
       text: "data by prison",
-      checked: true if filterValues.location,
       conditional: {
         html: locationOptionsHtml
       }


### PR DESCRIPTION
## Context

Building on the data reporting dashboard, users will need the ability to filter the data reports by custom dates.



## Changes in this PR
Add filters which allow the user to filter by custom dates.


## Screenshots of UI changes

![image](https://github.com/user-attachments/assets/4af2f5e1-e038-43ea-b876-f2a84fd23261)
![image](https://github.com/user-attachments/assets/cf0cff55-07a8-4ac7-b5bf-0b74bdca5e94)


## Release checklist

[Release process documentation](../doc/how-to/perform-a-release.md)

As part of our continuous deployment strategy we must ensure that this work is
ready to be released once merged.

### Pre-merge

- [ ] There are changes required to the Accredited Programmes API for this change to work...
  - [ ] ... and they have been released to production already

### Post-merge

<!-- The outer checkboxes can be completed pre-merge -->

- [ ] This adds, extends or meaningfully modifies a feature...
  - [ ] ... and I have written or updated an end-to-end test for the happy path in the [Accredited Programmes E2E repo](https://github.com/ministryofjustice/hmpps-accredited-programmes-e2e)
- [ ] This makes new expectations of the API...
  - [ ] ... and I have notified the API developer(s) of changes to the contract tests (Pact), or the API is already compliant
- [ ] [Manually approve](../doc/how-to/perform-a-release.md#releasing-to-the-preprod-environment) release to preprod
- [ ] [Manually approve](../doc/how-to/perform-a-release.md#releasing-to-the-production-environment) release to prod

<!-- Should a release fail at any step, you as the author should now lead the work to
fix it as soon as possible. You can monitor deployment failures in CircleCI
itself and application errors are found in
[Sentry](https://ministryofjustice.sentry.io/projects/hmpps-accredited-programmes-ui/?project=4505330122686464&referrer=sidebar&statsPeriod=24h). -->
