### PR TITLE
Add empty placeholder for prison filter

### DIFF
--- a/server/controllers/reportsController.test.ts
+++ b/server/controllers/reportsController.test.ts
@@ -29,6 +29,7 @@ describe('ReportsController', () => {
     { code: 'LEI', description: 'Leeds' },
   ]
   const prisonLocationOptions = [
+    { text: '', value: '' },
     { text: 'Leeds', value: 'LEI' },
     { text: 'Moorland', value: 'MDI' },
   ]
@@ -50,7 +51,7 @@ describe('ReportsController', () => {
   let controller: ReportsController
 
   beforeEach(() => {
-    mockOrganisationUtils.organisationRadioItems.mockReturnValue(prisonLocationOptions)
+    mockOrganisationUtils.organisationSelectItemsForPrisonFilter.mockReturnValue(prisonLocationOptions)
     mockStatisticsReportUtils.reportContentDataBlock.mockReturnValue(reportDataBlock)
     mockStatisticsReportUtils.filterValuesToApiParams.mockReturnValue(lastMonth)
     mockStatisticsReportUtils.queryParams.mockReturnValue(queryParams)

--- a/server/controllers/reportsController.ts
+++ b/server/controllers/reportsController.ts
@@ -81,7 +81,7 @@ export default class ReportsController {
         filterFormAction: reportsPaths.filter({}),
         filterValues: { dateFrom, dateTo, location, period: periodQuery, region },
         pageHeading: 'Accredited Programmes data',
-        prisonLocationOptions: OrganisationUtils.organisationRadioItems(organisations),
+        prisonLocationOptions: OrganisationUtils.organisationSelectItemsForPrisonFilter(organisations),
         reportDataBlocks: reports.map(report => StatisticsReportUtils.reportContentDataBlock(report)),
         subHeading,
       })

--- a/server/utils/organisationUtils.test.ts
+++ b/server/utils/organisationUtils.test.ts
@@ -61,6 +61,36 @@ describe('OrganisationUtils', () => {
     })
   })
 
+  describe('organisationSelectItemsForPrisonFilter', () => {
+    it('returns an array of `GovUkFrontendSelectItem` objects from an array of prisons, sorted by `prisonName`', () => {
+      const enabledOrganisations: Array<EnabledOrganisation> = [
+        { code: 'B', description: 'B Prison' },
+        { code: 'A', description: 'A Prison' },
+      ]
+
+      expect(OrganisationUtils.organisationSelectItemsForPrisonFilter(enabledOrganisations)).toEqual([
+        { text: '', value: '' },
+        { text: 'A Prison', value: 'A' },
+        { text: 'B Prison', value: 'B' },
+      ])
+    })
+
+    describe('when a organisation has an `undefined` code or description', () => {
+      it('filters out the organisation from the returned array', () => {
+        const enabledOrganisations: Array<EnabledOrganisation> = [
+          { code: 'B', description: 'B Prison' },
+          { code: undefined, description: 'A Prison' },
+          { code: 'A', description: undefined },
+        ]
+
+        expect(OrganisationUtils.organisationSelectItemsForPrisonFilter(enabledOrganisations)).toEqual([
+          { text: '', value: '' },
+          { text: 'B Prison', value: 'B' },
+        ])
+      })
+    })
+  })
+
   describe('organisationSelectItems', () => {
     it('returns an array of `GovukFrontendSelectItem` objects from an array of prisons', () => {
       const prisons = [

--- a/server/utils/organisationUtils.ts
+++ b/server/utils/organisationUtils.ts
@@ -41,6 +41,21 @@ export default class OrganisationUtils {
     })
   }
 
+  static organisationSelectItemsForPrisonFilter(
+    organisations: Array<EnabledOrganisation>,
+  ): Array<GovukFrontendSelectItem> {
+    const filteredItems: Array<GovukFrontendSelectItem> = organisations
+      .filter(({ code, description }) => code && description)
+      .sort((a, b) => a.description!.localeCompare(b.description!))
+      .map(({ description, code }) => ({
+        text: description!,
+        value: code!,
+      }))
+
+    filteredItems.unshift({ text: '', value: '' })
+    return filteredItems
+  }
+
   static organisationTableRows(organisations: Array<OrganisationWithOfferingId>): Array<GovukFrontendTableRow> {
     return organisations.map(organisation => {
       const offeringPath = findPaths.offerings.show({

--- a/server/views/reports/show.njk
+++ b/server/views/reports/show.njk
@@ -53,7 +53,7 @@
   name: "location",
   id: "location",
   label: {
-    text: "Find prison"
+    text: "Search prisons"
   },
   classes: "govuk-select--small, js-typeahead-select",
   errorMessage: errorMessages.location,
@@ -182,6 +182,6 @@
   {{ super() }}
   <script src="/assets/accessible-autocomplete.min.js" type="text/javascript"></script>
   <script nonce={{ cspNonce }}>
-    accessibleAutocomplete.enhanceSelectElement({defaultValue: 'Find prison', placeHolder: 'Find prison', showAllValues: true, selectElement: document.querySelector('.js-typeahead-select')});
+    accessibleAutocomplete.enhanceSelectElement({defaultValue: '', showAllValues: true, selectElement: document.querySelector('.js-typeahead-select')});
   </script>
 {% endblock bodyEnd %}


### PR DESCRIPTION
## Changes in this PR

Adds an empty placeholder to the prison search filter in reports to prevent auto selecting the first entry


## Screenshots of UI changes
<img width="357" alt="Screenshot 2025-01-28 at 17 07 29" src="https://github.com/user-attachments/assets/0f84da37-a27b-4698-b387-42fa81e2b832" />



## Release checklist

[Release process documentation](../doc/how-to/perform-a-release.md)

As part of our continuous deployment strategy we must ensure that this work is
ready to be released once merged.

### Pre-merge

- [ ] There are changes required to the Accredited Programmes API for this change to work...
  - [ ] ... and they have been released to production already

### Post-merge

<!-- The outer checkboxes can be completed pre-merge -->

- [ ] This adds, extends or meaningfully modifies a feature...
  - [ ] ... and I have written or updated an end-to-end test for the happy path in the [Accredited Programmes E2E repo](https://github.com/ministryofjustice/hmpps-accredited-programmes-e2e)
- [ ] This makes new expectations of the API...
  - [ ] ... and I have notified the API developer(s) of changes to the contract tests (Pact), or the API is already compliant
- [ ] [Manually approve](../doc/how-to/perform-a-release.md#releasing-to-the-preprod-environment) release to preprod
- [ ] [Manually approve](../doc/how-to/perform-a-release.md#releasing-to-the-production-environment) release to prod

<!-- Should a release fail at any step, you as the author should now lead the work to
fix it as soon as possible. You can monitor deployment failures in CircleCI
itself and application errors are found in
[Sentry](https://ministryofjustice.sentry.io/projects/hmpps-accredited-programmes-ui/?project=4505330122686464&referrer=sidebar&statsPeriod=24h). -->
