### PR TITLE
(APG-469b) Programme history table view within a referral

### DIFF
--- a/server/controllers/refer/new/courseParticipationsController.test.ts
+++ b/server/controllers/refer/new/courseParticipationsController.test.ts
@@ -481,62 +481,6 @@ describe('NewReferralsCourseParticipationsController', () => {
     })
   })
 
-  describe('show', () => {
-    it('renders the show template for a specific course participation', async () => {
-      const addedByUser = userFactory.build()
-      const course = courseFactory.build()
-      const courseParticipation = courseParticipationFactory.build({
-        addedBy: addedByUser.username,
-        courseName: course.name,
-        prisonNumber: person.prisonNumber,
-      })
-      const courseParticipationId = courseParticipation.id
-
-      request.params.courseParticipationId = courseParticipationId
-
-      personService.getPerson.mockResolvedValue(person)
-      referralService.getReferral.mockResolvedValue(draftReferral)
-      courseService.getCourse.mockResolvedValue(course)
-      courseService.getParticipation.mockResolvedValue(courseParticipation)
-
-      const requestHandler = controller.show()
-      await requestHandler(request, response, next)
-
-      expect(referralService.getReferral).toHaveBeenCalledWith(username, request.params.referralId)
-      expect(courseService.getParticipation).toHaveBeenCalledWith(username, courseParticipationId)
-      expect(courseService.presentCourseParticipation).toHaveBeenCalledWith(
-        userToken,
-        courseParticipation,
-        referralId,
-        undefined,
-        {
-          change: false,
-          remove: false,
-        },
-      )
-      expect(personService.getPerson).toHaveBeenCalledWith(username, draftReferral.prisonNumber)
-      expect(response.render).toHaveBeenCalledWith('referrals/new/courseParticipations/show', {
-        hideTitleServiceName: true,
-        pageHeading: 'Programme history details',
-        person,
-        referralId,
-        summaryListOptions,
-      })
-    })
-
-    describe('when the referral has been submitted', () => {
-      it('redirects to the referral confirmation action', async () => {
-        referralService.getReferral.mockResolvedValue(submittedReferral)
-
-        const requestHandler = controller.show()
-        await requestHandler(request, response, next)
-
-        expect(referralService.getReferral).toHaveBeenCalledWith(username, request.params.referralId)
-        expect(response.redirect).toHaveBeenCalledWith(referPaths.new.complete({ referralId }))
-      })
-    })
-  })
-
   describe('updateCourse', () => {
     describe.each([
       ['when the `courseName` is a non-empty string and not "Other"', false],

--- a/server/controllers/refer/new/courseParticipationsController.ts
+++ b/server/controllers/refer/new/courseParticipationsController.ts
@@ -228,38 +228,6 @@ export default class NewReferralsCourseParticipationsController {
     }
   }
 
-  show(): TypedRequestHandler<Request, Response> {
-    return async (req: Request, res: Response) => {
-      TypeUtils.assertHasUser(req)
-
-      const { courseParticipationId, referralId } = req.params
-
-      const referral = await this.referralService.getReferral(req.user.username, referralId)
-
-      if (referral.status !== 'referral_started') {
-        return res.redirect(referPaths.new.complete({ referralId }))
-      }
-
-      const courseParticipation = await this.courseService.getParticipation(req.user.username, courseParticipationId)
-      const summaryListOptions = await this.courseService.presentCourseParticipation(
-        req.user.token,
-        courseParticipation,
-        referralId,
-        undefined,
-        { change: false, remove: false },
-      )
-      const person = await this.personService.getPerson(req.user.username, referral.prisonNumber)
-
-      return res.render('referrals/new/courseParticipations/show', {
-        hideTitleServiceName: true,
-        pageHeading: 'Programme history details',
-        person,
-        referralId,
-        summaryListOptions,
-      })
-    }
-  }
-
   updateCourse(): TypedRequestHandler<Request, Response> {
     return async (req: Request, res: Response) => {
       TypeUtils.assertHasUser(req)

--- a/server/controllers/shared/referralsController.ts
+++ b/server/controllers/shared/referralsController.ts
@@ -4,6 +4,7 @@ import createError from 'http-errors'
 import { findPaths, referPathBase, referPaths } from '../../paths'
 import type { CourseService, OrganisationService, PersonService, ReferralService, UserService } from '../../services'
 import {
+  CourseParticipationUtils,
   CourseUtils,
   DateUtils,
   OffenceUtils,
@@ -120,17 +121,19 @@ export default class ReferralsController {
         throw createError(400, 'Referral has not been submitted.')
       }
 
-      const courseParticipationSummaryListsOptions = await this.courseService.getAndPresentParticipationsByPerson(
+      const courseParticipations = await this.courseService.getParticipationsByPerson(
         req.user.username,
-        req.user.token,
         sharedPageData.person.prisonNumber,
-        sharedPageData.referral.id,
-        { change: false, remove: false },
       )
 
       return res.render('referrals/show/programmeHistory', {
         ...sharedPageData,
-        courseParticipationSummaryListsOptions,
+        participationsTable: CourseParticipationUtils.table(
+          courseParticipations,
+          req.path,
+          referral.id,
+          'participations-table',
+        ),
       })
     }
   }

--- a/server/views/referrals/show/programmeHistory.njk
+++ b/server/views/referrals/show/programmeHistory.njk
@@ -1,15 +1,16 @@
 {% from "govuk/components/inset-text/macro.njk" import govukInsetText %}
 {% from "govuk/components/summary-list/macro.njk" import govukSummaryList %}
+{% from "govuk/components/table/macro.njk" import govukTable %}
 
 {% from "../../partials/keylessSummaryCard.njk" import keylessSummaryCard %}
 
 {% extends "./partials/referralLayout.njk" %}
 
 {% block primaryContent %}
-  {% if courseParticipationSummaryListsOptions.length %}
-    {% for summaryListOptions in courseParticipationSummaryListsOptions %}
-      {{ govukSummaryList(summaryListOptions) }}
-    {% endfor %}
+  {% if participationsTable.rows | length %}
+    <h3 class="govuk-heading-m">Programme history</h3>
+    <p class="govuk-body">This is a list of programmes that {{ person.name }} has started or completed.</p>
+    {{ govukTable(participationsTable) }}
   {% else %}
     {% set bodyText = "There is no Accredited Programme history for " + person.name + "." %}
     {{ keylessSummaryCard("Accredited Programme history", bodyText=bodyText, testId="no-programme-history-summary-card") }}


### PR DESCRIPTION
## Changes in this PR

- Remove unused controller method which was replaced in commit #841 
- Use `CourseParticipationUtils.table` on referral Programme history page.


## Screenshots of UI changes

![image](https://github.com/user-attachments/assets/0830c0c0-b073-4c0a-83e7-273a2ef32b53)


## Release checklist

[Release process documentation](../doc/how-to/perform-a-release.md)

As part of our continuous deployment strategy we must ensure that this work is
ready to be released once merged.

### Pre-merge

- [ ] There are changes required to the Accredited Programmes API for this change to work...
  - [ ] ... and they have been released to production already

### Post-merge

<!-- The outer checkboxes can be completed pre-merge -->

- [ ] This adds, extends or meaningfully modifies a feature...
  - [ ] ... and I have written or updated an end-to-end test for the happy path in the [Accredited Programmes E2E repo](https://github.com/ministryofjustice/hmpps-accredited-programmes-e2e)
- [ ] This makes new expectations of the API...
  - [ ] ... and I have notified the API developer(s) of changes to the contract tests (Pact), or the API is already compliant
- [ ] [Manually approve](../doc/how-to/perform-a-release.md#releasing-to-the-preprod-environment) release to preprod
- [ ] [Manually approve](../doc/how-to/perform-a-release.md#releasing-to-the-production-environment) release to prod

<!-- Should a release fail at any step, you as the author should now lead the work to
fix it as soon as possible. You can monitor deployment failures in CircleCI
itself and application errors are found in
[Sentry](https://ministryofjustice.sentry.io/projects/hmpps-accredited-programmes-ui/?project=4505330122686464&referrer=sidebar&statsPeriod=24h). -->
