### PR TITLE
(APG-509b) Building choices form

### DIFF
--- a/server/@types/ui/index.d.ts
+++ b/server/@types/ui/index.d.ts
@@ -223,7 +223,13 @@ type ReferralStatusHistoryPresenter = ReferralStatusHistory & {
   byLineText: MojTimelineItem['byline']['text']
 }
 
+interface BuildingChoicesSearchForm {
+  isConvictedOfSexualOffence: string
+  isInAWomensPrison: string
+}
+
 export type {
+  BuildingChoicesSearchForm,
   CaseListColumnHeader,
   CourseParticipationPresenter,
   CoursePresenter,

--- a/server/controllers/find/buildingChoicesController.test.ts
+++ b/server/controllers/find/buildingChoicesController.test.ts
@@ -1,0 +1,83 @@
+import type { DeepMocked } from '@golevelup/ts-jest'
+import { createMock } from '@golevelup/ts-jest'
+import type { NextFunction, Request, Response } from 'express'
+import { when } from 'jest-when'
+
+import BuildingChoicesController from './buildingChoicesController'
+import { findPaths } from '../../paths'
+import type { CourseService } from '../../services'
+import { courseFactory } from '../../testutils/factories'
+import { FormUtils } from '../../utils'
+
+jest.mock('../../utils/formUtils')
+
+describe('BuildingChoicesController', () => {
+  let request: DeepMocked<Request>
+  let response: DeepMocked<Response>
+  const next: DeepMocked<NextFunction> = createMock<NextFunction>({})
+
+  let controller: BuildingChoicesController
+
+  const username = 'SOME_USERNAME'
+  const courseId = 'A_COURSE_ID'
+  const courseService = createMock<CourseService>({})
+
+  beforeEach(() => {
+    request = createMock<Request>({ params: { courseId }, user: { username } })
+    response = createMock<Response>({})
+    controller = new BuildingChoicesController(courseService)
+  })
+
+  describe('show', () => {
+    it('should render the buildingChoices/show template', async () => {
+      const requestHandler = controller.show()
+      await requestHandler(request, response, next)
+
+      expect(FormUtils.setFieldErrors).toHaveBeenCalledWith(request, response, [
+        'isConvictedOfSexualOffence',
+        'isInAWomensPrison',
+      ])
+      expect(FormUtils.setFormValues).toHaveBeenCalledWith(request, response)
+      expect(response.render).toHaveBeenCalledWith('courses/offerings/buildingChoices/show', {
+        backLinkHref: findPaths.index({}),
+        pageHeading: "About the person you're referring",
+      })
+    })
+  })
+
+  describe('submit', () => {
+    describe('when all options are selected', () => {
+      it('should redirect to the course page of the first course in the response', async () => {
+        const returnedCourses = courseFactory.buildList(2)
+        const formValues = { isConvictedOfSexualOffence: 'no', isInAWomensPrison: 'yes' }
+
+        when(courseService.getBuildingChoicesVariants)
+          .calledWith(username, courseId, formValues)
+          .mockResolvedValue(returnedCourses)
+
+        request.body = formValues
+
+        const requestHandler = controller.submit()
+        await requestHandler(request, response, next)
+
+        expect(response.redirect).toHaveBeenCalledWith(findPaths.show({ courseId: returnedCourses[0].id }))
+      })
+    })
+
+    describe('when no options are selected', () => {
+      it('should redirect to the show page with errors', async () => {
+        request.body = { isConvictedOfSexualOffence: '', isInAWomensPrison: '' }
+
+        const requestHandler = controller.submit()
+        await requestHandler(request, response, next)
+
+        expect(request.flash).toHaveBeenCalledWith('isConvictedOfSexualOffenceError', 'Select an option')
+        expect(request.flash).toHaveBeenCalledWith('isInAWomensPrisonError', 'Select an option')
+        expect(request.flash).toHaveBeenCalledWith('formValues', [
+          JSON.stringify({ isConvictedOfSexualOffence: '', isInAWomensPrison: '' }),
+        ])
+        expect(response.redirect).toHaveBeenCalledWith(findPaths.buildingChoices.form.show({ courseId }))
+      })
+    })
+  })
+})

--- a/server/controllers/find/buildingChoicesController.ts
+++ b/server/controllers/find/buildingChoicesController.ts
@@ -1,0 +1,60 @@
+import type { Request, Response, TypedRequestHandler } from 'express'
+
+import { findPaths } from '../../paths'
+import type { CourseService } from '../../services'
+import { FormUtils, TypeUtils } from '../../utils'
+import type { BuildingChoicesSearchForm } from '@accredited-programmes/ui'
+
+export default class BuildingChoicesController {
+  constructor(private readonly courseService: CourseService) {}
+
+  show(): TypedRequestHandler<Request, Response> {
+    return async (req: Request, res: Response) => {
+      FormUtils.setFieldErrors(req, res, ['isConvictedOfSexualOffence', 'isInAWomensPrison'])
+      FormUtils.setFormValues(req, res)
+
+      res.render('courses/offerings/buildingChoices/show', {
+        backLinkHref: findPaths.index({}),
+        pageHeading: "About the person you're referring",
+      })
+    }
+  }
+
+  submit(): TypedRequestHandler<Request, Response> {
+    return async (req: Request, res: Response) => {
+      TypeUtils.assertHasUser(req)
+
+      let hasErrors = false
+      const { courseId } = req.params
+      const { isConvictedOfSexualOffence, isInAWomensPrison } = req.body as BuildingChoicesSearchForm
+
+      if (!isConvictedOfSexualOffence) {
+        req.flash('isConvictedOfSexualOffenceError', 'Select an option')
+        hasErrors = true
+      }
+
+      if (!isInAWomensPrison) {
+        req.flash('isInAWomensPrisonError', 'Select an option')
+        hasErrors = true
+      }
+
+      if (hasErrors) {
+        req.flash('formValues', [JSON.stringify({ isConvictedOfSexualOffence, isInAWomensPrison })])
+        return res.redirect(findPaths.buildingChoices.form.show({ courseId }))
+      }
+
+      const buildingChoicesCourseVariants = await this.courseService.getBuildingChoicesVariants(
+        req.user.username,
+        courseId,
+        {
+          isConvictedOfSexualOffence,
+          isInAWomensPrison,
+        },
+      )
+
+      const course = buildingChoicesCourseVariants[0]
+
+      return res.redirect(findPaths.show({ courseId: course.id }))
+    }
+  }
+}

--- a/server/controllers/find/coursesController.test.ts
+++ b/server/controllers/find/coursesController.test.ts
@@ -84,6 +84,7 @@ describe('CoursesController', () => {
         expect(response.render).toHaveBeenCalledWith('courses/show', {
           addOfferingPath: `/find/programmes/${course.id}/offerings/add`,
           course: coursePresenter,
+          isBuildingChoices: false,
           organisationsTableData: OrganisationUtils.organisationTableRows(organisationsWithOfferingIds),
           pageHeading: coursePresenter.displayName,
           updateProgrammePath: `/find/programmes/${course.id}/update`,
@@ -125,6 +126,7 @@ describe('CoursesController', () => {
         expect(response.render).toHaveBeenCalledWith('courses/show', {
           addOfferingPath: `/find/programmes/${course.id}/offerings/add`,
           course: coursePresenter,
+          isBuildingChoices: false,
           organisationsTableData: OrganisationUtils.organisationTableRows(existingOrganisationsWithOfferingIds),
           pageHeading: coursePresenter.displayName,
           updateProgrammePath: `/find/programmes/${course.id}/update`,

--- a/server/controllers/find/coursesController.ts
+++ b/server/controllers/find/coursesController.ts
@@ -51,6 +51,7 @@ export default class CoursesController {
       res.render('courses/show', {
         addOfferingPath: findPaths.offerings.add.create({ courseId: course.id }),
         course: coursePresenter,
+        isBuildingChoices: CourseUtils.isBuildingChoices(course.displayName),
         organisationsTableData,
         pageHeading: coursePresenter.displayName,
         updateProgrammePath: findPaths.course.update.show({ courseId: course.id }),

--- a/server/controllers/find/index.ts
+++ b/server/controllers/find/index.ts
@@ -2,6 +2,7 @@
 
 import AddCourseController from './addCourseController'
 import AddCourseOfferingController from './addCourseOfferingController'
+import BuildingChoicesController from './buildingChoicesController'
 import CourseOfferingsController from './courseOfferingsController'
 import CoursesController from './coursesController'
 import UpdateCourseController from './updateCourseController'
@@ -14,6 +15,7 @@ const controllers = (services: Services) => {
     services.courseService,
     services.organisationService,
   )
+  const buildingChoicesController = new BuildingChoicesController(services.courseService)
   const coursesController = new CoursesController(services.courseService, services.organisationService)
   const courseOfferingsController = new CourseOfferingsController(services.courseService, services.organisationService)
   const updateCourseController = new UpdateCourseController(services.courseService)
@@ -25,6 +27,7 @@ const controllers = (services: Services) => {
   return {
     addCourseController,
     addCourseOfferingController,
+    buildingChoicesController,
     courseOfferingsController,
     coursesController,
     updateCourseController,

--- a/server/data/accreditedProgrammesApi/courseClient.ts
+++ b/server/data/accreditedProgrammesApi/courseClient.ts
@@ -11,7 +11,7 @@ import type {
   CoursePrerequisite,
   Person,
 } from '@accredited-programmes/models'
-import type { Course } from '@accredited-programmes-api'
+import type { BuildingChoicesSearchRequest, Course } from '@accredited-programmes-api'
 import type { SystemToken } from '@hmpps-auth'
 
 export default class CourseClient {
@@ -68,6 +68,17 @@ export default class CourseClient {
 
   async find(courseId: Course['id']): Promise<Course> {
     return (await this.restClient.get({ path: apiPaths.courses.show({ courseId }) })) as Course
+  }
+
+  /* istanbul ignore next */
+  async findBuildingChoicesVariants(
+    courseId: Course['id'],
+    requestBody: BuildingChoicesSearchRequest,
+  ): Promise<Array<Course>> {
+    return (await this.restClient.post({
+      data: { ...requestBody },
+      path: apiPaths.courses.buildingChoices({ courseId }),
+    })) as Array<Course>
   }
 
   async findCourseAudiences(): Promise<Array<Audience>> {

--- a/server/paths/api.ts
+++ b/server/paths/api.ts
@@ -44,6 +44,7 @@ const referralStatusCodeReasonsPath = referralStatusCodeCategoriesPath.path(':ca
 export default {
   courses: {
     audiences: coursesPath.path('audiences'),
+    buildingChoices: coursesPath.path('building-choices/:courseId'),
     create: coursesPath,
     index: coursesPath,
     names: courseNamesPath,

--- a/server/paths/find.ts
+++ b/server/paths/find.ts
@@ -7,12 +7,20 @@ const coursePath = coursesPath.path(':courseId')
 const addCoursePath = coursesPath.path('add')
 const updateCoursePath = coursePath.path('update')
 
+const buildingChoicesPath = findPathBase.path('building-choices/:courseId')
+
 const addCourseOfferingPath = coursePath.path('offerings/add')
 const deleteCourseOfferingPath = coursePath.path('offerings/:courseOfferingId/delete')
 const courseOfferingPath = findPathBase.path('offerings/:courseOfferingId')
 const updateCourseOfferingPath = courseOfferingPath.path('update')
 
 export default {
+  buildingChoices: {
+    form: {
+      show: buildingChoicesPath,
+      submit: buildingChoicesPath,
+    },
+  },
   course: {
     add: {
       create: addCoursePath,

--- a/server/routes/find.ts
+++ b/server/routes/find.ts
@@ -5,12 +5,15 @@ import { findPaths } from '../paths'
 import { RouteUtils } from '../utils'
 
 export default function routes(controllers: Controllers, router: Router): Router {
-  const { get } = RouteUtils.actions(router)
-  const { coursesController, courseOfferingsController } = controllers
+  const { get, post } = RouteUtils.actions(router)
+  const { buildingChoicesController, coursesController, courseOfferingsController } = controllers
 
   get(findPaths.index.pattern, coursesController.index())
   get(findPaths.show.pattern, coursesController.show())
   get(findPaths.offerings.show.pattern, courseOfferingsController.show())
+
+  get(findPaths.buildingChoices.form.show.pattern, buildingChoicesController.show())
+  post(findPaths.buildingChoices.form.submit.pattern, buildingChoicesController.submit())
 
   return router
 }

--- a/server/services/courseService.test.ts
+++ b/server/services/courseService.test.ts
@@ -18,6 +18,7 @@ import {
 } from '../testutils/factories'
 import { CourseParticipationUtils, StringUtils } from '../utils'
 import type { CourseCreateRequest, CourseOffering, CourseParticipationUpdate } from '@accredited-programmes/models'
+import type { BuildingChoicesSearchForm } from '@accredited-programmes/ui'
 
 jest.mock('../data/accreditedProgrammesApi/courseClient')
 jest.mock('../data/hmppsAuthClient')
@@ -228,6 +229,35 @@ describe('CourseService', () => {
             remove: false,
           },
         )
+      })
+    })
+  })
+
+  describe('getBuildingChoicesVariants', () => {
+    it('returns the courses associated with a given offering', async () => {
+      const course = courseFactory.build()
+      const formRequestBody = { isConvictedOfSexualOffence: 'true', isInAWomensPrison: 'false' }
+
+      when(courseClient.findBuildingChoicesVariants)
+        .calledWith(course.id, { isConvictedOfSexualOffence: true, isInAWomensPrison: false })
+        .mockResolvedValue([course])
+
+      const result = await service.getBuildingChoicesVariants(username, course.id, formRequestBody)
+
+      expect(result).toEqual([course])
+      expect(courseClientBuilder).toHaveBeenCalledWith(systemToken)
+    })
+
+    describe('when either of the form request body values are not provided', () => {
+      it('throws an error', async () => {
+        const course = courseFactory.build()
+        const formRequestBody = { isConvictedOfSexualOffence: 'true' } as BuildingChoicesSearchForm
+
+        await expect(() =>
+          service.getBuildingChoicesVariants(username, course.id, formRequestBody),
+        ).rejects.toThrowError('Values for isConvictedOfSexualOffence and isInAWomensPrison must be provided.')
+
+        expect(courseClientBuilder).toHaveBeenCalledWith(systemToken)
       })
     })
   })

--- a/server/services/courseService.ts
+++ b/server/services/courseService.ts
@@ -14,7 +14,10 @@ import type {
   Person,
   Referral,
 } from '@accredited-programmes/models'
-import type { GovukFrontendSummaryListWithRowsWithKeysAndValues } from '@accredited-programmes/ui'
+import type {
+  BuildingChoicesSearchForm,
+  GovukFrontendSummaryListWithRowsWithKeysAndValues,
+} from '@accredited-programmes/ui'
 import type { Course } from '@accredited-programmes-api'
 import type { Prison } from '@prison-register-api'
 
@@ -99,6 +102,27 @@ export default class CourseService {
         this.presentCourseParticipation(userToken, participation, referralId, withActions),
       ),
     )
+  }
+
+  async getBuildingChoicesVariants(
+    username: Express.User['username'],
+    courseId: Course['id'],
+    requestBody: BuildingChoicesSearchForm,
+  ): Promise<Array<Course>> {
+    const hmppsAuthClient = this.hmppsAuthClientBuilder()
+    const systemToken = await hmppsAuthClient.getSystemClientToken(username)
+    const courseClient = this.courseClientBuilder(systemToken)
+
+    const { isConvictedOfSexualOffence, isInAWomensPrison } = requestBody
+
+    if (isConvictedOfSexualOffence === undefined || isInAWomensPrison === undefined) {
+      throw createError(400, 'Values for isConvictedOfSexualOffence and isInAWomensPrison must be provided.')
+    }
+
+    return courseClient.findBuildingChoicesVariants(courseId, {
+      isConvictedOfSexualOffence: isConvictedOfSexualOffence === 'true',
+      isInAWomensPrison: isInAWomensPrison === 'true',
+    })
   }
 
   async getCourse(username: Express.User['username'], courseId: Course['id']): Promise<Course> {

--- a/server/testutils/factories/course.ts
+++ b/server/testutils/factories/course.ts
@@ -33,6 +33,7 @@ export default Factory.define<Course>(({ params }) => {
       coursePrerequisiteFactory.riskCriteria().build(),
       coursePrerequisiteFactory.riskCriteria().build(),
       coursePrerequisiteFactory.setting().build(),
+      coursePrerequisiteFactory.needsCriteria().build(),
       coursePrerequisiteFactory.suitableForPeopleWithLDCs().build(),
       coursePrerequisiteFactory.equivalentNonLDCProgramme().build(),
       coursePrerequisiteFactory.equivalentLDCProgramme().build(),

--- a/server/testutils/factories/coursePrerequisite.ts
+++ b/server/testutils/factories/coursePrerequisite.ts
@@ -32,6 +32,13 @@ class CoursePrerequisiteFactory extends Factory<CoursePrerequisite> {
     })
   }
 
+  needsCriteria(description?: string) {
+    return this.params({
+      description: description || 'High need, based on their programme needs identifier score',
+      name: 'Needs criteria',
+    })
+  }
+
   riskCriteria(description?: string) {
     return this.params({
       description: description || 'High ESARA/SARA/OVP, High OGRS',

--- a/server/utils/courseUtils.test.ts
+++ b/server/utils/courseUtils.test.ts
@@ -25,6 +25,20 @@ describe('CourseUtils', () => {
     })
   })
 
+  describe('isBuildingChoices', () => {
+    it('returns true when the course displayName starts with "Building Choices:"', () => {
+      expect(CourseUtils.isBuildingChoices('Building Choices: moderate intensity')).toBe(true)
+    })
+
+    it('returns false when the course displayName does not start with "Building Choices:"', () => {
+      expect(CourseUtils.isBuildingChoices('Lime Course')).toBe(false)
+    })
+
+    it('returns false when the course displayName is undefined', () => {
+      expect(CourseUtils.isBuildingChoices()).toBe(false)
+    })
+  })
+
   describe('presentCourse', () => {
     it('returns course details with UI-formatted audience and prerequisite data', () => {
       const course = courseFactory.build({
@@ -40,6 +54,7 @@ describe('CourseUtils', () => {
           coursePrerequisiteFactory.equivalentNonLDCProgramme().build(),
           coursePrerequisiteFactory.equivalentLDCProgramme().build(),
           coursePrerequisiteFactory.timeToComplete().build(),
+          coursePrerequisiteFactory.needsCriteria().build(),
         ],
         id: 'lime-course-1',
         name: 'Lime Course',
@@ -65,6 +80,10 @@ describe('CourseUtils', () => {
           {
             key: { text: 'Risk criteria' },
             value: { html: course.coursePrerequisites[2].description },
+          },
+          {
+            key: { text: 'Needs criteria' },
+            value: { html: course.coursePrerequisites[8].description },
           },
           {
             key: { text: 'Learning needs' },
@@ -109,7 +128,7 @@ describe('CourseUtils', () => {
         const course = courseFactory.build({ displayName: 'Building Choices: moderate intensity' })
         const coursePresenter = CourseUtils.presentCourse(course)
 
-        expect(coursePresenter.href).toBe('/find/building-choices')
+        expect(coursePresenter.href).toBe(`/find/building-choices/${course.id}`)
       })
     })
   })

--- a/server/utils/courseUtils.test.ts
+++ b/server/utils/courseUtils.test.ts
@@ -103,5 +103,14 @@ describe('CourseUtils', () => {
         })
       })
     })
+
+    describe('when a course displayName starts with "Building Choices:"', () => {
+      it('sets the href to the building choices form', () => {
+        const course = courseFactory.build({ displayName: 'Building Choices: moderate intensity' })
+        const coursePresenter = CourseUtils.presentCourse(course)
+
+        expect(coursePresenter.href).toBe('/find/building-choices')
+      })
+    })
   })
 })

--- a/server/utils/courseUtils.ts
+++ b/server/utils/courseUtils.ts
@@ -28,11 +28,15 @@ export default class CourseUtils {
     })
   }
 
+  static isBuildingChoices(displayName?: string): boolean {
+    return displayName?.startsWith('Building Choices:') ?? false
+  }
+
   static presentCourse(course: Course): CoursePresenter {
     return {
       ...course,
       audienceTag: CourseUtils.audienceTag(course),
-      href: course.displayName?.startsWith('Building Choices:')
+      href: this.isBuildingChoices(course.displayName)
         ? findPaths.buildingChoices.form.show({ courseId: course.id })
         : findPaths.show({ courseId: course.id }),
       prerequisiteSummaryListRows: CourseUtils.prerequisiteSummaryListRows(course.coursePrerequisites),
@@ -51,14 +55,17 @@ export default class CourseUtils {
     prerequisites: Array<CoursePrerequisite>,
   ): Array<GovukFrontendSummaryListRowWithKeyAndValue> {
     const order: Record<CoursePrerequisite['name'], number> = {
-      'Equivalent LDC programme': 6,
-      'Equivalent non-LDC programme': 5,
-      Gender: 1,
-      'Learning needs': 3,
-      'Risk criteria': 2,
+      /* eslint-disable sort-keys */
       Setting: 0,
-      'Suitable for people with learning disabilities or challenges (LDC)?': 4,
-      'Time to complete': 7,
+      Gender: 1,
+      'Risk criteria': 2,
+      'Needs criteria': 3,
+      'Learning needs': 4,
+      'Suitable for people with learning disabilities or challenges (LDC)?': 5,
+      'Equivalent non-LDC programme': 6,
+      'Equivalent LDC programme': 7,
+      'Time to complete': 8,
+      /* eslint-enable sort-keys */
     }
 
     const summaryListRows: Array<GovukFrontendSummaryListRowWithKeyAndValue> = []

--- a/server/utils/courseUtils.ts
+++ b/server/utils/courseUtils.ts
@@ -32,7 +32,9 @@ export default class CourseUtils {
     return {
       ...course,
       audienceTag: CourseUtils.audienceTag(course),
-      href: findPaths.show({ courseId: course.id }),
+      href: course.displayName?.startsWith('Building Choices:')
+        ? findPaths.buildingChoices.form.show({ courseId: course.id })
+        : findPaths.show({ courseId: course.id }),
       prerequisiteSummaryListRows: CourseUtils.prerequisiteSummaryListRows(course.coursePrerequisites),
     }
   }

--- a/server/views/courses/_indexCourseSummary.njk
+++ b/server/views/courses/_indexCourseSummary.njk
@@ -9,7 +9,9 @@
         <a class="govuk-link" href="{{ course.href }}">{{ course.displayName }}</a>
       </h2>
 
-      {{ audienceTag(course.audienceTag) }}
+      {% if "building choices" not in course.displayName | lower %}
+        {{ audienceTag(course.audienceTag) }}
+      {% endif %}
 
       <p class="govuk-body">{{ course.description }}</p>
 

--- a/server/views/courses/offerings/buildingChoices/show.njk
+++ b/server/views/courses/offerings/buildingChoices/show.njk
@@ -1,0 +1,82 @@
+{% from "govuk/components/back-link/macro.njk" import govukBackLink %}
+{% from "govuk/components/button/macro.njk" import govukButton %}
+{% from "govuk/components/error-summary/macro.njk" import govukErrorSummary %}
+{% from "govuk/components/radios/macro.njk" import govukRadios %}
+
+{% extends "../../../partials/layout.njk" %}
+
+{% block backLink %}
+  {{ govukBackLink({
+    text: "Back",
+    href: backLinkHref
+  }) }}
+{% endblock backLink %}
+
+{% block content %}
+  <div class="govuk-grid-row">
+    <div class="govuk-grid-column-two-thirds">
+      {% if errors.list.length %}
+        {{ govukErrorSummary({
+          titleText: "There is a problem",
+          errorList: errors.list
+        }) }}
+      {% endif %}
+
+      <h1 class="govuk-heading-l">{{ pageHeading }}</h1>
+
+      <p class="govuk-body">Not all prisons can offer programmes to all prisoners. To see a list of suitable locations, tell us more about the person you're referring.</p>
+
+      <form method="post">
+        <input type="hidden" name="_csrf" value="{{ csrfToken }}"/>
+
+        {{ govukRadios({
+          classes: "govuk-radios--inline",
+          name: "isConvictedOfSexualOffence",
+          value: formValues.isConvictedOfSexualOffence,
+          fieldset: {
+            legend: {
+              text: "Have they been convicted of a sexual offence?",
+              classes: "govuk-fieldset__legend--m"
+            }
+          },
+          items: [
+            {
+              value: "true",
+              text: "Yes"
+            },
+            {
+              value: "false",
+              text: "No"
+            }
+          ],
+          errorMessage: errors.messages.isConvictedOfSexualOffence
+        }) }}
+
+        {{ govukRadios({
+          classes: "govuk-radios--inline",
+          name: "isInAWomensPrison",
+          value: formValues.isInAWomensPrison,
+          fieldset: {
+            legend: {
+              text: "Are they in a women's prison?",
+              classes: "govuk-fieldset__legend--m"
+            }
+          },
+          items: [
+            {
+              value: "true",
+              text: "Yes"
+            },
+            {
+              value: "false",
+              text: "No"
+            }
+          ],
+          errorMessage: errors.messages.isInAWomensPrison
+        }) }}
+
+        {{ govukButton({ text: "Continue" }) }}
+      </form>
+    </div>
+  </div>
+{% endblock content %}

--- a/server/views/courses/show.njk
+++ b/server/views/courses/show.njk
@@ -31,18 +31,20 @@
 
   <div class="govuk-grid-row">
     <div class="govuk-grid-column-two-thirds">
-      {{ audienceTag(course.audienceTag) }}
+      {% if not isBuildingChoices %}
+        {{ audienceTag(course.audienceTag) }}
 
-      <h2 class="govuk-heading-m">Programme criteria</h2>
+        <h2 class="govuk-heading-m">Programme criteria</h2>
 
-      {{ govukSummaryList({
-        classes: 'govuk-summary-list--no-border',
-        rows: course.prerequisiteSummaryListRows
-      }) }}
+        {{ govukSummaryList({
+          classes: 'govuk-summary-list--no-border',
+          rows: course.prerequisiteSummaryListRows
+        }) }}
 
-      <h2 class="govuk-heading-m">Programme description</h2>
+        <h2 class="govuk-heading-m">Programme description</h2>
 
-      <p class="govuk-body" data-testid="description-paragraph">{{ course.description }}</p>
+        <p class="govuk-body" data-testid="description-paragraph">{{ course.description }}</p>
+      {% endif %}
 
       <div class="header-with-actions">
         <h2 class="header-with-actions__title govuk-heading-m">Locations</h2>


### PR DESCRIPTION
## Context

When someone selects Building Choices they are prompted to answer 2 more questions. As per designs.



## Changes in this PR
- Add new BuildingChoicesController to display and submit the form
- Link to Building choices form from find page for Building choice courses


## Screenshots of UI changes

![image](https://github.com/user-attachments/assets/30a355b6-8247-43d9-9235-33625ed5569b)


## Release checklist

[Release process documentation](../doc/how-to/perform-a-release.md)

As part of our continuous deployment strategy we must ensure that this work is
ready to be released once merged.

### Pre-merge

- [ ] There are changes required to the Accredited Programmes API for this change to work...
  - [ ] ... and they have been released to production already

### Post-merge

<!-- The outer checkboxes can be completed pre-merge -->

- [ ] This adds, extends or meaningfully modifies a feature...
  - [ ] ... and I have written or updated an end-to-end test for the happy path in the [Accredited Programmes E2E repo](https://github.com/ministryofjustice/hmpps-accredited-programmes-e2e)
- [ ] This makes new expectations of the API...
  - [ ] ... and I have notified the API developer(s) of changes to the contract tests (Pact), or the API is already compliant
- [ ] [Manually approve](../doc/how-to/perform-a-release.md#releasing-to-the-preprod-environment) release to preprod
- [ ] [Manually approve](../doc/how-to/perform-a-release.md#releasing-to-the-production-environment) release to prod

<!-- Should a release fail at any step, you as the author should now lead the work to
fix it as soon as possible. You can monitor deployment failures in CircleCI
itself and application errors are found in
[Sentry](https://ministryofjustice.sentry.io/projects/hmpps-accredited-programmes-ui/?project=4505330122686464&referrer=sidebar&statsPeriod=24h). -->
