### PR TITLE
(APG-441) Handle duplicate referrals when submitting from draft

### DIFF
--- a/integration_tests/mockApis/referrals.ts
+++ b/integration_tests/mockApis/referrals.ts
@@ -222,15 +222,16 @@ export default {
       },
     }),
 
-  stubSubmitReferral: (referralId: Referral['id']): SuperAgentRequest =>
+  stubSubmitReferral: (args: { body: Referral; referralId: Referral['id']; status?: number }): SuperAgentRequest =>
     stubFor({
       request: {
         method: 'POST',
-        url: apiPaths.referrals.submit({ referralId }),
+        url: apiPaths.referrals.submit({ referralId: args.referralId }),
       },
       response: {
         headers: { 'Content-Type': 'application/json;charset=UTF-8' },
-        status: 204,
+        jsonBody: args.body,
+        status: args.status || 200,
       },
     }),
 


### PR DESCRIPTION
## Context

We need to handle duplicate referrals when submitting a draft referral.

## Changes in this PR
Handle 409 conflict in submit referral method.




## Release checklist

[Release process documentation](../doc/how-to/perform-a-release.md)

As part of our continuous deployment strategy we must ensure that this work is
ready to be released once merged.

### Pre-merge

- [ ] There are changes required to the Accredited Programmes API for this change to work...
  - [ ] ... and they have been released to production already

### Post-merge

<!-- The outer checkboxes can be completed pre-merge -->

- [ ] This adds, extends or meaningfully modifies a feature...
  - [ ] ... and I have written or updated an end-to-end test for the happy path in the [Accredited Programmes E2E repo](https://github.com/ministryofjustice/hmpps-accredited-programmes-e2e)
- [ ] This makes new expectations of the API...
  - [ ] ... and I have notified the API developer(s) of changes to the contract tests (Pact), or the API is already compliant
- [ ] [Manually approve](../doc/how-to/perform-a-release.md#releasing-to-the-preprod-environment) release to preprod
- [ ] [Manually approve](../doc/how-to/perform-a-release.md#releasing-to-the-production-environment) release to prod

<!-- Should a release fail at any step, you as the author should now lead the work to
fix it as soon as possible. You can monitor deployment failures in CircleCI
itself and application errors are found in
[Sentry](https://ministryofjustice.sentry.io/projects/hmpps-accredited-programmes-ui/?project=4505330122686464&referrer=sidebar&statsPeriod=24h). -->
