### PR TITLE
(APG-314b) Add course participations as draft and for a specific referral

### DIFF
--- a/server/controllers/refer/new/courseParticipationsController.test.ts
+++ b/server/controllers/refer/new/courseParticipationsController.test.ts
@@ -77,7 +77,12 @@ describe('NewReferralsCourseParticipationsController', () => {
           request.body.otherCourseName,
           request,
         )
-        expect(courseService.createParticipation).toHaveBeenCalledWith(username, draftReferral.prisonNumber, courseName)
+        expect(courseService.createParticipation).toHaveBeenCalledWith(username, {
+          courseName,
+          isDraft: true,
+          prisonNumber: person.prisonNumber,
+          referralId,
+        })
         expect(request.flash).toHaveBeenCalledWith('successMessage', 'You have successfully added a programme.')
         expect(response.redirect).toHaveBeenCalledWith(
           referPaths.new.programmeHistory.details.show({
@@ -112,11 +117,12 @@ describe('NewReferralsCourseParticipationsController', () => {
           request.body.otherCourseName,
           request,
         )
-        expect(courseService.createParticipation).toHaveBeenCalledWith(
-          username,
-          draftReferral.prisonNumber,
-          otherCourseName,
-        )
+        expect(courseService.createParticipation).toHaveBeenCalledWith(username, {
+          courseName: otherCourseName,
+          isDraft: true,
+          prisonNumber: person.prisonNumber,
+          referralId,
+        })
         expect(request.flash).toHaveBeenCalledWith('successMessage', 'You have successfully added a programme.')
         expect(response.redirect).toHaveBeenCalledWith(
           referPaths.new.programmeHistory.details.show({

--- a/server/controllers/refer/new/courseParticipationsController.ts
+++ b/server/controllers/refer/new/courseParticipationsController.ts
@@ -35,11 +35,12 @@ export default class NewReferralsCourseParticipationsController {
         return res.redirect(referPaths.new.programmeHistory.new({ referralId }))
       }
 
-      const courseParticipation = await this.courseService.createParticipation(
-        req.user.username,
-        referral.prisonNumber,
-        courseName as CourseParticipation['courseName'],
-      )
+      const courseParticipation = await this.courseService.createParticipation(req.user.username, {
+        courseName,
+        isDraft: true,
+        prisonNumber: referral.prisonNumber,
+        referralId,
+      })
 
       req.flash('successMessage', 'You have successfully added a programme.')
 

--- a/server/data/accreditedProgrammesApi/courseClient.test.ts
+++ b/server/data/accreditedProgrammesApi/courseClient.test.ts
@@ -13,7 +13,12 @@ import {
   courseParticipationSettingFactory,
 } from '../../testutils/factories'
 import type { CourseCreateRequest, CourseOffering } from '@accredited-programmes/models'
-import type { CourseParticipation, CourseParticipationUpdate, CoursePrerequisite } from '@accredited-programmes-api'
+import type {
+  CourseParticipation,
+  CourseParticipationCreate,
+  CourseParticipationUpdate,
+  CoursePrerequisite,
+} from '@accredited-programmes-api'
 
 pactWith({ consumer: 'Accredited Programmes UI', provider: 'Accredited Programmes API' }, provider => {
   let courseClient: CourseClient
@@ -159,13 +164,21 @@ pactWith({ consumer: 'Accredited Programmes UI', provider: 'Accredited Programme
 
   describe('createParticipation', () => {
     const courseParticipation = courseParticipationFactory.new().build()
+    const courseParticipationRequest = {
+      courseName: courseParticipation.courseName,
+      isDraft: true,
+      prisonNumber: courseParticipation.prisonNumber,
+      referralId: courseParticipation.referralId,
+    }
 
     const courseParticipationBody: InterfaceToTemplate<CourseParticipation> = {
       ...courseParticipation,
       outcome: { ...courseParticipationOutcomeFactory.build() },
       setting: { ...courseParticipationSettingFactory.build() },
     }
-    const { courseName, prisonNumber } = courseParticipation
+    const courseParticipationRequestBody: InterfaceToTemplate<CourseParticipationCreate> = {
+      ...courseParticipationRequest,
+    }
 
     beforeEach(() => {
       provider.addInteraction({
@@ -176,7 +189,7 @@ pactWith({ consumer: 'Accredited Programmes UI', provider: 'Accredited Programme
           status: 201,
         },
         withRequest: {
-          body: courseName ? { courseName, prisonNumber } : { prisonNumber },
+          body: courseParticipationRequestBody,
           headers: {
             authorization: `Bearer ${systemToken}`,
           },
@@ -187,7 +200,7 @@ pactWith({ consumer: 'Accredited Programmes UI', provider: 'Accredited Programme
     })
 
     it('creates a participation for the given person', async () => {
-      const result = await courseClient.createParticipation(prisonNumber, courseName)
+      const result = await courseClient.createParticipation(courseParticipationRequest)
 
       expect(result).toEqual(courseParticipationBody)
     })

--- a/server/data/accreditedProgrammesApi/courseClient.ts
+++ b/server/data/accreditedProgrammesApi/courseClient.ts
@@ -13,6 +13,7 @@ import type {
   BuildingChoicesSearchRequest,
   Course,
   CourseParticipation,
+  CourseParticipationCreate,
   CourseParticipationUpdate,
 } from '@accredited-programmes-api'
 import type { SystemToken } from '@hmpps-auth'
@@ -46,12 +47,9 @@ export default class CourseClient {
     })) as Course
   }
 
-  async createParticipation(
-    prisonNumber: CourseParticipation['prisonNumber'],
-    courseName: CourseParticipation['courseName'],
-  ): Promise<CourseParticipation> {
+  async createParticipation(participationCreateRequest: CourseParticipationCreate): Promise<CourseParticipation> {
     return (await this.restClient.post({
-      data: { courseName, prisonNumber },
+      data: { ...participationCreateRequest },
       path: apiPaths.participations.create({}),
     })) as CourseParticipation
   }

--- a/server/services/courseService.test.ts
+++ b/server/services/courseService.test.ts
@@ -14,12 +14,13 @@ import {
   courseParticipationFactory,
   coursePrerequisiteFactory,
   personFactory,
+  referralFactory,
   userFactory,
 } from '../testutils/factories'
 import { CourseParticipationUtils, StringUtils } from '../utils'
 import type { CourseCreateRequest, CourseOffering } from '@accredited-programmes/models'
 import type { BuildingChoicesSearchForm } from '@accredited-programmes/ui'
-import type { CourseParticipationUpdate } from '@accredited-programmes-api'
+import type { CourseParticipationCreate, CourseParticipationUpdate } from '@accredited-programmes-api'
 
 jest.mock('../data/accreditedProgrammesApi/courseClient')
 jest.mock('../data/hmppsAuthClient')
@@ -97,21 +98,34 @@ describe('CourseService', () => {
   })
 
   describe('createParticipation', () => {
-    it('creates a course participation using the `courseName` value', async () => {
+    it('creates a course participation using with the provided `CourseParticipationCreate` values', async () => {
+      const courseName = 'COURSE-NAME'
       const person = personFactory.build()
-      const courseParticipation = courseParticipationFactory.build()
-      const { courseName } = courseParticipation
+      const referral = referralFactory.build()
+
+      const participationCreateRequest: CourseParticipationCreate = {
+        courseName,
+        isDraft: true,
+        prisonNumber: person.prisonNumber,
+        referralId: referral.id,
+      }
+
+      const courseParticipation = courseParticipationFactory.build({
+        courseName,
+        prisonNumber: person.prisonNumber,
+        referralId: referral.id,
+      })
 
       when(courseClient.createParticipation)
-        .calledWith(person.prisonNumber, courseName)
+        .calledWith(participationCreateRequest)
         .mockResolvedValue(courseParticipation)
 
-      const result = await service.createParticipation(username, person.prisonNumber, courseName)
+      const result = await service.createParticipation(username, participationCreateRequest)
 
       expect(result).toEqual(courseParticipation)
 
       expect(courseClientBuilder).toHaveBeenCalledWith(systemToken)
-      expect(courseClient.createParticipation).toHaveBeenCalledWith(person.prisonNumber, courseName)
+      expect(courseClient.createParticipation).toHaveBeenCalledWith(participationCreateRequest)
     })
   })
 

--- a/server/services/courseService.ts
+++ b/server/services/courseService.ts
@@ -15,7 +15,13 @@ import type {
   BuildingChoicesSearchForm,
   GovukFrontendSummaryListWithRowsWithKeysAndValues,
 } from '@accredited-programmes/ui'
-import type { Course, CourseParticipation, CourseParticipationUpdate, Referral } from '@accredited-programmes-api'
+import type {
+  Course,
+  CourseParticipation,
+  CourseParticipationCreate,
+  CourseParticipationUpdate,
+  Referral,
+} from '@accredited-programmes-api'
 import type { Prison } from '@prison-register-api'
 
 export default class CourseService {
@@ -47,14 +53,13 @@ export default class CourseService {
 
   async createParticipation(
     username: Express.User['username'],
-    prisonNumber: CourseParticipation['prisonNumber'],
-    courseName: CourseParticipation['courseName'],
+    participationCreateRequest: CourseParticipationCreate,
   ): Promise<CourseParticipation> {
     const hmppsAuthClient = this.hmppsAuthClientBuilder()
     const systemToken = await hmppsAuthClient.getSystemClientToken(username)
     const courseClient = this.courseClientBuilder(systemToken)
 
-    return courseClient.createParticipation(prisonNumber, courseName)
+    return courseClient.createParticipation(participationCreateRequest)
   }
 
   async deleteOffering(


### PR DESCRIPTION
## Context

Course participations/Programme history records added as part of creating a new referral, need to remain in a draft state until the referral is eventually submitted.



## Changes in this PR
Call `POST /course-participations` with extra values:
- `isDraft: true`
- `referralId`


## Release checklist

[Release process documentation](../doc/how-to/perform-a-release.md)

As part of our continuous deployment strategy we must ensure that this work is
ready to be released once merged.

### Pre-merge

- [ ] There are changes required to the Accredited Programmes API for this change to work...
  - [ ] ... and they have been released to production already

### Post-merge

<!-- The outer checkboxes can be completed pre-merge -->

- [ ] This adds, extends or meaningfully modifies a feature...
  - [ ] ... and I have written or updated an end-to-end test for the happy path in the [Accredited Programmes E2E repo](https://github.com/ministryofjustice/hmpps-accredited-programmes-e2e)
- [ ] This makes new expectations of the API...
  - [ ] ... and I have notified the API developer(s) of changes to the contract tests (Pact), or the API is already compliant
- [ ] [Manually approve](../doc/how-to/perform-a-release.md#releasing-to-the-preprod-environment) release to preprod
- [ ] [Manually approve](../doc/how-to/perform-a-release.md#releasing-to-the-production-environment) release to prod

<!-- Should a release fail at any step, you as the author should now lead the work to
fix it as soon as possible. You can monitor deployment failures in CircleCI
itself and application errors are found in
[Sentry](https://ministryofjustice.sentry.io/projects/hmpps-accredited-programmes-ui/?project=4505330122686464&referrer=sidebar&statsPeriod=24h). -->
