### PR TITLE
(APG-641b) Use Audience values for course to populate programme strand filter

### DIFF
--- a/integration_tests/e2e/assess/caseList.cy.ts
+++ b/integration_tests/e2e/assess/caseList.cy.ts
@@ -1,6 +1,11 @@
 import { ApplicationRoles } from '../../../server/middleware/roleBasedAccessMiddleware'
 import { assessPaths } from '../../../server/paths'
-import { courseFactory, referralStatusRefDataFactory, referralViewFactory } from '../../../server/testutils/factories'
+import {
+  audienceFactory,
+  courseFactory,
+  referralStatusRefDataFactory,
+  referralViewFactory,
+} from '../../../server/testutils/factories'
 import FactoryHelpers from '../../../server/testutils/factories/factoryHelpers'
 import { PathUtils } from '../../../server/utils'
 import Page from '../../pages/page'
@@ -8,8 +13,11 @@ import { CaseListPage } from '../../pages/shared'
 import type { CaseListColumnHeader } from '@accredited-programmes/ui'
 
 context('Referral case lists', () => {
+  const generalOffenceAudience = audienceFactory.build({ name: 'General offence' })
   const limeCourse = courseFactory.build({ name: 'Lime Course' })
+  const limeCourseAudiences = [generalOffenceAudience, audienceFactory.build({ name: 'Sexual offence' })]
   const blueCourse = courseFactory.build({ name: 'Blue Course' })
+  const blueCourseAudiences = [generalOffenceAudience, audienceFactory.build({ name: 'General violence offence' })]
   const courses = [limeCourse, blueCourse]
   const closedReferralStatuses = [
     referralStatusRefDataFactory.build({ closed: true, code: 'WITHDRAWN', draft: false }),
@@ -39,6 +47,7 @@ context('Referral case lists', () => {
     cy.task('stubAuthUser')
     cy.task('stubDefaultCaseloads')
     cy.task('stubCoursesForOrganisation', { courses, organisationId: 'MRI' })
+    cy.task('stubCourseAudiences', { audiences: limeCourseAudiences, courseId: limeCourse.id })
     cy.task('stubReferralStatuses', referralStatuses)
     cy.signIn()
   })
@@ -330,6 +339,10 @@ context('Referral case lists', () => {
     })
 
     describe('when visiting the index, without specifying a course', () => {
+      beforeEach(() => {
+        cy.task('stubCourseAudiences', { audiences: blueCourseAudiences, courseId: blueCourse.id })
+      })
+
       it('redirects to the correct course case list page', () => {
         cy.task('stubFindReferralViews', {
           organisationId: 'MRI',

--- a/integration_tests/mockApis/courses.ts
+++ b/integration_tests/mockApis/courses.ts
@@ -3,7 +3,7 @@ import type { SuperAgentRequest } from 'superagent'
 import { apiPaths } from '../../server/paths'
 import { stubFor } from '../../wiremock'
 import type { CourseOffering } from '@accredited-programmes/models'
-import type { Course } from '@accredited-programmes-api'
+import type { Audience, Course } from '@accredited-programmes-api'
 import type { Prison } from '@prison-register-api'
 
 export default {
@@ -29,6 +29,22 @@ export default {
       response: {
         headers: { 'Content-Type': 'application/json;charset=UTF-8' },
         jsonBody: course,
+        status: 200,
+      },
+    }),
+
+  stubCourseAudiences: (args: { audiences: Array<Audience>; courseId: Course['id'] }): SuperAgentRequest =>
+    stubFor({
+      request: {
+        method: 'GET',
+        queryParameters: {
+          courseId: { equalTo: args.courseId },
+        },
+        urlPath: apiPaths.courses.audiences({}),
+      },
+      response: {
+        headers: { 'Content-Type': 'application/json;charset=UTF-8' },
+        jsonBody: args.audiences,
         status: 200,
       },
     }),

--- a/server/controllers/assess/caseListController.test.ts
+++ b/server/controllers/assess/caseListController.test.ts
@@ -7,7 +7,12 @@ import { when } from 'jest-when'
 import AssessCaseListController from './caseListController'
 import { assessPaths } from '../../paths'
 import type { CourseService, ReferenceDataService, ReferralService } from '../../services'
-import { courseFactory, referralStatusRefDataFactory, referralViewFactory } from '../../testutils/factories'
+import {
+  audienceFactory,
+  courseFactory,
+  referralStatusRefDataFactory,
+  referralViewFactory,
+} from '../../testutils/factories'
 import { CaseListUtils, PaginationUtils, PathUtils } from '../../utils'
 import type { Paginated, ReferralView } from '@accredited-programmes/models'
 import type {
@@ -45,6 +50,7 @@ describe('AssessCaseListController', () => {
 
   const orangeCourse = courseFactory.build({ name: 'Orange Course' })
   const limeCourse = courseFactory.build({ audience: 'Gang offence', name: 'Lime Course' })
+  const limeCourseAudiences = audienceFactory.buildList(2)
   const courses = [orangeCourse, limeCourse]
 
   beforeEach(() => {
@@ -158,6 +164,9 @@ describe('AssessCaseListController', () => {
       request.params = { courseId: limeCourse.id, referralStatusGroup }
 
       when(courseService.getCoursesByOrganisation).calledWith(username, activeCaseLoadId).mockResolvedValue(courses)
+      when(courseService.getCourseAudiences)
+        .calledWith(username, { courseId: limeCourse.id })
+        .mockResolvedValue(limeCourseAudiences)
 
       const openReferralViews = referralViewFactory.buildList(3, { status: 'referral_submitted' })
       const closedReferralViews = referralViewFactory.buildList(1, { status: 'programme_complete' })
@@ -257,7 +266,7 @@ describe('AssessCaseListController', () => {
           assessPaths.caseList.show({ courseId: limeCourse.id, referralStatusGroup }),
           queryParamsExcludingSort,
         )
-        expect(CaseListUtils.audienceSelectItems).toHaveBeenCalledWith(undefined)
+        expect(CaseListUtils.audienceSelectItems).toHaveBeenCalledWith(limeCourseAudiences, undefined)
         expect(CaseListUtils.primaryNavigationItems).toHaveBeenCalledWith(request.path, courses)
         expect(CaseListUtils.sortableTableHeadings).toHaveBeenCalledWith(
           pathWithQuery,
@@ -311,7 +320,7 @@ describe('AssessCaseListController', () => {
 
           expect(response.render).toHaveBeenCalledWith('referrals/caseList/assess/show', {
             action: assessPaths.caseList.filter({ courseId: limeCourse.id, referralStatusGroup }),
-            audienceSelectItems: CaseListUtils.audienceSelectItems('general offence'),
+            audienceSelectItems: CaseListUtils.audienceSelectItems(limeCourseAudiences, 'general offence'),
             nameOrId: uiNameOrIdQueryParam,
             pageHeading: 'Lime Course',
             pageTitleOverride: 'Manage open programme team referrals: Lime Course',
@@ -354,7 +363,7 @@ describe('AssessCaseListController', () => {
             assessPaths.caseList.show({ courseId: limeCourse.id, referralStatusGroup }),
             queryParamsExcludingSort,
           )
-          expect(CaseListUtils.audienceSelectItems).toHaveBeenCalledWith(uiAudienceQueryParam)
+          expect(CaseListUtils.audienceSelectItems).toHaveBeenCalledWith(limeCourseAudiences, uiAudienceQueryParam)
           expect(CaseListUtils.primaryNavigationItems).toHaveBeenCalledWith(request.path, courses)
           expect(CaseListUtils.sortableTableHeadings).toHaveBeenCalledWith(
             pathWithQuery,
@@ -444,7 +453,7 @@ describe('AssessCaseListController', () => {
           assessPaths.caseList.show({ courseId: limeCourse.id, referralStatusGroup: 'closed' }),
           queryParamsExcludingSort,
         )
-        expect(CaseListUtils.audienceSelectItems).toHaveBeenCalledWith(undefined)
+        expect(CaseListUtils.audienceSelectItems).toHaveBeenCalledWith(limeCourseAudiences, undefined)
         expect(CaseListUtils.primaryNavigationItems).toHaveBeenCalledWith(request.path, courses)
         expect(CaseListUtils.sortableTableHeadings).toHaveBeenCalledWith(
           pathWithQuery,

--- a/server/controllers/assess/caseListController.ts
+++ b/server/controllers/assess/caseListController.ts
@@ -79,7 +79,10 @@ export default class AssessCaseListController {
 
       const { activeCaseLoadId, username } = res.locals.user
 
-      const courses = await this.courseService.getCoursesByOrganisation(username, activeCaseLoadId)
+      const [courses, courseAudiences] = await Promise.all([
+        this.courseService.getCoursesByOrganisation(username, activeCaseLoadId),
+        this.courseService.getCourseAudiences(username, { courseId }),
+      ])
 
       const selectedCourse = courses.find(course => course.id === courseId)
 
@@ -143,7 +146,7 @@ export default class AssessCaseListController {
 
       return res.render('referrals/caseList/assess/show', {
         action: assessPaths.caseList.filter({ courseId, referralStatusGroup }),
-        audienceSelectItems: CaseListUtils.audienceSelectItems(audience),
+        audienceSelectItems: CaseListUtils.audienceSelectItems(courseAudiences, audience),
         nameOrId,
         pageHeading: selectedCourse.name,
         pageTitleOverride: `Manage ${referralStatusGroup} programme team referrals: ${selectedCourse.name}`,

--- a/server/data/accreditedProgrammesApi/courseClient.ts
+++ b/server/data/accreditedProgrammesApi/courseClient.ts
@@ -82,9 +82,12 @@ export default class CourseClient {
     })) as Array<Course>
   }
 
-  async findCourseAudiences(): Promise<Array<Audience>> {
+  async findCourseAudiences(query?: { courseId: Course['id'] }): Promise<Array<Audience>> {
     return (await this.restClient.get({
       path: apiPaths.courses.audiences({}),
+      query: {
+        ...(query?.courseId && { courseId: query.courseId }),
+      },
     })) as Array<Audience>
   }
 

--- a/server/services/courseService.test.ts
+++ b/server/services/courseService.test.ts
@@ -250,6 +250,21 @@ describe('CourseService', () => {
       expect(courseClientBuilder).toHaveBeenCalledWith(systemToken)
       expect(courseClient.findCourseAudiences).toHaveBeenCalled()
     })
+
+    describe('when there are query parameters', () => {
+      it('calls the client method with those query parameters', async () => {
+        const courseId = 'course-id'
+        const audiences = audienceFactory.buildList(3)
+        when(courseClient.findCourseAudiences).mockResolvedValue(audiences)
+
+        const result = await service.getCourseAudiences(username, { courseId })
+
+        expect(result).toEqual(audiences)
+
+        expect(courseClientBuilder).toHaveBeenCalledWith(systemToken)
+        expect(courseClient.findCourseAudiences).toHaveBeenCalledWith({ courseId })
+      })
+    })
   })
 
   describe('getCourseByOffering', () => {

--- a/server/services/courseService.ts
+++ b/server/services/courseService.ts
@@ -106,12 +106,15 @@ export default class CourseService {
     return courseClient.find(courseId)
   }
 
-  async getCourseAudiences(username: Express.User['username']): Promise<Array<Audience>> {
+  async getCourseAudiences(
+    username: Express.User['username'],
+    query?: { courseId: Course['id'] },
+  ): Promise<Array<Audience>> {
     const hmppsAuthClient = this.hmppsAuthClientBuilder()
     const systemToken = await hmppsAuthClient.getSystemClientToken(username)
     const courseClient = this.courseClientBuilder(systemToken)
 
-    return courseClient.findCourseAudiences()
+    return courseClient.findCourseAudiences(query)
   }
 
   async getCourseByOffering(username: Express.User['username'], courseOfferingId: CourseOffering['id']) {

--- a/server/utils/referrals/caseListUtils.test.ts
+++ b/server/utils/referrals/caseListUtils.test.ts
@@ -4,6 +4,7 @@ import { courseFactory, referralStatusRefDataFactory, referralViewFactory } from
 import FormUtils from '../formUtils'
 import type { ReferralStatus } from '@accredited-programmes/models'
 import type { CaseListColumnHeader, SortableCaseListColumnKey } from '@accredited-programmes/ui'
+import type { Audience } from '@accredited-programmes-api'
 
 jest.mock('../formUtils')
 
@@ -59,6 +60,16 @@ describe('CaseListUtils', () => {
   })
 
   describe('audienceSelectItems', () => {
+    const courseAudiences: Array<Audience> = [
+      { id: '1', name: 'General offence' },
+      { id: '2', name: 'Extremism offence' },
+      { id: '3', name: 'Gang offence' },
+      { id: '4', name: undefined },
+      { id: '5', name: 'General violence offence' },
+      { id: '6', name: 'Intimate partner violence offence' },
+      { id: '7', name: 'Sexual offence' },
+    ]
+
     const expectedItems = {
       'extremism offence': 'Extremism offence',
       'gang offence': 'Gang offence',
@@ -69,14 +80,14 @@ describe('CaseListUtils', () => {
     }
 
     it('makes a call to the `FormUtils.getSelectItems` method with an `undefined` `selectedValue` parameter', () => {
-      CaseListUtils.audienceSelectItems()
+      CaseListUtils.audienceSelectItems(courseAudiences)
 
       expect(FormUtils.getSelectItems).toHaveBeenCalledWith(expectedItems, undefined)
     })
 
     describe('when a selected value is provided', () => {
       it('makes a call to the `FormUtils.getSelectItems` method with the correct `selectedValue` parameter', () => {
-        CaseListUtils.audienceSelectItems('general offence')
+        CaseListUtils.audienceSelectItems(courseAudiences, 'general offence')
 
         expect(FormUtils.getSelectItems).toHaveBeenCalledWith(expectedItems, 'general offence')
       })

--- a/server/utils/referrals/caseListUtils.ts
+++ b/server/utils/referrals/caseListUtils.ts
@@ -8,7 +8,7 @@ import PathUtils from '../pathUtils'
 import StringUtils from '../stringUtils'
 import type { ReferralStatusGroup, ReferralStatusRefData, ReferralView } from '@accredited-programmes/models'
 import type { CaseListColumnHeader, MojFrontendNavigationItem, QueryParam } from '@accredited-programmes/ui'
-import type { Course, Referral } from '@accredited-programmes-api'
+import type { Audience, Course, Referral } from '@accredited-programmes-api'
 import type { GovukFrontendSelectItem, GovukFrontendTableHeadElement, GovukFrontendTableRow } from '@govuk-frontend'
 
 export default class CaseListUtils {
@@ -30,16 +30,9 @@ export default class CaseListUtils {
     })
   }
 
-  static audienceSelectItems(selectedValue?: string): Array<GovukFrontendSelectItem> {
+  static audienceSelectItems(audiences: Array<Audience>, selectedValue?: string): Array<GovukFrontendSelectItem> {
     return this.selectItems(
-      [
-        'Extremism offence',
-        'Gang offence',
-        'General offence',
-        'General violence offence',
-        'Intimate partner violence offence',
-        'Sexual offence',
-      ],
+      audiences.map(audience => audience.name).filter(audience => audience !== undefined),
       selectedValue,
     )
   }


### PR DESCRIPTION
## Context

When in case list view the strand filter currently returns the full list of possible strand values. We think it will be easier for users if they only get to see the strands that apply to that particular course/offering.



## Changes in this PR
Call  `/courses/audiences=courseId=course-id` and use those values to populate the Programme strand select input on the assess case list.



## Release checklist

[Release process documentation](../blob/main/doc/how-to/perform-a-release.md)

As part of our continuous deployment strategy we must ensure that this work is
ready to be released once merged.

### Pre-merge

- [ ] There are changes required to the Accredited Programmes API for this change to work...
  - [ ] ... and they have been released to production already

### Post-merge

<!-- The outer checkboxes can be completed pre-merge -->

- [ ] This adds, extends or meaningfully modifies a feature...
  - [ ] ... and I have written or updated an end-to-end test for the happy path in the [Accredited Programmes E2E repo](https://github.com/ministryofjustice/hmpps-accredited-programmes-e2e)
- [ ] This makes new expectations of the API...
  - [ ] ... and I have notified the API developer(s) of changes to the contract tests (Pact), or the API is already compliant
- [ ] [Manually approve](../doc/how-to/perform-a-release.md#releasing-to-the-preprod-environment) release to preprod
- [ ] [Manually approve](../doc/how-to/perform-a-release.md#releasing-to-the-production-environment) release to prod

<!-- Should a release fail at any step, you as the author should now lead the work to
fix it as soon as possible. You can monitor deployment failures in CircleCI
itself and application errors are found in
[Sentry](https://ministryofjustice.sentry.io/projects/hmpps-accredited-programmes-ui/?project=4505330122686464&referrer=sidebar&statsPeriod=24h). -->
