### PR TITLE
(APG-623) Add `programmePathway` to `session.pniFindAndReferData`

### DIFF
--- a/integration_tests/pages/find/recommendedPathway.ts
+++ b/integration_tests/pages/find/recommendedPathway.ts
@@ -25,8 +25,7 @@ export default class RecommendedPathwayPage extends Page {
   }
 
   shouldContainIntroText() {
-    cy.get('.govuk-body').should(
-      'contain.text',
+    this.shouldContainText(
       "This is the recommended Accredited Programme pathway. It is based on the person's risks and needs.",
     )
   }

--- a/server/@types/ui/index.d.ts
+++ b/server/@types/ui/index.d.ts
@@ -3,6 +3,7 @@ import type {
   Course,
   CourseOffering,
   CourseParticipation,
+  PniScore,
   Referral,
   ReferralStatusHistory,
 } from '@accredited-programmes-api'
@@ -234,6 +235,7 @@ interface BuildingChoicesSearchForm {
 
 interface PniFindAndReferData {
   prisonNumber?: Prisoner['prisonerNumber']
+  programmePathway?: PniScore['programmePathway']
 }
 
 export type {

--- a/server/controllers/find/recommendedPathwayController.test.ts
+++ b/server/controllers/find/recommendedPathwayController.test.ts
@@ -81,6 +81,10 @@ describe('RecommendedPathwayController', () => {
 
       await controller.show()(request, response, next)
 
+      expect(request.session.pniFindAndReferData).toEqual({
+        prisonNumber,
+        programmePathway: 'HIGH_INTENSITY_BC',
+      })
       expect(PniUtils.pathwayContent).toHaveBeenCalledWith(person.name, pni.programmePathway)
       expect(response.render).toHaveBeenCalledWith('find/recommendedPathway', {
         hasData: true,
@@ -109,6 +113,10 @@ describe('RecommendedPathwayController', () => {
 
         await controller.show()(request, response, next)
 
+        expect(request.session.pniFindAndReferData).toEqual({
+          prisonNumber,
+          programmePathway: 'ALTERNATIVE_PATHWAY',
+        })
         expect(PniUtils.pathwayContent).toHaveBeenCalledWith(person.name, pni.programmePathway)
         expect(response.render).toHaveBeenCalledWith('find/recommendedPathway', {
           hasData: true,
@@ -138,6 +146,10 @@ describe('RecommendedPathwayController', () => {
 
         await controller.show()(request, response, next)
 
+        expect(request.session.pniFindAndReferData).toEqual({
+          prisonNumber,
+          programmePathway: 'MISSING_INFORMATION',
+        })
         expect(PniUtils.pathwayContent).toHaveBeenCalledWith(person.name, 'MISSING_INFORMATION')
         expect(response.render).toHaveBeenCalledWith('find/recommendedPathway', {
           hasData: true,
@@ -163,6 +175,10 @@ describe('RecommendedPathwayController', () => {
 
         await controller.show()(request, response, next)
 
+        expect(request.session.pniFindAndReferData).toEqual({
+          prisonNumber,
+          programmePathway: 'UNKNOWN',
+        })
         expect(PniUtils.pathwayContent).toHaveBeenCalledWith(person.name, 'MISSING_INFORMATION')
         expect(response.render).toHaveBeenCalledWith('find/recommendedPathway', {
           hasData: false,
@@ -185,6 +201,10 @@ describe('RecommendedPathwayController', () => {
 
         await controller.show()(request, response, next)
 
+        expect(request.session.pniFindAndReferData).toEqual({
+          prisonNumber,
+          programmePathway: 'UNKNOWN',
+        })
         expect(PniUtils.pathwayContent).toHaveBeenCalledWith(person.name, undefined)
         expect(response.render).toHaveBeenCalledWith('find/recommendedPathway', {
           hasData: false,

--- a/server/controllers/find/recommendedPathwayController.ts
+++ b/server/controllers/find/recommendedPathwayController.ts
@@ -55,6 +55,11 @@ export default class RecommendedPathwayController {
         }
       }
 
+      req.session.pniFindAndReferData = {
+        prisonNumber,
+        programmePathway: pni?.programmePathway || 'UNKNOWN',
+      }
+
       return res.render('find/recommendedPathway', {
         hrefs: {
           back: findPaths.pniFind.personSearch.pattern,

--- a/server/views/find/recommendedPathway.njk
+++ b/server/views/find/recommendedPathway.njk
@@ -75,7 +75,7 @@
     <div class="govuk-grid-column-two-thirds">
       <h1 class="govuk-heading-l">{{ pageHeading }}</h1>
 
-      <p>This is the recommended Accredited Programme pathway. It is based on the person's risks and needs.</p>
+      <p class="govuk-body">This is the recommended Accredited Programme pathway. It is based on the person's risks and needs.</p>
 
       <div class="govuk-!-margin-bottom-6">
         {% include "../partials/pathway.njk" %}


### PR DESCRIPTION
## Context

This will be used by the subsequent step in the journey to show the appropiate content.



## Changes in this PR
- Add `programmePathway` to `session.pniFindAndReferData`
- Update integration test to use existing `shouldContainText` method.



## Release checklist

[Release process documentation](../doc/how-to/perform-a-release.md)

As part of our continuous deployment strategy we must ensure that this work is
ready to be released once merged.

### Pre-merge

- [ ] There are changes required to the Accredited Programmes API for this change to work...
  - [ ] ... and they have been released to production already

### Post-merge

<!-- The outer checkboxes can be completed pre-merge -->

- [ ] This adds, extends or meaningfully modifies a feature...
  - [ ] ... and I have written or updated an end-to-end test for the happy path in the [Accredited Programmes E2E repo](https://github.com/ministryofjustice/hmpps-accredited-programmes-e2e)
- [ ] This makes new expectations of the API...
  - [ ] ... and I have notified the API developer(s) of changes to the contract tests (Pact), or the API is already compliant
- [ ] [Manually approve](../doc/how-to/perform-a-release.md#releasing-to-the-preprod-environment) release to preprod
- [ ] [Manually approve](../doc/how-to/perform-a-release.md#releasing-to-the-production-environment) release to prod

<!-- Should a release fail at any step, you as the author should now lead the work to
fix it as soon as possible. You can monitor deployment failures in CircleCI
itself and application errors are found in
[Sentry](https://ministryofjustice.sentry.io/projects/hmpps-accredited-programmes-ui/?project=4505330122686464&referrer=sidebar&statsPeriod=24h). -->
