### PR TITLE
(APG-314d) Add client and service methods to call `course-participations/referral/{id}`

### DIFF
--- a/server/data/accreditedProgrammesApi/courseClient.ts
+++ b/server/data/accreditedProgrammesApi/courseClient.ts
@@ -131,6 +131,13 @@ export default class CourseClient {
   }
 
   /* istanbul ignore next */
+  async findParticipationsByReferral(referralId: string): Promise<Array<CourseParticipation>> {
+    return (await this.restClient.get({
+      path: apiPaths.participations.referral({ referralId }),
+    })) as Array<CourseParticipation>
+  }
+
+  /* istanbul ignore next */
   async updateCourse(courseId: Course['id'], courseUpdate: CourseCreateRequest): Promise<Course> {
     return (await this.restClient.put({
       data: { ...courseUpdate },

--- a/server/paths/api.ts
+++ b/server/paths/api.ts
@@ -81,6 +81,7 @@ export default {
   participations: {
     create: participationsPath,
     delete: participationPath,
+    referral: participationsPath.path('referral/:referralId'),
     show: participationPath,
     update: participationPath,
   },

--- a/server/services/courseService.test.ts
+++ b/server/services/courseService.test.ts
@@ -470,6 +470,23 @@ describe('CourseService', () => {
     })
   })
 
+  describe('getParticipationsByReferral', () => {
+    const referral = referralFactory.build()
+
+    it('returns a list of participations for a given referral', async () => {
+      const courseParticipations = courseParticipationFactory.buildList(2, { referralId: referral.id })
+
+      when(courseClient.findParticipationsByReferral).calledWith(referral.id).mockResolvedValue(courseParticipations)
+
+      const result = await service.getParticipationsByReferral(username, referral.id)
+
+      expect(result).toEqual(courseParticipations)
+
+      expect(courseClientBuilder).toHaveBeenCalledWith(systemToken)
+      expect(courseClient.findParticipationsByReferral).toHaveBeenCalledWith(referral.id)
+    })
+  })
+
   describe('presentCourseParticipation', () => {
     const addedByUser = userFactory.build({ name: 'john smith' })
     const courseParticipation = courseParticipationFactory.build({ addedBy: addedByUser.username })

--- a/server/services/courseService.ts
+++ b/server/services/courseService.ts
@@ -238,6 +238,17 @@ export default class CourseService {
     return courseClient.findParticipationsByPerson(prisonNumber)
   }
 
+  async getParticipationsByReferral(
+    username: Express.User['username'],
+    referralId: Referral['id'],
+  ): Promise<Array<CourseParticipation>> {
+    const hmppsAuthClient = this.hmppsAuthClientBuilder()
+    const systemToken = await hmppsAuthClient.getSystemClientToken(username)
+    const courseClient = this.courseClientBuilder(systemToken)
+
+    return courseClient.findParticipationsByReferral(referralId)
+  }
+
   async presentCourseParticipation(
     userToken: Express.User['token'],
     courseParticipation: CourseParticipation,


### PR DESCRIPTION
## Context

We need to get the course participations added by referral id so we can show them when creating a draft referral.

## Changes in this PR
Add Course client and service methods to call `/course-participations/referral/{id}`


## Release checklist

[Release process documentation](../doc/how-to/perform-a-release.md)

As part of our continuous deployment strategy we must ensure that this work is
ready to be released once merged.

### Pre-merge

- [ ] There are changes required to the Accredited Programmes API for this change to work...
  - [ ] ... and they have been released to production already

### Post-merge

<!-- The outer checkboxes can be completed pre-merge -->

- [ ] This adds, extends or meaningfully modifies a feature...
  - [ ] ... and I have written or updated an end-to-end test for the happy path in the [Accredited Programmes E2E repo](https://github.com/ministryofjustice/hmpps-accredited-programmes-e2e)
- [ ] This makes new expectations of the API...
  - [ ] ... and I have notified the API developer(s) of changes to the contract tests (Pact), or the API is already compliant
- [ ] [Manually approve](../doc/how-to/perform-a-release.md#releasing-to-the-preprod-environment) release to preprod
- [ ] [Manually approve](../doc/how-to/perform-a-release.md#releasing-to-the-production-environment) release to prod

<!-- Should a release fail at any step, you as the author should now lead the work to
fix it as soon as possible. You can monitor deployment failures in CircleCI
itself and application errors are found in
[Sentry](https://ministryofjustice.sentry.io/projects/hmpps-accredited-programmes-ui/?project=4505330122686464&referrer=sidebar&statsPeriod=24h). -->
