### PR TITLE
(APG-729b) Update `@ministryofjustice/hmpps-connect-dps-components` to v2

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -11,7 +11,7 @@
       "dependencies": {
         "@faker-js/faker": "^9.0.0",
         "@ministryofjustice/frontend": "3.5",
-        "@ministryofjustice/hmpps-connect-dps-components": "^1.2.0",
+        "@ministryofjustice/hmpps-connect-dps-components": "^2.1.0",
         "@sentry/node": "^9.0.0",
         "agentkeepalive": "^4.3.0",
         "applicationinsights": "^2.5.1",
@@ -1760,9 +1760,9 @@
       }
     },
     "node_modules/@ministryofjustice/hmpps-connect-dps-components": {
-      "version": "1.3.1",
-      "resolved": "https://registry.npmjs.org/@ministryofjustice/hmpps-connect-dps-components/-/hmpps-connect-dps-components-1.3.1.tgz",
-      "integrity": "sha512-JSMpCH/z8XUCLik+L3SKGyDNw5zaQWW9gHRF9L9bEBCP/LQgTMf8GCx87QJ0c9SaZ4+y2VaLZ+4+BOyoqaLkbA==",
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/@ministryofjustice/hmpps-connect-dps-components/-/hmpps-connect-dps-components-2.1.0.tgz",
+      "integrity": "sha512-cDZuYQrzUd3zutwXGEag75WmV++gEmS3Fe3Zx2sPgQrNgFyCIZUpdA7UFe63l5WHvHhoWIlxVzriFSSy/yvD1Q==",
       "license": "MIT",
       "dependencies": {
         "@types/node": "^20.17.6",

--- a/package.json
+++ b/package.json
@@ -60,7 +60,7 @@
   "dependencies": {
     "@faker-js/faker": "^9.0.0",
     "@ministryofjustice/frontend": "3.5",
-    "@ministryofjustice/hmpps-connect-dps-components": "^1.2.0",
+    "@ministryofjustice/hmpps-connect-dps-components": "^2.1.0",
     "@sentry/node": "^9.0.0",
     "agentkeepalive": "^4.3.0",
     "applicationinsights": "^2.5.1",

--- a/server/app.ts
+++ b/server/app.ts
@@ -48,13 +48,7 @@ export default function createApp(controllers: Controllers, services: Services):
   app.use(authorisationMiddleware())
   app.use(setUpCsrf())
   app.use(setUpCurrentUser(services))
-  app.get(
-    '*',
-    dpsComponents.getPageComponents({
-      dpsUrl: config.dpsUrl,
-      includeMeta: true,
-    }),
-  )
+  app.get('*', dpsComponents.getPageComponents({ dpsUrl: config.dpsUrl }))
   app.use(routes(controllers))
 
   // The Sentry middleware must be before any other error middleware and after all controllers


### PR DESCRIPTION
## Context

This should close #833. It needed an intervention as `includeMeta` has been replaced with `includeSharedData` in v2.x of https://github.com/ministryofjustice/hmpps-connect-dps-components/releases.



## Changes in this PR
Remove `includeMeta` as we weren't making use of anyway.  Must have been incorrectly included when we first implemented the shared components.

I have however raised [APG-747](https://dsdmoj.atlassian.net/browse/APG-747) as I think we should be using it, as well as the additional `dpsComponents.retrieveCaseLoadData`. Current scope is to update packages and doing now would take longer than we have time for at the moment.


## Release checklist

[Release process documentation](../blob/main/doc/how-to/perform-a-release.md)

As part of our continuous deployment strategy we must ensure that this work is
ready to be released once merged.

### Pre-merge

- [ ] There are changes required to the Accredited Programmes API for this change to work...
  - [ ] ... and they have been released to production already

### Post-merge

<!-- The outer checkboxes can be completed pre-merge -->

- [ ] This adds, extends or meaningfully modifies a feature...
  - [ ] ... and I have written or updated an end-to-end test for the happy path in the [Accredited Programmes E2E repo](https://github.com/ministryofjustice/hmpps-accredited-programmes-e2e)
- [ ] This makes new expectations of the API...
  - [ ] ... and I have notified the API developer(s) of changes to the contract tests (Pact), or the API is already compliant
- [ ] [Manually approve](../doc/how-to/perform-a-release.md#releasing-to-the-preprod-environment) release to preprod
- [ ] [Manually approve](../doc/how-to/perform-a-release.md#releasing-to-the-production-environment) release to prod

<!-- Should a release fail at any step, you as the author should now lead the work to
fix it as soon as possible. You can monitor deployment failures in CircleCI
itself and application errors are found in
[Sentry](https://ministryofjustice.sentry.io/projects/hmpps-accredited-programmes-ui/?project=4505330122686464&referrer=sidebar&statsPeriod=24h). -->


[APG-747]: https://dsdmoj.atlassian.net/browse/APG-747?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ