### PR TITLE
(APG-494) Move draft referral text above Continue button

### DIFF
--- a/integration_tests/e2e/refer/new/create.cy.ts
+++ b/integration_tests/e2e/refer/new/create.cy.ts
@@ -90,6 +90,7 @@ context('Searching for a person and creating a referral', () => {
       confirmPersonPage.shouldContainContinueButton()
       confirmPersonPage.shouldContainDifferentIdentifierLink()
       confirmPersonPage.shouldHavePersonInformation()
+      confirmPersonPage.shouldContainText('This will save a draft referral.')
     })
 
     describe("but the user's input is invalid", () => {

--- a/server/views/referrals/new/people/show.njk
+++ b/server/views/referrals/new/people/show.njk
@@ -32,6 +32,8 @@
         <input type="hidden" name="prisonNumber" value="{{ prisonNumber }}"/>
       </form>
 
+      <p class="govuk-body govuk-!-margin-bottom-6">This will save a draft referral.</p>
+
       <div class="govuk-button-group">
         {{ govukButton({ 
           text: "Continue",
@@ -44,7 +46,6 @@
         </a>
       </div>
 
-      <p>This will save a draft referral.</p>
     </div>
   </div>
 


### PR DESCRIPTION
## Context

On the Confirm Personal Details page, the text “This will save a draft referral” is placed after the “Continue” button. While sighted users may see this text before proceeding, users relying on screen readers may miss this crucial information, as it appears after the button, breaking the logical sequence of content. This affects screen reader users who require important information to be conveyed before they perform an action.



## Changes in this PR
Moved "This will save a draft referral." text to be above the Continue button.


## Screenshots of UI changes

### Before
![image](https://github.com/user-attachments/assets/82523cf5-27bc-4a51-a662-402330d51a07)


### After
![image](https://github.com/user-attachments/assets/244ec7c2-6716-49e6-bd8d-0a429185614a)



## Release checklist

[Release process documentation](../doc/how-to/perform-a-release.md)

As part of our continuous deployment strategy we must ensure that this work is
ready to be released once merged.

### Pre-merge

- [ ] There are changes required to the Accredited Programmes API for this change to work...
  - [ ] ... and they have been released to production already

### Post-merge

<!-- The outer checkboxes can be completed pre-merge -->

- [ ] This adds, extends or meaningfully modifies a feature...
  - [ ] ... and I have written or updated an end-to-end test for the happy path in the [Accredited Programmes E2E repo](https://github.com/ministryofjustice/hmpps-accredited-programmes-e2e)
- [ ] This makes new expectations of the API...
  - [ ] ... and I have notified the API developer(s) of changes to the contract tests (Pact), or the API is already compliant
- [ ] [Manually approve](../doc/how-to/perform-a-release.md#releasing-to-the-preprod-environment) release to preprod
- [ ] [Manually approve](../doc/how-to/perform-a-release.md#releasing-to-the-production-environment) release to prod

<!-- Should a release fail at any step, you as the author should now lead the work to
fix it as soon as possible. You can monitor deployment failures in CircleCI
itself and application errors are found in
[Sentry](https://ministryofjustice.sentry.io/projects/hmpps-accredited-programmes-ui/?project=4505330122686464&referrer=sidebar&statsPeriod=24h). -->
