### PR TITLE
(APG-385d) Report page updates

### DIFF
--- a/server/controllers/index.ts
+++ b/server/controllers/index.ts
@@ -10,7 +10,7 @@ import sharedControllers from './shared'
 
 export const controllers = (services: Services) => {
   const dashboardController = new DashboardController()
-  const reportsController = new ReportsController(services.organisationService, services.statisticsService)
+  const reportsController = new ReportsController(services.referenceDataService, services.statisticsService)
 
   return {
     dashboardController,

--- a/server/controllers/reportsController.test.ts
+++ b/server/controllers/reportsController.test.ts
@@ -90,6 +90,7 @@ describe('ReportsController', () => {
     const reportContent = reportContentFactory.build()
     const reportTypes = [
       'REFERRAL_COUNT',
+      'ON_PROGRAMME_COUNT',
       'PROGRAMME_COMPLETE_COUNT',
       'NOT_ELIGIBLE_COUNT',
       'WITHDRAWN_COUNT',

--- a/server/controllers/reportsController.test.ts
+++ b/server/controllers/reportsController.test.ts
@@ -1,10 +1,11 @@
 import { type DeepMocked, createMock } from '@golevelup/ts-jest'
 import type { NextFunction, Request, Response } from 'express'
 
-import type { OrganisationService, StatisticsService } from '../services'
+import type { ReferenceDataService, StatisticsService } from '../services'
 import ReportsController from './reportsController'
-import { prisonFactory, reportContentFactory } from '../testutils/factories'
+import { reportContentFactory } from '../testutils/factories'
 import { OrganisationUtils, PathUtils, StatisticsReportUtils } from '../utils'
+import type { EnabledOrganisation } from '@accredited-programmes-api'
 
 jest.mock('../utils/organisationUtils')
 jest.mock('../utils/statisticsReportUtils')
@@ -23,9 +24,9 @@ describe('ReportsController', () => {
   }
   const queryParams = [{ key: 'period', value: 'lastSixMonths' }]
   const pathWithQuery = '/reports?period=lastSixMonths'
-  const allOrganisations = [
-    prisonFactory.build({ prisonId: 'MDI', prisonName: 'Moorland' }),
-    prisonFactory.build({ prisonId: 'LEI', prisonName: 'Leeds' }),
+  const enabledOrganisations: Array<EnabledOrganisation> = [
+    { code: 'MDI', description: 'Moorland' },
+    { code: 'LEI', description: 'Leeds' },
   ]
   const prisonLocationOptions = [
     { text: 'Leeds', value: 'LEI' },
@@ -37,7 +38,7 @@ describe('ReportsController', () => {
   let response: DeepMocked<Response>
   const next: DeepMocked<NextFunction> = createMock<NextFunction>({})
 
-  const organisationsService = createMock<OrganisationService>({})
+  const referenceDataService = createMock<ReferenceDataService>({})
   const statisticsService = createMock<StatisticsService>({})
 
   const reportDataBlock = {
@@ -56,9 +57,9 @@ describe('ReportsController', () => {
     mockStatisticsReportUtils.validateFilterValues.mockReturnValue(errorMessages)
     mockPathUtils.pathWithQuery.mockReturnValue(pathWithQuery)
 
-    organisationsService.getAllOrganisations.mockResolvedValue(allOrganisations)
+    referenceDataService.getEnabledOrganisations.mockResolvedValue(enabledOrganisations)
 
-    controller = new ReportsController(organisationsService, statisticsService)
+    controller = new ReportsController(referenceDataService, statisticsService)
 
     request = createMock<Request>({
       user: { username },

--- a/server/controllers/reportsController.ts
+++ b/server/controllers/reportsController.ts
@@ -1,12 +1,12 @@
 import type { Request, Response, TypedRequestHandler } from 'express'
 
 import { reportsPaths } from '../paths'
-import type { OrganisationService, StatisticsService } from '../services'
+import type { ReferenceDataService, StatisticsService } from '../services'
 import { DateUtils, OrganisationUtils, PathUtils, StatisticsReportUtils, TypeUtils } from '../utils'
 
 export default class ReportsController {
   constructor(
-    private readonly organisationsService: OrganisationService,
+    private readonly referenceDataService: ReferenceDataService,
     private readonly statisticsService: StatisticsService,
   ) {}
 
@@ -60,10 +60,10 @@ export default class ReportsController {
             }),
           ),
         ),
-        this.organisationsService.getAllOrganisations(req.user.token),
+        this.referenceDataService.getEnabledOrganisations(req.user.token),
       ])
 
-      const selectedPrison = organisations.find(org => org.prisonId === location)?.prisonName
+      const selectedPrison = organisations.find(org => org.code === location)?.description
 
       const subHeading = [
         'Showing data',

--- a/server/controllers/reportsController.ts
+++ b/server/controllers/reportsController.ts
@@ -43,6 +43,7 @@ export default class ReportsController {
 
       const reportTypes = [
         'REFERRAL_COUNT',
+        'ON_PROGRAMME_COUNT',
         'PROGRAMME_COMPLETE_COUNT',
         'NOT_ELIGIBLE_COUNT',
         'WITHDRAWN_COUNT',

--- a/server/data/accreditedProgrammesApi/referenceDataClient.ts
+++ b/server/data/accreditedProgrammesApi/referenceDataClient.ts
@@ -9,6 +9,7 @@ import type {
   ReferralStatusRefData,
   ReferralStatusUppercase,
 } from '@accredited-programmes/models'
+import type { EnabledOrganisation } from '@accredited-programmes-api'
 import type { SystemToken } from '@hmpps-auth'
 
 export default class ReferenceDataClient {
@@ -20,6 +21,12 @@ export default class ReferenceDataClient {
       config.apis.accreditedProgrammesApi as ApiConfig,
       systemToken,
     )
+  }
+
+  async findEnabledOrganisations(): Promise<Array<EnabledOrganisation>> {
+    return (await this.restClient.get({
+      path: apiPaths.organisations.enabled({}),
+    })) as Array<EnabledOrganisation>
   }
 
   async findReferralStatusCodeCategories(

--- a/server/paths/api.ts
+++ b/server/paths/api.ts
@@ -75,6 +75,7 @@ export default {
   },
   organisations: {
     courses: coursesByOrganisationPath,
+    enabled: organisationsPath.path('enabled'),
   },
   participations: {
     create: participationsPath,

--- a/server/services/referenceDataService.test.ts
+++ b/server/services/referenceDataService.test.ts
@@ -10,6 +10,7 @@ import {
   referralStatusRefDataFactory,
 } from '../testutils/factories'
 import type { ReferralStatusUppercase } from '@accredited-programmes/models'
+import type { EnabledOrganisation } from '@accredited-programmes-api'
 
 jest.mock('../data/accreditedProgrammesApi/referenceDataClient')
 jest.mock('../data/hmppsAuthClient')
@@ -35,6 +36,21 @@ describe('ReferenceDataService', () => {
     hmppsAuthClientBuilder.mockReturnValue(hmppsAuthClient)
     referenceDataClientBuilder.mockReturnValue(referenceDataClient)
     hmppsAuthClient.getSystemClientToken.mockResolvedValue(systemToken)
+  })
+
+  describe('getEnabledOrganisations', () => {
+    it('should return enabled organisations', async () => {
+      const enabledOrganisations: Array<EnabledOrganisation> = [
+        { code: 'ORG1', description: 'Organisation 1' },
+        { code: 'ORG2', description: 'Organisation 2' },
+      ]
+
+      when(referenceDataClient.findEnabledOrganisations).mockResolvedValue(enabledOrganisations)
+
+      const result = await service.getEnabledOrganisations(username)
+
+      expect(result).toEqual(enabledOrganisations)
+    })
   })
 
   describe('getReferralStatusCodeCategories', () => {

--- a/server/services/referenceDataService.ts
+++ b/server/services/referenceDataService.ts
@@ -6,12 +6,21 @@ import type {
   ReferralStatusRefData,
   ReferralStatusUppercase,
 } from '@accredited-programmes/models'
+import type { EnabledOrganisation } from '@accredited-programmes-api'
 
 export default class ReferenceDataService {
   constructor(
     private readonly hmppsAuthClientBuilder: RestClientBuilderWithoutToken<HmppsAuthClient>,
     private readonly referenceDataClient: RestClientBuilder<ReferenceDataClient>,
   ) {}
+
+  async getEnabledOrganisations(username: Express.User['username']): Promise<Array<EnabledOrganisation>> {
+    const hmppsAuthClient = this.hmppsAuthClientBuilder()
+    const systemToken = await hmppsAuthClient.getSystemClientToken(username)
+    const referenceDataClient = this.referenceDataClient(systemToken)
+
+    return referenceDataClient.findEnabledOrganisations()
+  }
 
   async getReferralStatusCodeCategories(
     username: Express.User['username'],

--- a/server/utils/organisationUtils.test.ts
+++ b/server/utils/organisationUtils.test.ts
@@ -10,6 +10,7 @@ import {
 } from '../testutils/factories'
 import type { Course, CourseOffering, Organisation } from '@accredited-programmes/models'
 import type { OrganisationWithOfferingId } from '@accredited-programmes/ui'
+import type { EnabledOrganisation } from '@accredited-programmes-api'
 
 describe('OrganisationUtils', () => {
   describe('organisationFromPrison', () => {
@@ -34,15 +35,29 @@ describe('OrganisationUtils', () => {
 
   describe('organisationRadioItems', () => {
     it('returns an array of `GovukFrontendRadiosItem` objects from an array of prisons, sorted by `prisonName`', () => {
-      const prisons = [
-        prisonFactory.build({ prisonId: 'B', prisonName: 'B Prison' }),
-        prisonFactory.build({ prisonId: 'A', prisonName: 'A Prison' }),
+      const enabledOrganisations: Array<EnabledOrganisation> = [
+        { code: 'B', description: 'B Prison' },
+        { code: 'A', description: 'A Prison' },
       ]
 
-      expect(OrganisationUtils.organisationRadioItems(prisons)).toEqual([
+      expect(OrganisationUtils.organisationRadioItems(enabledOrganisations)).toEqual([
         { text: 'A Prison', value: 'A' },
         { text: 'B Prison', value: 'B' },
       ])
+    })
+
+    describe('when a organisation has an `undefined` code or description', () => {
+      it('filters out the organisation from the returned array', () => {
+        const enabledOrganisations: Array<EnabledOrganisation> = [
+          { code: 'B', description: 'B Prison' },
+          { code: undefined, description: 'A Prison' },
+          { code: 'A', description: undefined },
+        ]
+
+        expect(OrganisationUtils.organisationRadioItems(enabledOrganisations)).toEqual([
+          { text: 'B Prison', value: 'B' },
+        ])
+      })
     })
   })
 

--- a/server/utils/organisationUtils.ts
+++ b/server/utils/organisationUtils.ts
@@ -5,6 +5,7 @@ import type {
   OrganisationWithOfferingEmailsPresenter,
   OrganisationWithOfferingId,
 } from '@accredited-programmes/ui'
+import type { EnabledOrganisation } from '@accredited-programmes-api'
 import type { GovukFrontendRadiosItem, GovukFrontendSelectItem, GovukFrontendTableRow } from '@govuk-frontend'
 import type { Prison } from '@prison-register-api'
 
@@ -21,15 +22,14 @@ export default class OrganisationUtils {
     }
   }
 
-  static organisationRadioItems(organisations: Array<Prison>): Array<GovukFrontendRadiosItem> {
+  static organisationRadioItems(organisations: Array<EnabledOrganisation>): Array<GovukFrontendRadiosItem> {
     return organisations
-      .sort((a, b) => a.prisonName.localeCompare(b.prisonName))
-      .map(organisation => {
-        return {
-          text: organisation.prisonName,
-          value: organisation.prisonId,
-        }
-      })
+      .filter(({ code, description }) => code && description)
+      .sort((a, b) => a.description!.localeCompare(b.description!))
+      .map(({ description, code }) => ({
+        text: description!,
+        value: code!,
+      }))
   }
 
   static organisationSelectItems(organisations: Array<Prison>): Array<GovukFrontendSelectItem> {

--- a/server/utils/statisticsReportUtils.test.ts
+++ b/server/utils/statisticsReportUtils.test.ts
@@ -165,6 +165,7 @@ describe('StatisticsReportUtils', () => {
   describe('reportContentTitle', () => {
     it('returns the title for the given report type', () => {
       expect(StatisticsReportUtils.reportContentTitle('REFERRAL_COUNT')).toEqual('Total referrals submitted')
+      expect(StatisticsReportUtils.reportContentTitle('ON_PROGRAMME_COUNT')).toEqual('Total programmes started')
       expect(StatisticsReportUtils.reportContentTitle('PROGRAMME_COMPLETE_COUNT')).toEqual('Total programmes completed')
       expect(StatisticsReportUtils.reportContentTitle('NOT_ELIGIBLE_COUNT')).toEqual('Total referrals not eligible')
       expect(StatisticsReportUtils.reportContentTitle('WITHDRAWN_COUNT')).toEqual('Total referrals withdrawn')

--- a/server/utils/statisticsReportUtils.ts
+++ b/server/utils/statisticsReportUtils.ts
@@ -121,6 +121,8 @@ export default class StatisticsReportUtils {
     switch (reportType) {
       case 'REFERRAL_COUNT':
         return 'Total referrals submitted'
+      case 'ON_PROGRAMME_COUNT':
+        return 'Total programmes started'
       case 'PROGRAMME_COMPLETE_COUNT':
         return 'Total programmes completed'
       case 'NOT_ELIGIBLE_COUNT':


### PR DESCRIPTION
## Context

Building on the data reporting dashboard, users will need the ability to filter the data reports by prisons where ACP is enabled.


## Changes in this PR

- Show on programme count
- Only show enabled organisations in filters ist


## Screenshots of UI changes

![image](https://github.com/user-attachments/assets/163462fb-7230-43c7-9c47-3c493913029d)



## Release checklist

[Release process documentation](../doc/how-to/perform-a-release.md)

As part of our continuous deployment strategy we must ensure that this work is
ready to be released once merged.

### Pre-merge

- [ ] There are changes required to the Accredited Programmes API for this change to work...
  - [ ] ... and they have been released to production already

### Post-merge

<!-- The outer checkboxes can be completed pre-merge -->

- [ ] This adds, extends or meaningfully modifies a feature...
  - [ ] ... and I have written or updated an end-to-end test for the happy path in the [Accredited Programmes E2E repo](https://github.com/ministryofjustice/hmpps-accredited-programmes-e2e)
- [ ] This makes new expectations of the API...
  - [ ] ... and I have notified the API developer(s) of changes to the contract tests (Pact), or the API is already compliant
- [ ] [Manually approve](../doc/how-to/perform-a-release.md#releasing-to-the-preprod-environment) release to preprod
- [ ] [Manually approve](../doc/how-to/perform-a-release.md#releasing-to-the-production-environment) release to prod

<!-- Should a release fail at any step, you as the author should now lead the work to
fix it as soon as possible. You can monitor deployment failures in CircleCI
itself and application errors are found in
[Sentry](https://ministryofjustice.sentry.io/projects/hmpps-accredited-programmes-ui/?project=4505330122686464&referrer=sidebar&statsPeriod=24h). -->
