### PR TITLE
Change some h2s to h3s

### DIFF
--- a/server/controllers/refer/new/courseParticipationsController.test.ts
+++ b/server/controllers/refer/new/courseParticipationsController.test.ts
@@ -190,6 +190,7 @@ describe('NewReferralsCourseParticipationsController', () => {
         userToken,
         courseParticipation,
         referralId,
+        undefined,
         {
           change: false,
           remove: false,

--- a/server/controllers/refer/new/courseParticipationsController.ts
+++ b/server/controllers/refer/new/courseParticipationsController.ts
@@ -68,6 +68,7 @@ export default class NewReferralsCourseParticipationsController {
         req.user.token,
         courseParticipation,
         referralId,
+        undefined,
         { change: false, remove: false },
       )
       const person = await this.personService.getPerson(req.user.username, referral.prisonNumber)

--- a/server/controllers/refer/new/referralsController.test.ts
+++ b/server/controllers/refer/new/referralsController.test.ts
@@ -419,6 +419,7 @@ describe('NewReferralsController', () => {
         person.prisonNumber,
         referralId,
         { change: true, remove: false },
+        3,
       )
       expect(request.session.returnTo).toBe('check-answers')
       expect(response.render).toHaveBeenCalledWith('referrals/new/checkAnswers', {

--- a/server/controllers/refer/new/referralsController.ts
+++ b/server/controllers/refer/new/referralsController.ts
@@ -52,6 +52,7 @@ export default class NewReferralsController {
           person.prisonNumber,
           referralId,
           { change: true, remove: false },
+          3,
         ),
       ])
 

--- a/server/services/courseService.test.ts
+++ b/server/services/courseService.test.ts
@@ -180,13 +180,13 @@ describe('CourseService', () => {
     describe('when no actions are passed', () => {
       it('fetches the creator, then formats the participation and creator in the appropriate format for passing to a GOV.UK summary list Nunjucks macro', async () => {
         when(CourseParticipationUtils.summaryListOptions as jest.Mock)
-          .calledWith({ ...earliestCourseParticipation, addedByDisplayName }, 'a-referral-id', {
+          .calledWith({ ...earliestCourseParticipation, addedByDisplayName }, 'a-referral-id', undefined, {
             change: true,
             remove: true,
           })
           .mockReturnValue('course participation 1 options')
         when(CourseParticipationUtils.summaryListOptions as jest.Mock)
-          .calledWith({ ...latestCourseParticipation, addedByDisplayName }, 'a-referral-id', {
+          .calledWith({ ...latestCourseParticipation, addedByDisplayName }, 'a-referral-id', undefined, {
             change: true,
             remove: true,
           })
@@ -203,17 +203,25 @@ describe('CourseService', () => {
       })
     })
 
-    describe('when actions are passed', () => {
+    describe('when actions and headingLevel are passed', () => {
       it('uses the specified actions when creating options for the summary list Nunjucks macro', async () => {
-        await service.getAndPresentParticipationsByPerson(username, userToken, person.prisonNumber, 'a-referral-id', {
-          change: false,
-          remove: false,
-        })
+        await service.getAndPresentParticipationsByPerson(
+          username,
+          userToken,
+          person.prisonNumber,
+          'a-referral-id',
+          {
+            change: false,
+            remove: false,
+          },
+          3,
+        )
 
         expect(CourseParticipationUtils.summaryListOptions).toHaveBeenNthCalledWith(
           1,
           { ...earliestCourseParticipation, addedByDisplayName },
           'a-referral-id',
+          3,
           {
             change: false,
             remove: false,
@@ -224,6 +232,7 @@ describe('CourseService', () => {
           2,
           { ...latestCourseParticipation, addedByDisplayName },
           'a-referral-id',
+          3,
           {
             change: false,
             remove: false,
@@ -458,13 +467,13 @@ describe('CourseService', () => {
         .mockResolvedValue(addedByDisplayName)
 
       when(CourseParticipationUtils.summaryListOptions as jest.Mock)
-        .calledWith({ ...courseParticipation, addedByDisplayName }, referralId, {
+        .calledWith({ ...courseParticipation, addedByDisplayName }, referralId, 3, {
           change: true,
           remove: true,
         })
         .mockReturnValue('course participation 1 options')
 
-      const result = await service.presentCourseParticipation(userToken, courseParticipation, referralId)
+      const result = await service.presentCourseParticipation(userToken, courseParticipation, referralId, 3)
 
       expect(result).toEqual('course participation 1 options')
     })

--- a/server/services/courseService.ts
+++ b/server/services/courseService.ts
@@ -91,6 +91,7 @@ export default class CourseService {
       change: boolean
       remove: boolean
     },
+    headingLevel?: number,
   ): Promise<Array<GovukFrontendSummaryListWithRowsWithKeysAndValues>> {
     const sortedCourseParticipations = (await this.getParticipationsByPerson(username, prisonNumber)).sort(
       (participationA, participationB) => participationA.createdAt.localeCompare(participationB.createdAt),
@@ -98,7 +99,7 @@ export default class CourseService {
 
     return Promise.all(
       sortedCourseParticipations.map(participation =>
-        this.presentCourseParticipation(userToken, participation, referralId, withActions),
+        this.presentCourseParticipation(userToken, participation, referralId, headingLevel, withActions),
       ),
     )
   }
@@ -238,6 +239,7 @@ export default class CourseService {
     userToken: Express.User['token'],
     courseParticipation: CourseParticipation,
     referralId: Referral['id'],
+    headingLevel?: number,
     withActions = { change: true, remove: true },
   ): Promise<GovukFrontendSummaryListWithRowsWithKeysAndValues> {
     const addedByDisplayName = await this.userService.getFullNameFromUsername(userToken, courseParticipation.addedBy)
@@ -247,7 +249,12 @@ export default class CourseService {
       addedByDisplayName,
     }
 
-    return CourseParticipationUtils.summaryListOptions(courseParticipationPresenter, referralId, withActions)
+    return CourseParticipationUtils.summaryListOptions(
+      courseParticipationPresenter,
+      referralId,
+      headingLevel,
+      withActions,
+    )
   }
 
   async updateCourse(

--- a/server/utils/courseParticipationUtils.test.ts
+++ b/server/utils/courseParticipationUtils.test.ts
@@ -426,7 +426,7 @@ describe('CourseParticipationUtils', () => {
 
     describe('when all fields are present on the CourseParticipation', () => {
       it('generates an object to pass into a Nunjucks macro for a GOV.UK summary list with card', () => {
-        expect(CourseParticipationUtils.summaryListOptions(courseParticipationPresenter, referralId)).toEqual({
+        expect(CourseParticipationUtils.summaryListOptions(courseParticipationPresenter, referralId, 3)).toEqual({
           card: {
             actions: {
               items: [
@@ -443,6 +443,7 @@ describe('CourseParticipationUtils', () => {
               ],
             },
             title: {
+              headingLevel: 3,
               text: 'A mediocre course name (aMCN)',
             },
           },
@@ -485,6 +486,7 @@ describe('CourseParticipationUtils', () => {
         const summaryListOptions = CourseParticipationUtils.summaryListOptions(
           courseParticipationPresenter,
           referralId,
+          undefined,
           withActions,
         )
 

--- a/server/utils/courseParticipationUtils.ts
+++ b/server/utils/courseParticipationUtils.ts
@@ -112,6 +112,7 @@ export default class CourseParticipationUtils {
   static summaryListOptions(
     courseParticipation: CourseParticipationPresenter,
     referralId: Referral['id'],
+    headingLevel?: number,
     withActions = { change: true, remove: true },
   ): GovukFrontendSummaryListWithRowsWithKeysAndValues {
     const actions: GovukFrontendSummaryListCardActionsWithItems = { items: [] }
@@ -142,6 +143,7 @@ export default class CourseParticipationUtils {
       card: {
         actions,
         title: {
+          headingLevel,
           text: courseParticipation.courseName,
         },
       },

--- a/server/views/partials/keylessSummaryCard.njk
+++ b/server/views/partials/keylessSummaryCard.njk
@@ -1,9 +1,10 @@
 {% from "govuk/components/summary-list/macro.njk" import govukSummaryList %}
 
-{% macro keylessSummaryCard(title, actionItems = [], bodyText = undefined, bodyHtml = undefined, testId = '') %}
+{% macro keylessSummaryCard(title, actionItems = [], bodyText = undefined, bodyHtml = undefined, testId = '', headingLevel = undefined) %}
   {{ govukSummaryList({
     card: {
       title: {
+        headingLevel: headingLevel,
         text: title
       },
       actions: {

--- a/server/views/referrals/new/checkAnswers.njk
+++ b/server/views/referrals/new/checkAnswers.njk
@@ -65,6 +65,7 @@
       {{ govukSummaryList({
         card: {
           title: {
+            headingLevel: 3,
             text: "Personal details"
           }
         },
@@ -99,7 +100,12 @@
 
       <h2 class="govuk-heading-m">OASys information</h2>
 
-      {{ keylessSummaryCard("Confirm OASys information", bodyText="I confirm that the information is up to date.", testId="oasys-confirmation-summary-card") }}
+      {{ keylessSummaryCard(
+        "Confirm OASys information",
+        bodyText="I confirm that the information is up to date.",
+        testId="oasys-confirmation-summary-card",
+        headingLevel=3
+      ) }}
 
       <h2 class="govuk-heading-m" id="additionalInformation">Additional information</h2>
 
@@ -110,7 +116,8 @@
           href: referPaths.new.additionalInformation.show({ referralId: referralId })
         }],
         bodyText=additionalInformation,
-        testId="additional-information-summary-card"
+        testId="additional-information-summary-card",
+        headingLevel=3
       ) }}
 
       <hr class="govuk-section-break govuk-section-break--visible govuk-!-margin-bottom-6">

--- a/server/views/referrals/show/statusHistory/show.njk
+++ b/server/views/referrals/show/statusHistory/show.njk
@@ -4,6 +4,7 @@
 
 {% block supportingContent %}
   {{ mojTimeline({
+    headingLevel: 3,
     items: timelineItems,
     attributes: {
       "data-testid": "status-history-timeline"


### PR DESCRIPTION
## Context

An accessibility review suggested revising some heading structures to ensure that sub-headings are nested correctly beneath their respective section headings.

## Changes in this PR
- Change summary card headings on check your answers page, from h2 to h3
- Change status history timeline item headings, from h2 to h3


## Release checklist

[Release process documentation](../doc/how-to/perform-a-release.md)

As part of our continuous deployment strategy we must ensure that this work is
ready to be released once merged.

### Pre-merge

- [ ] There are changes required to the Accredited Programmes API for this change to work...
  - [ ] ... and they have been released to production already

### Post-merge

<!-- The outer checkboxes can be completed pre-merge -->

- [ ] This adds, extends or meaningfully modifies a feature...
  - [ ] ... and I have written or updated an end-to-end test for the happy path in the [Accredited Programmes E2E repo](https://github.com/ministryofjustice/hmpps-accredited-programmes-e2e)
- [ ] This makes new expectations of the API...
  - [ ] ... and I have notified the API developer(s) of changes to the contract tests (Pact), or the API is already compliant
- [ ] [Manually approve](../doc/how-to/perform-a-release.md#releasing-to-the-preprod-environment) release to preprod
- [ ] [Manually approve](../doc/how-to/perform-a-release.md#releasing-to-the-production-environment) release to prod

<!-- Should a release fail at any step, you as the author should now lead the work to
fix it as soon as possible. You can monitor deployment failures in CircleCI
itself and application errors are found in
[Sentry](https://ministryofjustice.sentry.io/projects/hmpps-accredited-programmes-ui/?project=4505330122686464&referrer=sidebar&statsPeriod=24h). -->
