### PR TITLE
(APG-376a) Add name or prison number search to assess case list

### DIFF
--- a/assets/scss/local.scss
+++ b/assets/scss/local.scss
@@ -19,38 +19,42 @@
   overflow-x: auto;
 }
 
-.filters {
-  @include govuk-responsive-padding(3);
-  @include govuk-responsive-margin(7, 'bottom');
+.horizontal-filter {
+  * {
+    width: 100%;
+  }
 
-  background-color: govuk-colour('light-grey');
+  :last-child {
+    margin-bottom: 0;
+  }
 
-  .form-controls {
+  .govuk-button {
+    margin-top: govuk-spacing(3);
+    margin-right: 0;
+  }
+
+  @include govuk-media-query($from: desktop) {
+    display: flex;
+    align-items: flex-end;
+    flex-wrap: wrap;
+    row-gap: govuk-spacing(3);
+
     * {
-      width: 100%;
+      width: auto;
     }
 
-    :last-child {
+    .govuk-select--restrict-width {
+      max-width: 250px;
+    }
+
+    .govuk-button {
+      margin-right: govuk-spacing(3);
+      margin-bottom: $govuk-border-width-form-element;
+    }
+
+    .govuk-form-group {
       margin-bottom: 0;
-    }
-
-    @include govuk-media-query($from: desktop) {
-      display: flex;
-      align-items: flex-end;
-      flex-wrap: wrap;
-
-      * {
-        width: auto;
-      }
-
-      .govuk-button {
-        margin-bottom: $govuk-border-width-form-element;
-      }
-
-      .govuk-form-group {
-        margin-bottom: 0;
-        margin-right: govuk-spacing(3);
-      }
+      margin-right: govuk-spacing(3);
     }
   }
 }

--- a/server/controllers/assess/caseListController.ts
+++ b/server/controllers/assess/caseListController.ts
@@ -4,7 +4,7 @@ import createError from 'http-errors'
 import { assessPaths } from '../../paths'
 import type { CourseService, ReferenceDataService, ReferralService } from '../../services'
 import { CaseListUtils, FormUtils, PaginationUtils, PathUtils, TypeUtils } from '../../utils'
-import type { ReferralStatusGroup } from '@accredited-programmes/models'
+import type { Paginated, ReferralStatusGroup, ReferralView } from '@accredited-programmes/models'
 import type { CaseListColumnHeader, SortableCaseListColumnKey } from '@accredited-programmes/ui'
 
 export default class AssessCaseListController {
@@ -19,17 +19,18 @@ export default class AssessCaseListController {
       TypeUtils.assertHasUser(req)
 
       const { courseId, referralStatusGroup } = req.params
-      const { audience, status } = req.body
+      const { audience, nameOrId, status } = req.body
 
-      if (!audience && !status) {
+      if (!audience && !status && !nameOrId) {
         req.flash('audienceError', 'Choose a filter')
+        req.flash('nameOrIdError', 'Enter a name or prison number')
         return res.redirect(assessPaths.caseList.show({ courseId, referralStatusGroup }))
       }
 
       return res.redirect(
         PathUtils.pathWithQuery(
           assessPaths.caseList.show({ courseId, referralStatusGroup }),
-          CaseListUtils.queryParamsExcludingPage(audience, status),
+          CaseListUtils.queryParamsExcludingPage(audience, status, undefined, undefined, nameOrId),
         ),
       )
     }
@@ -57,12 +58,20 @@ export default class AssessCaseListController {
       TypeUtils.assertHasUser(req)
 
       const { courseId } = req.params
-      const { page, status, strand: audience, sortColumn, sortDirection } = req.query as Record<string, string>
-      const referralsFiltered = !!status || !!audience
+      const {
+        nameOrId,
+        page,
+        status,
+        strand: audience,
+        sortColumn,
+        sortDirection,
+      } = req.query as Record<string, string>
+      const referralsFiltered = !!status || !!audience || !!nameOrId
       const { referralStatusGroup } = req.params as { referralStatusGroup: ReferralStatusGroup }
 
-      const isValidReferralStatusGroup = ['open', 'closed'].includes(referralStatusGroup)
-      FormUtils.setFieldErrors(req, res, ['audience', 'status'])
+      const statusGroups: Array<ReferralStatusGroup> = ['open', 'closed']
+      const isValidReferralStatusGroup = statusGroups.includes(referralStatusGroup)
+      FormUtils.setFieldErrors(req, res, ['audience', 'nameOrId', 'status'])
 
       if (!isValidReferralStatusGroup) {
         throw createError(404, 'Not found')
@@ -78,33 +87,45 @@ export default class AssessCaseListController {
         throw createError(404, `Course with ID ${courseId} not found.`)
       }
 
-      const [paginatedReferralViews, referralStatuses] = await Promise.all([
-        this.referralService.getReferralViews(username, activeCaseLoadId, {
-          audience: CaseListUtils.uiToApiAudienceQueryParam(audience),
-          courseName: selectedCourse.name,
-          page: page ? (Number(page) - 1).toString() : undefined,
-          sortColumn,
-          sortDirection,
-          status,
-          statusGroup: referralStatusGroup,
-        }),
+      const [allReferralViews, referralStatuses] = await Promise.all([
+        Object.fromEntries(
+          await Promise.all(
+            statusGroups.map(async group => {
+              const referralViews = await this.referralService.getReferralViews(username, activeCaseLoadId, {
+                audience: CaseListUtils.uiToApiAudienceQueryParam(audience),
+                courseName: selectedCourse.name,
+                nameOrId,
+                page: page ? (Number(page) - 1).toString() : undefined,
+                sortColumn,
+                sortDirection,
+                status,
+                statusGroup: group,
+              })
+              return [group, referralViews]
+            }),
+          ),
+        ) as Record<ReferralStatusGroup, Paginated<ReferralView>>,
         this.referenceDataService.getReferralStatuses(username),
       ])
 
-      const availableStatuses = referralStatuses.filter(referralStatus =>
-        referralStatusGroup === 'open' ? !referralStatus.closed && !referralStatus.draft : referralStatus.closed,
+      const openReferralStatuses = referralStatuses.filter(
+        referralStatus => !referralStatus.closed && !referralStatus.draft,
       )
+
+      const closedReferralStatuses = referralStatuses.filter(referralStatus => referralStatus.closed)
+
+      const selectedReferralViews = allReferralViews[referralStatusGroup]
 
       const pagination = PaginationUtils.pagination(
         req.path,
-        CaseListUtils.queryParamsExcludingPage(audience, status, sortColumn, sortDirection),
-        paginatedReferralViews.pageNumber,
-        paginatedReferralViews.totalPages,
+        CaseListUtils.queryParamsExcludingPage(audience, status, sortColumn, sortDirection, nameOrId),
+        selectedReferralViews.pageNumber,
+        selectedReferralViews.totalPages,
       )
 
       const basePathExcludingSort = PathUtils.pathWithQuery(
         assessPaths.caseList.show({ courseId, referralStatusGroup }),
-        CaseListUtils.queryParamsExcludingSort(audience, status, page),
+        CaseListUtils.queryParamsExcludingSort(audience, status, page, nameOrId),
       )
 
       /* eslint-disable sort-keys */
@@ -123,13 +144,25 @@ export default class AssessCaseListController {
       return res.render('referrals/caseList/assess/show', {
         action: assessPaths.caseList.filter({ courseId, referralStatusGroup }),
         audienceSelectItems: CaseListUtils.audienceSelectItems(audience),
+        nameOrId,
         pageHeading: selectedCourse.name,
         pagination,
         primaryNavigationItems: CaseListUtils.primaryNavigationItems(req.path, courses),
         referralStatusGroup,
-        referralStatusSelectItems: CaseListUtils.statusSelectItems(availableStatuses, status),
+        referralStatusSelectItems: {
+          closed: CaseListUtils.statusSelectItems(closedReferralStatuses, status, true),
+          open: CaseListUtils.statusSelectItems(openReferralStatuses, status, true),
+        },
         referralsFiltered,
-        subNavigationItems: CaseListUtils.assessSubNavigationItems(req.path, courseId),
+        subNavigationItems: CaseListUtils.assessSubNavigationItems(
+          req.path,
+          courseId,
+          {
+            closed: allReferralViews.closed.totalElements,
+            open: allReferralViews.open.totalElements,
+          },
+          CaseListUtils.queryParamsExcludingPage(audience, status, sortColumn, sortDirection, nameOrId),
+        ),
         tableHeadings: CaseListUtils.sortableTableHeadings(
           basePathExcludingSort,
           caseListColumns,
@@ -137,7 +170,7 @@ export default class AssessCaseListController {
           sortDirection,
         ),
         tableRows: CaseListUtils.tableRows(
-          paginatedReferralViews.content,
+          selectedReferralViews.content,
           Object.values(caseListColumns).map(value => value),
         ),
       })

--- a/server/data/accreditedProgrammesApi/referralClient.ts
+++ b/server/data/accreditedProgrammesApi/referralClient.ts
@@ -100,6 +100,7 @@ export default class ReferralClient {
     query?: {
       audience?: string
       courseName?: string
+      nameOrId?: string
       page?: string
       sortColumn?: string
       sortDirection?: string
@@ -112,6 +113,7 @@ export default class ReferralClient {
       query: {
         ...(query?.audience && { audience: query.audience }),
         ...(query?.courseName && { courseName: query.courseName }),
+        ...(query?.nameOrId && { nameOrId: query.nameOrId }),
         ...(query?.page && { page: query.page }),
         ...(query?.sortColumn && { sortColumn: query.sortColumn }),
         ...(query?.sortDirection && { sortDirection: query.sortDirection }),

--- a/server/services/referralService.test.ts
+++ b/server/services/referralService.test.ts
@@ -338,6 +338,7 @@ describe('ReferralService', () => {
         const query: {
           audience: string
           courseName: string
+          nameOrId: string
           page: string
           sortColumn: string
           sortDirection: string
@@ -346,6 +347,7 @@ describe('ReferralService', () => {
         } = {
           audience: 'General offence',
           courseName: 'Lime Course',
+          nameOrId: 'Hatton',
           page: '1',
           sortColumn: 'surname',
           sortDirection: 'ascending',

--- a/server/services/referralService.ts
+++ b/server/services/referralService.ts
@@ -139,6 +139,7 @@ export default class ReferralService {
     query?: {
       audience?: string
       courseName?: string
+      nameOrId?: string
       page?: string
       sortColumn?: string
       sortDirection?: string

--- a/server/utils/formUtils.test.ts
+++ b/server/utils/formUtils.test.ts
@@ -36,6 +36,15 @@ describe('FormUtils', () => {
         ])
       })
     })
+
+    describe('when the placeholder should be hidden', () => {
+      it('formats the options in the appropriate format for passing to a GOV.UK Select nunjucks macro without a placeholder', () => {
+        expect(FormUtils.getSelectItems(items, undefined, true)).toEqual([
+          { selected: false, text: 'Option A', value: 'optionA' },
+          { selected: false, text: 'Option B', value: 'optionB' },
+        ])
+      })
+    })
   })
 
   describe('setFieldErrors', () => {

--- a/server/utils/formUtils.ts
+++ b/server/utils/formUtils.ts
@@ -7,9 +7,13 @@ import type {
 } from '@govuk-frontend'
 
 export default class FormUtils {
-  static getSelectItems(items: Record<string, string>, selectedValue?: string): Array<GovukFrontendSelectItem> {
+  static getSelectItems(
+    items: Record<string, string>,
+    selectedValue?: string,
+    hidePlaceholder?: boolean,
+  ): Array<GovukFrontendSelectItem> {
     return [
-      { selected: Boolean(!selectedValue), text: 'Select', value: '' },
+      ...(!hidePlaceholder ? [{ selected: Boolean(!selectedValue), text: 'Select', value: '' }] : []),
       ...Object.entries(items).map(([value, text]) => ({
         selected: value === selectedValue,
         text,

--- a/server/views/referrals/caseList/assess/selectWithOptGroup.njk
+++ b/server/views/referrals/caseList/assess/selectWithOptGroup.njk
@@ -1,0 +1,69 @@
+{% from "govuk/components/error-message/macro.njk" import govukErrorMessage %}
+{% from "govuk/components/hint/macro.njk" import govukHint %}
+{% from "govuk/components/label/macro.njk" import govukLabel %}
+{% macro govukSelectWithOptgroup(params) %}
+  {#- a record of other elements that we need to associate with the input using
+  aria-describedby – for example hints or error messages -#}
+  {% set describedBy = params.describedBy if params.describedBy else 
+    "" %}
+  {% set prompt = params.prompt if params.prompt else 
+    "Please select" %}
+  <div class="govuk-form-group {%- if params.errorMessage %} govuk-form-group--error{% endif %} {%- if params.formGroup.classes %} {{ params.formGroup.classes }}{% endif %}" {%- for attribute, value in params.formGroup.attributes %} {{ attribute }}="{{ value }}"{% endfor %}>
+    {{ govukLabel({
+    html: params.label.html,
+    text: params.label.text,
+    classes: params.label.classes,
+    isPageHeading: params.label.isPageHeading,
+    attributes: params.label.attributes,
+    for: params.id
+  }) | indent(2) | trim }}
+    {% if params.hint %}
+      {% set hintId = params.id + '-hint' %}
+      {% set describedBy = describedBy + ' ' + hintId if describedBy else 
+        hintId %}
+      {{ govukHint({
+    id: hintId,
+    classes: params.hint.classes,
+    attributes: params.hint.attributes,
+    html: params.hint.html,
+    text: params.hint.text
+  }) | indent(2) | trim }}
+    {% endif %}
+    {% if params.errorMessage %}
+      {% set errorId = params.id + '-error' %}
+      {% set describedBy = describedBy + ' ' + errorId if describedBy else 
+        errorId %}
+      {{ govukErrorMessage({
+    id: errorId,
+    classes: params.errorMessage.classes,
+    attributes: params.errorMessage.attributes,
+    html: params.errorMessage.html,
+    text: params.errorMessage.text,
+    visuallyHiddenText: params.errorMessage.visuallyHiddenText
+  }) | indent(2) | trim }}
+    {% endif %}
+    <select class="govuk-select
+    {%- if params.classes %} {{ params.classes }}{% endif %}{%- if params.errorMessage %} govuk-select--error{% endif %}" id="{{ params.id }}" name="{{ params.name }}"
+    {%- if params.disabled %} disabled{% endif %}
+    {%- if describedBy %} aria-describedby="{{ describedBy }}"{% endif %}
+    {%- for attribute, value in params.attributes %} {{ attribute }}="{{ value }}"{% endfor %}>
+      <option value="" selected>{{ prompt }}</option>
+      {% for optgroup in params.items %}
+        {% if optgroup %}
+          <optgroup label="{{ optgroup.label }}">
+            {% for item in optgroup.items %}
+              {% if item %}
+                {# Allow selecting by text content (the value for an option when no value attribute is specified) #}
+                {% set effectiveValue = item.value | default(item.text) %}
+                <option {%- if item.value !== undefined %} value="{{ item.value }}"{% endif %}
+              {{-" selected" if item.selected | default((effectiveValue == params.value and item.selected != false) if params.value else false, true) }}
+              {{-" disabled" if item.disabled }}
+              {%- for attribute, value in item.attributes %} {{ attribute }}="{{ value }}"{% endfor %}>{{ item.text }}</option>
+              {% endif %}
+            {% endfor %}
+          </optgroup>
+        {% endif %}
+      {% endfor %}
+    </select>
+  </div>
+{% endmacro %}

--- a/server/views/referrals/caseList/assess/show.njk
+++ b/server/views/referrals/caseList/assess/show.njk
@@ -1,10 +1,13 @@
 {% from "govuk/components/button/macro.njk" import govukButton %}
 {% from "govuk/components/error-summary/macro.njk" import govukErrorSummary %}
+{% from "govuk/components/input/macro.njk" import govukInput %}
 {% from "govuk/components/pagination/macro.njk" import govukPagination %}
 {% from "govuk/components/select/macro.njk" import govukSelect %}
 {% from "govuk/components/table/macro.njk" import govukTable %}
 {% from "moj/components/primary-navigation/macro.njk" import mojPrimaryNavigation %}
 {% from "moj/components/sub-navigation/macro.njk" import mojSubNavigation %}
+
+{% from "./selectWithOptGroup.njk" import govukSelectWithOptgroup %}
 
 {% extends "../../../partials/layout.njk" %}
 
@@ -37,6 +40,20 @@
       <form class="form-controls" action="{{ action }}" method="post">
         <input type="hidden" name="_csrf" value="{{ csrfToken }}"/>
 
+        {{ govukInput({
+          label: {
+            text: "Search by name or prison number"
+          },
+          classes: "govuk-!-width-full",
+          id: "nameOrId",
+          name: "nameOrId",
+          value: nameOrId,
+          attributes: {
+            "data-testid": "search-input"
+          },
+          errorMessage: errors.messages.nameOrId
+        }) }}
+
         {{ govukSelect({
           id: "audience",
           name: "audience",
@@ -50,13 +67,24 @@
           errorMessage: errors.messages.audience
         }) }}
 
-        {{ govukSelect({
+        {{
+          govukSelectWithOptgroup({
           id: "status",
           name: "status",
+          prompt: "Select",
           label: {
             text: "Referral status"
           },
-          items: referralStatusSelectItems,
+          items: [
+            {
+              label: 'Open referrals',
+              items: referralStatusSelectItems.open
+            },
+            {
+              label: 'Closed referrals',
+              items: referralStatusSelectItems.closed
+            }
+          ],
           attributes: {
             "data-testid": "referral-status-select"
           },

--- a/server/views/referrals/caseList/assess/show.njk
+++ b/server/views/referrals/caseList/assess/show.njk
@@ -35,70 +35,81 @@
 
   {% if tableRows | length or(not tableRows | length and referralsFiltered) %}
 
-    <div class="filters">
-      <h2 class="govuk-heading-m">Filters</h2>
-      <form class="form-controls" action="{{ action }}" method="post">
-        <input type="hidden" name="_csrf" value="{{ csrfToken }}"/>
+    <div class="moj-filter govuk-!-margin-bottom-7">
+      <div class="moj-filter__header">
+        <div class="moj-filter__header-title">
+          <h2 class="govuk-heading-m">Filters</h2>
+        </div>
+      </div>
 
-        {{ govukInput({
-          label: {
-            text: "Search by name or prison number"
-          },
-          classes: "govuk-!-width-full",
-          id: "nameOrId",
-          name: "nameOrId",
-          value: nameOrId,
-          attributes: {
-            "data-testid": "search-input"
-          },
-          errorMessage: errors.messages.nameOrId
-        }) }}
+      <div class="moj-filter__content">
+        <div class="moj-filter__options">
+          <form class="horizontal-filter" action="{{ action }}" method="post">
+            <input type="hidden" name="_csrf" value="{{ csrfToken }}"/>
 
-        {{ govukSelect({
-          id: "audience",
-          name: "audience",
-          label: {
-            text: "Programme strand"
-          },
-          items: audienceSelectItems,
-            attributes: {
-            "data-testid": "programme-strand-select"
-          },
-          errorMessage: errors.messages.audience
-        }) }}
+            {{ govukInput({
+              label: {
+                text: "Search by name or prison number"
+              },
+              classes: "govuk-!-width-full",
+              id: "nameOrId",
+              name: "nameOrId",
+              value: nameOrId,
+              attributes: {
+                "data-testid": "search-input"
+              },
+              errorMessage: errors.messages.nameOrId
+            }) }}
 
-        {{
-          govukSelectWithOptgroup({
-          id: "status",
-          name: "status",
-          prompt: "Select",
-          label: {
-            text: "Referral status"
-          },
-          items: [
-            {
-              label: 'Open referrals',
-              items: referralStatusSelectItems.open
-            },
-            {
-              label: 'Closed referrals',
-              items: referralStatusSelectItems.closed
-            }
-          ],
-          attributes: {
-            "data-testid": "referral-status-select"
-          },
-          errorMessage: errors.messages.audience
-        }) }}
+            {{ govukSelect({
+              id: "audience",
+              name: "audience",
+              label: {
+                text: "Programme strand"
+              },
+              items: audienceSelectItems,
+                attributes: {
+                "data-testid": "programme-strand-select"
+              },
+              classes: "govuk-select--restrict-width",
+              errorMessage: errors.messages.audience
+            }) }}
 
-        <span class="govuk-button-group">
-          {{ govukButton({
-            text: "Apply filters"
-          }) }}
+            {{
+              govukSelectWithOptgroup({
+              id: "status",
+              name: "status",
+              prompt: "Select",
+              label: {
+                text: "Referral status"
+              },
+              items: [
+                {
+                  label: 'Open referrals',
+                  items: referralStatusSelectItems.open
+                },
+                {
+                  label: 'Closed referrals',
+                  items: referralStatusSelectItems.closed
+                }
+              ],
+              attributes: {
+                "data-testid": "referral-status-select"
+              },
+              classes: "govuk-select--restrict-width",
+              errorMessage: errors.messages.audience
+            }) }}
 
-          <a href="{{ referralStatusGroup }}" class="govuk-link govuk-link--no-visited-state">Clear filters</a>
-        </span>
-      </form>
+            <span class="govuk-button-group">
+              {{ govukButton({
+                text: "Apply filters"
+              }) }}
+
+              <a href="{{ referralStatusGroup }}" class="govuk-link govuk-link--no-visited-state">Clear filters</a>
+            </span>
+          </form>
+        </div>
+      </div>
     </div>
 
   {% endif %}


### PR DESCRIPTION
## Context

We need the ability to search case lists.


## Changes in this PR
- Add search functionality to assess case list
- Show number of results for both open and closed referrals
- Show all referral statuses, in option groups


## Screenshots of UI changes

![image](https://github.com/user-attachments/assets/ff1ad53e-53d9-4026-8355-291ae1d3cadd)



## Release checklist

[Release process documentation](../doc/how-to/perform-a-release.md)

As part of our continuous deployment strategy we must ensure that this work is
ready to be released once merged.

### Pre-merge

- [ ] There are changes required to the Accredited Programmes API for this change to work...
  - [ ] ... and they have been released to production already

### Post-merge

<!-- The outer checkboxes can be completed pre-merge -->

- [ ] This adds, extends or meaningfully modifies a feature...
  - [ ] ... and I have written or updated an end-to-end test for the happy path in the [Accredited Programmes E2E repo](https://github.com/ministryofjustice/hmpps-accredited-programmes-e2e)
- [ ] This makes new expectations of the API...
  - [ ] ... and I have notified the API developer(s) of changes to the contract tests (Pact), or the API is already compliant
- [ ] [Manually approve](../doc/how-to/perform-a-release.md#releasing-to-the-preprod-environment) release to preprod
- [ ] [Manually approve](../doc/how-to/perform-a-release.md#releasing-to-the-production-environment) release to prod

<!-- Should a release fail at any step, you as the author should now lead the work to
fix it as soon as possible. You can monitor deployment failures in CircleCI
itself and application errors are found in
[Sentry](https://ministryofjustice.sentry.io/projects/hmpps-accredited-programmes-ui/?project=4505330122686464&referrer=sidebar&statsPeriod=24h). -->
