### PR TITLE
(APG-456a) Use `Referral` type from AcP API

### DIFF
--- a/integration_tests/mockApis/oasys.ts
+++ b/integration_tests/mockApis/oasys.ts
@@ -8,11 +8,10 @@ import type {
   Health,
   LearningNeeds,
   OffenceDetail,
-  Referral,
   RisksAndAlerts,
   RoshAnalysis,
 } from '@accredited-programmes/models'
-import type { Attitude, Behaviour, Lifestyle, Psychiatric, Relationships } from '@accredited-programmes-api'
+import type { Attitude, Behaviour, Lifestyle, Psychiatric, Referral, Relationships } from '@accredited-programmes-api'
 
 export default {
   stubAssessmentDateInfo: (args: {

--- a/integration_tests/mockApis/referrals.ts
+++ b/integration_tests/mockApis/referrals.ts
@@ -5,12 +5,11 @@ import { stubFor } from '../../wiremock'
 import type {
   ConfirmationFields,
   Paginated,
-  Referral,
   ReferralStatusGroup,
   ReferralStatusRefData,
   ReferralView,
 } from '@accredited-programmes/models'
-import type { ReferralStatusHistory } from '@accredited-programmes-api'
+import type { Referral, ReferralStatusHistory } from '@accredited-programmes-api'
 
 interface ReferralAndScenarioOptions {
   referral: Referral

--- a/integration_tests/pages/page.ts
+++ b/integration_tests/pages/page.ts
@@ -10,13 +10,7 @@ import {
   ShowRisksAndNeedsUtils,
 } from '../../server/utils'
 import Helpers from '../support/helpers'
-import type {
-  CourseOffering,
-  Organisation,
-  Person,
-  Referral,
-  ReferralStatusRefData,
-} from '@accredited-programmes/models'
+import type { CourseOffering, Organisation, Person, ReferralStatusRefData } from '@accredited-programmes/models'
 import type {
   CourseParticipationPresenter,
   CoursePresenter,
@@ -28,6 +22,7 @@ import type {
   MojTimelineItem,
   ReferralStatusHistoryPresenter,
 } from '@accredited-programmes/ui'
+import type { Referral } from '@accredited-programmes-api'
 import type {
   GovukFrontendRadiosItem,
   GovukFrontendSummaryListCardTitle,

--- a/integration_tests/pages/refer/new/additionalInformation.ts
+++ b/integration_tests/pages/refer/new/additionalInformation.ts
@@ -1,5 +1,6 @@
 import Page from '../../page'
-import type { Person, Referral } from '@accredited-programmes/models'
+import type { Person } from '@accredited-programmes/models'
+import type { Referral } from '@accredited-programmes-api'
 
 export default class NewReferralAdditionalInformationPage extends Page {
   person: Person

--- a/integration_tests/pages/refer/new/checkAnswers.ts
+++ b/integration_tests/pages/refer/new/checkAnswers.ts
@@ -1,9 +1,9 @@
 import { referPaths } from '../../../../server/paths'
 import { CourseUtils, NewReferralUtils } from '../../../../server/utils'
 import Page from '../../page'
-import type { CourseOffering, Organisation, Person, Referral } from '@accredited-programmes/models'
+import type { CourseOffering, Organisation, Person } from '@accredited-programmes/models'
 import type { CourseParticipationPresenter, CoursePresenter } from '@accredited-programmes/ui'
-import type { Course } from '@accredited-programmes-api'
+import type { Course, Referral } from '@accredited-programmes-api'
 import type { User, UserEmail } from '@manage-users-api'
 
 export default class NewReferralCheckAnswersPage extends Page {
@@ -75,7 +75,7 @@ export default class NewReferralCheckAnswersPage extends Page {
     cy.get('[data-testid="additional-information-summary-card"]').then(summaryCardElement => {
       this.shouldContainKeylessSummaryCard(
         'Add additional information',
-        this.referral.additionalInformation,
+        this.referral.additionalInformation as string,
         summaryCardElement,
       )
     })

--- a/integration_tests/pages/refer/new/confirmOasys.ts
+++ b/integration_tests/pages/refer/new/confirmOasys.ts
@@ -1,5 +1,6 @@
 import Page from '../../page'
-import type { Person, Referral } from '@accredited-programmes/models'
+import type { Person } from '@accredited-programmes/models'
+import type { Referral } from '@accredited-programmes-api'
 
 export default class NewReferralConfirmOasysPage extends Page {
   person: Person

--- a/integration_tests/pages/refer/new/delete.ts
+++ b/integration_tests/pages/refer/new/delete.ts
@@ -1,6 +1,7 @@
 import { referralFactory, referralViewFactory } from '../../../../server/testutils/factories'
 import Page from '../../page'
-import type { Person, Referral } from '@accredited-programmes/models'
+import type { Person } from '@accredited-programmes/models'
+import type { Referral } from '@accredited-programmes-api'
 
 export default class NewReferralTaskListPage extends Page {
   person: Person

--- a/integration_tests/pages/refer/new/deleteProgrammeHistory.ts
+++ b/integration_tests/pages/refer/new/deleteProgrammeHistory.ts
@@ -1,5 +1,6 @@
 import Page from '../../page'
-import type { CourseParticipation, Person, Referral } from '@accredited-programmes/models'
+import type { CourseParticipation, Person } from '@accredited-programmes/models'
+import type { Referral } from '@accredited-programmes-api'
 
 export default class NewReferralDeleteProgrammeHistoryPage extends Page {
   participation: CourseParticipation

--- a/integration_tests/pages/refer/new/duplicate.ts
+++ b/integration_tests/pages/refer/new/duplicate.ts
@@ -1,8 +1,8 @@
 import { CourseUtils, ShowReferralUtils } from '../../../../server/utils'
 import Page from '../../page'
-import type { CourseOffering, Organisation, Person, Referral } from '@accredited-programmes/models'
+import type { CourseOffering, Organisation, Person } from '@accredited-programmes/models'
 import type { CoursePresenter } from '@accredited-programmes/ui'
-import type { Course } from '@accredited-programmes-api'
+import type { Course, Referral } from '@accredited-programmes-api'
 import type { User } from '@manage-users-api'
 
 export default class NewReferralDuplicatePage extends Page {

--- a/integration_tests/pages/refer/new/programmeHistory.ts
+++ b/integration_tests/pages/refer/new/programmeHistory.ts
@@ -1,7 +1,8 @@
 import Helpers from '../../../support/helpers'
 import Page from '../../page'
-import type { Person, Referral } from '@accredited-programmes/models'
+import type { Person } from '@accredited-programmes/models'
 import type { CourseParticipationPresenter } from '@accredited-programmes/ui'
+import type { Referral } from '@accredited-programmes-api'
 
 export default class NewReferralProgrammeHistoryPage extends Page {
   participations: Array<CourseParticipationPresenter>

--- a/integration_tests/pages/refer/new/taskList.ts
+++ b/integration_tests/pages/refer/new/taskList.ts
@@ -2,9 +2,9 @@ import { referPaths } from '../../../../server/paths'
 import { CourseUtils, NewReferralUtils } from '../../../../server/utils'
 import Helpers from '../../../support/helpers'
 import Page from '../../page'
-import type { CourseOffering, Organisation, Referral } from '@accredited-programmes/models'
+import type { CourseOffering, Organisation } from '@accredited-programmes/models'
 import type { CoursePresenter } from '@accredited-programmes/ui'
-import type { Course } from '@accredited-programmes-api'
+import type { Course, Referral } from '@accredited-programmes-api'
 
 export default class NewReferralTaskListPage extends Page {
   course: CoursePresenter

--- a/integration_tests/pages/shared/showReferral/additionalInformation.ts
+++ b/integration_tests/pages/shared/showReferral/additionalInformation.ts
@@ -1,8 +1,7 @@
 import { CourseUtils, DateUtils } from '../../../../server/utils'
 import Helpers from '../../../support/helpers'
 import Page from '../../page'
-import type { Referral } from '@accredited-programmes/models'
-import type { Course } from '@accredited-programmes-api'
+import type { Course, Referral } from '@accredited-programmes-api'
 
 export default class AdditionalInformationPage extends Page {
   referral: Referral
@@ -21,7 +20,7 @@ export default class AdditionalInformationPage extends Page {
     cy.get('[data-testid="additional-information-summary-card"]').then(summaryCardElement => {
       this.shouldContainKeylessSummaryCard(
         'Additional information',
-        this.referral.additionalInformation,
+        this.referral.additionalInformation as string,
         summaryCardElement,
       )
     })

--- a/integration_tests/support/sharedTests.ts
+++ b/integration_tests/support/sharedTests.ts
@@ -53,8 +53,9 @@ import {
   ThinkingAndBehavingPage,
 } from '../pages/shared'
 import EmotionalWellbeing from '../pages/shared/showReferral/risksAndNeeds/emotionalWellbeing'
-import type { Person, Referral, ReferralStatusRefData, SentenceDetails } from '@accredited-programmes/models'
+import type { Person, ReferralStatusRefData, SentenceDetails } from '@accredited-programmes/models'
 import type { CourseParticipationPresenter, ReferralStatusHistoryPresenter } from '@accredited-programmes/ui'
+import type { Referral } from '@accredited-programmes-api'
 import type { User, UserEmail } from '@manage-users-api'
 import type { PrisonerWithBookingId } from '@prisoner-search'
 

--- a/script/utils/generateApiSeeds/tableRecords.ts
+++ b/script/utils/generateApiSeeds/tableRecords.ts
@@ -17,7 +17,8 @@ import {
 import { randomStatus } from '../../../server/testutils/factories/referral'
 import { StringUtils } from '../../../server/utils'
 import { caseloads, prisoners } from '../../../wiremock/stubs'
-import type { Organisation, Referral } from '@accredited-programmes/models'
+import type { Organisation } from '@accredited-programmes/models'
+import type { Referral } from '@accredited-programmes-api'
 
 export default class TableRecords {
   static course(): Array<CourseRecord> {

--- a/server/@types/accreditedProgrammesApi/index.d.ts
+++ b/server/@types/accreditedProgrammesApi/index.d.ts
@@ -288,13 +288,28 @@ export interface ReferralEntity {
   oasysConfirmed: boolean
   hasReviewedProgrammeHistory: boolean
   status: string
-  /** @example "2024-11-06T20:22:18" */
+  /** @example "2024-12-02T15:41:56" */
   submittedOn?: object
   deleted: boolean
+  /** @uniqueItems true */
+  staffDetails: StaffEntity[]
 }
 
 export interface ReferrerUserEntity {
   username: string
+}
+
+export interface StaffEntity {
+  /** @format uuid */
+  id?: string
+  staffId?: number
+  firstName: string
+  lastName: string
+  primaryEmail: string
+  username: string
+  pomType: 'PRIMARY_POM' | 'SECONDARY_POM'
+  accountType: 'GENERAL' | 'ADMIN'
+  referral: ReferralEntity
 }
 
 export interface ReferralCreate {
@@ -356,6 +371,19 @@ export interface Referral {
   statusColour?: string
   /** @example "null" */
   submittedOn?: string
+  /** @example null */
+  prisonOffenderManagers: StaffDetail[]
+}
+
+/** @example null */
+export interface StaffDetail {
+  staffId: number
+  firstName: string
+  lastName: string
+  primaryEmail: string
+  username: string
+  type: 'PRIMARY_POM' | 'SECONDARY_POM'
+  accountType: 'GENERAL' | 'ADMIN'
 }
 
 export interface PeopleSearchResponse {
@@ -1081,6 +1109,10 @@ export interface Relationships {
   prevCloseRelationships?: string
   /** @example "0-No problems" */
   emotionalCongruence?: string
+  /** @example "0-No problems" */
+  relationshipWithPartner?: string
+  /** @example "No" */
+  prevOrCurrentDomesticAbuse?: string
 }
 
 export interface Psychiatric {
@@ -1113,8 +1145,8 @@ export interface OffenceDetail {
   stalking?: boolean
   /** @example false */
   recognisesImpact?: boolean
-  /** @format int32 */
-  numberOfOthersInvolved?: number
+  /** @example "null" */
+  numberOfOthersInvolved?: string
   /** @example "There were two others involved who absconded at the scene" */
   othersInvolvedDetail?: string
   /** @example "This person is easily lead" */

--- a/server/@types/accreditedProgrammesApi/index.d.ts
+++ b/server/@types/accreditedProgrammesApi/index.d.ts
@@ -288,7 +288,7 @@ export interface ReferralEntity {
   oasysConfirmed: boolean
   hasReviewedProgrammeHistory: boolean
   status: string
-  /** @example "2024-12-02T15:41:56" */
+  /** @example "2024-12-05T11:36:41" */
   submittedOn?: object
   deleted: boolean
   /** @uniqueItems true */
@@ -622,9 +622,9 @@ export interface ReportContent {
 }
 
 export interface ReportStatusCountProjection {
-  orgId: string
   count: number
   status: string
+  orgId: string
 }
 
 export interface ReportTypes {

--- a/server/@types/models/Referral.ts
+++ b/server/@types/models/Referral.ts
@@ -1,8 +1,7 @@
-import type { CourseOffering } from './CourseOffering'
 import type { Organisation } from './Organisation'
 import type { Person } from './Person'
 import type { TagColour } from '@accredited-programmes/ui'
-import type { Course } from '@accredited-programmes-api'
+import type { Course, Referral } from '@accredited-programmes-api'
 import type { User } from '@manage-users-api'
 import type { Prisoner } from '@prisoner-search'
 
@@ -33,21 +32,6 @@ interface ConfirmationFields {
   secondaryDescription: string
   secondaryHeading: string
   warningText: string
-}
-
-type Referral = {
-  id: string // eslint-disable-next-line @typescript-eslint/member-ordering
-  additionalInformation: string
-  hasReviewedProgrammeHistory: boolean
-  oasysConfirmed: boolean
-  offeringId: CourseOffering['id']
-  prisonNumber: Person['prisonNumber']
-  referrerUsername: Express.User['username']
-  status: ReferralStatus
-  closed?: boolean
-  statusColour?: TagColour
-  statusDescription?: string
-  submittedOn?: string
 }
 
 type ReferralUpdate = {
@@ -115,7 +99,7 @@ type ReferralView = {
   prisonNumber?: Person['prisonNumber']
   referrerUsername?: User['username']
   sentenceType?: string
-  status?: ReferralStatus
+  status?: string
   statusColour?: Referral['statusColour']
   statusDescription?: Referral['statusDescription']
   submittedOn?: Referral['submittedOn']
@@ -128,7 +112,6 @@ export { referralStatusGroups, referralStatuses }
 
 export type {
   ConfirmationFields,
-  Referral,
   ReferralStatus,
   ReferralStatusCategory,
   ReferralStatusGroup,

--- a/server/@types/models/index.d.ts
+++ b/server/@types/models/index.d.ts
@@ -19,7 +19,6 @@ import type { Paginated } from './Paginated'
 import type { KeyDates, Person, SentenceDetails } from './Person'
 import type {
   ConfirmationFields,
-  Referral,
   ReferralStatus,
   ReferralStatusCategory,
   ReferralStatusGroup,
@@ -55,7 +54,6 @@ export type {
   OrganisationAddress,
   Paginated,
   Person,
-  Referral,
   ReferralStatus,
   ReferralStatusCategory,
   ReferralStatusGroup,

--- a/server/@types/ui/index.d.ts
+++ b/server/@types/ui/index.d.ts
@@ -1,5 +1,5 @@
-import type { CourseParticipation, Organisation, Person, Referral, RiskLevel } from '@accredited-programmes/models'
-import type { Course, CourseOffering, ReferralStatusHistory } from '@accredited-programmes-api'
+import type { CourseParticipation, Organisation, Person, RiskLevel } from '@accredited-programmes/models'
+import type { Course, CourseOffering, Referral, ReferralStatusHistory } from '@accredited-programmes-api'
 import type {
   GovukFrontendButton,
   GovukFrontendPagination,

--- a/server/controllers/assess/pniController.test.ts
+++ b/server/controllers/assess/pniController.test.ts
@@ -14,7 +14,8 @@ import {
 } from '../../testutils/factories'
 import Helpers from '../../testutils/helpers'
 import { CourseUtils, PniUtils, ShowReferralUtils } from '../../utils'
-import type { Person, Referral } from '@accredited-programmes/models'
+import type { Person } from '@accredited-programmes/models'
+import type { Referral } from '@accredited-programmes-api'
 
 jest.mock('../../utils/referrals/showReferralUtils')
 jest.mock('../../utils/risksAndNeeds/pniUtils')

--- a/server/controllers/assess/updateStatusDecisionController.test.ts
+++ b/server/controllers/assess/updateStatusDecisionController.test.ts
@@ -15,8 +15,9 @@ import {
 } from '../../testutils/factories'
 import Helpers from '../../testutils/helpers'
 import { FormUtils, ReferralUtils, ShowReferralUtils } from '../../utils'
-import type { ConfirmationFields, Person, Referral, ReferralStatusRefData } from '@accredited-programmes/models'
+import type { ConfirmationFields, Person, ReferralStatusRefData } from '@accredited-programmes/models'
 import type { MojTimelineItem, ReferralStatusHistoryPresenter } from '@accredited-programmes/ui'
+import type { Referral } from '@accredited-programmes-api'
 import type { GovukFrontendRadiosItem } from '@govuk-frontend'
 
 jest.mock('../../utils/formUtils')

--- a/server/controllers/shared/categoryController.test.ts
+++ b/server/controllers/shared/categoryController.test.ts
@@ -14,8 +14,9 @@ import {
 } from '../../testutils/factories'
 import Helpers from '../../testutils/helpers'
 import { FormUtils, ReferralUtils, ShowReferralUtils } from '../../utils'
-import type { Person, Referral, ReferralStatusCategory } from '@accredited-programmes/models'
+import type { Person, ReferralStatusCategory } from '@accredited-programmes/models'
 import type { MojTimelineItem, ReferralStatusHistoryPresenter } from '@accredited-programmes/ui'
+import type { Referral } from '@accredited-programmes-api'
 import type { GovukFrontendRadiosItem } from '@govuk-frontend'
 
 jest.mock('../../utils/formUtils')

--- a/server/controllers/shared/reasonController.test.ts
+++ b/server/controllers/shared/reasonController.test.ts
@@ -14,8 +14,9 @@ import {
 } from '../../testutils/factories'
 import Helpers from '../../testutils/helpers'
 import { FormUtils, ReferralUtils, ShowReferralUtils } from '../../utils'
-import type { Person, Referral, ReferralStatusReason } from '@accredited-programmes/models'
+import type { Person, ReferralStatusReason } from '@accredited-programmes/models'
 import type { MojTimelineItem, ReferralStatusHistoryPresenter } from '@accredited-programmes/ui'
+import type { Referral } from '@accredited-programmes-api'
 import type { GovukFrontendFieldsetLegend, GovukFrontendRadiosItem } from '@govuk-frontend'
 
 jest.mock('../../utils/formUtils')

--- a/server/controllers/shared/referralsController.test.ts
+++ b/server/controllers/shared/referralsController.test.ts
@@ -26,11 +26,12 @@ import {
   SentenceInformationUtils,
   ShowReferralUtils,
 } from '../../utils'
-import type { Person, Referral, ReferralStatusRefData } from '@accredited-programmes/models'
+import type { Person, ReferralStatusRefData } from '@accredited-programmes/models'
 import type {
   GovukFrontendSummaryListWithRowsWithKeysAndValues,
   ReferralSharedPageData,
 } from '@accredited-programmes/ui'
+import type { Referral } from '@accredited-programmes-api'
 import type { GovukFrontendSummaryList } from '@govuk-frontend'
 import type { User } from '@manage-users-api'
 

--- a/server/controllers/shared/risksAndNeedsController.test.ts
+++ b/server/controllers/shared/risksAndNeedsController.test.ts
@@ -44,8 +44,9 @@ import {
   ShowRisksAndNeedsUtils,
   ThinkingAndBehavingUtils,
 } from '../../utils'
-import type { Person, Referral, ReferralStatusRefData } from '@accredited-programmes/models'
+import type { Person, ReferralStatusRefData } from '@accredited-programmes/models'
 import type { OspBox, RiskBox, RisksAndNeedsSharedPageData } from '@accredited-programmes/ui'
+import type { Referral } from '@accredited-programmes-api'
 import type { GovukFrontendTable } from '@govuk-frontend'
 
 jest.mock('../../utils/dateUtils')

--- a/server/controllers/shared/statusHistoryController.test.ts
+++ b/server/controllers/shared/statusHistoryController.test.ts
@@ -16,8 +16,9 @@ import {
 } from '../../testutils/factories'
 import Helpers from '../../testutils/helpers'
 import { CourseUtils, ShowReferralUtils } from '../../utils'
-import type { Person, Referral, ReferralStatusRefData } from '@accredited-programmes/models'
+import type { Person, ReferralStatusRefData } from '@accredited-programmes/models'
 import type { MojTimelineItem, ReferralStatusHistoryPresenter } from '@accredited-programmes/ui'
+import type { Referral } from '@accredited-programmes-api'
 
 jest.mock('../../utils/referrals/showReferralUtils')
 

--- a/server/controllers/shared/updateStatusSelectionController.test.ts
+++ b/server/controllers/shared/updateStatusSelectionController.test.ts
@@ -14,8 +14,9 @@ import {
 } from '../../testutils/factories'
 import Helpers from '../../testutils/helpers'
 import { FormUtils, ShowReferralUtils } from '../../utils'
-import type { ConfirmationFields, Person, Referral } from '@accredited-programmes/models'
+import type { ConfirmationFields, Person } from '@accredited-programmes/models'
 import type { MojTimelineItem, ReferralStatusHistoryPresenter } from '@accredited-programmes/ui'
+import type { Referral } from '@accredited-programmes-api'
 
 jest.mock('../../utils/formUtils')
 jest.mock('../../utils/referrals/showReferralUtils')

--- a/server/data/accreditedProgrammesApi/oasysClient.ts
+++ b/server/data/accreditedProgrammesApi/oasysClient.ts
@@ -8,11 +8,10 @@ import type {
   Health,
   LearningNeeds,
   OffenceDetail,
-  Referral,
   RisksAndAlerts,
   RoshAnalysis,
 } from '@accredited-programmes/models'
-import type { Attitude, Behaviour, Lifestyle, Psychiatric, Relationships } from '@accredited-programmes-api'
+import type { Attitude, Behaviour, Lifestyle, Psychiatric, Referral, Relationships } from '@accredited-programmes-api'
 import type { SystemToken } from '@hmpps-auth'
 
 export default class OasysClient {

--- a/server/data/accreditedProgrammesApi/pniClient.ts
+++ b/server/data/accreditedProgrammesApi/pniClient.ts
@@ -2,8 +2,7 @@
 import config, { type ApiConfig } from '../../config'
 import { apiPaths } from '../../paths'
 import RestClient from '../restClient'
-import type { Referral } from '@accredited-programmes/models'
-import type { PniScore } from '@accredited-programmes-api'
+import type { PniScore, Referral } from '@accredited-programmes-api'
 import type { SystemToken } from '@hmpps-auth'
 
 export default class PniClient {

--- a/server/data/accreditedProgrammesApi/referralClient.test.ts
+++ b/server/data/accreditedProgrammesApi/referralClient.test.ts
@@ -60,7 +60,7 @@ pactWith({ consumer: 'Accredited Programmes UI', provider: 'Accredited Programme
         state: 'Referral 0c46ed09-170b-4c0f-aee8-a24eeaeeddaa exists with status REFERRAL_STARTED',
         uponReceiving: 'A request for referral 0c46ed09-170b-4c0f-aee8-a24eeaeeddaa',
         willRespondWith: {
-          body: Matchers.like(referral),
+          body: Matchers.like({ ...referral, prisonOffenderManagers: [] }),
           status: 200,
         },
         withRequest: {

--- a/server/data/accreditedProgrammesApi/referralClient.test.ts
+++ b/server/data/accreditedProgrammesApi/referralClient.test.ts
@@ -21,7 +21,7 @@ pactWith({ consumer: 'Accredited Programmes UI', provider: 'Accredited Programme
   })
 
   describe('create', () => {
-    const createdReferralResponse: Partial<Referral> = { id: faker.string.uuid() }
+    const createdReferralResponse: Pick<Referral, 'id'> = { id: faker.string.uuid() }
     const prisonNumber = 'A1234AA'
 
     beforeEach(() => {

--- a/server/data/accreditedProgrammesApi/referralClient.ts
+++ b/server/data/accreditedProgrammesApi/referralClient.ts
@@ -7,7 +7,6 @@ import RestClient from '../restClient'
 import type {
   ConfirmationFields,
   Paginated,
-  Referral,
   ReferralStatusGroup,
   ReferralStatusRefData,
   ReferralStatusUpdate,
@@ -15,7 +14,7 @@ import type {
   ReferralUpdate,
   ReferralView,
 } from '@accredited-programmes/models'
-import type { ReferralStatusHistory } from '@accredited-programmes-api'
+import type { Referral, ReferralStatusHistory } from '@accredited-programmes-api'
 import type { SystemToken } from '@hmpps-auth'
 
 export default class ReferralClient {

--- a/server/services/courseService.ts
+++ b/server/services/courseService.ts
@@ -12,13 +12,12 @@ import type {
   CourseParticipationUpdate,
   CoursePrerequisite,
   Person,
-  Referral,
 } from '@accredited-programmes/models'
 import type {
   BuildingChoicesSearchForm,
   GovukFrontendSummaryListWithRowsWithKeysAndValues,
 } from '@accredited-programmes/ui'
-import type { Course } from '@accredited-programmes-api'
+import type { Course, Referral } from '@accredited-programmes-api'
 import type { Prison } from '@prison-register-api'
 
 export default class CourseService {

--- a/server/services/oasysService.ts
+++ b/server/services/oasysService.ts
@@ -8,11 +8,10 @@ import type {
   Health,
   LearningNeeds,
   OffenceDetail,
-  Referral,
   RisksAndAlerts,
   RoshAnalysis,
 } from '@accredited-programmes/models'
-import type { Attitude, Behaviour, Lifestyle, Psychiatric, Relationships } from '@accredited-programmes-api'
+import type { Attitude, Behaviour, Lifestyle, Psychiatric, Referral, Relationships } from '@accredited-programmes-api'
 
 export default class OasysService {
   constructor(

--- a/server/services/pniService.ts
+++ b/server/services/pniService.ts
@@ -2,8 +2,7 @@ import createHttpError from 'http-errors'
 
 import type { HmppsAuthClient, PniClient, RestClientBuilder, RestClientBuilderWithoutToken } from '../data'
 import type { SanitisedError } from '../sanitisedError'
-import type { Referral } from '@accredited-programmes/models'
-import type { PniScore } from '@accredited-programmes-api'
+import type { PniScore, Referral } from '@accredited-programmes-api'
 
 export default class PniService {
   constructor(

--- a/server/services/referralService.ts
+++ b/server/services/referralService.ts
@@ -5,7 +5,6 @@ import type {
   ConfirmationFields,
   Organisation,
   Paginated,
-  Referral,
   ReferralStatusGroup,
   ReferralStatusRefData,
   ReferralStatusUpdate,
@@ -14,6 +13,7 @@ import type {
   ReferralView,
 } from '@accredited-programmes/models'
 import type { ReferralStatusHistoryPresenter } from '@accredited-programmes/ui'
+import type { Referral } from '@accredited-programmes-api'
 import type { User } from '@manage-users-api'
 
 export default class ReferralService {

--- a/server/testutils/factories/referral.ts
+++ b/server/testutils/factories/referral.ts
@@ -2,7 +2,8 @@ import { faker } from '@faker-js/faker'
 import { Factory } from 'fishery'
 
 import { referralStatuses } from '../../@types/models/Referral'
-import type { Referral, ReferralStatus } from '@accredited-programmes/models'
+import type { ReferralStatus } from '@accredited-programmes/models'
+import type { Referral } from '@accredited-programmes-api'
 
 class ReferralFactory extends Factory<Referral> {
   closed() {
@@ -39,7 +40,7 @@ class ReferralFactory extends Factory<Referral> {
     })
   }
 }
-const closedStatuses: Array<ReferralStatus> = ['programme_complete', 'deselected', 'not_suitable', 'withdrawn']
+const closedStatuses: Array<string> = ['programme_complete', 'deselected', 'not_suitable', 'withdrawn']
 
 const randomStatus = (availableStatuses?: Array<ReferralStatus>) =>
   faker.helpers.arrayElement(availableStatuses || referralStatuses)
@@ -88,6 +89,7 @@ export default ReferralFactory.define(({ params }) => {
     oasysConfirmed: faker.datatype.boolean(),
     offeringId: faker.string.uuid(),
     prisonNumber: faker.string.alphanumeric({ length: 7 }),
+    prisonOffenderManagers: [],
     referrerUsername: faker.internet.username(),
     status,
     submittedOn: status !== 'referral_started' ? faker.date.past().toISOString() : undefined,

--- a/server/utils/courseParticipationUtils.ts
+++ b/server/utils/courseParticipationUtils.ts
@@ -8,7 +8,6 @@ import type {
   CourseParticipationOutcome,
   CourseParticipationSetting,
   CourseParticipationUpdate,
-  Referral,
 } from '@accredited-programmes/models'
 import type {
   CourseParticipationPresenter,
@@ -16,6 +15,7 @@ import type {
   GovukFrontendSummaryListRowWithKeyAndValue,
   GovukFrontendSummaryListWithRowsWithKeysAndValues,
 } from '@accredited-programmes/ui'
+import type { Referral } from '@accredited-programmes-api'
 import type { GovukFrontendSummaryListRowKey } from '@govuk-frontend'
 
 interface CourseParticipationDetailsBody {

--- a/server/utils/referrals/caseListUtils.ts
+++ b/server/utils/referrals/caseListUtils.ts
@@ -6,9 +6,9 @@ import DateUtils from '../dateUtils'
 import FormUtils from '../formUtils'
 import PathUtils from '../pathUtils'
 import StringUtils from '../stringUtils'
-import type { Referral, ReferralStatusGroup, ReferralStatusRefData, ReferralView } from '@accredited-programmes/models'
+import type { ReferralStatusGroup, ReferralStatusRefData, ReferralView } from '@accredited-programmes/models'
 import type { CaseListColumnHeader, MojFrontendNavigationItem, QueryParam } from '@accredited-programmes/ui'
-import type { Course } from '@accredited-programmes-api'
+import type { Course, Referral } from '@accredited-programmes-api'
 import type { GovukFrontendSelectItem, GovukFrontendTableHeadElement, GovukFrontendTableRow } from '@govuk-frontend'
 
 export default class CaseListUtils {

--- a/server/utils/referrals/newReferralUtils.ts
+++ b/server/utils/referrals/newReferralUtils.ts
@@ -1,5 +1,5 @@
 import { referPaths } from '../../paths'
-import type { CourseOffering, Organisation, Person, Referral } from '@accredited-programmes/models'
+import type { CourseOffering, Organisation, Person } from '@accredited-programmes/models'
 import type {
   CoursePresenter,
   GovukFrontendSummaryListRowWithKeyAndValue,
@@ -7,6 +7,7 @@ import type {
   ReferralTaskListStatusTag,
   ReferralTaskListStatusText,
 } from '@accredited-programmes/ui'
+import type { Referral } from '@accredited-programmes-api'
 import type { User, UserEmail } from '@manage-users-api'
 
 export default class NewReferralUtils {

--- a/server/utils/referrals/showReferralUtils.ts
+++ b/server/utils/referrals/showReferralUtils.ts
@@ -3,7 +3,7 @@ import type { Request } from 'express'
 import CaseListUtils from './caseListUtils'
 import { assessPathBase, assessPaths, referPaths } from '../../paths'
 import DateUtils from '../dateUtils'
-import type { CourseOffering, Organisation, Referral, ReferralStatusRefData } from '@accredited-programmes/models'
+import type { CourseOffering, Organisation, ReferralStatusRefData } from '@accredited-programmes/models'
 import type {
   CoursePresenter,
   GovukFrontendSummaryListRowWithKeyAndValue,
@@ -11,6 +11,7 @@ import type {
   MojTimelineItem,
   ReferralStatusHistoryPresenter,
 } from '@accredited-programmes/ui'
+import type { Referral } from '@accredited-programmes-api'
 import type { GovukFrontendButton } from '@govuk-frontend'
 import type { User, UserEmail } from '@manage-users-api'
 

--- a/server/utils/referrals/showRisksAndNeedsUtils.ts
+++ b/server/utils/referrals/showRisksAndNeedsUtils.ts
@@ -1,8 +1,8 @@
 import type { Request } from 'express'
 
 import { assessPathBase, assessPaths, referPaths } from '../../paths'
-import type { Referral } from '@accredited-programmes/models'
 import type { MojFrontendNavigationItem } from '@accredited-programmes/ui'
+import type { Referral } from '@accredited-programmes-api'
 
 const noInfoString = 'No information available'
 export default class ShowRisksAndNeedsUtils {


### PR DESCRIPTION
## Context

We're gradually moving away from manually specifying the API types and using the ones auto generated from the AcP API swagger.

`Referral` now has an additional `prisonOffenderManagers` property so this allows us to use that in prep for adding the POM details to referral details.

## Changes in this PR
Switch to use the `Referral` type from the API.

## Release checklist

[Release process documentation](../doc/how-to/perform-a-release.md)

As part of our continuous deployment strategy we must ensure that this work is
ready to be released once merged.

### Pre-merge

- [ ] There are changes required to the Accredited Programmes API for this change to work...
  - [ ] ... and they have been released to production already

### Post-merge

<!-- The outer checkboxes can be completed pre-merge -->

- [ ] This adds, extends or meaningfully modifies a feature...
  - [ ] ... and I have written or updated an end-to-end test for the happy path in the [Accredited Programmes E2E repo](https://github.com/ministryofjustice/hmpps-accredited-programmes-e2e)
- [ ] This makes new expectations of the API...
  - [ ] ... and I have notified the API developer(s) of changes to the contract tests (Pact), or the API is already compliant
- [ ] [Manually approve](../doc/how-to/perform-a-release.md#releasing-to-the-preprod-environment) release to preprod
- [ ] [Manually approve](../doc/how-to/perform-a-release.md#releasing-to-the-production-environment) release to prod

<!-- Should a release fail at any step, you as the author should now lead the work to
fix it as soon as possible. You can monitor deployment failures in CircleCI
itself and application errors are found in
[Sentry](https://ministryofjustice.sentry.io/projects/hmpps-accredited-programmes-ui/?project=4505330122686464&referrer=sidebar&statsPeriod=24h). -->
