### PR TITLE
(APG-715b) Add "Selected problem areas" beneath Learning needs section 4.7 

### DIFF
--- a/assets/scss/overrides.scss
+++ b/assets/scss/overrides.scss
@@ -23,3 +23,7 @@
     cursor: not-allowed;
   }
 }
+
+.no-border {
+  border: none !important;
+}

--- a/server/testutils/factories/learningNeeds.ts
+++ b/server/testutils/factories/learningNeeds.ts
@@ -5,6 +5,7 @@ import FactoryHelpers from './factoryHelpers'
 import type { LearningNeeds } from '@accredited-programmes-api'
 
 const problemAreaOptions = ['Numeracy', 'Reading', 'Writing']
+
 class LearningNeedsFactory extends Factory<LearningNeeds> {
   withAllOptionalFields() {
     return this.params({
@@ -26,7 +27,9 @@ export default LearningNeedsFactory.define(
     basicSkillsScoreDescription: FactoryHelpers.optionalArrayElement(faker.lorem.sentence()),
     learningDifficulties: FactoryHelpers.optionalArrayElement(faker.lorem.sentence()),
     noFixedAbodeOrTransient: FactoryHelpers.optionalArrayElement(faker.datatype.boolean()),
-    problemAreas: faker.helpers.arrayElements(problemAreaOptions),
+    problemAreas: FactoryHelpers.optionalArrayElement<LearningNeeds['problemAreas']>([
+      faker.helpers.arrayElements(problemAreaOptions, { max: 3, min: 0 }),
+    ]),
     problemsReadWriteNum: FactoryHelpers.optionalArrayElement(faker.lorem.sentence()),
     qualifications: FactoryHelpers.optionalArrayElement(faker.lorem.sentence()),
     workRelatedSkills: FactoryHelpers.optionalArrayElement(faker.lorem.sentence()),

--- a/server/utils/risksAndNeeds/learningNeedsUtils.test.ts
+++ b/server/utils/risksAndNeeds/learningNeedsUtils.test.ts
@@ -1,16 +1,17 @@
 import LearningNeedsUtils from './learningNeedsUtils'
-import type { LearningNeeds } from '@accredited-programmes-api'
+import { learningNeedsFactory } from '../../testutils/factories'
 
 describe('LearningNeedsUtils', () => {
-  const learningNeeds: LearningNeeds = {
+  const learningNeeds = learningNeedsFactory.build({
     basicSkillsScore: '6',
     basicSkillsScoreDescription: 'Extra detail about the learning needs score',
     learningDifficulties: '0 - No problems',
     noFixedAbodeOrTransient: false,
+    problemAreas: undefined,
     problemsReadWriteNum: '0 - No problems',
     qualifications: '0 - Any qualifications',
     workRelatedSkills: '0 - No problems',
-  }
+  })
 
   describe('informationSummaryListRows', () => {
     it('formats the learnng needs data in the appropriate format for passing to a GOV.UK summary list Nunjucks macro', () => {
@@ -36,6 +37,45 @@ describe('LearningNeedsUtils', () => {
           value: { text: '0 - Any qualifications' },
         },
       ])
+    })
+
+    describe('when there are problem areas', () => {
+      it('includes the "Selected problem areas" row with a list of the problem areas', () => {
+        const learningNeedsWithProblemAreas = learningNeedsFactory.build({
+          ...learningNeeds,
+          problemAreas: ['Numeracy', 'Reading'],
+        })
+
+        expect(LearningNeedsUtils.informationSummaryListRows(learningNeedsWithProblemAreas)).toEqual([
+          {
+            key: { text: '3.3 - Currently of no fixed abode or in transient accommodation' },
+            value: { text: 'No' },
+          },
+          {
+            key: { text: '4.4 - Work related skills' },
+            value: { text: '0 - No problems' },
+          },
+          {
+            classes: 'no-border',
+            key: { text: '4.7 - Has problems with reading, writing or numeracy' },
+            value: { text: '0 - No problems' },
+          },
+          {
+            key: { text: 'Selected problem areas' },
+            value: {
+              html: '<ul class="govuk-list"><li>Numeracy</li><li>Reading</li></ul>',
+            },
+          },
+          {
+            key: { text: '4.8 - Has learning difficulties (optional)' },
+            value: { text: '0 - No problems' },
+          },
+          {
+            key: { text: '4.9 - Educational or formal professional / vocational qualifications (optional)' },
+            value: { text: '0 - Any qualifications' },
+          },
+        ])
+      })
     })
   })
 

--- a/server/utils/risksAndNeeds/learningNeedsUtils.ts
+++ b/server/utils/risksAndNeeds/learningNeedsUtils.ts
@@ -4,6 +4,8 @@ import type { LearningNeeds } from '@accredited-programmes-api'
 
 export default class LearningNeedsUtils {
   static informationSummaryListRows(learningNeeds: LearningNeeds): Array<GovukFrontendSummaryListRowWithKeyAndValue> {
+    const { problemAreas } = learningNeeds
+
     return [
       {
         key: { text: '3.3 - Currently of no fixed abode or in transient accommodation' },
@@ -14,9 +16,20 @@ export default class LearningNeedsUtils {
         value: { text: ShowRisksAndNeedsUtils.textValue(learningNeeds.workRelatedSkills) },
       },
       {
+        classes: problemAreas?.length ? 'no-border' : undefined,
         key: { text: '4.7 - Has problems with reading, writing or numeracy' },
         value: { text: ShowRisksAndNeedsUtils.textValue(learningNeeds.problemsReadWriteNum) },
       },
+      ...(problemAreas?.length
+        ? [
+            {
+              key: { text: 'Selected problem areas' },
+              value: {
+                html: `<ul class="govuk-list">${problemAreas.map(area => `<li>${area}</li>`).join('')}</ul>`,
+              },
+            },
+          ]
+        : []),
       {
         key: { text: '4.8 - Has learning difficulties (optional)' },
         value: { text: ShowRisksAndNeedsUtils.textValue(learningNeeds.learningDifficulties) },


### PR DESCRIPTION
## Context

To support users understanding of a persons Learning Difficulties and Challenges (LDC), we need to show some additional information within section 4.7.

As per designs, we need to display a flag for ‘Numeracy’, ‘Reading’ or 'Writing’. This information will come from the BE. It could return any combination between none and all 3 being returned.

## Changes in this PR
- Update `LearningNeedsFactory` to randomise the problemAreas return value
- Add `.no-border` class to overrides.scss
- Update `LearningNeedsUtils.informationSummaryListRows` to show render `problemAreas` values as unordered list in a new row beneath section 4.7, but then conditionally apply the new `.no-border` css class to the above row if there are problem areas to display.

Integrations already existing for this section and use the `LearningNeedsFactory`.


## Screenshots of UI changes

Without problem areas:
![image](https://github.com/user-attachments/assets/ab0ddec7-1eb1-41b0-9b91-2675991dd880)

With problem areas:
![image](https://github.com/user-attachments/assets/83b4f83a-c0cb-4e38-b1f3-8a2d7c2bdb92)



