### PR TITLE
(APG-388) Combine reasons with categories onto one page for deselect and withdraw

### DIFF
--- a/integration_tests/mockApis/referenceData.ts
+++ b/integration_tests/mockApis/referenceData.ts
@@ -59,6 +59,24 @@ export default {
       },
     }),
 
+  stubReferralStatusCodeReasonsWithCategory: (args: {
+    reasons: Array<ReferralStatusReason>
+    referralStatus: ReferralStatusUppercase
+  }): SuperAgentRequest =>
+    stubFor({
+      request: {
+        method: 'GET',
+        url: apiPaths.referenceData.referralStatuses.statusCodeReasonsWithCategories({
+          referralStatusCode: args.referralStatus,
+        }),
+      },
+      response: {
+        headers: { 'Content-Type': 'application/json;charset=UTF-8' },
+        jsonBody: args.reasons,
+        status: 200,
+      },
+    }),
+
   stubReferralStatuses: (referralStatuses: Array<ReferralStatusRefData>): SuperAgentRequest =>
     stubFor({
       request: {

--- a/integration_tests/pages/shared/withdraw/reason.ts
+++ b/integration_tests/pages/shared/withdraw/reason.ts
@@ -13,8 +13,13 @@ export default class WithdrawReasonPage extends Page {
   }
 
   shouldContainWithdrawalReasonRadioItems(referralStatusReasons: Array<ReferralStatusReason>) {
-    cy.get('[data-testid="reason-options"]').within(() => {
-      this.shouldContainRadioItems(ReferralUtils.statusOptionsToRadioItems(referralStatusReasons))
+    const groupedOptions = ReferralUtils.groupReasonsByCategory(referralStatusReasons)
+    const reasonFieldsets = ReferralUtils.createReasonsFieldset(groupedOptions)
+
+    reasonFieldsets.forEach(reasonFieldset => {
+      cy.get(`[data-testid="${reasonFieldset.testId}"]`).within(() => {
+        this.shouldContainRadioItems(reasonFieldset.radios)
+      })
     })
   }
 }

--- a/server/@types/accreditedProgrammesApi/index.d.ts
+++ b/server/@types/accreditedProgrammesApi/index.d.ts
@@ -221,6 +221,64 @@ export interface ReferralCreated {
   referralId: string
 }
 
+export interface CourseEntity {
+  /** @format uuid */
+  id?: string
+  /** @format int64 */
+  version: number
+  name: string
+  identifier: string
+  description?: string
+  alternateName?: string
+  /** @uniqueItems true */
+  prerequisites: PrerequisiteEntity[]
+  /** @uniqueItems true */
+  offerings: OfferingEntity[]
+  audience: string
+  audienceColour?: string
+  withdrawn: boolean
+  listDisplayName?: string
+}
+
+export interface OfferingEntity {
+  /** @format uuid */
+  id?: string
+  /** @format int64 */
+  version: number
+  organisationId: string
+  contactEmail: string
+  secondaryContactEmail?: string
+  withdrawn: boolean
+  referable: boolean
+  course: CourseEntity
+}
+
+export interface PrerequisiteEntity {
+  name: string
+  description: string
+}
+
+export interface ReferralEntity {
+  /** @format uuid */
+  id?: string
+  /** @format int64 */
+  version: number
+  offering: OfferingEntity
+  prisonNumber: string
+  referrer: ReferrerUserEntity
+  additionalInformation?: string
+  oasysConfirmed: boolean
+  hasReviewedProgrammeHistory: boolean
+  status: string
+  /** @example "2024-10-16T02:21:59" */
+  submittedOn?: object
+  deleted: boolean
+}
+
+export interface ReferrerUserEntity {
+  username: string
+}
+
 export interface ReferralCreate {
   /**
    * The id (UUID) of an active offering
@@ -449,6 +507,12 @@ export interface ReportContent {
   parameters: Parameters
   /** The result of the statistics query */
   content: Content
+}
+
+export interface ReportStatusCountProjection {
+  count: number
+  status: string
+  orgId: string
 }
 
 export interface ReportTypes {
@@ -1188,10 +1252,10 @@ export interface IndividualRiskScores {
   ogrs3?: number
   /** @example 2 */
   ovp?: number
-  /** @example 0 */
-  ospDc?: number
-  /** @example 1 */
-  ospIic?: number
+  /** @example "0" */
+  ospDc?: string
+  /** @example "1" */
+  ospIic?: string
   /** @example 5 */
   rsr?: number
   /** @example "LOW" */

--- a/server/controllers/assess/updateStatusDecisionController.test.ts
+++ b/server/controllers/assess/updateStatusDecisionController.test.ts
@@ -288,7 +288,7 @@ describe('UpdateStatusDecisionController', () => {
     })
 
     describe('when `statusDecision` is `WITHDRAWN`', () => {
-      it('should redirect to the category page show page', async () => {
+      it('should redirect to the reason show page', async () => {
         request.body = { statusDecision: 'WITHDRAWN' }
 
         const requestHandler = controller.submit()
@@ -301,13 +301,13 @@ describe('UpdateStatusDecisionController', () => {
           referralId: referral.id,
         })
         expect(response.redirect).toHaveBeenCalledWith(
-          assessPaths.updateStatus.category.show({ referralId: referral.id }),
+          assessPaths.updateStatus.reason.show({ referralId: referral.id }),
         )
       })
     })
 
     describe('when `statusDecision` is `DESELECTED`', () => {
-      it('should redirect to the category page show page', async () => {
+      it('should redirect to the reason show page', async () => {
         request.body = { statusDecision: 'DESELECTED' }
 
         const requestHandler = controller.submit()
@@ -320,13 +320,13 @@ describe('UpdateStatusDecisionController', () => {
           referralId: referral.id,
         })
         expect(response.redirect).toHaveBeenCalledWith(
-          assessPaths.updateStatus.category.show({ referralId: referral.id }),
+          assessPaths.updateStatus.reason.show({ referralId: referral.id }),
         )
       })
     })
 
     describe('when `statusDecision` is `DESELECTED|OPEN`', () => {
-      it('should set the correct `referralStatusUpdateData` values and redirect to the category page show page', async () => {
+      it('should set the correct `referralStatusUpdateData` values and redirect to the reason show page', async () => {
         request.body = { statusDecision: 'DESELECTED|OPEN' }
 
         const requestHandler = controller.submit()
@@ -339,7 +339,7 @@ describe('UpdateStatusDecisionController', () => {
           referralId: referral.id,
         })
         expect(response.redirect).toHaveBeenCalledWith(
-          assessPaths.updateStatus.category.show({ referralId: referral.id }),
+          assessPaths.updateStatus.reason.show({ referralId: referral.id }),
         )
       })
     })

--- a/server/controllers/assess/updateStatusDecisionController.ts
+++ b/server/controllers/assess/updateStatusDecisionController.ts
@@ -101,7 +101,7 @@ export default class UpdateStatusDecisionController {
       }
 
       if (statusDecisionValue === 'DESELECTED' || statusDecisionValue === 'WITHDRAWN') {
-        return res.redirect(assessPaths.updateStatus.category.show({ referralId }))
+        return res.redirect(assessPaths.updateStatus.reason.show({ referralId }))
       }
 
       return res.redirect(assessPaths.updateStatus.selection.show({ referralId }))

--- a/server/controllers/refer/updateStatusActionsController.test.ts
+++ b/server/controllers/refer/updateStatusActionsController.test.ts
@@ -39,7 +39,7 @@ describe('UpdateStatusActionsController', () => {
   })
 
   describe('withdraw', () => {
-    it('should set `referralStatusUpdateData` in the session and redirect to the update status select category show page', async () => {
+    it('should set `referralStatusUpdateData` in the session and redirect to the update status select reason show page', async () => {
       controller.withdraw()(request, response, next)
 
       expect(request.session.referralStatusUpdateData).toEqual({
@@ -48,7 +48,7 @@ describe('UpdateStatusActionsController', () => {
         initialStatusDecision: 'WITHDRAWN',
         referralId,
       })
-      expect(response.redirect).toHaveBeenCalledWith(referPaths.updateStatus.category.show({ referralId }))
+      expect(response.redirect).toHaveBeenCalledWith(referPaths.updateStatus.reason.show({ referralId }))
     })
   })
 })

--- a/server/controllers/refer/updateStatusActionsController.ts
+++ b/server/controllers/refer/updateStatusActionsController.ts
@@ -30,7 +30,7 @@ export default class UpdateStatusActionsController {
         referralId,
       }
 
-      return res.redirect(referPaths.updateStatus.category.show({ referralId }))
+      return res.redirect(referPaths.updateStatus.reason.show({ referralId }))
     }
   }
 }

--- a/server/data/accreditedProgrammesApi/referenceDataClient.ts
+++ b/server/data/accreditedProgrammesApi/referenceDataClient.ts
@@ -60,6 +60,14 @@ export default class ReferenceDataClient {
     })) as Array<ReferralStatusReason>
   }
 
+  async findReferralStatusCodeReasonsWithCategory(
+    referralStatusCode: Extract<ReferralStatusUppercase, 'DESELECTED' | 'WITHDRAWN'>,
+  ): Promise<Array<ReferralStatusReason>> {
+    return (await this.restClient.get({
+      path: apiPaths.referenceData.referralStatuses.statusCodeReasonsWithCategories({ referralStatusCode }),
+    })) as Array<ReferralStatusReason>
+  }
+
   async findReferralStatuses(): Promise<Array<ReferralStatusRefData>> {
     return (await this.restClient.get({
       path: apiPaths.referenceData.referralStatuses.show({}),

--- a/server/paths/api.ts
+++ b/server/paths/api.ts
@@ -99,6 +99,7 @@ export default {
       show: referralStatusesPath,
       statusCodeCategories: referralStatusCodeCategoriesPath,
       statusCodeReasons: referralStatusCodeReasonsPath,
+      statusCodeReasonsWithCategories: referralStatusCodeCategoriesPath.path('reasons'),
     },
   },
   referrals: {

--- a/server/services/referenceDataService.test.ts
+++ b/server/services/referenceDataService.test.ts
@@ -112,6 +112,20 @@ describe('ReferenceDataService', () => {
     })
   })
 
+  describe('getReferralStatusCodeReasonsWithCategory', () => {
+    it('should return referral status code reasons with category', async () => {
+      const reasons = referralStatusReasonFactory.buildList(2, { referralCategoryCode: 'C' })
+
+      when(referenceDataClient.findReferralStatusCodeReasonsWithCategory)
+        .calledWith(referralStatusCode)
+        .mockResolvedValue(reasons)
+
+      const result = await service.getReferralStatusCodeReasonsWithCategory(username, referralStatusCode)
+
+      expect(result).toEqual(reasons)
+    })
+  })
+
   describe('getReferralStatuses', () => {
     it('should return referral statuses', async () => {
       const referralStatuses = referralStatusRefDataFactory.buildList(2)

--- a/server/services/referenceDataService.ts
+++ b/server/services/referenceDataService.ts
@@ -59,6 +59,17 @@ export default class ReferenceDataService {
     return referenceDataClient.findReferralStatusCodeReasons(categoryCode, referralStatusCode, query)
   }
 
+  async getReferralStatusCodeReasonsWithCategory(
+    username: Express.User['username'],
+    referralStatusCode: Extract<ReferralStatusUppercase, 'DESELECTED' | 'WITHDRAWN'>,
+  ): Promise<Array<ReferralStatusReason>> {
+    const hmppsAuthClient = this.hmppsAuthClientBuilder()
+    const systemToken = await hmppsAuthClient.getSystemClientToken(username)
+    const referenceDataClient = this.referenceDataClient(systemToken)
+
+    return referenceDataClient.findReferralStatusCodeReasonsWithCategory(referralStatusCode)
+  }
+
   async getReferralStatuses(username: Express.User['username']): Promise<Array<ReferralStatusRefData>> {
     const hmppsAuthClient = this.hmppsAuthClientBuilder()
     const systemToken = await hmppsAuthClient.getSystemClientToken(username)

--- a/server/testutils/factories/pniScore.ts
+++ b/server/testutils/factories/pniScore.ts
@@ -52,8 +52,8 @@ export default Factory.define<PniScore>(() => {
     RiskScore: {
       IndividualRiskScores: {
         ogrs3: FactoryHelpers.optionalNumber(3),
-        ospDc: FactoryHelpers.optionalNumber(3),
-        ospIic: FactoryHelpers.optionalNumber(3),
+        ospDc: FactoryHelpers.optionalNumber(3)?.toString(),
+        ospIic: FactoryHelpers.optionalNumber(3)?.toString(),
         ovp: FactoryHelpers.optionalNumber(3),
         rsr: FactoryHelpers.optionalNumber(3),
         sara: FactoryHelpers.optionalArrayElement(['LOW', 'MEDIUM', 'HIGH']),

--- a/server/utils/referrals/referralUtils.test.ts
+++ b/server/utils/referrals/referralUtils.test.ts
@@ -3,6 +3,64 @@ import { referralStatusRefDataFactory } from '../../testutils/factories'
 import type { ReferralStatusCategory } from '@accredited-programmes/models'
 
 describe('ReferralUtils', () => {
+  describe('createReasonsFieldset', () => {
+    it('creates an array of fieldsets with a legend and radios property', () => {
+      const groupedOptions = {
+        W_ADMIN: [
+          { code: 'A', description: 'Category A', referralCategoryCode: 'W_ADMIN' },
+          { code: 'B', description: 'Category B', referralCategoryCode: 'W_ADMIN' },
+        ],
+      }
+      expect(ReferralUtils.createReasonsFieldset(groupedOptions)).toEqual([
+        {
+          legend: {
+            text: 'Administrative error',
+          },
+          radios: [
+            { checked: false, text: 'Category A', value: 'A' },
+            { checked: false, text: 'Category B', value: 'B' },
+          ],
+          testId: 'W_ADMIN-reason-options',
+        },
+      ])
+    })
+
+    describe('when a selected item is provided', () => {
+      it('should mark the corresponding radio item as checked', () => {
+        const groupedOptions = {
+          W_ADMIN: [
+            { code: 'A', description: 'Category A', referralCategoryCode: 'W_ADMIN' },
+            { code: 'B', description: 'Category B', referralCategoryCode: 'W_ADMIN' },
+          ],
+        }
+        expect(ReferralUtils.createReasonsFieldset(groupedOptions, 'B')).toEqual([
+          {
+            legend: {
+              text: 'Administrative error',
+            },
+            radios: [
+              { checked: false, text: 'Category A', value: 'A' },
+              { checked: true, text: 'Category B', value: 'B' },
+            ],
+            testId: 'W_ADMIN-reason-options',
+          },
+        ])
+      })
+    })
+  })
+
+  describe('groupReasonsByCategory', () => {
+    it('groups an array of items by a `referralCategoryCode` property', () => {
+      const items = [
+        { code: 'A', description: 'Category A', referralCategoryCode: 'WITHDRAWN' },
+        { code: 'B', description: 'Category B', referralCategoryCode: 'WITHDRAWN' },
+      ]
+      expect(ReferralUtils.groupReasonsByCategory(items)).toEqual({
+        WITHDRAWN: items,
+      })
+    })
+  })
+
   describe('statusOptionsToRadioItems', () => {
     it('formats an array of options with a `code` and `description` in the appropriate format for passing to a GOV.UK radios Nunjucks macro', () => {
       const statusCategories: Array<ReferralStatusCategory> = [

--- a/server/utils/referrals/referralUtils.ts
+++ b/server/utils/referrals/referralUtils.ts
@@ -1,6 +1,36 @@
-import type { GovukFrontendRadiosItem } from '@govuk-frontend'
+import type { ReferralStatusCategory, ReferralStatusReason } from '@accredited-programmes-api'
+import type { GovukFrontendFieldsetLegend, GovukFrontendRadiosItem } from '@govuk-frontend'
 
 export default class ReferralUtils {
+  static createReasonsFieldset(
+    groupedOptions: Record<ReferralStatusCategory['referralStatusCode'], Array<ReferralStatusReason>>,
+    selectedItemCode?: string,
+  ): Array<{ legend: GovukFrontendFieldsetLegend; radios: Array<GovukFrontendRadiosItem>; testId: string }> {
+    return Object.entries(groupedOptions).map(([categoryCode, reasons]) => {
+      return {
+        legend: {
+          text: this.categoryCodeToText(categoryCode),
+        },
+        radios: ReferralUtils.statusOptionsToRadioItems(reasons, selectedItemCode),
+        testId: `${categoryCode}-reason-options`,
+      }
+    })
+  }
+
+  static groupReasonsByCategory<T extends { code: string; description: string; referralCategoryCode: string }>(
+    items: Array<T>,
+  ): Record<string, Array<T>> {
+    return items.reduce<Record<string, Array<T>>>((acc, item) => {
+      if (!acc[item.referralCategoryCode]) {
+        acc[item.referralCategoryCode] = []
+      }
+
+      acc[item.referralCategoryCode].push(item)
+
+      return acc
+    }, {})
+  }
+
   static statusOptionsToRadioItems<T extends { code: string; description: string; hintText?: string }>(
     items: Array<T>,
     selectedItemCode?: string,
@@ -25,5 +55,20 @@ export default class ReferralUtils {
 
       return acc
     }, [])
+  }
+
+  private static categoryCodeToText(code: string): string {
+    switch (code.split('_')[1]) {
+      case 'ADMIN':
+        return 'Administrative error'
+      case 'MOTIVATION':
+        return 'Motivation and behaviour'
+      case 'OPERATIONAL':
+        return 'Operational'
+      case 'PERSONAL':
+        return 'Personal and health'
+      default:
+        return code
+    }
   }
 }

--- a/server/utils/risksAndNeeds/pniUtils.test.ts
+++ b/server/utils/risksAndNeeds/pniUtils.test.ts
@@ -45,8 +45,8 @@ describe('PniUtils', () => {
     RiskScore: {
       IndividualRiskScores: {
         ogrs3: 1,
-        ospDc: 2,
-        ospIic: 3,
+        ospDc: '2',
+        ospIic: '3',
         ovp: 4,
         rsr: 5,
         sara: 'MEDIUM',

--- a/server/views/referrals/updateStatus/reason/show.njk
+++ b/server/views/referrals/updateStatus/reason/show.njk
@@ -8,15 +8,40 @@
   <form method="post">
     <input type="hidden" name="_csrf" value="{{ csrfToken }}"/>
 
+    {% for fieldset in reasonsFieldsets %}
+      {{ govukRadios({
+        name: "reasonCode",
+        fieldset: {
+          legend: {
+            text: fieldset.legend.text,
+            classes: "govuk-fieldset__legend--m"
+          }
+        },
+        value: formValues.reasonCode,
+        items: fieldset.radios,        
+        errorMessage: errors.messages.reasonCode,
+        attributes: {
+          "data-testid": fieldset.testId
+        }
+      }) }}
+    {% endfor %}
+
+    <div class="govuk-radios__divider govuk-!-margin-bottom-6">or</div>
+
     {{ govukRadios({
       name: "reasonCode",
       fieldset: {
         legend: {
-          text: radioLegend,
+          text: "Other reason",
           classes: "govuk-fieldset__legend--m"
         }
       },
-      items: radioItems,
+      items: [
+        {
+          value: "OTHER",
+          text: "Other"
+        }
+      ],
       errorMessage: errors.messages.reasonCode,
       attributes: {
         "data-testid": "reason-options"


### PR DESCRIPTION
## Changes in this PR
Combine category and reason steps into one page for Withdraw and Deselection journeys.


## Screenshots of UI changes

![localhost_3000_assess_referrals_222d04ac-cd1b-448c-bb9a-060a4f84425f_update-status_reason](https://github.com/user-attachments/assets/5f148c30-1149-43a2-a96f-fc6e0f3614f8)


## Release checklist

[Release process documentation](../doc/how-to/perform-a-release.md)

As part of our continuous deployment strategy we must ensure that this work is
ready to be released once merged.

### Pre-merge

- [ ] There are changes required to the Accredited Programmes API for this change to work...
  - [ ] ... and they have been released to production already

### Post-merge

<!-- The outer checkboxes can be completed pre-merge -->

- [ ] This adds, extends or meaningfully modifies a feature...
  - [ ] ... and I have written or updated an end-to-end test for the happy path in the [Accredited Programmes E2E repo](https://github.com/ministryofjustice/hmpps-accredited-programmes-e2e)
- [ ] This makes new expectations of the API...
  - [ ] ... and I have notified the API developer(s) of changes to the contract tests (Pact), or the API is already compliant
- [ ] [Manually approve](../doc/how-to/perform-a-release.md#releasing-to-the-preprod-environment) release to preprod
- [ ] [Manually approve](../doc/how-to/perform-a-release.md#releasing-to-the-production-environment) release to prod

<!-- Should a release fail at any step, you as the author should now lead the work to
fix it as soon as possible. You can monitor deployment failures in CircleCI
itself and application errors are found in
[Sentry](https://ministryofjustice.sentry.io/projects/hmpps-accredited-programmes-ui/?project=4505330122686464&referrer=sidebar&statsPeriod=24h). -->
