### PR TITLE
(APG-715a) Switch to use generated `LearningNeeds` type from API

### DIFF
--- a/integration_tests/mockApis/oasys.ts
+++ b/integration_tests/mockApis/oasys.ts
@@ -6,7 +6,6 @@ import type {
   AssessmentDateInfo,
   DrugAlcoholDetail,
   Health,
-  LearningNeeds,
   OffenceDetail,
   RisksAndAlerts,
   RoshAnalysis,
@@ -14,6 +13,7 @@ import type {
 import type {
   Attitude,
   Behaviour,
+  LearningNeeds,
   Lifestyle,
   PniScore,
   Psychiatric,

--- a/integration_tests/pages/shared/showReferral/risksAndNeeds/learningNeeds.ts
+++ b/integration_tests/pages/shared/showReferral/risksAndNeeds/learningNeeds.ts
@@ -1,7 +1,6 @@
 import { CourseUtils, LearningNeedsUtils } from '../../../../../server/utils'
 import Page from '../../../page'
-import type { LearningNeeds } from '@accredited-programmes/models'
-import type { Course } from '@accredited-programmes-api'
+import type { Course, LearningNeeds } from '@accredited-programmes-api'
 
 export default class LearningNeedsPage extends Page {
   learningNeeds: LearningNeeds

--- a/server/@types/models/LearningNeeds.ts
+++ b/server/@types/models/LearningNeeds.ts
@@ -1,9 +1,0 @@
-export type LearningNeeds = {
-  basicSkillsScore?: string
-  basicSkillsScoreDescription?: string
-  learningDifficulties?: string
-  noFixedAbodeOrTransient?: boolean
-  problemsReadWriteNum?: string
-  qualifications?: string
-  workRelatedSkills?: string
-}

--- a/server/@types/models/index.d.ts
+++ b/server/@types/models/index.d.ts
@@ -5,7 +5,6 @@ import type { CourseOffering } from './CourseOffering'
 import type { CoursePrerequisite } from './CoursePrerequisite'
 import type { DrugAlcoholDetail } from './DrugAlcoholDetail'
 import type { Health } from './Health'
-import type { LearningNeeds } from './LearningNeeds'
 import type { OffenceDetail } from './OffenceDetail'
 import type { Organisation } from './Organisation'
 import type { OrganisationAddress } from './OrganisationAddress'
@@ -38,7 +37,6 @@ export type {
   DrugAlcoholDetail,
   Health,
   KeyDates,
-  LearningNeeds,
   OffenceDetail,
   Organisation,
   OrganisationAddress,

--- a/server/data/accreditedProgrammesApi/oasysClient.ts
+++ b/server/data/accreditedProgrammesApi/oasysClient.ts
@@ -6,12 +6,19 @@ import type {
   AssessmentDateInfo,
   DrugAlcoholDetail,
   Health,
-  LearningNeeds,
   OffenceDetail,
   RisksAndAlerts,
   RoshAnalysis,
 } from '@accredited-programmes/models'
-import type { Attitude, Behaviour, Lifestyle, Psychiatric, Referral, Relationships } from '@accredited-programmes-api'
+import type {
+  Attitude,
+  Behaviour,
+  LearningNeeds,
+  Lifestyle,
+  Psychiatric,
+  Referral,
+  Relationships,
+} from '@accredited-programmes-api'
 import type { SystemToken } from '@hmpps-auth'
 
 export default class OasysClient {

--- a/server/services/oasysService.ts
+++ b/server/services/oasysService.ts
@@ -6,12 +6,19 @@ import type {
   AssessmentDateInfo,
   DrugAlcoholDetail,
   Health,
-  LearningNeeds,
   OffenceDetail,
   RisksAndAlerts,
   RoshAnalysis,
 } from '@accredited-programmes/models'
-import type { Attitude, Behaviour, Lifestyle, Psychiatric, Referral, Relationships } from '@accredited-programmes-api'
+import type {
+  Attitude,
+  Behaviour,
+  LearningNeeds,
+  Lifestyle,
+  Psychiatric,
+  Referral,
+  Relationships,
+} from '@accredited-programmes-api'
 
 export default class OasysService {
   constructor(

--- a/server/testutils/factories/learningNeeds.ts
+++ b/server/testutils/factories/learningNeeds.ts
@@ -2,8 +2,9 @@ import { faker } from '@faker-js/faker'
 import { Factory } from 'fishery'
 
 import FactoryHelpers from './factoryHelpers'
-import type { LearningNeeds } from '@accredited-programmes/models'
+import type { LearningNeeds } from '@accredited-programmes-api'
 
+const problemAreaOptions = ['Numeracy', 'Reading', 'Writing']
 class LearningNeedsFactory extends Factory<LearningNeeds> {
   withAllOptionalFields() {
     return this.params({
@@ -11,6 +12,7 @@ class LearningNeedsFactory extends Factory<LearningNeeds> {
       basicSkillsScoreDescription: faker.lorem.sentence(),
       learningDifficulties: faker.lorem.sentence(),
       noFixedAbodeOrTransient: faker.datatype.boolean(),
+      problemAreas: faker.helpers.arrayElements(problemAreaOptions),
       problemsReadWriteNum: faker.lorem.sentence(),
       qualifications: faker.lorem.sentence(),
       workRelatedSkills: faker.lorem.sentence(),
@@ -24,6 +26,7 @@ export default LearningNeedsFactory.define(
     basicSkillsScoreDescription: FactoryHelpers.optionalArrayElement(faker.lorem.sentence()),
     learningDifficulties: FactoryHelpers.optionalArrayElement(faker.lorem.sentence()),
     noFixedAbodeOrTransient: FactoryHelpers.optionalArrayElement(faker.datatype.boolean()),
+    problemAreas: faker.helpers.arrayElements(problemAreaOptions),
     problemsReadWriteNum: FactoryHelpers.optionalArrayElement(faker.lorem.sentence()),
     qualifications: FactoryHelpers.optionalArrayElement(faker.lorem.sentence()),
     workRelatedSkills: FactoryHelpers.optionalArrayElement(faker.lorem.sentence()),

--- a/server/utils/risksAndNeeds/learningNeedsUtils.test.ts
+++ b/server/utils/risksAndNeeds/learningNeedsUtils.test.ts
@@ -1,5 +1,5 @@
 import LearningNeedsUtils from './learningNeedsUtils'
-import type { LearningNeeds } from '@accredited-programmes/models'
+import type { LearningNeeds } from '@accredited-programmes-api'
 
 describe('LearningNeedsUtils', () => {
   const learningNeeds: LearningNeeds = {

--- a/server/utils/risksAndNeeds/learningNeedsUtils.ts
+++ b/server/utils/risksAndNeeds/learningNeedsUtils.ts
@@ -1,6 +1,6 @@
 import ShowRisksAndNeedsUtils from '../referrals/showRisksAndNeedsUtils'
-import type { LearningNeeds } from '@accredited-programmes/models'
 import type { GovukFrontendSummaryListRowWithKeyAndValue } from '@accredited-programmes/ui'
+import type { LearningNeeds } from '@accredited-programmes-api'
 
 export default class LearningNeedsUtils {
   static informationSummaryListRows(learningNeeds: LearningNeeds): Array<GovukFrontendSummaryListRowWithKeyAndValue> {


### PR DESCRIPTION
## Context

To support users understanding of a persons Learning Difficulties and Challenges (LDC), we need to show some additional information within section 4.7.

As per designs, we need to display a flag for ‘Numeracy’, ‘Reading’ or 'Writing’. This information will come from the BE. It could return any combination between none and all 3 being returned.

Our existing `LearningNeeds` type didn't match what was being returned from the API and didn't include the required `problemAreas` property.

## Changes in this PR

- Remove the `LearningNeeds` type
- Use the `LearningNeeds` type from `accredited-programmes-api`