### PR TITLE
(APG-459) Update label text when searching for a prison number

### DIFF
--- a/integration_tests/pages/refer/new/findPerson.ts
+++ b/integration_tests/pages/refer/new/findPerson.ts
@@ -15,7 +15,7 @@ export default class NewReferralFindPersonPage extends Page {
 
   shouldContainIdentifierForm() {
     cy.get('form').within(() => {
-      cy.contains('.govuk-label', "Enter the prison number. We'll import their details into your application.").should(
+      cy.contains('.govuk-label', "Enter a prison number. We'll import the person's details into the referral.").should(
         'have.attr',
         'for',
         'prisonNumber',

--- a/server/views/referrals/new/new.njk
+++ b/server/views/referrals/new/new.njk
@@ -33,7 +33,7 @@
 
         {{ govukInput({
           label: {
-            text: "Enter the prison number. We'll import their details into your application."
+            text: "Enter a prison number. We'll import the person's details into the referral."
           },
           hint: {
             text: "For example, a prison number is A1234AA"


### PR DESCRIPTION
## Context

Content needs updating on the page where you enter a prison number. We’d identified this when we tested the end-to-end journey pre-launch.



## Changes in this PR
Label text update




## Release checklist

[Release process documentation](../doc/how-to/perform-a-release.md)

As part of our continuous deployment strategy we must ensure that this work is
ready to be released once merged.

### Pre-merge

- [ ] There are changes required to the Accredited Programmes API for this change to work...
  - [ ] ... and they have been released to production already

### Post-merge

<!-- The outer checkboxes can be completed pre-merge -->

- [x] This adds, extends or meaningfully modifies a feature...
  - [x] ... and I have written or updated an end-to-end test for the happy path in the [Accredited Programmes E2E repo](https://github.com/ministryofjustice/hmpps-accredited-programmes-e2e)
- [ ] This makes new expectations of the API...
  - [ ] ... and I have notified the API developer(s) of changes to the contract tests (Pact), or the API is already compliant
- [ ] [Manually approve](../doc/how-to/perform-a-release.md#releasing-to-the-preprod-environment) release to preprod
- [ ] [Manually approve](../doc/how-to/perform-a-release.md#releasing-to-the-production-environment) release to prod

<!-- Should a release fail at any step, you as the author should now lead the work to
fix it as soon as possible. You can monitor deployment failures in CircleCI
itself and application errors are found in
[Sentry](https://ministryofjustice.sentry.io/projects/hmpps-accredited-programmes-ui/?project=4505330122686464&referrer=sidebar&statsPeriod=24h). -->
