### PR TITLE
Add referralId for participation related pact tests

### DIFF
--- a/server/data/accreditedProgrammesApi/courseClient.test.ts
+++ b/server/data/accreditedProgrammesApi/courseClient.test.ts
@@ -24,6 +24,7 @@ pactWith({ consumer: 'Accredited Programmes UI', provider: 'Accredited Programme
   let courseClient: CourseClient
 
   const systemToken = 'token-1'
+  const referralId = '0c46ed09-170b-4c0f-aee8-a24eeaeeddab'
 
   beforeEach(() => {
     courseClient = new CourseClient(systemToken)
@@ -163,7 +164,7 @@ pactWith({ consumer: 'Accredited Programmes UI', provider: 'Accredited Programme
   })
 
   describe('createParticipation', () => {
-    const courseParticipation = courseParticipationFactory.new().build()
+    const courseParticipation = courseParticipationFactory.new().build({ referralId })
     const courseParticipationRequest = {
       courseName: courseParticipation.courseName,
       isDraft: true,
@@ -472,6 +473,7 @@ pactWith({ consumer: 'Accredited Programmes UI', provider: 'Accredited Programme
     const courseParticipation = courseParticipationFactory.withAllOptionalFields().build({
       id: '0cff5da9-1e90-4ee2-a5cb-94dc49c4b004',
       outcome: courseParticipationOutcomeFactory.incomplete(true).build(),
+      referralId,
       setting: courseParticipationSettingFactory.build(),
     })
 
@@ -512,11 +514,13 @@ pactWith({ consumer: 'Accredited Programmes UI', provider: 'Accredited Programme
         id: '0cff5da9-1e90-4ee2-a5cb-94dc49c4b004',
         outcome: courseParticipationOutcomeFactory.incomplete(true).build(),
         prisonNumber: 'A1234AA',
+        referralId,
       }),
       courseParticipationFactory.withAllOptionalFields().build({
         id: 'eb357e5d-5416-43bf-a8d2-0dc8fd92162e',
         outcome: courseParticipationOutcomeFactory.incomplete(true).build(),
         prisonNumber: 'A1234AA',
+        referralId,
       }),
     ]
 
@@ -592,6 +596,7 @@ pactWith({ consumer: 'Accredited Programmes UI', provider: 'Accredited Programme
     const courseParticipation = courseParticipationFactory.build({
       id: 'cc8eb19e-050a-4aa9-92e0-c654e5cfe281',
       outcome: courseParticipationOutcomeFactory.incomplete().build(),
+      referralId,
     })
 
     const courseParticipationUpdate = {


### PR DESCRIPTION
## Context
Use `0c46ed09-170b-4c0f-aee8-a24eeaeeddab` for `createCourseParticipation` in PactContractTest.kt



## Release checklist

[Release process documentation](../doc/how-to/perform-a-release.md)

As part of our continuous deployment strategy we must ensure that this work is
ready to be released once merged.

### Pre-merge

- [ ] There are changes required to the Accredited Programmes API for this change to work...
  - [ ] ... and they have been released to production already

### Post-merge

<!-- The outer checkboxes can be completed pre-merge -->

- [ ] This adds, extends or meaningfully modifies a feature...
  - [ ] ... and I have written or updated an end-to-end test for the happy path in the [Accredited Programmes E2E repo](https://github.com/ministryofjustice/hmpps-accredited-programmes-e2e)
- [ ] This makes new expectations of the API...
  - [ ] ... and I have notified the API developer(s) of changes to the contract tests (Pact), or the API is already compliant
- [ ] [Manually approve](../doc/how-to/perform-a-release.md#releasing-to-the-preprod-environment) release to preprod
- [ ] [Manually approve](../doc/how-to/perform-a-release.md#releasing-to-the-production-environment) release to prod

<!-- Should a release fail at any step, you as the author should now lead the work to
fix it as soon as possible. You can monitor deployment failures in CircleCI
itself and application errors are found in
[Sentry](https://ministryofjustice.sentry.io/projects/hmpps-accredited-programmes-ui/?project=4505330122686464&referrer=sidebar&statsPeriod=24h). -->
