### PR TITLE
Add pre and post risk criteria strings to pre requisites list

### DIFF
--- a/server/testutils/factories/coursePrerequisite.ts
+++ b/server/testutils/factories/coursePrerequisite.ts
@@ -46,6 +46,21 @@ class CoursePrerequisiteFactory extends Factory<CoursePrerequisite> {
     })
   }
 
+  riskCritieriaPost(description?: string) {
+    return this.params({
+      description:
+        description || 'The person should not score high in any risk areas for the moderate intensity pathway.',
+      name: 'Risk criteria post',
+    })
+  }
+
+  riskCritieriaPre(description?: string) {
+    return this.params({
+      description: description || 'Medium in at least one of these areas:',
+      name: 'Risk criteria pre',
+    })
+  }
+
   setting(description?: string) {
     return this.params({
       description: description || 'Custody',

--- a/server/utils/courseUtils.test.ts
+++ b/server/utils/courseUtils.test.ts
@@ -81,21 +81,24 @@ describe('CourseUtils', () => {
 
   describe('presentCourse', () => {
     it('returns course details with UI-formatted audience and prerequisite data', () => {
+      const coursePrerequisites = [
+        coursePrerequisiteFactory.gender().build(),
+        coursePrerequisiteFactory.learningNeeds().build(),
+        coursePrerequisiteFactory.riskCriteria().build(),
+        coursePrerequisiteFactory.setting().build(),
+        coursePrerequisiteFactory.suitableForPeopleWithLDCs().build(),
+        coursePrerequisiteFactory.equivalentNonLDCProgramme().build(),
+        coursePrerequisiteFactory.equivalentLDCProgramme().build(),
+        coursePrerequisiteFactory.timeToComplete().build(),
+        coursePrerequisiteFactory.needsCriteria().build(),
+        coursePrerequisiteFactory.riskCritieriaPost().build(),
+        coursePrerequisiteFactory.riskCritieriaPre().build(),
+      ]
       const course = courseFactory.build({
         alternateName: 'LC',
         audience: 'Intimate partner violence offence',
         audienceColour: 'green',
-        coursePrerequisites: [
-          coursePrerequisiteFactory.gender().build(),
-          coursePrerequisiteFactory.learningNeeds().build(),
-          coursePrerequisiteFactory.riskCriteria().build(),
-          coursePrerequisiteFactory.setting().build(),
-          coursePrerequisiteFactory.suitableForPeopleWithLDCs().build(),
-          coursePrerequisiteFactory.equivalentNonLDCProgramme().build(),
-          coursePrerequisiteFactory.equivalentLDCProgramme().build(),
-          coursePrerequisiteFactory.timeToComplete().build(),
-          coursePrerequisiteFactory.needsCriteria().build(),
-        ],
+        coursePrerequisites,
         id: 'lime-course-1',
         name: 'Lime Course',
       })
@@ -111,39 +114,41 @@ describe('CourseUtils', () => {
         prerequisiteSummaryListRows: [
           {
             key: { text: 'Setting' },
-            value: { html: course.coursePrerequisites[3].description },
+            value: { html: coursePrerequisites[3].description },
           },
           {
             key: { text: 'Gender' },
-            value: { html: course.coursePrerequisites[0].description },
+            value: { html: coursePrerequisites[0].description },
           },
           {
             key: { text: 'Risk criteria' },
-            value: { html: course.coursePrerequisites[2].description },
+            value: {
+              html: `${coursePrerequisites[10].description}<br><br>${coursePrerequisites[2].description}<br><br>${coursePrerequisites[9].description}`,
+            },
           },
           {
             key: { text: 'Needs criteria' },
-            value: { html: course.coursePrerequisites[8].description },
+            value: { html: coursePrerequisites[8].description },
           },
           {
             key: { text: 'Learning needs' },
-            value: { html: course.coursePrerequisites[1].description },
+            value: { html: coursePrerequisites[1].description },
           },
           {
             key: { text: 'Suitable for people with learning disabilities or challenges (LDC)?' },
-            value: { html: course.coursePrerequisites[4].description },
+            value: { html: coursePrerequisites[4].description },
           },
           {
             key: { text: 'Equivalent non-LDC programme' },
-            value: { html: course.coursePrerequisites[5].description },
+            value: { html: coursePrerequisites[5].description },
           },
           {
             key: { text: 'Equivalent LDC programme' },
-            value: { html: course.coursePrerequisites[6].description },
+            value: { html: coursePrerequisites[6].description },
           },
           {
             key: { text: 'Time to complete' },
-            value: { html: course.coursePrerequisites[7].description },
+            value: { html: coursePrerequisites[7].description },
           },
         ],
       })

--- a/server/utils/courseUtils.ts
+++ b/server/utils/courseUtils.ts
@@ -61,7 +61,7 @@ export default class CourseUtils {
       href: this.isBuildingChoices(course.displayName)
         ? findPaths.buildingChoices.form.show({ courseId: course.id })
         : findPaths.show({ courseId: course.id }),
-      prerequisiteSummaryListRows: CourseUtils.prerequisiteSummaryListRows(course.coursePrerequisites),
+      prerequisiteSummaryListRows: this.prerequisiteSummaryListRows(course.coursePrerequisites),
     }
   }
 
@@ -92,22 +92,41 @@ export default class CourseUtils {
 
     const summaryListRows: Array<GovukFrontendSummaryListRowWithKeyAndValue> = []
 
-    prerequisites.forEach(prerequisite => {
-      const index = order[prerequisite.name]
+    const prerequisitesCopy = [...prerequisites]
+    prerequisitesCopy
+      .sort((a, b) => a.name.localeCompare(b.name))
+      .forEach(prerequisite => {
+        const index = order[prerequisite.name]
 
-      if (index === undefined) {
-        return
-      }
+        if (prerequisite.name === 'Risk criteria pre' || prerequisite.name === 'Risk criteria post') {
+          const riskCriteriaItems = summaryListRows[order['Risk criteria']]
 
-      if (summaryListRows[index]) {
-        ;(summaryListRows[index].value as HasHtmlString).html += `<br>${prerequisite.description}`
-      } else {
-        summaryListRows[index] = {
-          key: { text: prerequisite.name },
-          value: { html: prerequisite.description },
+          if (riskCriteriaItems) {
+            const { description } = prerequisite
+            const existingHtml = riskCriteriaItems.value.html
+
+            riskCriteriaItems.value.html =
+              prerequisite.name === 'Risk criteria pre'
+                ? `${description}<br><br>${existingHtml}`
+                : `${existingHtml}<br><br>${description}`
+          }
+
+          return
         }
-      }
-    })
+
+        if (index === undefined) {
+          return
+        }
+
+        if (summaryListRows[index]) {
+          ;(summaryListRows[index].value as HasHtmlString).html += `<br>${prerequisite.description}`
+        } else {
+          summaryListRows[index] = {
+            key: { text: prerequisite.name },
+            value: { html: prerequisite.description },
+          }
+        }
+      })
 
     return summaryListRows
   }


### PR DESCRIPTION
## Context

Additional text needs to be displayed above and below risk criteria for Building choices programmes.



## Changes in this PR
Updated Course presenter util to handle pre and post risk criteria keys.


## Screenshots of UI changes

![image](https://github.com/user-attachments/assets/1ec48d58-ef00-49bf-89bc-e25af657e180)



## Release checklist

[Release process documentation](../doc/how-to/perform-a-release.md)

As part of our continuous deployment strategy we must ensure that this work is
ready to be released once merged.

### Pre-merge

- [ ] There are changes required to the Accredited Programmes API for this change to work...
  - [ ] ... and they have been released to production already

### Post-merge

<!-- The outer checkboxes can be completed pre-merge -->

- [ ] This adds, extends or meaningfully modifies a feature...
  - [ ] ... and I have written or updated an end-to-end test for the happy path in the [Accredited Programmes E2E repo](https://github.com/ministryofjustice/hmpps-accredited-programmes-e2e)
- [ ] This makes new expectations of the API...
  - [ ] ... and I have notified the API developer(s) of changes to the contract tests (Pact), or the API is already compliant
- [ ] [Manually approve](../doc/how-to/perform-a-release.md#releasing-to-the-preprod-environment) release to preprod
- [ ] [Manually approve](../doc/how-to/perform-a-release.md#releasing-to-the-production-environment) release to prod

<!-- Should a release fail at any step, you as the author should now lead the work to
fix it as soon as possible. You can monitor deployment failures in CircleCI
itself and application errors are found in
[Sentry](https://ministryofjustice.sentry.io/projects/hmpps-accredited-programmes-ui/?project=4505330122686464&referrer=sidebar&statsPeriod=24h). -->
