### PR TITLE
(APG-408) Add link from homepage to report data

### DIFF
--- a/integration_tests/e2e/app.cy.ts
+++ b/integration_tests/e2e/app.cy.ts
@@ -73,6 +73,7 @@ context('App', () => {
       const indexPage = Page.verifyOnPage(IndexPage)
       indexPage.shouldContainLink('Find a programme and make a referral', '/find/programmes')
       indexPage.shouldContainLink('My referrals', '/refer/referrals/case-list')
+      indexPage.shouldContainLink('Reporting data', '/reports')
     })
   })
 
@@ -85,6 +86,7 @@ context('App', () => {
       const indexPage = Page.verifyOnPage(IndexPage)
       indexPage.shouldContainLink('Find a programme and make a referral', '/find/programmes')
       indexPage.shouldContainLink('Manage your programme team’s referrals', '/assess/referrals/case-list')
+      indexPage.shouldContainLink('Reporting data', '/reports')
     })
   })
 

--- a/server/controllers/dashboardController.test.ts
+++ b/server/controllers/dashboardController.test.ts
@@ -27,6 +27,7 @@ describe('DashboardController', () => {
         findPath: findPaths.index({}),
         pageHeading: 'Accredited Programmes: find and refer',
         referCaseListPath: '/refer/referrals/case-list',
+        reportPath: '/reports',
       })
     })
   })

--- a/server/controllers/dashboardController.ts
+++ b/server/controllers/dashboardController.ts
@@ -1,6 +1,6 @@
 import type { Request, RequestHandler, Response } from 'express'
 
-import { assessPaths, findPaths, referPaths } from '../paths'
+import { assessPaths, findPaths, referPaths, reportsPaths } from '../paths'
 
 export default class DashboardController {
   index(): RequestHandler {
@@ -10,6 +10,7 @@ export default class DashboardController {
         findPath: findPaths.index({}),
         pageHeading: 'Accredited Programmes: find and refer',
         referCaseListPath: referPaths.caseList.index({}),
+        reportPath: reportsPaths.show({}),
       })
     }
   }

--- a/server/views/dashboard/index.njk
+++ b/server/views/dashboard/index.njk
@@ -54,6 +54,14 @@
         </div>
       {% endif %}
 
+      <div class="govuk-grid-column-one-third dashboard__card-wrapper">
+        <div class="dashboard__card">
+          <h2 class="govuk-heading-m dashboard__card-heading">
+            <a class="govuk-link dashboard__card-link" href="{{ reportPath }}">Reporting data</a>
+          </h2>
+          <p class="govuk-body dashboard__card-description">See data about Accredited programmes.</p>
+        </div>
+      </div>
     </div>
   </div>
 {% endblock content %}


### PR DESCRIPTION
## Context

New report page needs to be easily accessible to all users.



## Changes in this PR
Add link on the service homepage to the new reports page at /reports.


## Screenshots of UI changes

![image](https://github.com/user-attachments/assets/616c5556-e259-4cf4-9558-a206412fffd9)



## Release checklist

[Release process documentation](../doc/how-to/perform-a-release.md)

As part of our continuous deployment strategy we must ensure that this work is
ready to be released once merged.

### Pre-merge

- [ ] There are changes required to the Accredited Programmes API for this change to work...
  - [ ] ... and they have been released to production already

### Post-merge

<!-- The outer checkboxes can be completed pre-merge -->

- [ ] This adds, extends or meaningfully modifies a feature...
  - [ ] ... and I have written or updated an end-to-end test for the happy path in the [Accredited Programmes E2E repo](https://github.com/ministryofjustice/hmpps-accredited-programmes-e2e)
- [ ] This makes new expectations of the API...
  - [ ] ... and I have notified the API developer(s) of changes to the contract tests (Pact), or the API is already compliant
- [ ] [Manually approve](../doc/how-to/perform-a-release.md#releasing-to-the-preprod-environment) release to preprod
- [ ] [Manually approve](../doc/how-to/perform-a-release.md#releasing-to-the-production-environment) release to prod

<!-- Should a release fail at any step, you as the author should now lead the work to
fix it as soon as possible. You can monitor deployment failures in CircleCI
itself and application errors are found in
[Sentry](https://ministryofjustice.sentry.io/projects/hmpps-accredited-programmes-ui/?project=4505330122686464&referrer=sidebar&statsPeriod=24h). -->
