### PR TITLE
Update MoJ Frontend to 3.7

### DIFF
--- a/integration_tests/pages/page.ts
+++ b/integration_tests/pages/page.ts
@@ -577,8 +577,8 @@ export default abstract class Page {
   }
 
   shouldContainTimelineItems(items: Array<MojTimelineItem>, element: JQuery<HTMLElement>): void {
-    // eslint-disable-next-line global-require, @typescript-eslint/no-var-requires
-    const mojFilters = require('@ministryofjustice/frontend/moj/filters/all')()
+    // eslint-disable-next-line
+    const mojFilters = require('@ministryofjustice/frontend/moj/filters/all.js')()
 
     cy.wrap(element).within(() => {
       items.forEach((item, itemIndex) => {

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,7 @@
       "license": "MIT",
       "dependencies": {
         "@faker-js/faker": "^9.0.0",
-        "@ministryofjustice/frontend": "3.5",
+        "@ministryofjustice/frontend": "^3.7.0",
         "@ministryofjustice/hmpps-connect-dps-components": "^2.1.0",
         "@sentry/node": "^9.0.0",
         "agentkeepalive": "^4.3.0",
@@ -1744,19 +1744,16 @@
       "integrity": "sha512-2IHAOaLauc8qaAitvWS+U931T+ze+7MNWrDHY47IENP5y2UA0vqJDu67kWZDdpCN1fFC77sfgfB+HV7SrKshnQ=="
     },
     "node_modules/@ministryofjustice/frontend": {
-      "version": "3.5.0",
-      "resolved": "https://registry.npmjs.org/@ministryofjustice/frontend/-/frontend-3.5.0.tgz",
-      "integrity": "sha512-GbPNJtO2jOMncUAPkgu/e9uuI1FH5pxOYyug29esqpQ6v6AUBBAYbCl2RH/5AC87RJprtMYsM9X/yMBMCGdLnw==",
-      "license": "MIT",
-      "dependencies": {
-        "govuk-frontend": "^5.0.0",
-        "moment": "^2.27.0"
-      },
+      "version": "3.7.0",
+      "resolved": "https://registry.npmjs.org/@ministryofjustice/frontend/-/frontend-3.7.0.tgz",
+      "integrity": "sha512-o84Sqy+1jqc1vaxIZfyG4VwJzdpDUK88O9COJFVLcFmW+Np80onlFlGAVjDUxNHYvtBdJx40w1dayq53wmtxgQ==",
       "engines": {
         "node": ">= 4.2.0"
       },
       "peerDependencies": {
-        "jquery": "^3.6.0"
+        "govuk-frontend": "5.x",
+        "jquery": "3.x",
+        "moment": "2.x"
       }
     },
     "node_modules/@ministryofjustice/hmpps-connect-dps-components": {

--- a/package.json
+++ b/package.json
@@ -59,7 +59,7 @@
   },
   "dependencies": {
     "@faker-js/faker": "^9.0.0",
-    "@ministryofjustice/frontend": "3.5",
+    "@ministryofjustice/frontend": "^3.7.0",
     "@ministryofjustice/hmpps-connect-dps-components": "^2.1.0",
     "@sentry/node": "^9.0.0",
     "agentkeepalive": "^4.3.0",

--- a/server/utils/nunjucksSetup.ts
+++ b/server/utils/nunjucksSetup.ts
@@ -57,8 +57,8 @@ export default function nunjucksSetup(app: express.Express, path: pathModule.Pla
   njkEnv.addGlobal('findPaths', findPaths)
   njkEnv.addGlobal('referPaths', referPaths)
 
-  // eslint-disable-next-line global-require, @typescript-eslint/no-var-requires
-  const mojFilters = require('@ministryofjustice/frontend/moj/filters/all')()
+  // eslint-disable-next-line
+  const mojFilters = require('@ministryofjustice/frontend/moj/filters/all.js')()
 
   Object.keys(mojFilters).forEach(filterName => {
     njkEnv.addFilter(filterName, mojFilters[filterName])


### PR DESCRIPTION
Renovate did raise this initially but it needed a manual change to add the file extension where we import the MoJ nunjucks filters.

I expect this was due to a change made in 3.6 https://github.com/ministryofjustice/moj-frontend/releases/tag/v3.6.0.
