### PR TITLE
(APG-686) Use `pniFindAndReferData.prisonNumber` if available when raising a referral

### DIFF
--- a/server/controllers/find/coursesController.test.ts
+++ b/server/controllers/find/coursesController.test.ts
@@ -22,13 +22,21 @@ describe('CoursesController', () => {
   let controller: CoursesController
 
   beforeEach(() => {
-    request = createMock<Request>({ user: { token: userToken } })
+    request = createMock<Request>({
+      session: {
+        pniFindAndReferData: {
+          prisonNumber: 'some-prison-number',
+          programmePathway: 'HIGH_INTENSITY_BC',
+        },
+      },
+      user: { token: userToken },
+    })
     response = createMock<Response>({})
     controller = new CoursesController(courseService, organisationService)
   })
 
   describe('index', () => {
-    it('renders the courses index template with alphabetically-sorted courses', async () => {
+    it('renders the courses index template with alphabetically-sorted courses and reset any pniFindAndReferData', async () => {
       const courseA = courseFactory.build({ name: 'Course A' })
       const courseB = courseFactory.build({ name: 'Course B' })
       const courseC = courseFactory.build({ name: 'Course C' })
@@ -37,9 +45,12 @@ describe('CoursesController', () => {
 
       const sortedCourses = [courseA, courseB, courseC]
 
+      expect(request.session.pniFindAndReferData).toBeDefined()
+
       const requestHandler = controller.index()
       await requestHandler(request, response, next)
 
+      expect(request.session.pniFindAndReferData).toBeUndefined()
       expect(response.render).toHaveBeenCalledWith('courses/index', {
         addProgrammePath: findPaths.course.add.show({}),
         courses: sortedCourses.map(course => CourseUtils.presentCourse(course)),

--- a/server/controllers/find/coursesController.ts
+++ b/server/controllers/find/coursesController.ts
@@ -15,6 +15,8 @@ export default class CoursesController {
     return async (req: Request, res: Response) => {
       TypeUtils.assertHasUser(req)
 
+      delete req.session.pniFindAndReferData
+
       const courses = await this.courseService.getCourses(req.user.token)
       const coursesToDisplay = courses
         .filter(course => course.displayOnProgrammeDirectory)

--- a/server/controllers/refer/new/referralsController.test.ts
+++ b/server/controllers/refer/new/referralsController.test.ts
@@ -118,10 +118,12 @@ describe('NewReferralsController', () => {
     const courseId = course.id
     const courseOfferingId = referableCourseOffering.id
 
-    it('renders the referral new template', async () => {
+    beforeEach(() => {
       request.params.courseId = courseId
       request.params.courseOfferingId = courseOfferingId
+    })
 
+    it('renders the referral new template', async () => {
       courseService.getCourseByOffering.mockResolvedValue(course)
 
       const emptyErrorsLocal = { list: [], messages: {} }
@@ -140,6 +142,18 @@ describe('NewReferralsController', () => {
       })
 
       expect(FormUtils.setFieldErrors).toHaveBeenCalledWith(request, response, ['prisonNumber'])
+    })
+
+    describe('when there is a `prisonNumber` in `pnFindAndReferData`', () => {
+      it('should redirect to the new referral people show path', async () => {
+        const prisonNumber = 'A1234AA'
+        request.session.pniFindAndReferData = { prisonNumber }
+
+        const requestHandler = controller.new()
+        await requestHandler(request, response, next)
+
+        expect(response.redirect).toHaveBeenCalledWith(referPaths.new.people.show({ courseOfferingId, prisonNumber }))
+      })
     })
   })
 

--- a/server/controllers/refer/new/referralsController.ts
+++ b/server/controllers/refer/new/referralsController.ts
@@ -149,10 +149,15 @@ export default class NewReferralsController {
       TypeUtils.assertHasUser(req)
 
       const { courseId, courseOfferingId } = req.params
+      const pniFindPrisonNumber = req.session.pniFindAndReferData?.prisonNumber
+
+      if (pniFindPrisonNumber) {
+        return res.redirect(referPaths.new.people.show({ courseOfferingId, prisonNumber: pniFindPrisonNumber }))
+      }
 
       FormUtils.setFieldErrors(req, res, ['prisonNumber'])
 
-      res.render('referrals/new/new', {
+      return res.render('referrals/new/new', {
         courseId,
         courseOfferingId,
         pageHeading: "Enter the person's identifier",


### PR DESCRIPTION
## Context

When raising a referral using the new PNI find journey then we need to carry the previously entered prison number through so the user doesn't get asked to enter it again.

## Changes in this PR
- Update `NewReferralsController.new` method  to redirect to person show details page if there is a `prisonNumber` in `req.session.pniFindAndReferData`
- Reset the `req.session.pniFindAndReferData` object when viewing the current find directory so the user still has the option to search using the existing journey.



## Release checklist

[Release process documentation](../doc/how-to/perform-a-release.md)

As part of our continuous deployment strategy we must ensure that this work is
ready to be released once merged.

### Pre-merge

- [ ] There are changes required to the Accredited Programmes API for this change to work...
  - [ ] ... and they have been released to production already

### Post-merge

<!-- The outer checkboxes can be completed pre-merge -->

- [ ] This adds, extends or meaningfully modifies a feature...
  - [ ] ... and I have written or updated an end-to-end test for the happy path in the [Accredited Programmes E2E repo](https://github.com/ministryofjustice/hmpps-accredited-programmes-e2e)
- [ ] This makes new expectations of the API...
  - [ ] ... and I have notified the API developer(s) of changes to the contract tests (Pact), or the API is already compliant
- [ ] [Manually approve](../doc/how-to/perform-a-release.md#releasing-to-the-preprod-environment) release to preprod
- [ ] [Manually approve](../doc/how-to/perform-a-release.md#releasing-to-the-production-environment) release to prod

<!-- Should a release fail at any step, you as the author should now lead the work to
fix it as soon as possible. You can monitor deployment failures in CircleCI
itself and application errors are found in
[Sentry](https://ministryofjustice.sentry.io/projects/hmpps-accredited-programmes-ui/?project=4505330122686464&referrer=sidebar&statsPeriod=24h). -->
