### PR TITLE
(APG-314c) Add individual programme history page

### DIFF
--- a/integration_tests/e2e/refer/new/programmeHistory.cy.ts
+++ b/integration_tests/e2e/refer/new/programmeHistory.cy.ts
@@ -18,6 +18,7 @@ import {
   NewReferralProgrammeHistoryDetailsPage,
   NewReferralProgrammeHistoryPage,
   NewReferralSelectProgrammePage,
+  NewReferralShowProgrammeHistoryPage,
   NewReferralTaskListPage,
 } from '../../../pages/refer'
 import type { CourseParticipationPresenter } from '@accredited-programmes/ui'
@@ -63,6 +64,10 @@ context('Programme history', () => {
   })
   const programmeHistoryPath = referPaths.new.programmeHistory.index({ referralId: referral.id })
   const newParticipationPath = referPaths.new.programmeHistory.new({ referralId: referral.id })
+  const showProgrammeHistoryPath = referPaths.new.programmeHistory.show({
+    courseParticipationId: courseParticipationWithKnownCourseName.id,
+    referralId: referral.id,
+  })
 
   beforeEach(() => {
     cy.task('reset')
@@ -702,6 +707,35 @@ context('Programme history', () => {
         referral,
       })
       programmeHistoryPage.shouldContainSuccessMessage('You have successfully removed a programme.')
+    })
+  })
+
+  describe('When viewing an individual programme history page', () => {
+    beforeEach(() => {
+      cy.task('stubParticipation', courseParticipationWithKnownCourseName)
+      cy.task('stubCourse', courses[0])
+
+      cy.visit(showProgrammeHistoryPath)
+    })
+
+    it('shows the details of that programme history record', () => {
+      const showProgrammeHistoryPage = Page.verifyOnPage(NewReferralShowProgrammeHistoryPage, {
+        participation: courseParticipationWithKnownCourseName,
+        person,
+        referral,
+      })
+
+      showProgrammeHistoryPage.shouldHavePersonDetails(person)
+      showProgrammeHistoryPage.shouldContainBackLink(programmeHistoryPath)
+      showProgrammeHistoryPage.shouldContainHomeLink()
+      showProgrammeHistoryPage.shouldContainHistorySummaryCards(
+        [courseParticipationWithKnownCourseNamePresenter],
+        referral.id,
+        {
+          change: false,
+          remove: false,
+        },
+      )
     })
   })
 })

--- a/integration_tests/pages/refer/index.ts
+++ b/integration_tests/pages/refer/index.ts
@@ -11,6 +11,7 @@ import NewReferralProgrammeHistoryPage from './new/programmeHistory'
 import NewReferralProgrammeHistoryDetailsPage from './new/programmeHistoryDetails'
 import NewReferralSelectProgrammePage from './new/selectProgramme'
 import NewReferralShowPersonPage from './new/showPerson'
+import NewReferralShowProgrammeHistoryPage from './new/showProgrammeHistory'
 import NewReferralStartPage from './new/start'
 import NewReferralTaskListPage from './new/taskList'
 
@@ -28,6 +29,7 @@ export {
   NewReferralProgrammeHistoryPage,
   NewReferralSelectProgrammePage,
   NewReferralShowPersonPage,
+  NewReferralShowProgrammeHistoryPage,
   NewReferralStartPage,
   NewReferralTaskListPage,
 }

--- a/integration_tests/pages/refer/new/showProgrammeHistory.ts
+++ b/integration_tests/pages/refer/new/showProgrammeHistory.ts
@@ -1,0 +1,22 @@
+import Page from '../../page'
+import type { Person } from '@accredited-programmes/models'
+import type { CourseParticipation, Referral } from '@accredited-programmes-api'
+
+export default class NewReferralShowProgrammeHistoryPage extends Page {
+  participation: CourseParticipation
+
+  person: Person
+
+  referral: Referral
+
+  constructor(args: { participation: CourseParticipation; person: Person; referral: Referral }) {
+    super('Programme history details', {
+      hideTitleServiceName: true,
+    })
+
+    const { participation, person, referral } = args
+    this.participation = participation
+    this.person = person
+    this.referral = referral
+  }
+}

--- a/server/controllers/refer/new/courseParticipationsController.ts
+++ b/server/controllers/refer/new/courseParticipationsController.ts
@@ -217,6 +217,38 @@ export default class NewReferralsCourseParticipationsController {
     }
   }
 
+  show(): TypedRequestHandler<Request, Response> {
+    return async (req: Request, res: Response) => {
+      TypeUtils.assertHasUser(req)
+
+      const { courseParticipationId, referralId } = req.params
+
+      const referral = await this.referralService.getReferral(req.user.username, referralId)
+
+      if (referral.status !== 'referral_started') {
+        return res.redirect(referPaths.new.complete({ referralId }))
+      }
+
+      const courseParticipation = await this.courseService.getParticipation(req.user.username, courseParticipationId)
+      const summaryListOptions = await this.courseService.presentCourseParticipation(
+        req.user.token,
+        courseParticipation,
+        referralId,
+        undefined,
+        { change: false, remove: false },
+      )
+      const person = await this.personService.getPerson(req.user.username, referral.prisonNumber)
+
+      return res.render('referrals/new/courseParticipations/show', {
+        hideTitleServiceName: true,
+        pageHeading: 'Programme history details',
+        person,
+        referralId,
+        summaryListOptions,
+      })
+    }
+  }
+
   updateCourse(): TypedRequestHandler<Request, Response> {
     return async (req: Request, res: Response) => {
       TypeUtils.assertHasUser(req)

--- a/server/paths/refer.ts
+++ b/server/paths/refer.ts
@@ -64,6 +64,7 @@ export default {
       editProgramme: newReferralProgrammeHistoryProgrammePath,
       index: newReferralProgrammeHistoryPath,
       new: newReferralProgrammeHistoryPath.path('new'),
+      show: newReferralProgrammeHistoryShowPath,
       updateProgramme: newReferralProgrammeHistoryProgrammePath,
       updateReviewedStatus: newReferralProgrammeHistoryPath,
     },

--- a/server/routes/refer.ts
+++ b/server/routes/refer.ts
@@ -60,6 +60,7 @@ export default function routes(controllers: Controllers, router: Router): Router
   )
   get(referPaths.new.programmeHistory.new.pattern, newReferralsCourseParticipationsController.new())
   post(referPaths.new.programmeHistory.create.pattern, newReferralsCourseParticipationsController.create())
+  get(referPaths.new.programmeHistory.show.pattern, newReferralsCourseParticipationsController.show())
   get(referPaths.new.programmeHistory.editProgramme.pattern, newReferralsCourseParticipationsController.editCourse())
   put(
     referPaths.new.programmeHistory.updateProgramme.pattern,

--- a/server/views/referrals/new/courseParticipations/show.njk
+++ b/server/views/referrals/new/courseParticipations/show.njk
@@ -1,0 +1,25 @@
+{% from "govuk/components/back-link/macro.njk" import govukBackLink %}
+{% from "govuk/components/summary-list/macro.njk" import govukSummaryList %}
+
+{% extends "../../../partials/layout.njk" %}
+
+{% block personBanner %}
+  {% include "../../_personBanner.njk" %}
+{% endblock personBanner %}
+
+{% block backLink %}
+  {{ govukBackLink({
+    text: "Back",
+    href: referPaths.new.programmeHistory.index({ referralId: referralId })
+  }) }}
+{% endblock backLink %}
+
+{% block content %}
+  <h1 class="govuk-heading-l">{{ pageHeading }}</h1>
+
+  <div class="govuk-grid-row">
+    <div class="govuk-grid-column-two-thirds">
+      {{ govukSummaryList(summaryListOptions) }}
+    </div>
+  </div>
+{% endblock content %}


### PR DESCRIPTION
## Context

Each programme history page needs it's own individual route to link to from the upcoming table view.

## Changes in this PR
Add new route and template for individual programme history records.


## Screenshots of UI changes

![image](https://github.com/user-attachments/assets/ef564644-679d-4265-8f41-c390647d55c8)


## Release checklist

[Release process documentation](../doc/how-to/perform-a-release.md)

As part of our continuous deployment strategy we must ensure that this work is
ready to be released once merged.

### Pre-merge

- [ ] There are changes required to the Accredited Programmes API for this change to work...
  - [ ] ... and they have been released to production already

### Post-merge

<!-- The outer checkboxes can be completed pre-merge -->

- [ ] This adds, extends or meaningfully modifies a feature...
  - [ ] ... and I have written or updated an end-to-end test for the happy path in the [Accredited Programmes E2E repo](https://github.com/ministryofjustice/hmpps-accredited-programmes-e2e)
- [ ] This makes new expectations of the API...
  - [ ] ... and I have notified the API developer(s) of changes to the contract tests (Pact), or the API is already compliant
- [ ] [Manually approve](../doc/how-to/perform-a-release.md#releasing-to-the-preprod-environment) release to preprod
- [ ] [Manually approve](../doc/how-to/perform-a-release.md#releasing-to-the-production-environment) release to prod

<!-- Should a release fail at any step, you as the author should now lead the work to
fix it as soon as possible. You can monitor deployment failures in CircleCI
itself and application errors are found in
[Sentry](https://ministryofjustice.sentry.io/projects/hmpps-accredited-programmes-ui/?project=4505330122686464&referrer=sidebar&statsPeriod=24h). -->
