### PR TITLE
(APG-497) Add supporting text for conditional field labels for screen readers

### DIFF
--- a/integration_tests/pages/refer/new/programmeHistoryDetails.ts
+++ b/integration_tests/pages/refer/new/programmeHistoryDetails.ts
@@ -55,8 +55,8 @@ export default class NewReferralProgrammeHistoryDetailsPage extends Page {
   shouldContainOutcomeRadioItems() {
     cy.get('[data-testid="outcome-options"]').within(() => {
       this.shouldContainRadioItems([
-        { text: 'Complete', value: 'complete' },
-        { text: 'Incomplete', value: 'incomplete' },
+        { text: 'Complete If complete, optionally enter the year completed.', value: 'complete' },
+        { text: 'Incomplete If incomplete, optionally enter the year started.', value: 'incomplete' },
       ])
     })
   }
@@ -64,8 +64,8 @@ export default class NewReferralProgrammeHistoryDetailsPage extends Page {
   shouldContainSettingRadioItems() {
     cy.get('[data-testid="setting-options"]').within(() => {
       this.shouldContainRadioItems([
-        { text: 'Community', value: 'community' },
-        { text: 'Custody', value: 'custody' },
+        { text: 'Community If community setting, optionally enter the location.', value: 'community' },
+        { text: 'Custody If custody setting, optionally enter the location.', value: 'custody' },
       ])
     })
   }

--- a/integration_tests/pages/refer/new/selectProgramme.ts
+++ b/integration_tests/pages/refer/new/selectProgramme.ts
@@ -21,7 +21,7 @@ export default class NewReferralSelectProgrammePage extends Page {
   shouldContainCourseOptions() {
     this.shouldContainRadioItems([
       ...this.courses.map(course => ({ text: course.name, value: course.name })),
-      { text: 'Other', value: 'Other' },
+      { text: 'Other If other, enter the programme name.', value: 'Other' },
     ])
   }
 

--- a/server/views/referrals/new/courseParticipations/course.njk
+++ b/server/views/referrals/new/courseParticipations/course.njk
@@ -58,7 +58,7 @@
           },
           items: courseRadioOptions.concat({
             value: "Other",
-            text: "Other",
+            html: 'Other<span class="govuk-visually-hidden">If other, enter the programme name.</span>',
             conditional: {
               html: otherCourseHtml
             },

--- a/server/views/referrals/new/courseParticipations/details/show.njk
+++ b/server/views/referrals/new/courseParticipations/details/show.njk
@@ -102,7 +102,7 @@
           items: [
             {
               value: "community",
-              text: "Community",
+              html: 'Community<span class="govuk-visually-hidden">If community setting, optionally enter the location.</span>',
               conditional: {
                 html: communityLocationHtml
               },
@@ -113,7 +113,7 @@
             },
             {
               value: "custody",
-              text: "Custody",
+              html: 'Custody<span class="govuk-visually-hidden">If custody setting, optionally enter the location.</span>',
               conditional: {
                 html: custodyLocationHtml
               },
@@ -139,7 +139,7 @@
           items: [
             {
               value: "complete",
-              text: "Complete",
+              html: 'Complete<span class="govuk-visually-hidden">If complete, optionally enter the year completed.</span>',
               conditional: {
                 html: yearCompletedHtml
               },
@@ -150,7 +150,7 @@
             },
             {
               value: "incomplete",
-              text: "Incomplete",
+              html: 'Incomplete<span class="govuk-visually-hidden">If incomplete, optionally enter the year started.</span>',
               conditional: {
                 html: yearStartedHtml
               },

--- a/server/views/reports/show.njk
+++ b/server/views/reports/show.njk
@@ -104,7 +104,7 @@
                   },
                   {
                     value: "custom",
-                    text: "custom dates",
+                    html: 'custom dates<span class="govuk-visually-hidden">If custom dates, enter the date from and date to.</span>',
                     conditional: {
                       html: customDatesHtml
                     }
@@ -131,7 +131,7 @@
                   },
                   {
                     value: "prison",
-                    text: "data by prison",
+                    html: 'data by prison<span class="govuk-visually-hidden">If data by prison, select a prison.</span>',
                     conditional: {
                       html: locationOptionsHtml
                     }


### PR DESCRIPTION
## Context

We have been recommended to add supporting text for screen readers to conditionally revealed radio button elements.

## Changes in this PR
Add supporting text within a `govuk-visualy-hidden` `span` to all uses of conditional radio items.


## Release checklist

[Release process documentation](../doc/how-to/perform-a-release.md)

As part of our continuous deployment strategy we must ensure that this work is
ready to be released once merged.

### Pre-merge

- [ ] There are changes required to the Accredited Programmes API for this change to work...
  - [ ] ... and they have been released to production already

### Post-merge

<!-- The outer checkboxes can be completed pre-merge -->

- [ ] This adds, extends or meaningfully modifies a feature...
  - [ ] ... and I have written or updated an end-to-end test for the happy path in the [Accredited Programmes E2E repo](https://github.com/ministryofjustice/hmpps-accredited-programmes-e2e)
- [ ] This makes new expectations of the API...
  - [ ] ... and I have notified the API developer(s) of changes to the contract tests (Pact), or the API is already compliant
- [ ] [Manually approve](../doc/how-to/perform-a-release.md#releasing-to-the-preprod-environment) release to preprod
- [ ] [Manually approve](../doc/how-to/perform-a-release.md#releasing-to-the-production-environment) release to prod

<!-- Should a release fail at any step, you as the author should now lead the work to
fix it as soon as possible. You can monitor deployment failures in CircleCI
itself and application errors are found in
[Sentry](https://ministryofjustice.sentry.io/projects/hmpps-accredited-programmes-ui/?project=4505330122686464&referrer=sidebar&statsPeriod=24h). -->
