### PR TITLE
(APG-554) Show error specific content when there has been an PNI API error

### DIFF
--- a/assets/scss/components/_pathway-content.scss
+++ b/assets/scss/components/_pathway-content.scss
@@ -29,7 +29,8 @@
     }
   }
 
-  &--missing {
+  &--missing,
+  &--error {
     border-color: #1d70b8;
 
     #{$self}__heading {

--- a/server/controllers/assess/pniController.test.ts
+++ b/server/controllers/assess/pniController.test.ts
@@ -154,4 +154,22 @@ describe('PniController', () => {
       })
     })
   })
+
+  describe('when the pni service throws an error', () => {
+    it('render the pni page with the correct response locals', async () => {
+      pniService.getPni.mockRejectedValue(new Error('Some error'))
+
+      const requestHandler = controller.show()
+      await requestHandler(request, response, next)
+
+      expect(PniUtils.pathwayContent).toHaveBeenCalledWith(person.name, undefined)
+      expect(response.render).toHaveBeenCalledWith(
+        'referrals/show/pni/show',
+        expect.objectContaining({
+          hasData: false,
+          pathwayContent,
+        }),
+      )
+    })
+  })
 })

--- a/server/services/pniService.test.ts
+++ b/server/services/pniService.test.ts
@@ -56,20 +56,6 @@ describe('PniService', () => {
     })
 
     describe('when the PNI client throws an error', () => {
-      it('returns null when the error status is 400', async () => {
-        const clientError = createError(400)
-        pniClient.findPni.mockRejectedValue(clientError)
-
-        const result = await service.getPni(username, prisonNumber)
-
-        expect(result).toBeNull()
-
-        expect(hmppsAuthClientBuilder).toHaveBeenCalled()
-        expect(hmppsAuthClient.getSystemClientToken).toHaveBeenCalledWith(username)
-        expect(pniClientBuilder).toHaveBeenCalledWith(systemToken)
-        expect(pniClient.findPni).toHaveBeenCalledWith(prisonNumber, undefined)
-      })
-
       it('returns null when the error status is 404', async () => {
         const clientError = createError(404)
         pniClient.findPni.mockRejectedValue(clientError)

--- a/server/services/pniService.ts
+++ b/server/services/pniService.ts
@@ -1,7 +1,7 @@
-import createError from 'http-errors'
-import type { ResponseError } from 'superagent'
+import createHttpError from 'http-errors'
 
 import type { HmppsAuthClient, PniClient, RestClientBuilder, RestClientBuilderWithoutToken } from '../data'
+import type { SanitisedError } from '../sanitisedError'
 import type { Referral } from '@accredited-programmes/models'
 import type { PniScore } from '@accredited-programmes-api'
 
@@ -25,13 +25,13 @@ export default class PniService {
 
       return pni
     } catch (error) {
-      const knownError = error as ResponseError
+      const sanitisedError = error as SanitisedError
 
-      if (knownError.status === 400 || knownError.status === 404) {
+      if (sanitisedError.status === 404) {
         return null
       }
 
-      throw createError(knownError.status || 500, `Error fetching PNI data for prison number ${prisonNumber}.`)
+      throw createHttpError(sanitisedError.status || 500, `Error fetching PNI data for prison number ${prisonNumber}.`)
     }
   }
 }

--- a/server/utils/risksAndNeeds/pniUtils.test.ts
+++ b/server/utils/risksAndNeeds/pniUtils.test.ts
@@ -109,15 +109,26 @@ describe('PniUtils', () => {
       })
     })
 
-    it('returns the pathway content for the given person name and an unknown programme pathway', () => {
-      const pathwayContent = PniUtils.pathwayContent(personName)
+    it('returns the pathway content for the given person name and MISSING_INFORMATION programme pathway', () => {
+      const pathwayContent = PniUtils.pathwayContent(personName, 'MISSING_INFORMATION')
 
       expect(pathwayContent).toEqual({
         bodyText:
           'There is not enough information in the layer 3 assessment to calculate the recommended programme pathway.',
         class: 'pathway-content--missing',
-        dataTestId: 'unknown-pathway',
+        dataTestId: 'missing-informaton-pathway-content',
         headingText: 'Information missing',
+      })
+    })
+
+    it('returns the error pathway content when the pathway is undefined', () => {
+      const pathwayContent = PniUtils.pathwayContent(personName)
+
+      expect(pathwayContent).toEqual({
+        bodyText: 'The service cannot calculate the recommended pathway at the moment. Try again later.',
+        class: 'pathway-content--error',
+        dataTestId: 'error-pathway-content',
+        headingText: 'Error',
       })
     })
   })

--- a/server/utils/risksAndNeeds/pniUtils.ts
+++ b/server/utils/risksAndNeeds/pniUtils.ts
@@ -55,13 +55,20 @@ export default class PniUtils {
           dataTestId: 'alternative-pathway-content',
           headingText: 'Not eligible',
         }
-      default:
+      case 'MISSING_INFORMATION':
         return {
           bodyText:
             'There is not enough information in the layer 3 assessment to calculate the recommended programme pathway.',
           class: 'pathway-content--missing',
-          dataTestId: 'unknown-pathway',
+          dataTestId: 'missing-informaton-pathway-content',
           headingText: 'Information missing',
+        }
+      default:
+        return {
+          bodyText: 'The service cannot calculate the recommended pathway at the moment. Try again later.',
+          class: 'pathway-content--error',
+          dataTestId: 'error-pathway-content',
+          headingText: 'Error',
         }
     }
   }


### PR DESCRIPTION
## Context

In the event of an API error, other than a 404, we need to display something more meaningful to the user, so they know to try again later.

## Changes in this PR
Update PNI utils, service and controller to show error content when there has been an API error, but still show Missing Information if there is a 404 error.


## Screenshots of UI changes
Missing information in OASys or no assessment found (404 from api):
![image](https://github.com/user-attachments/assets/77e2d896-2b5e-472e-b68e-f1b66585f357)

Any other API error:
![image](https://github.com/user-attachments/assets/2ed225d4-e300-4ae5-948a-44b41d1fd25d)



## Release checklist

[Release process documentation](../doc/how-to/perform-a-release.md)

As part of our continuous deployment strategy we must ensure that this work is
ready to be released once merged.

### Pre-merge

- [ ] There are changes required to the Accredited Programmes API for this change to work...
  - [ ] ... and they have been released to production already

### Post-merge

<!-- The outer checkboxes can be completed pre-merge -->

- [ ] This adds, extends or meaningfully modifies a feature...
  - [ ] ... and I have written or updated an end-to-end test for the happy path in the [Accredited Programmes E2E repo](https://github.com/ministryofjustice/hmpps-accredited-programmes-e2e)
- [ ] This makes new expectations of the API...
  - [ ] ... and I have notified the API developer(s) of changes to the contract tests (Pact), or the API is already compliant
- [ ] [Manually approve](../doc/how-to/perform-a-release.md#releasing-to-the-preprod-environment) release to preprod
- [ ] [Manually approve](../doc/how-to/perform-a-release.md#releasing-to-the-production-environment) release to prod

<!-- Should a release fail at any step, you as the author should now lead the work to
fix it as soon as possible. You can monitor deployment failures in CircleCI
itself and application errors are found in
[Sentry](https://ministryofjustice.sentry.io/projects/hmpps-accredited-programmes-ui/?project=4505330122686464&referrer=sidebar&statsPeriod=24h). -->
