### PR TITLE
(APG-469a) Individual page for programme history

### DIFF
--- a/integration_tests/e2e/refer/new/programmeHistory.cy.ts
+++ b/integration_tests/e2e/refer/new/programmeHistory.cy.ts
@@ -118,9 +118,15 @@ context('Programme history', () => {
         programmeHistoryPage.shouldContainHomeLink()
         programmeHistoryPage.shouldNotContainSuccessMessage()
         programmeHistoryPage.shouldContainPreHistoryParagraph()
-        programmeHistoryPage.shouldContainHistoryTable(existingParticipations, referral.id, 'existing-participations')
+        programmeHistoryPage.shouldContainHistoryTable(
+          existingParticipations,
+          programmeHistoryPath,
+          referral.id,
+          'existing-participations',
+        )
         programmeHistoryPage.shouldContainHistoryTable(
           referralParticipations,
+          programmeHistoryPath,
           referral.id,
           'referral-participations',
           true,

--- a/integration_tests/pages/page.ts
+++ b/integration_tests/pages/page.ts
@@ -207,11 +207,12 @@ export default abstract class Page {
 
   shouldContainHistoryTable(
     participations: Array<CourseParticipation>,
+    requestPath: string,
     referralId: Referral['id'],
     testId: string,
     editable = false,
   ) {
-    const { rows } = CourseParticipationUtils.table(participations, referralId, testId, editable)
+    const { rows } = CourseParticipationUtils.table(participations, requestPath, referralId, testId, editable)
 
     cy.get(`[data-testid="${testId}"] .govuk-table__body`).within(() => {
       cy.get('.govuk-table__row').each((tableRowElement, tableRowElementIndex) => {

--- a/server/controllers/refer/new/courseParticipationsController.test.ts
+++ b/server/controllers/refer/new/courseParticipationsController.test.ts
@@ -348,10 +348,10 @@ describe('NewReferralsCourseParticipationsController', () => {
       ;(request.flash as jest.Mock).mockImplementation(() => [])
 
       when(CourseParticipationUtils.table)
-        .calledWith(existingParticipations, referralId, 'existing-participations')
+        .calledWith(existingParticipations, request.path, referralId, 'existing-participations')
         .mockReturnValue(existingParticipationsTable)
       when(CourseParticipationUtils.table)
-        .calledWith(referralParticipations, referralId, 'referral-participations', true)
+        .calledWith(referralParticipations, request.path, referralId, 'referral-participations', true)
         .mockReturnValue(referralParticipationsTable)
     })
 

--- a/server/controllers/refer/new/courseParticipationsController.ts
+++ b/server/controllers/refer/new/courseParticipationsController.ts
@@ -177,6 +177,7 @@ export default class NewReferralsCourseParticipationsController {
         action: `${referPaths.new.programmeHistory.updateReviewedStatus({ referralId: referral.id })}?_method=PUT`,
         existingParticipationsTable: CourseParticipationUtils.table(
           existingParticipations,
+          req.path,
           referralId,
           'existing-participations',
         ),
@@ -188,6 +189,7 @@ export default class NewReferralsCourseParticipationsController {
         referralId,
         referralParticipationsTable: CourseParticipationUtils.table(
           referralParticipations,
+          req.path,
           referralId,
           'referral-participations',
           true,

--- a/server/controllers/shared/index.ts
+++ b/server/controllers/shared/index.ts
@@ -1,6 +1,7 @@
 /* istanbul ignore file */
 
 import CategoryController from './categoryController'
+import ProgrammeHistoryDetailController from './programmeHistoryDetailController'
 import ReasonController from './reasonController'
 import ReferralsController from './referralsController'
 import RisksAndNeedsController from './risksAndNeedsController'
@@ -9,6 +10,12 @@ import UpdateStatusSelectionController from './updateStatusSelectionController'
 import type { Services } from '../../services'
 
 const controllers = (services: Services) => {
+  const programmeHistoryDetailController = new ProgrammeHistoryDetailController(
+    services.courseService,
+    services.personService,
+    services.referralService,
+  )
+
   const referralsController = new ReferralsController(
     services.courseService,
     services.organisationService,
@@ -50,6 +57,7 @@ const controllers = (services: Services) => {
 
   return {
     categoryController,
+    programmeHistoryDetailController,
     reasonController,
     referralsController,
     risksAndNeedsController,

--- a/server/controllers/shared/programmeHistoryDetailController.test.ts
+++ b/server/controllers/shared/programmeHistoryDetailController.test.ts
@@ -1,0 +1,198 @@
+import type { DeepMocked } from '@golevelup/ts-jest'
+import { createMock } from '@golevelup/ts-jest'
+import type { NextFunction, Request, Response } from 'express'
+
+import ProgrammeHistoryDetailController from './programmeHistoryDetailController'
+import { assessPaths, referPaths } from '../../paths'
+import assess from '../../paths/assess'
+import refer from '../../paths/refer'
+import type { CourseService, PersonService, ReferralService } from '../../services'
+import {
+  courseFactory,
+  courseParticipationFactory,
+  personFactory,
+  referralFactory,
+  userFactory,
+} from '../../testutils/factories'
+import Helpers from '../../testutils/helpers'
+import type { GovukFrontendSummaryListWithRowsWithKeysAndValues } from '@accredited-programmes/ui'
+
+describe('ProgrammeHistoryDetailController', () => {
+  const username = 'SOME_USERNAME'
+  const userToken = 'SOME_TOKEN'
+  let request: DeepMocked<Request>
+  let response: DeepMocked<Response>
+  const next: DeepMocked<NextFunction> = createMock<NextFunction>({})
+
+  const courseService = createMock<CourseService>({})
+  const personService = createMock<PersonService>({})
+  const referralService = createMock<ReferralService>({})
+
+  let controller: ProgrammeHistoryDetailController
+
+  const addedByUser = userFactory.build()
+  const course = courseFactory.build()
+  const person = personFactory.build()
+  const courseParticipation = courseParticipationFactory.build({
+    addedBy: addedByUser.username,
+    courseName: course.name,
+    prisonNumber: person.prisonNumber,
+  })
+  const referral = referralFactory.build({ prisonNumber: person.prisonNumber })
+
+  const summaryListOptions = 'summary list options' as unknown as GovukFrontendSummaryListWithRowsWithKeysAndValues
+
+  beforeEach(() => {
+    request = createMock<Request>({
+      params: {
+        courseParticipationId: courseParticipation.id,
+        referralId: referral.id,
+      },
+      user: {
+        token: userToken,
+        username,
+      },
+    })
+    response = Helpers.createMockResponseWithCaseloads()
+
+    controller = new ProgrammeHistoryDetailController(courseService, personService, referralService)
+    courseService.presentCourseParticipation.mockResolvedValue(summaryListOptions)
+    courseService.getParticipation.mockResolvedValue(courseParticipation)
+    personService.getPerson.mockResolvedValue(person)
+    referralService.getReferral.mockResolvedValue(referral)
+  })
+
+  afterEach(() => {
+    jest.resetAllMocks()
+  })
+
+  describe('show', () => {
+    describe('when the request is for a new referral', () => {
+      beforeEach(() => {
+        request.path = referPaths.new.programmeHistory.show({
+          courseParticipationId: courseParticipation.id,
+          referralId: referral.id,
+        })
+      })
+
+      it('renders the show programme history detail template for a specific course participation', async () => {
+        const requestHandler = controller.show()
+        await requestHandler(request, response, next)
+
+        expect(referralService.getReferral).toHaveBeenCalledWith(username, request.params.referralId)
+        expect(courseService.getParticipation).toHaveBeenCalledWith(username, courseParticipation.id)
+        expect(courseService.presentCourseParticipation).toHaveBeenCalledWith(
+          userToken,
+          courseParticipation,
+          referral.id,
+          undefined,
+          {
+            change: false,
+            remove: false,
+          },
+        )
+        expect(personService.getPerson).toHaveBeenCalledWith(username, referral.prisonNumber)
+        expect(response.render).toHaveBeenCalledWith('referrals/show/programmeHistoryDetail', {
+          backLinkHref: referPaths.new.programmeHistory.index({ referralId: referral.id }),
+          hideTitleServiceName: true,
+          pageHeading: 'Programme history details',
+          person,
+          referralId: referral.id,
+          summaryListOptions,
+        })
+      })
+
+      describe('but the participation and referral are not for the same person', () => {
+        it('redirects to the correct path', async () => {
+          const anotherPerson = personFactory.build()
+          const anotherReferral = referralFactory.build({ prisonNumber: anotherPerson.prisonNumber })
+
+          referralService.getReferral.mockResolvedValue(anotherReferral)
+
+          const requestHandler = controller.show()
+          await requestHandler(request, response, next)
+
+          expect(response.redirect).toHaveBeenCalledWith(
+            referPaths.new.programmeHistory.index({ referralId: referral.id }),
+          )
+        })
+      })
+    })
+
+    describe('when the request is for an existing referral', () => {
+      describe('and on the assess path', () => {
+        beforeEach(() => {
+          request.path = assessPaths.show.programmeHistoryDetail({
+            courseParticipationId: courseParticipation.id,
+            referralId: referral.id,
+          })
+        })
+
+        it('renders the show programme history detail template with the correct response locals', async () => {
+          const requestHandler = controller.show()
+          await requestHandler(request, response, next)
+
+          expect(response.render).toHaveBeenCalledWith(
+            'referrals/show/programmeHistoryDetail',
+            expect.objectContaining({
+              backLinkHref: `${assess.show.programmeHistory({ referralId: referral.id })}#content`,
+            }),
+          )
+        })
+
+        describe('but the participation and referral are not for the same person', () => {
+          it('redirects to the correct path', async () => {
+            const anotherPerson = personFactory.build()
+            const anotherReferral = referralFactory.build({ prisonNumber: anotherPerson.prisonNumber })
+
+            referralService.getReferral.mockResolvedValue(anotherReferral)
+
+            const requestHandler = controller.show()
+            await requestHandler(request, response, next)
+
+            expect(response.redirect).toHaveBeenCalledWith(
+              `${assessPaths.show.programmeHistory({ referralId: referral.id })}#content`,
+            )
+          })
+        })
+      })
+
+      describe('and on the refer path', () => {
+        beforeEach(() => {
+          request.path = referPaths.show.programmeHistoryDetail({
+            courseParticipationId: courseParticipation.id,
+            referralId: referral.id,
+          })
+        })
+
+        it('renders the show programme history detail template with the correct response locals', async () => {
+          const requestHandler = controller.show()
+          await requestHandler(request, response, next)
+
+          expect(response.render).toHaveBeenCalledWith(
+            'referrals/show/programmeHistoryDetail',
+            expect.objectContaining({
+              backLinkHref: `${refer.show.programmeHistory({ referralId: referral.id })}#content`,
+            }),
+          )
+        })
+
+        describe('but the participation and referral are not for the same person', () => {
+          it('redirects to the correct path', async () => {
+            const anotherPerson = personFactory.build()
+            const anotherReferral = referralFactory.build({ prisonNumber: anotherPerson.prisonNumber })
+
+            referralService.getReferral.mockResolvedValue(anotherReferral)
+
+            const requestHandler = controller.show()
+            await requestHandler(request, response, next)
+
+            expect(response.redirect).toHaveBeenCalledWith(
+              `${referPaths.show.programmeHistory({ referralId: referral.id })}#content`,
+            )
+          })
+        })
+      })
+    })
+  })
+})

--- a/server/controllers/shared/programmeHistoryDetailController.ts
+++ b/server/controllers/shared/programmeHistoryDetailController.ts
@@ -1,0 +1,55 @@
+import type { Request, Response, TypedRequestHandler } from 'express'
+
+import { assessPathBase, assessPaths, referPaths } from '../../paths'
+import type { CourseService, PersonService, ReferralService } from '../../services'
+import { TypeUtils } from '../../utils'
+
+export default class ProgrammeHistoryDetailController {
+  constructor(
+    private readonly courseService: CourseService,
+    private readonly personService: PersonService,
+    private readonly referralService: ReferralService,
+  ) {}
+
+  show(): TypedRequestHandler<Request, Response> {
+    return async (req: Request, res: Response) => {
+      TypeUtils.assertHasUser(req)
+
+      const isAssess = req.path.startsWith(assessPathBase.pattern)
+      const isNewReferral = req.path.startsWith(referPaths.new.create.pattern)
+      const paths = isAssess ? assessPaths : referPaths
+
+      const { courseParticipationId, referralId } = req.params
+
+      const previousPage = isNewReferral
+        ? referPaths.new.programmeHistory.index({ referralId })
+        : `${paths.show.programmeHistory({ referralId })}#content`
+
+      const [referral, courseParticipation] = await Promise.all([
+        this.referralService.getReferral(req.user.username, referralId),
+        this.courseService.getParticipation(req.user.username, courseParticipationId),
+      ])
+
+      if (courseParticipation.prisonNumber !== referral.prisonNumber) {
+        return res.redirect(previousPage)
+      }
+
+      const [summaryListOptions, person] = await Promise.all([
+        this.courseService.presentCourseParticipation(req.user.token, courseParticipation, referralId, undefined, {
+          change: false,
+          remove: false,
+        }),
+        this.personService.getPerson(req.user.username, referral.prisonNumber),
+      ])
+
+      return res.render('referrals/show/programmeHistoryDetail', {
+        backLinkHref: previousPage,
+        hideTitleServiceName: true,
+        pageHeading: 'Programme history details',
+        person,
+        referralId,
+        summaryListOptions,
+      })
+    }
+  }
+}

--- a/server/paths/assess.ts
+++ b/server/paths/assess.ts
@@ -6,6 +6,7 @@ const courseCaseListPath = assessPathBase.path('referrals/course/:courseId/case-
 const referralShowPathBase = assessPathBase.path('referrals/:referralId')
 
 const risksAndNeedsPathBase = referralShowPathBase.path('risks-and-needs')
+const showProgrammeHistoryPath = referralShowPathBase.path('programme-history')
 
 const updateStatusPathBase = referralShowPathBase.path('update-status')
 const updateStatusSelectDecision = updateStatusPathBase.path('decision')
@@ -24,7 +25,8 @@ export default {
     offenceHistory: referralShowPathBase.path('offence-history'),
     personalDetails: referralShowPathBase.path('personal-details'),
     pni: referralShowPathBase.path('pni'),
-    programmeHistory: referralShowPathBase.path('programme-history'),
+    programmeHistory: showProgrammeHistoryPath,
+    programmeHistoryDetail: showProgrammeHistoryPath.path(':courseParticipationId'),
     releaseDates: referralShowPathBase.path('release-dates'),
     risksAndNeeds: {
       alcoholMisuse: risksAndNeedsPathBase.path('alcohol-misuse'),

--- a/server/paths/refer.ts
+++ b/server/paths/refer.ts
@@ -22,6 +22,7 @@ const newReferralAdditionalInformationPath = newReferralShowPath.path('additiona
 const referralShowPathBase = referralsPath.path(':referralId')
 
 const risksAndNeedsPathBase = referralShowPathBase.path('risks-and-needs')
+const showProgrammeHistoryPath = referralShowPathBase.path('programme-history')
 
 const updateStatusPathBase = referralShowPathBase.path('update-status')
 const updateStatusSelectCategory = updateStatusPathBase.path('category')
@@ -79,7 +80,8 @@ export default {
     duplicate: referralShowPathBase.path('duplicate'),
     offenceHistory: referralShowPathBase.path('offence-history'),
     personalDetails: referralShowPathBase.path('personal-details'),
-    programmeHistory: referralShowPathBase.path('programme-history'),
+    programmeHistory: showProgrammeHistoryPath,
+    programmeHistoryDetail: showProgrammeHistoryPath.path(':courseParticipationId'),
     releaseDates: referralShowPathBase.path('release-dates'),
     risksAndNeeds: {
       alcoholMisuse: risksAndNeedsPathBase.path('alcohol-misuse'),

--- a/server/routes/assess.ts
+++ b/server/routes/assess.ts
@@ -12,6 +12,7 @@ export default function routes(controllers: Controllers, router: Router): Router
     assessCaseListController,
     categoryController,
     pniController,
+    programmeHistoryDetailController,
     reasonController,
     referralsController,
     risksAndNeedsController,
@@ -32,6 +33,7 @@ export default function routes(controllers: Controllers, router: Router): Router
   get(assessPaths.show.offenceHistory.pattern, referralsController.offenceHistory())
   get(assessPaths.show.personalDetails.pattern, referralsController.personalDetails())
   get(assessPaths.show.programmeHistory.pattern, referralsController.programmeHistory())
+  get(assessPaths.show.programmeHistoryDetail.pattern, programmeHistoryDetailController.show())
   get(assessPaths.show.releaseDates.pattern, referralsController.releaseDates())
   get(assessPaths.show.sentenceInformation.pattern, referralsController.sentenceInformation())
 

--- a/server/routes/refer.ts
+++ b/server/routes/refer.ts
@@ -14,6 +14,7 @@ export default function routes(controllers: Controllers, router: Router): Router
   } = RouteUtils.actions(router, { allowedRoles: [ApplicationRoles.ACP_REFERRER] })
   const {
     categoryController,
+    programmeHistoryDetailController,
     referCaseListController,
     newReferralsAdditionalInformationController,
     newReferralsCourseParticipationDetailsController,
@@ -60,7 +61,7 @@ export default function routes(controllers: Controllers, router: Router): Router
   )
   get(referPaths.new.programmeHistory.new.pattern, newReferralsCourseParticipationsController.new())
   post(referPaths.new.programmeHistory.create.pattern, newReferralsCourseParticipationsController.create())
-  get(referPaths.new.programmeHistory.show.pattern, newReferralsCourseParticipationsController.show())
+  get(referPaths.new.programmeHistory.show.pattern, programmeHistoryDetailController.show())
   get(referPaths.new.programmeHistory.editProgramme.pattern, newReferralsCourseParticipationsController.editCourse())
   put(
     referPaths.new.programmeHistory.updateProgramme.pattern,
@@ -82,6 +83,7 @@ export default function routes(controllers: Controllers, router: Router): Router
   get(referPaths.show.offenceHistory.pattern, referralsController.offenceHistory())
   get(referPaths.show.personalDetails.pattern, referralsController.personalDetails())
   get(referPaths.show.programmeHistory.pattern, referralsController.programmeHistory())
+  get(referPaths.show.programmeHistoryDetail.pattern, programmeHistoryDetailController.show())
   get(referPaths.show.releaseDates.pattern, referralsController.releaseDates())
   get(referPaths.show.sentenceInformation.pattern, referralsController.sentenceInformation())
 

--- a/server/views/referrals/show/programmeHistoryDetail.njk
+++ b/server/views/referrals/show/programmeHistoryDetail.njk
@@ -1,0 +1,25 @@
+{% from "govuk/components/back-link/macro.njk" import govukBackLink %}
+{% from "govuk/components/summary-list/macro.njk" import govukSummaryList %}
+
+{% extends "../../partials/layout.njk" %}
+
+{% block personBanner %}
+  {% include "../_personBanner.njk" %}
+{% endblock personBanner %}
+
+{% block backLink %}
+  {{ govukBackLink({
+    text: "Back",
+    href: backLinkHref
+  }) }}
+{% endblock backLink %}
+
+{% block content %}
+  <h1 class="govuk-heading-l">{{ pageHeading }}</h1>
+
+  <div class="govuk-grid-row">
+    <div class="govuk-grid-column-two-thirds">
+      {{ govukSummaryList(summaryListOptions) }}
+    </div>
+  </div>
+{% endblock content %}


### PR DESCRIPTION
## Context

Each programme history page needs it's own individual route to link to from the upcoming table view. Originally done in #835 but then realised it needed to be linked to from other pages and be slightly more flexible in use.

## Changes in this PR
Created a new `ProgrammeHistoryDetailController` with `show` method that is used by multiple routes.



## Release checklist

[Release process documentation](../doc/how-to/perform-a-release.md)

As part of our continuous deployment strategy we must ensure that this work is
ready to be released once merged.

### Pre-merge

- [ ] There are changes required to the Accredited Programmes API for this change to work...
  - [ ] ... and they have been released to production already

### Post-merge

<!-- The outer checkboxes can be completed pre-merge -->

- [ ] This adds, extends or meaningfully modifies a feature...
  - [ ] ... and I have written or updated an end-to-end test for the happy path in the [Accredited Programmes E2E repo](https://github.com/ministryofjustice/hmpps-accredited-programmes-e2e)
- [ ] This makes new expectations of the API...
  - [ ] ... and I have notified the API developer(s) of changes to the contract tests (Pact), or the API is already compliant
- [ ] [Manually approve](../doc/how-to/perform-a-release.md#releasing-to-the-preprod-environment) release to preprod
- [ ] [Manually approve](../doc/how-to/perform-a-release.md#releasing-to-the-production-environment) release to prod

<!-- Should a release fail at any step, you as the author should now lead the work to
fix it as soon as possible. You can monitor deployment failures in CircleCI
itself and application errors are found in
[Sentry](https://ministryofjustice.sentry.io/projects/hmpps-accredited-programmes-ui/?project=4505330122686464&referrer=sidebar&statsPeriod=24h). -->
