### PR TITLE
(APG-600) No offerings/locations text update

### DIFF
--- a/integration_tests/pages/find/course.ts
+++ b/integration_tests/pages/find/course.ts
@@ -22,10 +22,7 @@ export default class CoursePage extends Page {
   }
 
   shouldContainNoOfferingsText() {
-    cy.get('[data-testid="no-offerings-text"]').should(
-      'have.text',
-      `To find out where ${this.course.displayName} is offered, speak to your Offender Management Unit (custody) or regional probation team (community).`,
-    )
+    cy.get('[data-testid="no-offerings-text"]').should('have.text', CourseUtils.noOfferingsMessage(this.course.name))
   }
 
   shouldContainOfferingsText() {

--- a/server/controllers/find/coursesController.test.ts
+++ b/server/controllers/find/coursesController.test.ts
@@ -52,10 +52,17 @@ describe('CoursesController', () => {
 
   describe('show', () => {
     let course: Course
+    const noOfferingsMessage = 'No offerings found for this course.'
 
     beforeEach(() => {
       course = courseFactory.build()
       courseService.getCourse.mockResolvedValue(course)
+
+      jest.spyOn(CourseUtils, 'noOfferingsMessage').mockReturnValue(noOfferingsMessage)
+    })
+
+    afterEach(() => {
+      jest.restoreAllMocks()
     })
 
     describe('when all organisations are returned by the organisation service', () => {
@@ -85,6 +92,7 @@ describe('CoursesController', () => {
           addOfferingPath: `/find/programmes/${course.id}/offerings/add`,
           course: coursePresenter,
           isBuildingChoices: false,
+          noOfferingsMessage,
           organisationsTableData: OrganisationUtils.organisationTableRows(organisationsWithOfferingIds),
           pageHeading: coursePresenter.displayName,
           updateProgrammePath: `/find/programmes/${course.id}/update`,
@@ -127,6 +135,7 @@ describe('CoursesController', () => {
           addOfferingPath: `/find/programmes/${course.id}/offerings/add`,
           course: coursePresenter,
           isBuildingChoices: false,
+          noOfferingsMessage,
           organisationsTableData: OrganisationUtils.organisationTableRows(existingOrganisationsWithOfferingIds),
           pageHeading: coursePresenter.displayName,
           updateProgrammePath: `/find/programmes/${course.id}/update`,

--- a/server/controllers/find/coursesController.ts
+++ b/server/controllers/find/coursesController.ts
@@ -52,6 +52,7 @@ export default class CoursesController {
         addOfferingPath: findPaths.offerings.add.create({ courseId: course.id }),
         course: coursePresenter,
         isBuildingChoices: CourseUtils.isBuildingChoices(course.displayName),
+        noOfferingsMessage: CourseUtils.noOfferingsMessage(course.name),
         organisationsTableData,
         pageHeading: coursePresenter.displayName,
         updateProgrammePath: findPaths.course.update.show({ courseId: course.id }),

--- a/server/utils/courseUtils.test.ts
+++ b/server/utils/courseUtils.test.ts
@@ -79,6 +79,30 @@ describe('CourseUtils', () => {
     })
   })
 
+  describe('noOfferingsMessage', () => {
+    it('returns a message for when a course has no offerings', () => {
+      expect(CourseUtils.noOfferingsMessage('Test Course')).toBe(
+        'To find out where Test Course runs and for more information, speak to your Offender Management Unit (custody) or regional probation team (community).',
+      )
+    })
+
+    describe('when the course name is "Healthy Identity Intervention"', () => {
+      it('returns a message to say the user should contact the regional psychology counter-terrorism lead or regional psychology team', () => {
+        expect(CourseUtils.noOfferingsMessage('Healthy Identity Intervention')).toBe(
+          'To find out where Healthy Identity Intervention runs and for more information, contact the regional psychology counter-terrorism lead or regional psychology team.',
+        )
+      })
+    })
+
+    describe('when the course name is "Healthy Sex Programme"', () => {
+      it('returns a message with the contact details for the national psychology team', () => {
+        expect(CourseUtils.noOfferingsMessage('Healthy Sex Programme')).toBe(
+          'To find out where Healthy Sex Programme runs and for more information, email the national psychology team: <a href="mailto:NationalHSP@justice.gov.uk">NationalHSP@justice.gov.uk</a>',
+        )
+      })
+    })
+  })
+
   describe('presentCourse', () => {
     it('returns course details with UI-formatted audience and prerequisite data', () => {
       const coursePrerequisites = [

--- a/server/utils/courseUtils.ts
+++ b/server/utils/courseUtils.ts
@@ -54,6 +54,25 @@ export default class CourseUtils {
     return displayName?.startsWith('Building Choices:') ?? false
   }
 
+  static noOfferingsMessage(courseName: Course['name']): string {
+    const actionStrings = new Map<Course['name'], string>([
+      [
+        'Healthy Identity Intervention',
+        'contact the regional psychology counter-terrorism lead or regional psychology team.',
+      ],
+      [
+        'Healthy Sex Programme',
+        'email the national psychology team: <a href="mailto:NationalHSP@justice.gov.uk">NationalHSP@justice.gov.uk</a>',
+      ],
+    ])
+
+    const actionString =
+      actionStrings.get(courseName) ||
+      'speak to your Offender Management Unit (custody) or regional probation team (community).'
+
+    return `To find out where ${courseName} runs and for more information, ${actionString}`
+  }
+
   static presentCourse(course: Course): CoursePresenter {
     return {
       ...course,

--- a/server/views/courses/show.njk
+++ b/server/views/courses/show.njk
@@ -64,7 +64,7 @@
 
         {% include "./_locationsTable.njk" %}
       {% else %}
-        <p data-testid="no-offerings-text">To find out where {{ course.displayName }} is offered, speak to your Offender Management Unit (custody) or regional probation team (community).</p>
+        <p data-testid="no-offerings-text">{{ noOfferingsMessage | safe }}</p>
       {% endif %}
     </div>
   </div>


### PR DESCRIPTION
## Context

The Directorate Programme Managers asked for an update to the contact details for 2 programmes: HSP and HII. We don’t allow referrals to these programmes so there isn’t a contact page with an email address. This information sits under ‘Locations’ on the programme details page.

## Changes in this PR
Add new `noOfferingsMessage` method to `CourseUtils` to handle messaging for these 2 courses and the default messaging for other courses.


## Screenshots of UI changes

### Before
![image](https://github.com/user-attachments/assets/026d2cea-59b0-43a1-afa6-ac6822999ff9)


### After
Healthy Identity Intervention:
![image](https://github.com/user-attachments/assets/19daa48a-3d15-49bf-86d9-246d74686ed5)

Healthy Sex Programme:
![image](https://github.com/user-attachments/assets/0e7ff8b7-4a96-4523-83b3-f00e574abab0)

Any other courses without locations:
![image](https://github.com/user-attachments/assets/e125fe8e-0d78-4f7b-98b1-a087a72c47f7)




## Release checklist

[Release process documentation](../doc/how-to/perform-a-release.md)

As part of our continuous deployment strategy we must ensure that this work is
ready to be released once merged.

### Pre-merge

- [ ] There are changes required to the Accredited Programmes API for this change to work...
  - [ ] ... and they have been released to production already

### Post-merge

<!-- The outer checkboxes can be completed pre-merge -->

- [ ] This adds, extends or meaningfully modifies a feature...
  - [ ] ... and I have written or updated an end-to-end test for the happy path in the [Accredited Programmes E2E repo](https://github.com/ministryofjustice/hmpps-accredited-programmes-e2e)
- [ ] This makes new expectations of the API...
  - [ ] ... and I have notified the API developer(s) of changes to the contract tests (Pact), or the API is already compliant
- [ ] [Manually approve](../doc/how-to/perform-a-release.md#releasing-to-the-preprod-environment) release to preprod
- [ ] [Manually approve](../doc/how-to/perform-a-release.md#releasing-to-the-production-environment) release to prod

<!-- Should a release fail at any step, you as the author should now lead the work to
fix it as soon as possible. You can monitor deployment failures in CircleCI
itself and application errors are found in
[Sentry](https://ministryofjustice.sentry.io/projects/hmpps-accredited-programmes-ui/?project=4505330122686464&referrer=sidebar&statsPeriod=24h). -->
