### PR TITLE
(APG-376b) Add search box to refer case list

### DIFF
--- a/integration_tests/pages/refer/new/delete.ts
+++ b/integration_tests/pages/refer/new/delete.ts
@@ -24,6 +24,17 @@ export default class NewReferralTaskListPage extends Page {
     cy.task('stubFindMyReferralViews', {
       queryParameters: { statusGroup: { equalTo: 'draft' } },
       referralViews: draftReferralViews,
+      totalElements: draftReferralViews.length,
+    })
+    cy.task('stubFindMyReferralViews', {
+      queryParameters: { statusGroup: { equalTo: 'open' } },
+      referralViews: [],
+      totalElements: 0,
+    })
+    cy.task('stubFindMyReferralViews', {
+      queryParameters: { statusGroup: { equalTo: 'closed' } },
+      referralViews: [],
+      totalElements: 0,
     })
 
     this.shouldContainButton('Delete draft').click()

--- a/integration_tests/pages/shared/caseList.ts
+++ b/integration_tests/pages/shared/caseList.ts
@@ -24,6 +24,11 @@ export default class CaseListPage extends Page {
     this.referralViews = referralViews
   }
 
+  searchFor(searchTerm: string) {
+    cy.get('[data-testid="search-input"]').type(searchTerm)
+    cy.get('form').submit()
+  }
+
   shouldClearFilters() {
     this.shouldContainLink('Clear filters', 'open').click()
   }
@@ -59,6 +64,10 @@ export default class CaseListPage extends Page {
     })
   }
 
+  shouldContainSearchInput(searchTerm?: string) {
+    cy.get('[data-testid="search-input"]').should('have.value', searchTerm || '')
+  }
+
   shouldContainStatusNavigation(
     currentReferralStatusGroup: ReferralStatusGroup,
     courseId?: Course['id'],
@@ -83,7 +92,7 @@ export default class CaseListPage extends Page {
                 'href',
                 courseId
                   ? PathUtils.pathWithQuery(assessPaths.caseList.show({ courseId, referralStatusGroup }), queryParams)
-                  : referPaths.caseList.show({ referralStatusGroup }),
+                  : PathUtils.pathWithQuery(referPaths.caseList.show({ referralStatusGroup }), queryParams),
               )
 
               if (currentReferralStatusGroup === referralStatusGroup) {

--- a/server/controllers/refer/caseListController.ts
+++ b/server/controllers/refer/caseListController.ts
@@ -5,11 +5,26 @@ import { referralStatusGroups } from '../../@types/models/Referral'
 import { referPaths } from '../../paths'
 import type { ReferralService } from '../../services'
 import { CaseListUtils, PaginationUtils, PathUtils, TypeUtils } from '../../utils'
-import type { ReferralStatusGroup } from '@accredited-programmes/models'
+import type { Paginated, ReferralStatusGroup, ReferralView } from '@accredited-programmes/models'
 import { type CaseListColumnHeader, type SortableCaseListColumnKey } from '@accredited-programmes/ui'
 
 export default class ReferCaseListController {
   constructor(private readonly referralService: ReferralService) {}
+
+  filter(): TypedRequestHandler<Request, Response> {
+    return async (req: Request, res: Response) => {
+      TypeUtils.assertHasUser(req)
+      const { referralStatusGroup } = req.params
+      const { nameOrId } = req.body
+
+      return res.redirect(
+        PathUtils.pathWithQuery(
+          referPaths.caseList.show({ referralStatusGroup }),
+          CaseListUtils.queryParamsExcludingPage(undefined, undefined, undefined, undefined, nameOrId),
+        ),
+      )
+    }
+  }
 
   indexRedirect(): TypedRequestHandler<Request, Response> {
     return async (req: Request, res: Response) => {
@@ -23,7 +38,7 @@ export default class ReferCaseListController {
     return async (req: Request, res: Response) => {
       TypeUtils.assertHasUser(req)
 
-      const { page, sortColumn, sortDirection } = req.query as Record<string, string>
+      const { nameOrId, page, sortColumn, sortDirection } = req.query as Record<string, string>
       const { username } = res.locals.user
       const { referralStatusGroup } = req.params as { referralStatusGroup: ReferralStatusGroup }
 
@@ -33,25 +48,34 @@ export default class ReferCaseListController {
         throw createHttpError(404, 'Not found')
       }
 
-      const paginatedReferralViews = await this.referralService.getMyReferralViews(username, {
-        page: page ? (Number(page) - 1).toString() : undefined,
-        sortColumn,
-        sortDirection,
-        statusGroup: referralStatusGroup,
-      })
+      const allReferralViews: Record<ReferralStatusGroup, Paginated<ReferralView>> = Object.fromEntries(
+        await Promise.all(
+          referralStatusGroups.map(async group => {
+            const referralViews = await this.referralService.getMyReferralViews(username, {
+              nameOrId,
+              page: page ? (Number(page) - 1).toString() : undefined,
+              sortColumn,
+              sortDirection,
+              statusGroup: group,
+            })
+            return [group, referralViews]
+          }),
+        ),
+      )
+      const selectedReferralViews = allReferralViews[referralStatusGroup]
 
-      let paginatedReferralViewsContent = paginatedReferralViews.content
+      let selectedReferralViewsPaginatedContent = selectedReferralViews.content
 
       const pagination = PaginationUtils.pagination(
         req.path,
-        CaseListUtils.queryParamsExcludingPage(undefined, undefined, sortColumn, sortDirection),
-        paginatedReferralViews.pageNumber,
-        paginatedReferralViews.totalPages,
+        CaseListUtils.queryParamsExcludingPage(undefined, undefined, sortColumn, sortDirection, nameOrId),
+        selectedReferralViews.pageNumber,
+        selectedReferralViews.totalPages,
       )
 
       const basePathExcludingSort = PathUtils.pathWithQuery(
         referPaths.caseList.show({ referralStatusGroup }),
-        CaseListUtils.queryParamsExcludingSort(undefined, undefined, page),
+        CaseListUtils.queryParamsExcludingSort(undefined, undefined, page, nameOrId),
       )
 
       /* eslint-disable sort-keys */
@@ -67,8 +91,8 @@ export default class ReferCaseListController {
       const isDraftCaseList = referralStatusGroup === 'draft'
 
       if (isDraftCaseList) {
-        paginatedReferralViewsContent = await Promise.all(
-          paginatedReferralViewsContent.map(async referralView => {
+        selectedReferralViewsPaginatedContent = await Promise.all(
+          selectedReferralViewsPaginatedContent.map(async referralView => {
             const tasksCompleted = await this.referralService.getNumberOfTasksCompleted(username, referralView.id)
             return { ...referralView, tasksCompleted }
           }),
@@ -80,12 +104,23 @@ export default class ReferCaseListController {
       req.session.recentCaseListPath = req.originalUrl
 
       return res.render('referrals/caseList/refer/show', {
+        action: referPaths.caseList.filter({ referralStatusGroup }),
         draftReferralDeletedMessage: req.flash('draftReferralDeletedMessage')[0],
         isMyReferralsPage: true,
+        nameOrId,
+        otherStatusGroups: referralStatusGroups.filter(group => group !== referralStatusGroup),
         pageHeading: 'My referrals',
         pagination,
         referralStatusGroup,
-        subNavigationItems: CaseListUtils.referSubNavigationItems(req.path),
+        subNavigationItems: CaseListUtils.referSubNavigationItems(
+          req.path,
+          {
+            closed: allReferralViews.closed.totalElements,
+            draft: allReferralViews.draft.totalElements,
+            open: allReferralViews.open.totalElements,
+          },
+          CaseListUtils.queryParamsExcludingPage(undefined, undefined, sortColumn, sortDirection, nameOrId),
+        ),
         tableHeadings: [
           ...CaseListUtils.sortableTableHeadings(
             basePathExcludingSort,
@@ -96,7 +131,7 @@ export default class ReferCaseListController {
           ...(isDraftCaseList ? [{ text: 'Progress' }] : []),
         ],
         tableRows: CaseListUtils.tableRows(
-          paginatedReferralViewsContent,
+          selectedReferralViewsPaginatedContent,
           [
             ...Object.values(sortableCaseListColumns).map(value => value),
             ...(isDraftCaseList ? (['Progress'] as Array<CaseListColumnHeader>) : []),

--- a/server/data/accreditedProgrammesApi/referralClient.ts
+++ b/server/data/accreditedProgrammesApi/referralClient.ts
@@ -70,6 +70,7 @@ export default class ReferralClient {
   }
 
   async findMyReferralViews(query?: {
+    nameOrId?: string
     page?: string
     sortColumn?: string
     sortDirection?: string
@@ -79,6 +80,7 @@ export default class ReferralClient {
     return (await this.restClient.get({
       path: apiPaths.referrals.myDashboard({}),
       query: {
+        ...(query?.nameOrId && { nameOrId: query.nameOrId }),
         ...(query?.page && { page: query.page }),
         ...(query?.status && { status: query.status }),
         ...(query?.statusGroup && { statusGroup: query.statusGroup }),

--- a/server/paths/refer.ts
+++ b/server/paths/refer.ts
@@ -30,6 +30,7 @@ const updateStatusSelectionShowPath = updateStatusPathBase.path('selection')
 
 export default {
   caseList: {
+    filter: caseListPath.path(':referralStatusGroup'),
     index: caseListPath,
     show: caseListPath.path(':referralStatusGroup'),
   },

--- a/server/routes/refer.ts
+++ b/server/routes/refer.ts
@@ -30,6 +30,7 @@ export default function routes(controllers: Controllers, router: Router): Router
     updateStatusSelectionController,
   } = controllers
 
+  post(referPaths.caseList.filter.pattern, referCaseListController.filter())
   get(referPaths.caseList.index.pattern, referCaseListController.indexRedirect())
   get(referPaths.caseList.show.pattern, referCaseListController.show())
 

--- a/server/services/referralService.test.ts
+++ b/server/services/referralService.test.ts
@@ -142,7 +142,8 @@ describe('ReferralService', () => {
 
     describe('with query values', () => {
       it('makes the correct call to the referral client', async () => {
-        const query: { page: string; status: string; statusGroup: ReferralStatusGroup } = {
+        const query: { nameOrId: string; page: string; status: string; statusGroup: ReferralStatusGroup } = {
+          nameOrId: 'Hatton',
           page: '1',
           status: 'REFERRAL_SUBMITTED',
           statusGroup: 'open',

--- a/server/services/referralService.ts
+++ b/server/services/referralService.ts
@@ -62,6 +62,7 @@ export default class ReferralService {
   async getMyReferralViews(
     username: Express.User['username'],
     query?: {
+      nameOrId?: string
       page?: string
       sortColumn?: string
       sortDirection?: string

--- a/server/utils/referrals/caseListUtils.test.ts
+++ b/server/utils/referrals/caseListUtils.test.ts
@@ -264,21 +264,52 @@ describe('CaseListUtils', () => {
         {
           active: true,
           href: '/refer/referrals/case-list/open',
-          text: 'Open referrals',
+          text: 'Open referrals (15)',
         },
         {
           active: false,
           href: '/refer/referrals/case-list/draft',
-          text: 'Draft referrals',
+          text: 'Draft referrals (10)',
         },
         {
           active: false,
           href: '/refer/referrals/case-list/closed',
-          text: 'Closed referrals',
+          text: 'Closed referrals (5)',
         },
       ]
 
-      expect(CaseListUtils.referSubNavigationItems(currentPath)).toEqual(expectedItems)
+      expect(CaseListUtils.referSubNavigationItems(currentPath, { closed: 5, draft: 10, open: 15 })).toEqual(
+        expectedItems,
+      )
+    })
+
+    describe('with query params', () => {
+      it('returns an array of sub navigation items for my referrals with query params', () => {
+        const currentPath = '/refer/referrals/case-list/open'
+        const expectedItems = [
+          {
+            active: true,
+            href: '/refer/referrals/case-list/open?nameOrId=Hatton',
+            text: 'Open referrals (15)',
+          },
+          {
+            active: false,
+            href: '/refer/referrals/case-list/draft?nameOrId=Hatton',
+            text: 'Draft referrals (10)',
+          },
+          {
+            active: false,
+            href: '/refer/referrals/case-list/closed?nameOrId=Hatton',
+            text: 'Closed referrals (5)',
+          },
+        ]
+
+        expect(
+          CaseListUtils.referSubNavigationItems(currentPath, { closed: 5, draft: 10, open: 15 }, [
+            { key: 'nameOrId', value: 'Hatton' },
+          ]),
+        ).toEqual(expectedItems)
+      })
     })
   })
 

--- a/server/utils/referrals/caseListUtils.ts
+++ b/server/utils/referrals/caseListUtils.ts
@@ -128,14 +128,18 @@ export default class CaseListUtils {
     return queryParams
   }
 
-  static referSubNavigationItems(currentPath: Request['path']): Array<MojFrontendNavigationItem> {
+  static referSubNavigationItems(
+    currentPath: Request['path'],
+    counts: Record<ReferralStatusGroup, number>,
+    queryParams: Array<QueryParam> = [],
+  ): Array<MojFrontendNavigationItem> {
     return referralStatusGroups.map(referralStatusGroup => {
       const path = referPaths.caseList.show({ referralStatusGroup })
 
       return {
         active: currentPath === path,
-        href: path,
-        text: `${StringUtils.properCase(referralStatusGroup)} referrals`,
+        href: PathUtils.pathWithQuery(path, queryParams),
+        text: `${StringUtils.properCase(referralStatusGroup)} referrals (${counts[referralStatusGroup]})`,
       }
     })
   }

--- a/server/views/referrals/caseList/refer/show.njk
+++ b/server/views/referrals/caseList/refer/show.njk
@@ -1,3 +1,5 @@
+{% from "govuk/components/button/macro.njk" import govukButton %}
+{% from "govuk/components/input/macro.njk" import govukInput %}
 {% from "govuk/components/notification-banner/macro.njk" import govukNotificationBanner %}
 {% from "govuk/components/pagination/macro.njk" import govukPagination %}
 {% from "govuk/components/table/macro.njk" import govukTable %}
@@ -17,6 +19,27 @@
 
   <h1 class="govuk-heading-l">{{ pageHeading }}</h1>
 
+  <form class="horizontal-filter govuk-!-margin-bottom-6" action="{{ action }}" method="post">
+    <input type="hidden" name="_csrf" value="{{ csrfToken }}"/>
+    {{ govukInput({
+      label: {
+        text: "Search by name or prison number",
+        classes: "govuk-label--m"
+      },
+      classes: "govuk-!-width-full",
+      id: "nameOrId",
+      name: "nameOrId",
+      value: nameOrId,
+        attributes: {
+          "data-testid": "search-input"
+        },
+      errorMessage: errors.messages.nameOrId
+    }) }}
+    {{ govukButton({
+      text: "Search"
+    }) }}
+  </form>
+
   {{ mojSubNavigation({
     label: 'Sub navigation',
     items: subNavigationItems
@@ -33,7 +56,11 @@
     {{ govukPagination(pagination) }}
 
   {% else %}
-    <p class="govuk-body">You have no {{ referralStatusGroup }} referrals.</p>
+    {% if nameOrId %}
+      <p class="govuk-body">No person found in {{ referralStatusGroup }} referrals. Try another name, or search {{ otherStatusGroups | join(" or ") }} referrals.</p>
+    {% else %}
+      <p class="govuk-body">You have no {{ referralStatusGroup }} referrals.</p>
+    {% endif %}
   {% endif %}
 
 {% endblock content %}


### PR DESCRIPTION
## Context

Allow users to search their referrals with name or prison number.



## Changes in this PR
- Add search box to my referrals case list page
- Show total count for each referral group in sub navigation


## Screenshots of UI changes

![image](https://github.com/user-attachments/assets/91abaca1-99f4-463d-ba09-860ea57be00c)



## Release checklist

[Release process documentation](../doc/how-to/perform-a-release.md)

As part of our continuous deployment strategy we must ensure that this work is
ready to be released once merged.

### Pre-merge

- [ ] There are changes required to the Accredited Programmes API for this change to work...
  - [ ] ... and they have been released to production already

### Post-merge

<!-- The outer checkboxes can be completed pre-merge -->

- [ ] This adds, extends or meaningfully modifies a feature...
  - [ ] ... and I have written or updated an end-to-end test for the happy path in the [Accredited Programmes E2E repo](https://github.com/ministryofjustice/hmpps-accredited-programmes-e2e)
- [ ] This makes new expectations of the API...
  - [ ] ... and I have notified the API developer(s) of changes to the contract tests (Pact), or the API is already compliant
- [ ] [Manually approve](../doc/how-to/perform-a-release.md#releasing-to-the-preprod-environment) release to preprod
- [ ] [Manually approve](../doc/how-to/perform-a-release.md#releasing-to-the-production-environment) release to prod

<!-- Should a release fail at any step, you as the author should now lead the work to
fix it as soon as possible. You can monitor deployment failures in CircleCI
itself and application errors are found in
[Sentry](https://ministryofjustice.sentry.io/projects/hmpps-accredited-programmes-ui/?project=4505330122686464&referrer=sidebar&statsPeriod=24h). -->
