### PR TITLE
(APG-554) Show error specific content when the pathway is not known

### DIFF
--- a/assets/scss/components/_pathway-content.scss
+++ b/assets/scss/components/_pathway-content.scss
@@ -29,7 +29,8 @@
     }
   }
 
-  &--missing {
+  &--missing,
+  &--error {
     border-color: #1d70b8;
 
     #{$self}__heading {

--- a/server/services/pniService.test.ts
+++ b/server/services/pniService.test.ts
@@ -56,40 +56,13 @@ describe('PniService', () => {
     })
 
     describe('when the PNI client throws an error', () => {
-      it('returns null when the error status is 400', async () => {
-        const clientError = createError(400)
-        pniClient.findPni.mockRejectedValue(clientError)
-
-        const result = await service.getPni(username, prisonNumber)
-
-        expect(result).toBeNull()
-
-        expect(hmppsAuthClientBuilder).toHaveBeenCalled()
-        expect(hmppsAuthClient.getSystemClientToken).toHaveBeenCalledWith(username)
-        expect(pniClientBuilder).toHaveBeenCalledWith(systemToken)
-        expect(pniClient.findPni).toHaveBeenCalledWith(prisonNumber, undefined)
-      })
-
-      it('returns null when the error status is 404', async () => {
-        const clientError = createError(404)
-        pniClient.findPni.mockRejectedValue(clientError)
-
-        const result = await service.getPni(username, prisonNumber)
-
-        expect(result).toBeNull()
-
-        expect(hmppsAuthClientBuilder).toHaveBeenCalled()
-        expect(hmppsAuthClient.getSystemClientToken).toHaveBeenCalledWith(username)
-        expect(pniClientBuilder).toHaveBeenCalledWith(systemToken)
-        expect(pniClient.findPni).toHaveBeenCalledWith(prisonNumber, undefined)
-      })
-
-      it('re-throws the error when the status is not 404', async () => {
+      it('returns null', async () => {
         const clientError = createError(500)
         pniClient.findPni.mockRejectedValue(clientError)
 
-        const expectedError = createError(500, `Error fetching PNI data for prison number ${prisonNumber}.`)
-        await expect(service.getPni(username, prisonNumber)).rejects.toThrow(expectedError)
+        const result = await service.getPni(username, prisonNumber)
+
+        expect(result).toBeNull()
 
         expect(hmppsAuthClientBuilder).toHaveBeenCalled()
         expect(hmppsAuthClient.getSystemClientToken).toHaveBeenCalledWith(username)

--- a/server/services/pniService.ts
+++ b/server/services/pniService.ts
@@ -1,6 +1,3 @@
-import createError from 'http-errors'
-import type { ResponseError } from 'superagent'
-
 import type { HmppsAuthClient, PniClient, RestClientBuilder, RestClientBuilderWithoutToken } from '../data'
 import type { Referral } from '@accredited-programmes/models'
 import type { PniScore } from '@accredited-programmes-api'
@@ -25,13 +22,7 @@ export default class PniService {
 
       return pni
     } catch (error) {
-      const knownError = error as ResponseError
-
-      if (knownError.status === 400 || knownError.status === 404) {
-        return null
-      }
-
-      throw createError(knownError.status || 500, `Error fetching PNI data for prison number ${prisonNumber}.`)
+      return null
     }
   }
 }

--- a/server/utils/risksAndNeeds/pniUtils.test.ts
+++ b/server/utils/risksAndNeeds/pniUtils.test.ts
@@ -109,15 +109,26 @@ describe('PniUtils', () => {
       })
     })
 
-    it('returns the pathway content for the given person name and an unknown programme pathway', () => {
-      const pathwayContent = PniUtils.pathwayContent(personName)
+    it('returns the pathway content for the given person name and MISSING_INFORMATION programme pathway', () => {
+      const pathwayContent = PniUtils.pathwayContent(personName, 'MISSING_INFORMATION')
 
       expect(pathwayContent).toEqual({
         bodyText:
           'There is not enough information in the layer 3 assessment to calculate the recommended programme pathway.',
         class: 'pathway-content--missing',
-        dataTestId: 'unknown-pathway',
+        dataTestId: 'missing-informaton-pathway-content',
         headingText: 'Information missing',
+      })
+    })
+
+    it('returns the error pathway content when the pathway is undefined', () => {
+      const pathwayContent = PniUtils.pathwayContent(personName)
+
+      expect(pathwayContent).toEqual({
+        bodyText: 'The service cannot calculate the recommended pathway at the moment. Try again later.',
+        class: 'pathway-content--error',
+        dataTestId: 'error-pathway-content',
+        headingText: 'Error',
       })
     })
   })

--- a/server/utils/risksAndNeeds/pniUtils.ts
+++ b/server/utils/risksAndNeeds/pniUtils.ts
@@ -55,13 +55,20 @@ export default class PniUtils {
           dataTestId: 'alternative-pathway-content',
           headingText: 'Not eligible',
         }
-      default:
+      case 'MISSING_INFORMATION':
         return {
           bodyText:
             'There is not enough information in the layer 3 assessment to calculate the recommended programme pathway.',
           class: 'pathway-content--missing',
-          dataTestId: 'unknown-pathway',
+          dataTestId: 'missing-informaton-pathway-content',
           headingText: 'Information missing',
+        }
+      default:
+        return {
+          bodyText: 'The service cannot calculate the recommended pathway at the moment. Try again later.',
+          class: 'pathway-content--error',
+          dataTestId: 'error-pathway-content',
+          headingText: 'Error',
         }
     }
   }


### PR DESCRIPTION
## Context

At the moment, we show the Information missing content, even when there has been an error.  This should only appear when the pathway is INFORMATION_MISSING.  Instead, we should show an error specific message for any errors relating to retrieving a PNI score.

## Changes in this PR
Show error specific content when the pathway is not known.


## Screenshots of UI changes
![image](https://github.com/user-attachments/assets/044df2c9-a9b2-4c52-9dd3-2d8b88655f1d)



## Release checklist

[Release process documentation](../doc/how-to/perform-a-release.md)

As part of our continuous deployment strategy we must ensure that this work is
ready to be released once merged.

### Pre-merge

- [ ] There are changes required to the Accredited Programmes API for this change to work...
  - [ ] ... and they have been released to production already

### Post-merge

<!-- The outer checkboxes can be completed pre-merge -->

- [ ] This adds, extends or meaningfully modifies a feature...
  - [ ] ... and I have written or updated an end-to-end test for the happy path in the [Accredited Programmes E2E repo](https://github.com/ministryofjustice/hmpps-accredited-programmes-e2e)
- [ ] This makes new expectations of the API...
  - [ ] ... and I have notified the API developer(s) of changes to the contract tests (Pact), or the API is already compliant
- [ ] [Manually approve](../doc/how-to/perform-a-release.md#releasing-to-the-preprod-environment) release to preprod
- [ ] [Manually approve](../doc/how-to/perform-a-release.md#releasing-to-the-production-environment) release to prod

<!-- Should a release fail at any step, you as the author should now lead the work to
fix it as soon as possible. You can monitor deployment failures in CircleCI
itself and application errors are found in
[Sentry](https://ministryofjustice.sentry.io/projects/hmpps-accredited-programmes-ui/?project=4505330122686464&referrer=sidebar&statsPeriod=24h). -->
