### PR TITLE
(APG-486) Change names in case lists to be surname, forename

### DIFF
--- a/server/utils/referrals/caseListUtils.test.ts
+++ b/server/utils/referrals/caseListUtils.test.ts
@@ -517,7 +517,7 @@ describe('CaseListUtils', () => {
     describe('Name and prison number', () => {
       it('returns a HTML string with the prisoner name on the first line, which links to the referral, and their prison number on a new line', () => {
         expect(CaseListUtils.tableRowContent(referralView, 'Name and prison number')).toEqual(
-          '<a class="govuk-link" href="/assess/referrals/referral-123/personal-details?updatePerson=true">Del Hatton</a><br>ABC1234',
+          '<a class="govuk-link" href="/assess/referrals/referral-123/personal-details?updatePerson=true">Hatton, Del</a><br>ABC1234',
         )
       })
 
@@ -530,7 +530,7 @@ describe('CaseListUtils', () => {
               assessPaths,
             ),
           ).toEqual(
-            '<a class="govuk-link" href="/refer/referrals/new/referral-123?updatePerson=true">Del Hatton</a><br>ABC1234',
+            '<a class="govuk-link" href="/refer/referrals/new/referral-123?updatePerson=true">Hatton, Del</a><br>ABC1234',
           )
         })
       })
@@ -538,7 +538,7 @@ describe('CaseListUtils', () => {
       describe('when referPaths is passed in as the paths argument', () => {
         it('links to the Refer show status history referral page', () => {
           expect(CaseListUtils.tableRowContent(referralView, 'Name and prison number', referPaths)).toEqual(
-            '<a class="govuk-link" href="/refer/referrals/referral-123/status-history?updatePerson=true">Del Hatton</a><br>ABC1234',
+            '<a class="govuk-link" href="/refer/referrals/referral-123/status-history?updatePerson=true">Hatton, Del</a><br>ABC1234',
           )
         })
       })

--- a/server/utils/referrals/caseListUtils.ts
+++ b/server/utils/referrals/caseListUtils.ts
@@ -285,7 +285,7 @@ export default class CaseListUtils {
   }
 
   private static formattedPrisonerName(forename?: ReferralView['forename'], surname?: ReferralView['surname']): string {
-    return StringUtils.convertToTitleCase([forename, surname].filter(nameComponent => nameComponent).join(' '))
+    return StringUtils.convertToTitleCase([surname, forename].filter(nameComponent => nameComponent).join(', '))
   }
 
   private static nameAndPrisonNumberHtml(


### PR DESCRIPTION
## Context

Based on user feedback, we should change the way we display peoples name in the case list views so it is surname first.  This will also match how it is displayed in DPS too. 

## Changes in this PR
Update `formattedPrisonerName` util to display names as **Surname, Forename** in case lists.


## Screenshots of UI changes

![image](https://github.com/user-attachments/assets/df56a082-293e-4b4a-bdbc-e5aea73b067c)


## Release checklist

[Release process documentation](../doc/how-to/perform-a-release.md)

As part of our continuous deployment strategy we must ensure that this work is
ready to be released once merged.

### Pre-merge

- [ ] There are changes required to the Accredited Programmes API for this change to work...
  - [ ] ... and they have been released to production already

### Post-merge

<!-- The outer checkboxes can be completed pre-merge -->

- [ ] This adds, extends or meaningfully modifies a feature...
  - [ ] ... and I have written or updated an end-to-end test for the happy path in the [Accredited Programmes E2E repo](https://github.com/ministryofjustice/hmpps-accredited-programmes-e2e)
- [ ] This makes new expectations of the API...
  - [ ] ... and I have notified the API developer(s) of changes to the contract tests (Pact), or the API is already compliant
- [ ] [Manually approve](../doc/how-to/perform-a-release.md#releasing-to-the-preprod-environment) release to preprod
- [ ] [Manually approve](../doc/how-to/perform-a-release.md#releasing-to-the-production-environment) release to prod

<!-- Should a release fail at any step, you as the author should now lead the work to
fix it as soon as possible. You can monitor deployment failures in CircleCI
itself and application errors are found in
[Sentry](https://ministryofjustice.sentry.io/projects/hmpps-accredited-programmes-ui/?project=4505330122686464&referrer=sidebar&statsPeriod=24h). -->
