### PR TITLE
(APG-314e) Update Accredited Programme history page for refer

### DIFF
--- a/integration_tests/mockApis/courseParticipations.ts
+++ b/integration_tests/mockApis/courseParticipations.ts
@@ -60,6 +60,22 @@ export default {
       },
     }),
 
+  stubParticipationsByReferral: (args: {
+    courseParticipations: Array<CourseParticipation>
+    referralId: CourseParticipation['referralId']
+  }): SuperAgentRequest =>
+    stubFor({
+      request: {
+        method: 'GET',
+        url: apiPaths.participations.referral({ referralId: args.referralId }),
+      },
+      response: {
+        headers: { 'Content-Type': 'application/json;charset=UTF-8' },
+        jsonBody: args.courseParticipations,
+        status: 200,
+      },
+    }),
+
   stubUpdateParticipation: (courseParticipation: CourseParticipation): SuperAgentRequest =>
     stubFor({
       request: {

--- a/integration_tests/pages/page.ts
+++ b/integration_tests/pages/page.ts
@@ -22,7 +22,7 @@ import type {
   MojTimelineItem,
   ReferralStatusHistoryPresenter,
 } from '@accredited-programmes/ui'
-import type { Referral } from '@accredited-programmes-api'
+import type { CourseParticipation, Referral } from '@accredited-programmes-api'
 import type {
   GovukFrontendRadiosItem,
   GovukFrontendSummaryListCardTitle,
@@ -203,6 +203,35 @@ export default abstract class Page {
             this.shouldContainSummaryCard(participation.courseName, actions, rows, summaryCardElement)
           })
       })
+  }
+
+  shouldContainHistoryTable(
+    participations: Array<CourseParticipation>,
+    referralId: Referral['id'],
+    testId: string,
+    editable = false,
+  ) {
+    const { rows } = CourseParticipationUtils.table(participations, referralId, testId, editable)
+
+    cy.get(`[data-testid="${testId}"] .govuk-table__body`).within(() => {
+      cy.get('.govuk-table__row').each((tableRowElement, tableRowElementIndex) => {
+        const row = rows[tableRowElementIndex]
+
+        cy.wrap(tableRowElement).within(() => {
+          row.forEach((cell, cellIndex) => {
+            cy.get('.govuk-table__cell')
+              .eq(cellIndex)
+              .then(cellElement => {
+                if ('text' in cell) {
+                  cy.wrap(cellElement).should('contain.text', cell.text)
+                } else {
+                  cy.wrap(cellElement).should('contain.html', cell.html)
+                }
+              })
+          })
+        })
+      })
+    })
   }
 
   shouldContainHomeLink(): void {

--- a/integration_tests/pages/refer/new/deleteProgrammeHistory.ts
+++ b/integration_tests/pages/refer/new/deleteProgrammeHistory.ts
@@ -23,6 +23,7 @@ export default class NewReferralDeleteProgrammeHistoryPage extends Page {
 
   confirm() {
     cy.task('stubParticipationsByPerson', { courseParticipations: [], prisonNumber: this.person.prisonNumber })
+    cy.task('stubParticipationsByReferral', { courseParticipations: [], referralId: this.referral.id })
     this.shouldContainButton('Confirm').click()
   }
 }

--- a/integration_tests/pages/refer/new/programmeHistory.ts
+++ b/integration_tests/pages/refer/new/programmeHistory.ts
@@ -1,24 +1,20 @@
 import Helpers from '../../../support/helpers'
 import Page from '../../page'
 import type { Person } from '@accredited-programmes/models'
-import type { CourseParticipationPresenter } from '@accredited-programmes/ui'
 import type { Referral } from '@accredited-programmes-api'
 
 export default class NewReferralProgrammeHistoryPage extends Page {
-  participations: Array<CourseParticipationPresenter>
-
   person: Person
 
   referral: Referral
 
-  constructor(args: { participations: Array<CourseParticipationPresenter>; person: Person; referral: Referral }) {
+  constructor(args: { person: Person; referral: Referral }) {
     super('Accredited Programme history', {
       hideTitleServiceName: true,
       pageTitleOverride: "Person's Accredited Programme history",
     })
 
-    const { participations, person, referral } = args
-    this.participations = participations
+    const { person, referral } = args
     this.person = person
     this.referral = referral
   }
@@ -55,18 +51,8 @@ export default class NewReferralProgrammeHistoryPage extends Page {
   shouldContainPreHistoryParagraph() {
     cy.get('[data-testid="pre-history-paragraph"]').should(
       'have.text',
-      'Add a programme if you know they completed or started a programme not listed here. Return to the tasklist once you’ve added all known programme history.',
+      `This is a list of programmes ${this.person.name} has started or completed. You can add missing programme history.`,
     )
-  }
-
-  shouldContainPreHistoryText() {
-    cy.get('[data-testid="history-text"]').then(historyTextElement => {
-      const { actual, expected } = Helpers.parseHtml(
-        historyTextElement,
-        `The history shows ${this.person.name} has previously started or completed an Accredited Programme.`,
-      )
-      expect(actual).to.equal(expected)
-    })
   }
 
   shouldContainSuccessMessage(message: string) {

--- a/integration_tests/pages/refer/new/programmeHistoryDetails.ts
+++ b/integration_tests/pages/refer/new/programmeHistoryDetails.ts
@@ -161,8 +161,12 @@ export default class NewReferralProgrammeHistoryDetailsPage extends Page {
     cy.task('stubUpdateParticipation', this.courseParticipation)
     cy.task('stubCourse', this.course)
     cy.task('stubParticipationsByPerson', {
-      courseParticipations: [this.courseParticipation],
+      courseParticipations: [],
       prisonNumber: this.person.prisonNumber,
+    })
+    cy.task('stubParticipationsByReferral', {
+      courseParticipations: [this.courseParticipation],
+      referralId: this.courseParticipation.referralId,
     })
     this.shouldContainButton('Continue').click()
   }

--- a/server/views/referrals/new/courseParticipations/index.njk
+++ b/server/views/referrals/new/courseParticipations/index.njk
@@ -2,6 +2,7 @@
 {% from "govuk/components/button/macro.njk" import govukButton %}
 {% from "govuk/components/inset-text/macro.njk" import govukInsetText %}
 {% from "govuk/components/summary-list/macro.njk" import govukSummaryList %}
+{% from "govuk/components/table/macro.njk" import govukTable %}
 {% from "moj/components/banner/macro.njk" import mojBanner %}
 
 {% extends "../../../partials/layout.njk" %}
@@ -33,32 +34,42 @@
         }) }}
       {% endif %}
 
-      {{ govukInsetText({
-        classes: "govuk-!-margin-top-0",
-        text: historyText,
-        attributes: {
-          "data-testid": "history-text"
-        }
-      }) }}
+      {% if historyText %}
+        {{ govukInsetText({
+          classes: "govuk-!-margin-top-0",
+          text: historyText,
+          attributes: {
+            "data-testid": "history-text"
+          }
+        }) }}
+      {% endif %}
 
-      {% if summaryListsOptions.length %}
-        <p class="govuk-body" data-testid="pre-history-paragraph">Add a programme if you know they completed or started a programme not listed here. Return to the tasklist once you’ve added all known programme history.</p>
+      {% if existingParticipationsTable.rows | length %}
+        <p class="govuk-body" data-testid="pre-history-paragraph">This is a list of programmes {{ person.name }} has started or completed. You can add missing programme history.</p>
       {% else %}
         <p class="govuk-body" data-testid="no-history-paragraph-1">The programme team may use information about a person's Accredited Programme history to assess whether they are suitable.</p>
 
         <p class="govuk-body" data-testid="no-history-paragraph-2">You can continue by adding a programme history or skip this section of the referral if the history is not known.</p>
       {% endif %}
+    </div>
+  </div>
 
-      {% for summaryListOptions in summaryListsOptions %}
-        {{ govukSummaryList(summaryListOptions) }}
-      {% endfor %}
+  <div>
+    {% if existingParticipationsTable.rows | length %}
+      {{ govukTable(existingParticipationsTable) }}
+    {% endif %}
 
-      <form action="{{ action }}" method="post">
-        <input type="hidden" name="_csrf" value="{{ csrfToken }}"/>
-        <input type="hidden" name="hasReviewedProgrammeHistory" value="true"/>
+    {% if referralParticipationsTable.rows | length %}
+      <h2 class="govuk-heading-m">Programmes you've added</h2>
+      {{ govukTable(referralParticipationsTable) }}
+    {% endif %}
 
-        <div class="govuk-button-group">
-          {{ govukButton({
+    <form action="{{ action }}" method="post">
+      <input type="hidden" name="_csrf" value="{{ csrfToken }}"/>
+      <input type="hidden" name="hasReviewedProgrammeHistory" value="true"/>
+
+      <div class="govuk-button-group">
+        {{ govukButton({
             text: "Add a programme",
             href: referPaths.new.programmeHistory.new({ referralId: referralId }),
             attributes: {
@@ -66,12 +77,11 @@
             }
           }) }}
 
-          {{ govukButton({
+        {{ govukButton({
             text: "Return to tasklist",
             classes: "govuk-button--secondary"
           }) }}
-        </div>
-      </form>
-    </div>
+      </div>
+    </form>
   </div>
 {% endblock content %}


### PR DESCRIPTION
## Context

Currently, any user can edit any programme history record for a person when creating a new referral.  A user should only be able to change or remove the history record they have added as part of that referral.  



## Changes in this PR

- Implement new design for the Accredited programme history page when raising a referral.
- Show history records added as part of current draft referral in a separate table with Change and Remove action links.


## Screenshots of UI changes
![image](https://github.com/user-attachments/assets/5eb77396-94e4-4ec4-9ab0-1768c0fadae0)



## Release checklist

[Release process documentation](../doc/how-to/perform-a-release.md)

As part of our continuous deployment strategy we must ensure that this work is
ready to be released once merged.

### Pre-merge

- [ ] There are changes required to the Accredited Programmes API for this change to work...
  - [ ] ... and they have been released to production already

### Post-merge

<!-- The outer checkboxes can be completed pre-merge -->

- [ ] This adds, extends or meaningfully modifies a feature...
  - [ ] ... and I have written or updated an end-to-end test for the happy path in the [Accredited Programmes E2E repo](https://github.com/ministryofjustice/hmpps-accredited-programmes-e2e)
- [ ] This makes new expectations of the API...
  - [ ] ... and I have notified the API developer(s) of changes to the contract tests (Pact), or the API is already compliant
- [ ] [Manually approve](../doc/how-to/perform-a-release.md#releasing-to-the-preprod-environment) release to preprod
- [ ] [Manually approve](../doc/how-to/perform-a-release.md#releasing-to-the-production-environment) release to prod

<!-- Should a release fail at any step, you as the author should now lead the work to
fix it as soon as possible. You can monitor deployment failures in CircleCI
itself and application errors are found in
[Sentry](https://ministryofjustice.sentry.io/projects/hmpps-accredited-programmes-ui/?project=4505330122686464&referrer=sidebar&statsPeriod=24h). -->
