### PR TITLE
(APG-478) Update PNI page to handle information missing scenarios

### DIFF
--- a/server/utils/risksAndNeeds/pniUtils.test.ts
+++ b/server/utils/risksAndNeeds/pniUtils.test.ts
@@ -65,7 +65,7 @@ describe('PniUtils', () => {
       expect(PniUtils.needScoreToString(0)).toBe('Low need')
       expect(PniUtils.needScoreToString(1)).toBe('Medium need')
       expect(PniUtils.needScoreToString(2)).toBe('High need')
-      expect(PniUtils.needScoreToString()).toBe('Unknown')
+      expect(PniUtils.needScoreToString(null)).toBe('Cannot calculate – information missing')
     })
   })
 
@@ -166,6 +166,14 @@ describe('PniUtils', () => {
           },
         },
       ])
+    })
+  })
+
+  describe('scoreValueText', () => {
+    it('returns the string representation of the given score', () => {
+      expect(PniUtils.scoreValueText(0)).toBe('0')
+      expect(PniUtils.scoreValueText(null)).toBe('Score missing')
+      expect(PniUtils.scoreValueText(undefined)).toBe('Score missing')
     })
   })
 

--- a/server/utils/risksAndNeeds/pniUtils.ts
+++ b/server/utils/risksAndNeeds/pniUtils.ts
@@ -1,4 +1,3 @@
-import ShowRisksAndNeedsUtils from '../referrals/showRisksAndNeedsUtils'
 import type { Person } from '@accredited-programmes/models'
 import type { GovukFrontendSummaryListRowWithKeyAndValue } from '@accredited-programmes/ui'
 import type {
@@ -10,7 +9,7 @@ import type {
 } from '@accredited-programmes-api'
 
 export default class PniUtils {
-  static needScoreToString(needScore?: number): string {
+  static needScoreToString(needScore: number | null): string {
     switch (needScore) {
       case 0:
         return 'Low need'
@@ -19,7 +18,7 @@ export default class PniUtils {
       case 2:
         return 'High need'
       default:
-        return 'Unknown'
+        return 'Cannot calculate – information missing'
     }
   }
 
@@ -76,9 +75,7 @@ export default class PniUtils {
           text: '6.1 - Current relationship with close family',
         },
         value: {
-          text: ShowRisksAndNeedsUtils.textValue(
-            relationshipDomainScore.individualRelationshipScores.curRelCloseFamily?.toString(),
-          ),
+          text: this.scoreValueText(relationshipDomainScore.individualRelationshipScores.curRelCloseFamily),
         },
       },
       {
@@ -86,9 +83,7 @@ export default class PniUtils {
           text: '6.6 - Previous experience of close relationships',
         },
         value: {
-          text: ShowRisksAndNeedsUtils.textValue(
-            relationshipDomainScore.individualRelationshipScores.prevExpCloseRel?.toString(),
-          ),
+          text: this.scoreValueText(relationshipDomainScore.individualRelationshipScores.prevExpCloseRel),
         },
       },
       {
@@ -96,9 +91,7 @@ export default class PniUtils {
           text: '7.3 - Easily influenced by criminal associates',
         },
         value: {
-          text: ShowRisksAndNeedsUtils.textValue(
-            relationshipDomainScore.individualRelationshipScores.easilyInfluenced?.toString(),
-          ),
+          text: this.scoreValueText(relationshipDomainScore.individualRelationshipScores.easilyInfluenced),
         },
       },
       {
@@ -106,8 +99,8 @@ export default class PniUtils {
           text: '11.3 - Aggressive or controlling behaviour',
         },
         value: {
-          text: ShowRisksAndNeedsUtils.textValue(
-            relationshipDomainScore.individualRelationshipScores.aggressiveControllingBehaviour?.toString(),
+          text: this.scoreValueText(
+            relationshipDomainScore.individualRelationshipScores.aggressiveControllingBehaviour,
           ),
         },
       },
@@ -122,6 +115,10 @@ export default class PniUtils {
     ]
   }
 
+  static scoreValueText(value?: number | null): string {
+    return value?.toString() || 'Score missing'
+  }
+
   static selfManagementSummaryListRows(
     selfManagementDomainScore: SelfManagementDomainScore,
   ): Array<GovukFrontendSummaryListRowWithKeyAndValue> {
@@ -131,9 +128,7 @@ export default class PniUtils {
           text: '11.2 - Impulsivity',
         },
         value: {
-          text: ShowRisksAndNeedsUtils.textValue(
-            selfManagementDomainScore.individualSelfManagementScores.impulsivity?.toString(),
-          ),
+          text: this.scoreValueText(selfManagementDomainScore.individualSelfManagementScores.impulsivity),
         },
       },
       {
@@ -141,9 +136,7 @@ export default class PniUtils {
           text: '11.4 - Temper control',
         },
         value: {
-          text: ShowRisksAndNeedsUtils.textValue(
-            selfManagementDomainScore.individualSelfManagementScores.temperControl?.toString(),
-          ),
+          text: this.scoreValueText(selfManagementDomainScore.individualSelfManagementScores.temperControl),
         },
       },
       {
@@ -151,9 +144,7 @@ export default class PniUtils {
           text: '11.6 - Problem-solving skills',
         },
         value: {
-          text: ShowRisksAndNeedsUtils.textValue(
-            selfManagementDomainScore.individualSelfManagementScores.problemSolvingSkills?.toString(),
-          ),
+          text: this.scoreValueText(selfManagementDomainScore.individualSelfManagementScores.problemSolvingSkills),
         },
       },
       {
@@ -161,9 +152,7 @@ export default class PniUtils {
           text: '10.1 - Difficulties coping',
         },
         value: {
-          text: ShowRisksAndNeedsUtils.textValue(
-            selfManagementDomainScore.individualSelfManagementScores.difficultiesCoping?.toString(),
-          ),
+          text: this.scoreValueText(selfManagementDomainScore.individualSelfManagementScores.difficultiesCoping),
         },
       },
       {
@@ -184,7 +173,7 @@ export default class PniUtils {
           text: '11.11 - Sexual Pre-occupation',
         },
         value: {
-          text: ShowRisksAndNeedsUtils.textValue(sexDomainScore.individualSexScores.sexualPreOccupation?.toString()),
+          text: this.scoreValueText(sexDomainScore.individualSexScores.sexualPreOccupation),
         },
       },
       {
@@ -192,9 +181,7 @@ export default class PniUtils {
           text: '11.12 - Offence related Sexual Interests',
         },
         value: {
-          text: ShowRisksAndNeedsUtils.textValue(
-            sexDomainScore.individualSexScores.offenceRelatedSexualInterests?.toString(),
-          ),
+          text: this.scoreValueText(sexDomainScore.individualSexScores.offenceRelatedSexualInterests),
         },
       },
       {
@@ -202,7 +189,7 @@ export default class PniUtils {
           text: '6.12 Emotional congruence with children or feeling closer to children than adults',
         },
         value: {
-          text: ShowRisksAndNeedsUtils.textValue(sexDomainScore.individualSexScores.emotionalCongruence?.toString()),
+          text: this.scoreValueText(sexDomainScore.individualSexScores.emotionalCongruence),
         },
       },
       {
@@ -225,9 +212,7 @@ export default class PniUtils {
           text: '12.1 Pro-criminal attitudes',
         },
         value: {
-          text: ShowRisksAndNeedsUtils.textValue(
-            thinkingDomainScore.individualThinkingScores.proCriminalAttitudes?.toString(),
-          ),
+          text: this.scoreValueText(thinkingDomainScore.individualThinkingScores.proCriminalAttitudes),
         },
       },
       {
@@ -235,9 +220,7 @@ export default class PniUtils {
           text: '12.9 Hostile orientation',
         },
         value: {
-          text: ShowRisksAndNeedsUtils.textValue(
-            thinkingDomainScore.individualThinkingScores.hostileOrientation?.toString(),
-          ),
+          text: this.scoreValueText(thinkingDomainScore.individualThinkingScores.hostileOrientation),
         },
       },
       {

--- a/server/views/referrals/show/pni/show.njk
+++ b/server/views/referrals/show/pni/show.njk
@@ -3,14 +3,12 @@
 
 {% extends "../partials/rootLayout.njk" %}
 
-{% set showCalculatedData = hasData and not missingInformation %}
-
 {% block supportingContent %}
   <p data-testid="programme-needs-identifier-message">This is the recommended Accredited Programmes pathway. It is based on the person's risks and needs.</p>
 
   {% include "./_pathway.njk" %}
 
-  {% if showCalculatedData %}
+  {% if hasData %}
     <hr class="govuk-section-break govuk-section-break--xl govuk-section-break--visible">
   {% endif %}
 {% endblock supportingContent %}
@@ -18,14 +16,14 @@
 {% block content %}
   {{ super() }}
 
-  {% if showCalculatedData %}
+  {% if hasData %}
     <div id="content" class="govuk-grid-row">
       <div class="govuk-grid-column-three-quarters">
-        <h2 class="govuk-heading-m" data-testid="calculated-sub-heading">How is this calculated?</h2>
+        <h2 class="govuk-heading-m" data-testid="calculated-sub-heading">{{ 'What information is missing' if missingInformation else 'How is this calculated?' }}</h2>
         <p>The recommended pathway is based on a combination of:</p>
         <ul class="govuk-list govuk-list--bullet govuk-!-margin-bottom-8">
           <li>
-            <a href="{{ riskScoresHref }}">risk scores</a>
+            <a href="{{ riskScoresHref }}">risk scores</a>{{ ' – check whether any relevant risk scores are missing' if missingInformation }}
           </li>
           <li>the programme needs identifier (PNI), which uses the following scores</li>
         </ul>


### PR DESCRIPTION
## Context

Currently, if there is missing information then we don't show even the scores that we do have.  If only some fields are missing from the PNI, we want to show the scores we do have and give users more information about what fields are missing.



## Changes in this PR
- Show available scores if there is missing information
- Update content


## Screenshots of UI changes

![image](https://github.com/user-attachments/assets/7f01367a-d463-4a50-8a7a-d76ce240da38)



## Release checklist

[Release process documentation](../doc/how-to/perform-a-release.md)

As part of our continuous deployment strategy we must ensure that this work is
ready to be released once merged.

### Pre-merge

- [ ] There are changes required to the Accredited Programmes API for this change to work...
  - [ ] ... and they have been released to production already

### Post-merge

<!-- The outer checkboxes can be completed pre-merge -->

- [ ] This adds, extends or meaningfully modifies a feature...
  - [ ] ... and I have written or updated an end-to-end test for the happy path in the [Accredited Programmes E2E repo](https://github.com/ministryofjustice/hmpps-accredited-programmes-e2e)
- [ ] This makes new expectations of the API...
  - [ ] ... and I have notified the API developer(s) of changes to the contract tests (Pact), or the API is already compliant
- [ ] [Manually approve](../doc/how-to/perform-a-release.md#releasing-to-the-preprod-environment) release to preprod
- [ ] [Manually approve](../doc/how-to/perform-a-release.md#releasing-to-the-production-environment) release to prod

<!-- Should a release fail at any step, you as the author should now lead the work to
fix it as soon as possible. You can monitor deployment failures in CircleCI
itself and application errors are found in
[Sentry](https://ministryofjustice.sentry.io/projects/hmpps-accredited-programmes-ui/?project=4505330122686464&referrer=sidebar&statsPeriod=24h). -->
