### PR TITLE
Revert "(APG-554) Show error specific content when the pathway is not known"

### DIFF
--- a/assets/scss/components/_pathway-content.scss
+++ b/assets/scss/components/_pathway-content.scss
@@ -29,8 +29,7 @@
     }
   }
 
-  &--missing,
-  &--error {
+  &--missing {
     border-color: #1d70b8;
 
     #{$self}__heading {

--- a/server/services/pniService.ts
+++ b/server/services/pniService.ts
@@ -1,3 +1,6 @@
+import createError from 'http-errors'
+import type { ResponseError } from 'superagent'
+
 import type { HmppsAuthClient, PniClient, RestClientBuilder, RestClientBuilderWithoutToken } from '../data'
 import type { Referral } from '@accredited-programmes/models'
 import type { PniScore } from '@accredited-programmes-api'
@@ -22,7 +25,13 @@ export default class PniService {
 
       return pni
     } catch (error) {
-      return null
+      const knownError = error as ResponseError
+
+      if (knownError.status === 400 || knownError.status === 404) {
+        return null
+      }
+
+      throw createError(knownError.status || 500, `Error fetching PNI data for prison number ${prisonNumber}.`)
     }
   }
 }

--- a/server/utils/risksAndNeeds/pniUtils.test.ts
+++ b/server/utils/risksAndNeeds/pniUtils.test.ts
@@ -109,26 +109,15 @@ describe('PniUtils', () => {
       })
     })
 
-    it('returns the pathway content for the given person name and MISSING_INFORMATION programme pathway', () => {
-      const pathwayContent = PniUtils.pathwayContent(personName, 'MISSING_INFORMATION')
+    it('returns the pathway content for the given person name and an unknown programme pathway', () => {
+      const pathwayContent = PniUtils.pathwayContent(personName)
 
       expect(pathwayContent).toEqual({
         bodyText:
           'There is not enough information in the layer 3 assessment to calculate the recommended programme pathway.',
         class: 'pathway-content--missing',
-        dataTestId: 'missing-informaton-pathway-content',
+        dataTestId: 'unknown-pathway',
         headingText: 'Information missing',
-      })
-    })
-
-    it('returns the error pathway content when the pathway is undefined', () => {
-      const pathwayContent = PniUtils.pathwayContent(personName)
-
-      expect(pathwayContent).toEqual({
-        bodyText: 'The service cannot calculate the recommended pathway at the moment. Try again later.',
-        class: 'pathway-content--error',
-        dataTestId: 'error-pathway-content',
-        headingText: 'Error',
       })
     })
   })

--- a/server/utils/risksAndNeeds/pniUtils.ts
+++ b/server/utils/risksAndNeeds/pniUtils.ts
@@ -55,20 +55,13 @@ export default class PniUtils {
           dataTestId: 'alternative-pathway-content',
           headingText: 'Not eligible',
         }
-      case 'MISSING_INFORMATION':
+      default:
         return {
           bodyText:
             'There is not enough information in the layer 3 assessment to calculate the recommended programme pathway.',
           class: 'pathway-content--missing',
-          dataTestId: 'missing-informaton-pathway-content',
+          dataTestId: 'unknown-pathway',
           headingText: 'Information missing',
-        }
-      default:
-        return {
-          bodyText: 'The service cannot calculate the recommended pathway at the moment. Try again later.',
-          class: 'pathway-content--error',
-          dataTestId: 'error-pathway-content',
-          headingText: 'Error',
         }
     }
   }


### PR DESCRIPTION
Reverts ministryofjustice/hmpps-accredited-programmes-ui#804

API change required to return MISSING_INFORMATION programmePathway for other scenarios.