### PR TITLE
APG-675 Unhappy Path Start Transfer to BC Journey

### DIFF
--- a/server/controllers/assess/index.ts
+++ b/server/controllers/assess/index.ts
@@ -2,6 +2,7 @@
 
 import AssessCaseListController from './caseListController'
 import PniController from './pniController'
+import TransferReferralController from './transferReferralController'
 import UpdateStatusDecisionController from './updateStatusDecisionController'
 import type { Services } from '../../services'
 
@@ -24,9 +25,18 @@ const controllers = (services: Services) => {
     services.referralService,
   )
 
+  const transferReferralController = new TransferReferralController(
+    services.courseService,
+    services.organisationService,
+    services.personService,
+    services.pniService,
+    services.referralService,
+  )
+
   return {
     assessCaseListController,
     pniController,
+    transferReferralController,
     updateStatusDecisionController,
   }
 }

--- a/server/controllers/assess/transferReferralController.test.ts
+++ b/server/controllers/assess/transferReferralController.test.ts
@@ -1,0 +1,176 @@
+import type { DeepMocked } from '@golevelup/ts-jest'
+import { createMock } from '@golevelup/ts-jest'
+import type { NextFunction, Request, Response } from 'express'
+
+import TransferReferralController from './transferReferralController'
+import { assessPaths } from '../../paths'
+import type { CourseService, OrganisationService, PersonService, PniService, ReferralService } from '../../services'
+import {
+  courseFactory,
+  courseOfferingFactory,
+  organisationFactory,
+  personFactory,
+  pniScoreFactory,
+  referralFactory,
+} from '../../testutils/factories'
+import Helpers from '../../testutils/helpers'
+import type { CourseOffering, Organisation, Person } from '@accredited-programmes/models'
+import type { Course, PniScore, Referral } from '@accredited-programmes-api'
+
+jest.mock('../../utils/formUtils')
+jest.mock('../../utils/referrals/referralUtils')
+jest.mock('../../utils/referrals/showReferralUtils')
+
+describe('TransferReferralController', () => {
+  const userToken = 'SOME_TOKEN'
+  const username = 'USERNAME'
+
+  let request: DeepMocked<Request>
+  let response: DeepMocked<Response>
+  const next: DeepMocked<NextFunction> = createMock<NextFunction>({})
+
+  const courseService = createMock<CourseService>({})
+  const orgService = createMock<OrganisationService>({})
+  const pniService = createMock<PniService>({})
+  const personService = createMock<PersonService>({})
+  const referralService = createMock<ReferralService>({})
+
+  let person: Person
+  let referral: Referral
+  let org: Organisation
+  let course: Course
+  let buildingChoicesCourse: Course
+  let offering: CourseOffering
+  let pniResult: PniScore
+
+  let controller: TransferReferralController
+
+  beforeEach(() => {
+    person = personFactory.build()
+    referral = referralFactory.submitted().build({ prisonNumber: person.prisonNumber })
+    org = organisationFactory.build()
+    course = courseFactory.build()
+    buildingChoicesCourse = courseFactory.build()
+    offering = courseOfferingFactory.build()
+    pniResult = pniScoreFactory.build()
+
+    personService.getPerson.mockResolvedValue(person)
+    referralService.getReferral.mockResolvedValue(referral)
+    orgService.getOrganisation.mockResolvedValue(org)
+    courseService.getCourseByOffering.mockResolvedValue(course)
+    courseService.getOffering.mockResolvedValue(offering)
+    courseService.getBuildingChoicesCourseByReferral.mockResolvedValue(buildingChoicesCourse)
+    pniService.getPni.mockResolvedValue(pniResult)
+
+    controller = new TransferReferralController(courseService, orgService, personService, pniService, referralService)
+
+    request = createMock<Request>({
+      params: { referralId: referral.id },
+      user: { token: userToken, username },
+    })
+    response = Helpers.createMockResponseWithCaseloads()
+  })
+
+  afterEach(() => {
+    jest.clearAllMocks()
+  })
+
+  describe('show tests', () => {
+    it('Renders missing risks and needs error page when referral is not elligible for transfer', async () => {
+      pniService.getPni.mockResolvedValue(null)
+      const pageHeading = 'This referral cannot be moved to Building Choices'
+      const errorMessages = [
+        `This referral cannot be moved. Risk and need scores are missing for ${person.name}, so the recommended programme intensity (high or moderate) cannot be calculated.`,
+        `You can see which scores are missing in the <a href="${assessPaths.show.pni({ referralId: referral.id })}">programme needs identifier</a>.`,
+        'Update the missing information in OASys to move the referral, or withdraw this referral and submit a new one.',
+      ]
+
+      const requestHandler = controller.show()
+      await requestHandler(request, response, next)
+
+      expect(response.render).toHaveBeenCalledWith('referrals/transfer/error', {
+        errorMessages,
+        pageHeading,
+        person,
+        returnLinkHref: assessPaths.show.personalDetails({ referralId: referral.id }),
+      })
+    })
+    it('Redirects to case list when referral is not elligible to be transferred', async () => {
+      const closedReferral = referralFactory.closed().build()
+      referralService.getReferral.mockResolvedValue(closedReferral)
+      request.params.referralId = closedReferral.id
+
+      const requestHandler = controller.show()
+      await requestHandler(request, response, next)
+
+      expect(response.redirect).toHaveBeenCalledWith(
+        assessPaths.show.personalDetails({ referralId: closedReferral.id }),
+      )
+    })
+    it('Renders inelligble due to risks and needs score error page when pni score is ALTERNATIVE_PATHWAY', async () => {
+      pniService.getPni.mockResolvedValue(pniScoreFactory.build({ programmePathway: 'ALTERNATIVE_PATHWAY' }))
+      const pageHeading = 'This referral cannot be moved to Building Choices'
+      const errorMessages = [
+        `This referral cannot be moved because the risk and need scores suggest that ${person.name} is not eligible for Building Choices. You can see these scores in the programme needs identifier.`,
+      ]
+
+      const requestHandler = controller.show()
+      await requestHandler(request, response, next)
+
+      expect(response.render).toHaveBeenCalledWith('referrals/transfer/error', {
+        errorMessages,
+        pageHeading,
+        person,
+        returnLinkHref: assessPaths.show.personalDetails({ referralId: referral.id }),
+      })
+    })
+    it('Renders inelligble due to risks and needs score error page when pni is missing', async () => {
+      pniService.getPni.mockRejectedValue(null)
+      const pageHeading = 'This referral cannot be moved to Building Choices'
+      const errorMessages = [
+        `This referral cannot be moved. Risk and need scores are missing for ${person.name}, so the recommended programme intensity (high or moderate) cannot be calculated.`,
+        `You can see which scores are missing in the <a href="${assessPaths.show.pni({ referralId: referral.id })}">programme needs identifier</a>.`,
+        'Update the missing information in OASys to move the referral, or withdraw this referral and submit a new one.',
+      ]
+
+      const requestHandler = controller.show()
+      await requestHandler(request, response, next)
+
+      expect(courseService.getBuildingChoicesCourseByReferral).toHaveBeenCalledTimes(0)
+      expect(response.render).toHaveBeenCalledWith('referrals/transfer/error', {
+        errorMessages,
+        pageHeading,
+        person,
+        returnLinkHref: assessPaths.show.personalDetails({ referralId: referral.id }),
+      })
+    })
+    it('Renders no BC course at prison error when no target BC course is found', async () => {
+      pniService.getPni.mockResolvedValue(pniScoreFactory.build({ programmePathway: 'HIGH_INTENSITY' }))
+      courseService.getBuildingChoicesCourseByReferral.mockResolvedValue(null)
+      const pageHeading = 'This referral cannot be moved to Building Choices'
+      const errorMessages = [
+        `This referral cannot be moved because ${org.name} does not offer Building Choices: ${course.intensity?.toLocaleLowerCase()} intensity.`,
+        'Close this referral and submit a new one to a different location.',
+      ]
+
+      const requestHandler = controller.show()
+      await requestHandler(request, response, next)
+
+      expect(response.render).toHaveBeenCalledWith('referrals/transfer/error', {
+        errorMessages,
+        pageHeading,
+        person,
+        returnLinkHref: assessPaths.show.personalDetails({ referralId: referral.id }),
+      })
+    })
+    it('Redirects to the enter reason page when referral is elligible for transfer', async () => {
+      pniService.getPni.mockResolvedValue(pniScoreFactory.build({ programmePathway: 'HIGH_INTENSITY' }))
+      const requestHandler = controller.show()
+      await requestHandler(request, response, next)
+
+      expect(response.redirect).toHaveBeenCalledWith(
+        assessPaths.transferToBuildingChoices.reason.show({ referralId: referral.id }),
+      )
+    })
+  })
+})

--- a/server/controllers/assess/transferReferralController.ts
+++ b/server/controllers/assess/transferReferralController.ts
@@ -1,0 +1,94 @@
+import type { Request, Response, TypedRequestHandler } from 'express'
+
+import { assessPaths } from '../../paths'
+import type { CourseService, OrganisationService, PersonService, PniService, ReferralService } from '../../services'
+import { TypeUtils } from '../../utils'
+
+export default class TransferReferralController {
+  constructor(
+    private readonly courseService: CourseService,
+    private readonly organisationService: OrganisationService,
+    private readonly personService: PersonService,
+    private readonly pniService: PniService,
+    private readonly referralService: ReferralService,
+  ) {}
+
+  show(): TypedRequestHandler<Request, Response> {
+    return async (req: Request, res: Response) => {
+      const { referralId } = req.params
+      TypeUtils.assertHasUser(req)
+      const { token: userToken, username } = req.user
+
+      const returnLinkHref = assessPaths.show.personalDetails({ referralId })
+
+      const referral = await this.referralService.getReferral(username, referralId)
+      if (referral.closed || referral.status === 'on_programme') {
+        return res.redirect(assessPaths.show.personalDetails({ referralId }))
+      }
+
+      const person = await this.personService.getPerson(username, referral.prisonNumber)
+      const pni = await this.pniService
+        .getPni(username, referral.prisonNumber, { gender: person.gender, savePNI: false })
+        .catch(() => {
+          return null
+        })
+
+      const pageHeading = 'This referral cannot be moved to Building Choices'
+      let errorMessages
+
+      if (!pni || pni.programmePathway === 'MISSING_INFORMATION') {
+        errorMessages = [
+          `This referral cannot be moved. Risk and need scores are missing for ${person.name}, so the recommended programme intensity (high or moderate) cannot be calculated.`,
+          `You can see which scores are missing in the <a href="${assessPaths.show.pni({ referralId })}">programme needs identifier</a>.`,
+          'Update the missing information in OASys to move the referral, or withdraw this referral and submit a new one.',
+        ]
+      }
+
+      if (pni?.programmePathway === 'ALTERNATIVE_PATHWAY') {
+        errorMessages = [
+          `This referral cannot be moved because the risk and need scores suggest that ${person.name} is not eligible for Building Choices. You can see these scores in the programme needs identifier.`,
+        ]
+      }
+
+      if (errorMessages) {
+        return res.render('referrals/transfer/error', {
+          errorMessages,
+          pageHeading,
+          person,
+          returnLinkHref,
+        })
+      }
+
+      const [course, courseOffering] = await Promise.all([
+        this.courseService.getCourseByOffering(username, referral.offeringId),
+        this.courseService.getOffering(username, referral.offeringId),
+      ])
+
+      const [targetBuildingChoicesCourse, organisation] = await Promise.all([
+        pni?.programmePathway
+          ? this.courseService.getBuildingChoicesCourseByReferral(username, referralId, pni.programmePathway)
+          : null,
+        this.organisationService.getOrganisation(userToken, courseOffering.organisationId),
+      ])
+
+      if (!targetBuildingChoicesCourse) {
+        errorMessages = [
+          `This referral cannot be moved because ${organisation.name} does not offer Building Choices: ${course.intensity?.toLocaleLowerCase()} intensity.`,
+          'Close this referral and submit a new one to a different location.',
+        ]
+      }
+
+      if (errorMessages) {
+        return res.render('referrals/transfer/error', {
+          errorMessages,
+          pageHeading,
+          person,
+          returnLinkHref,
+        })
+      }
+
+      // Placeholder for happy path
+      return res.redirect(assessPaths.transferToBuildingChoices.reason.show({ referralId }))
+    }
+  }
+}

--- a/server/data/accreditedProgrammesApi/courseClient.ts
+++ b/server/data/accreditedProgrammesApi/courseClient.ts
@@ -15,6 +15,8 @@ import type {
   CourseParticipation,
   CourseParticipationCreate,
   CourseParticipationUpdate,
+  PniScore,
+  Referral,
 } from '@accredited-programmes-api'
 import type { SystemToken } from '@hmpps-auth'
 
@@ -74,6 +76,17 @@ export default class CourseClient {
 
   async find(courseId: Course['id']): Promise<Course> {
     return (await this.restClient.get({ path: apiPaths.courses.show({ courseId }) })) as Course
+  }
+
+  /* istanbul ignore next */
+  async findBuildingChoicesCourseByReferral(
+    referralId: Referral['id'],
+    programmePathway: PniScore['programmePathway'],
+  ): Promise<Course> {
+    return (await this.restClient.get({
+      path: apiPaths.courses.buildingChoicesByReferral({ referralId }),
+      query: programmePathway,
+    })) as Course
   }
 
   /* istanbul ignore next */

--- a/server/paths/api.ts
+++ b/server/paths/api.ts
@@ -45,6 +45,7 @@ export default {
   courses: {
     audiences: coursesPath.path('audiences'),
     buildingChoices: coursesPath.path('building-choices/:courseId'),
+    buildingChoicesByReferral: coursesPath.path('building-choices/referral/:referralId'),
     create: coursesPath,
     index: coursesPath,
     names: courseNamesPath,

--- a/server/paths/assess.ts
+++ b/server/paths/assess.ts
@@ -14,19 +14,15 @@ const updateStatusSelectCategory = updateStatusPathBase.path('category')
 const updateStatusSelectReason = updateStatusPathBase.path('reason')
 const updateStatusSelectionShowPath = updateStatusPathBase.path('selection')
 
-const moveToBuildingChoicesPathBase = referralShowPathBase.path('move-to-building-choices')
-const moveToBuildingChoicesReason = moveToBuildingChoicesPathBase.path('reason')
+const transferToBuildingChoicesPathBase = referralShowPathBase.path('transfer-to-building-choices')
+const transferToBuildingChoicesCheck = transferToBuildingChoicesPathBase.path('check')
+const transferToBuildingChoicesReason = transferToBuildingChoicesPathBase.path('reason')
 
 export default {
   caseList: {
     filter: courseCaseListPath.path(':referralStatusGroup'),
     index: caseListIndex,
     show: courseCaseListPath.path(':referralStatusGroup'),
-  },
-  moveToBuildingChoices: {
-    reason: {
-      show: moveToBuildingChoicesReason,
-    },
   },
   show: {
     additionalInformation: referralShowPathBase.path('additional-information'),
@@ -52,6 +48,14 @@ export default {
     },
     sentenceInformation: referralShowPathBase.path('sentence-information'),
     statusHistory: referralShowPathBase.path('status-history'),
+  },
+  transferToBuildingChoices: {
+    check: {
+      show: transferToBuildingChoicesCheck,
+    },
+    reason: {
+      show: transferToBuildingChoicesReason,
+    },
   },
   updateStatus: {
     category: {

--- a/server/routes/assess.ts
+++ b/server/routes/assess.ts
@@ -17,6 +17,7 @@ export default function routes(controllers: Controllers, router: Router): Router
     referralsController,
     risksAndNeedsController,
     statusHistoryController,
+    transferReferralController,
     updateStatusDecisionController,
     updateStatusSelectionController,
   } = controllers
@@ -61,6 +62,8 @@ export default function routes(controllers: Controllers, router: Router): Router
 
   get(assessPaths.updateStatus.selection.show.pattern, updateStatusSelectionController.show())
   post(assessPaths.updateStatus.selection.reason.submit.pattern, updateStatusSelectionController.submitReason())
+
+  get(assessPaths.transferToBuildingChoices.check.show.pattern, transferReferralController.show())
 
   return router
 }

--- a/server/services/courseService.test.ts
+++ b/server/services/courseService.test.ts
@@ -14,6 +14,7 @@ import {
   courseParticipationFactory,
   coursePrerequisiteFactory,
   personFactory,
+  pniScoreFactory,
   referralFactory,
   userFactory,
 } from '../testutils/factories'
@@ -164,6 +165,57 @@ describe('CourseService', () => {
 
       expect(courseClientBuilder).toHaveBeenCalledWith(systemToken)
       expect(courseClient.findCourseNames).toHaveBeenCalled()
+    })
+  })
+
+  describe('getBuildingChoicesCourseByReferral', () => {
+    it('returns the building choices course for transfer for the provided referral', async () => {
+      const course = courseFactory.build()
+      const referral = referralFactory.build()
+      const pni = pniScoreFactory.build()
+
+      when(courseClient.findBuildingChoicesCourseByReferral)
+        .calledWith(referral.id, pni.programmePathway)
+        .mockResolvedValue(course)
+
+      const result = await service.getBuildingChoicesCourseByReferral(username, referral.id, pni.programmePathway)
+
+      expect(result).toEqual(course)
+      expect(courseClientBuilder).toHaveBeenCalledWith(systemToken)
+    })
+    it('returns null when no building choices course is found for the referral', async () => {
+      const clientError = createError(404)
+      const referral = referralFactory.build()
+      const pni = pniScoreFactory.build()
+
+      when(courseClient.findBuildingChoicesCourseByReferral)
+        .calledWith(referral.id, pni.programmePathway)
+        .mockRejectedValue(clientError)
+
+      const result = await service.getBuildingChoicesCourseByReferral(username, referral.id, pni.programmePathway)
+
+      expect(result).toBeNull()
+      expect(courseClientBuilder).toHaveBeenCalledWith(systemToken)
+    })
+    it('rethrows the error when error status is not 404', async () => {
+      const clientError = createError(500)
+      const referral = referralFactory.build()
+      const pni = pniScoreFactory.build()
+
+      const expectedError = createError(
+        500,
+        `Error fetching building choices course data for referral ${referral.id} and pathway ${pni.programmePathway}.`,
+      )
+
+      when(courseClient.findBuildingChoicesCourseByReferral)
+        .calledWith(referral.id, pni.programmePathway)
+        .mockRejectedValue(clientError)
+
+      await expect(
+        service.getBuildingChoicesCourseByReferral(username, referral.id, pni.programmePathway),
+      ).rejects.toThrow(expectedError)
+
+      expect(courseClientBuilder).toHaveBeenCalledWith(systemToken)
     })
   })
 

--- a/server/services/courseService.ts
+++ b/server/services/courseService.ts
@@ -3,6 +3,7 @@ import type { ResponseError } from 'superagent'
 
 import type UserService from './userService'
 import type { CourseClient, HmppsAuthClient, RestClientBuilder, RestClientBuilderWithoutToken } from '../data'
+import type { SanitisedError } from '../sanitisedError'
 import { CourseParticipationUtils } from '../utils'
 import type {
   Audience,
@@ -20,6 +21,7 @@ import type {
   CourseParticipation,
   CourseParticipationCreate,
   CourseParticipationUpdate,
+  PniScore,
   Referral,
 } from '@accredited-programmes-api'
 import type { Prison } from '@prison-register-api'
@@ -83,6 +85,30 @@ export default class CourseService {
     const courseClient = this.courseClientBuilder(systemToken)
 
     return courseClient.destroyParticipation(courseParticipationId)
+  }
+
+  async getBuildingChoicesCourseByReferral(
+    username: Express.User['username'],
+    referralId: Referral['id'],
+    programmePathway: PniScore['programmePathway'],
+  ): Promise<Course | null> {
+    const hmppsAuthClient = this.hmppsAuthClientBuilder()
+    const systemToken = await hmppsAuthClient.getSystemClientToken(username)
+    const courseClient = this.courseClientBuilder(systemToken)
+    try {
+      const bcCourse = await courseClient.findBuildingChoicesCourseByReferral(referralId, programmePathway)
+      return bcCourse
+    } catch (error) {
+      const sanitisedError = error as SanitisedError
+
+      if (sanitisedError.status === 404) {
+        return null
+      }
+      throw createError(
+        sanitisedError.status || 500,
+        `Error fetching building choices course data for referral ${referralId} and pathway ${programmePathway}.`,
+      )
+    }
   }
 
   async getBuildingChoicesVariants(

--- a/server/utils/referrals/showReferralUtils.test.ts
+++ b/server/utils/referrals/showReferralUtils.test.ts
@@ -32,57 +32,63 @@ describe('ShowReferralUtils', () => {
 
   describe('Menu buttons', () => {
     describe('when in the assess journey', () => {
-      it('when the course is not building choices, the referral is not closed or on programme, shows the update and move to building choices buttons in the menu', () => {
-        expect(
-          ShowReferralUtils.buttonMenu(course, submittedReferral, {
-            currentPath: assessPaths.show.statusHistory({ referralId: submittedReferral.id }),
-          }),
-        ).toEqual({
-          button: {
-            classes: 'govuk-button--secondary',
-            text: 'Update referral',
-          },
-          items: [
-            {
-              attributes: {
-                'aria-disabled': false,
+      describe('when the course is not building choices, the referral is not closed or on programme', () => {
+        it('shows the update and move to building choices buttons in the menu', () => {
+          expect(
+            ShowReferralUtils.buttonMenu(course, submittedReferral, {
+              currentPath: assessPaths.show.statusHistory({ referralId: submittedReferral.id }),
+            }),
+          ).toEqual({
+            button: {
+              classes: 'govuk-button--secondary',
+              text: 'Update referral',
+            },
+            items: [
+              {
+                attributes: {
+                  'aria-disabled': false,
+                },
+                classes: 'govuk-button--secondary',
+                href: assessPaths.updateStatus.decision.show({ referralId: submittedReferral.id }),
+                text: 'Update status',
               },
-              classes: 'govuk-button--secondary',
-              href: assessPaths.updateStatus.decision.show({ referralId: submittedReferral.id }),
-              text: 'Update status',
-            },
-            {
-              classes: 'govuk-button--secondary',
-              href: assessPaths.moveToBuildingChoices.reason.show({ referralId: submittedReferral.id }),
-              text: 'Move to Building Choices',
-            },
-          ],
+              {
+                classes: 'govuk-button--secondary',
+                href: assessPaths.transferToBuildingChoices.check.show({ referralId: submittedReferral.id }),
+                text: 'Move to Building Choices',
+              },
+            ],
+          })
         })
-      })
-      it('when the course is building choices, returns an empty menu', () => {
-        expect(
-          ShowReferralUtils.buttonMenu(buildingChoicesCourse, submittedReferral, {
-            currentPath: assessPaths.show.statusHistory({ referralId: submittedReferral.id }),
-          }),
-        ).toEqual({
-          button: {
-            classes: 'govuk-button--secondary',
-            text: 'Update referral',
-          },
-          items: [],
+        describe('when the course is building choices', () => {
+          it('returns an empty menu', () => {
+            expect(
+              ShowReferralUtils.buttonMenu(buildingChoicesCourse, submittedReferral, {
+                currentPath: assessPaths.show.statusHistory({ referralId: submittedReferral.id }),
+              }),
+            ).toEqual({
+              button: {
+                classes: 'govuk-button--secondary',
+                text: 'Update referral',
+              },
+              items: [],
+            })
+          })
         })
-      })
-      it('when the referral status is on programme, returns an empty menu', () => {
-        expect(
-          ShowReferralUtils.buttonMenu(course, onProgrammeReferral, {
-            currentPath: assessPaths.show.statusHistory({ referralId: submittedReferral.id }),
-          }),
-        ).toEqual({
-          button: {
-            classes: 'govuk-button--secondary',
-            text: 'Update referral',
-          },
-          items: [],
+        describe('when the referral status is on programme', () => {
+          it('returns an empty menu', () => {
+            expect(
+              ShowReferralUtils.buttonMenu(course, onProgrammeReferral, {
+                currentPath: assessPaths.show.statusHistory({ referralId: submittedReferral.id }),
+              }),
+            ).toEqual({
+              button: {
+                classes: 'govuk-button--secondary',
+                text: 'Update referral',
+              },
+              items: [],
+            })
+          })
         })
       })
     })

--- a/server/utils/referrals/showReferralUtils.ts
+++ b/server/utils/referrals/showReferralUtils.ts
@@ -45,7 +45,7 @@ export default class ShowReferralUtils {
             },
             {
               classes: 'govuk-button--secondary',
-              href: assessPaths.moveToBuildingChoices.reason.show({ referralId: referral.id }),
+              href: assessPaths.transferToBuildingChoices.check.show({ referralId: referral.id }),
               text: 'Move to Building Choices',
             },
           ]

--- a/server/views/referrals/transfer/error.njk
+++ b/server/views/referrals/transfer/error.njk
@@ -1,0 +1,25 @@
+{% from "govuk/components/button/macro.njk" import govukButton %}
+
+{% extends "./partials/layout.njk" %}
+
+{% block content %}
+  <div class="govuk-grid-row">
+    <div class="govuk-grid-column-two-thirds">
+
+      <h1 class="govuk-heading-l">{{ pageHeading }}</h1>
+
+      {% for message in errorMessages %}
+        <p class="govuk-body">{{ message | safe }}</p>
+      {% endfor %}
+    </div>
+  </div>
+
+  <div class="govuk-grid-row">
+    <div class="govuk-grid-column-two-thirds">
+      {{ govukButton({
+        text: "Return to referral details",
+        href: returnLinkHref
+      }) }}
+    </div>
+  </div>
+{% endblock content %}

--- a/server/views/referrals/transfer/partials/layout.njk
+++ b/server/views/referrals/transfer/partials/layout.njk
@@ -1,0 +1,54 @@
+{% from "govuk/components/back-link/macro.njk" import govukBackLink %}
+{% from "govuk/components/button/macro.njk" import govukButton %}
+{% from "govuk/components/error-summary/macro.njk" import govukErrorSummary %}
+{% from "govuk/components/radios/macro.njk" import govukRadios %}
+{% from "moj/components/timeline/macro.njk" import mojTimeline %}
+
+{% extends "../../../partials/layout.njk" %}
+
+{% block personBanner %}
+  {% include "../../_personBanner.njk" %}
+{% endblock personBanner %}
+
+{% block backLink %}
+  {{ govukBackLink({
+    classes: "js-back-link",
+    text: "Back",
+    href: backLinkHref
+  }) }}
+{% endblock backLink %}
+
+{% block content %}
+  <div class="govuk-grid-row">
+    <div class="govuk-grid-column-two-thirds">
+      {% if errors.list | length %}
+        {{ govukErrorSummary({
+            titleText: "There is a problem",
+            errorList: errors.list
+          }) }}
+      {% endif %}
+
+      <h1 class="govuk-heading-l">{{ pageHeading }}</h1>
+
+      {% block statusContent %}{% endblock statusContent %}
+
+      <h2 class="govuk-heading-m">Current status</h2>
+
+      {{ mojTimeline({
+          items: timelineItems,
+          attributes: {
+            "data-testid": "status-history-timeline"
+          },
+          classes: "govuk-!-margin-bottom-0"
+        }) }}
+    </div>
+  </div>
+
+  <hr class="govuk-section-break govuk-section-break--xl govuk-section-break--visible">
+
+  <div class="govuk-grid-row">
+    <div class="govuk-grid-column-two-thirds">
+      {% block statusAction %}{% endblock statusAction %}
+    </div>
+  </div>
+{% endblock content %}


### PR DESCRIPTION
## Context

Provides a mechanism for checking if a referral can be transferred to building choices and if not displaying the relevant error. This does not include the path for duplicate referrals as this is part of APG-695


## Release checklist

[Release process documentation](../doc/how-to/perform-a-release.md)

As part of our continuous deployment strategy we must ensure that this work is
ready to be released once merged.

### Pre-merge

- [ ] There are changes required to the Accredited Programmes API for this change to work...
  - [ ] ... and they have been released to production already

### Post-merge

<!-- The outer checkboxes can be completed pre-merge -->

- [ ] This adds, extends or meaningfully modifies a feature...
  - [ ] ... and I have written or updated an end-to-end test for the happy path in the [Accredited Programmes E2E repo](https://github.com/ministryofjustice/hmpps-accredited-programmes-e2e)
- [ ] This makes new expectations of the API...
  - [ ] ... and I have notified the API developer(s) of changes to the contract tests (Pact), or the API is already compliant
- [ ] [Manually approve](../doc/how-to/perform-a-release.md#releasing-to-the-preprod-environment) release to preprod
- [ ] [Manually approve](../doc/how-to/perform-a-release.md#releasing-to-the-production-environment) release to prod

<!-- Should a release fail at any step, you as the author should now lead the work to
fix it as soon as possible. You can monitor deployment failures in CircleCI
itself and application errors are found in
[Sentry](https://ministryofjustice.sentry.io/projects/hmpps-accredited-programmes-ui/?project=4505330122686464&referrer=sidebar&statsPeriod=24h). -->
