### PR TITLE
(APG-385e) Update content on the report page

### DIFF
--- a/server/controllers/reportsController.test.ts
+++ b/server/controllers/reportsController.test.ts
@@ -130,7 +130,7 @@ describe('ReportsController', () => {
         pageHeading: 'Accredited Programmes data',
         prisonLocationOptions,
         reportDataBlocks: Array(reportTypes.length).fill(reportDataBlock),
-        subHeading: 'Showing data from 1 January 2024 to 31 January 2024',
+        subHeading: 'Showing national data from 1 January 2024 to 31 January 2024',
       })
     })
 

--- a/server/controllers/reportsController.ts
+++ b/server/controllers/reportsController.ts
@@ -66,7 +66,7 @@ export default class ReportsController {
       const selectedPrison = organisations.find(org => org.code === location)?.description
 
       const subHeading = [
-        'Showing data',
+        selectedPrison ? 'Showing data' : 'Showing national data',
         selectedPrison ? `for ${selectedPrison}` : '',
         'from',
         DateUtils.govukFormattedFullDateString(apiParams.startDate),

--- a/server/utils/statisticsReportUtils.test.ts
+++ b/server/utils/statisticsReportUtils.test.ts
@@ -169,7 +169,7 @@ describe('StatisticsReportUtils', () => {
       expect(StatisticsReportUtils.reportContentTitle('PROGRAMME_COMPLETE_COUNT')).toEqual('Total programmes completed')
       expect(StatisticsReportUtils.reportContentTitle('NOT_ELIGIBLE_COUNT')).toEqual('Total referrals not eligible')
       expect(StatisticsReportUtils.reportContentTitle('WITHDRAWN_COUNT')).toEqual('Total referrals withdrawn')
-      expect(StatisticsReportUtils.reportContentTitle('DESELECTED_COUNT')).toEqual('Total referrals deselected')
+      expect(StatisticsReportUtils.reportContentTitle('DESELECTED_COUNT')).toEqual('Total participants deselected')
     })
 
     describe('when the report type is unknown', () => {

--- a/server/utils/statisticsReportUtils.ts
+++ b/server/utils/statisticsReportUtils.ts
@@ -130,7 +130,7 @@ export default class StatisticsReportUtils {
       case 'WITHDRAWN_COUNT':
         return 'Total referrals withdrawn'
       case 'DESELECTED_COUNT':
-        return 'Total referrals deselected'
+        return 'Total participants deselected'
       default:
         return 'Unknown'
     }


### PR DESCRIPTION
## Context
Content updates


## Changes in this PR
Add "national" before data when no prison is selected.
Change "Total referrals deselected" to "Total participants deselected"



## Release checklist

[Release process documentation](../doc/how-to/perform-a-release.md)

As part of our continuous deployment strategy we must ensure that this work is
ready to be released once merged.

### Pre-merge

- [ ] There are changes required to the Accredited Programmes API for this change to work...
  - [ ] ... and they have been released to production already

### Post-merge

<!-- The outer checkboxes can be completed pre-merge -->

- [ ] This adds, extends or meaningfully modifies a feature...
  - [ ] ... and I have written or updated an end-to-end test for the happy path in the [Accredited Programmes E2E repo](https://github.com/ministryofjustice/hmpps-accredited-programmes-e2e)
- [ ] This makes new expectations of the API...
  - [ ] ... and I have notified the API developer(s) of changes to the contract tests (Pact), or the API is already compliant
- [ ] [Manually approve](../doc/how-to/perform-a-release.md#releasing-to-the-preprod-environment) release to preprod
- [ ] [Manually approve](../doc/how-to/perform-a-release.md#releasing-to-the-production-environment) release to prod

<!-- Should a release fail at any step, you as the author should now lead the work to
fix it as soon as possible. You can monitor deployment failures in CircleCI
itself and application errors are found in
[Sentry](https://ministryofjustice.sentry.io/projects/hmpps-accredited-programmes-ui/?project=4505330122686464&referrer=sidebar&statsPeriod=24h). -->
