### PR TITLE
(APG-695) Add new client and service methods for getting duplicate referrals

### DIFF
--- a/server/data/accreditedProgrammesApi/referralClient.ts
+++ b/server/data/accreditedProgrammesApi/referralClient.ts
@@ -68,6 +68,16 @@ export default class ReferralClient {
     })) as ConfirmationFields
   }
 
+  async findDuplicateReferrals(offeringId: string, prisonNumber: Referral['prisonNumber']): Promise<Array<Referral>> {
+    return (await this.restClient.get({
+      path: apiPaths.referrals.duplicates({}),
+      query: {
+        offeringId,
+        prisonNumber,
+      },
+    })) as Array<Referral>
+  }
+
   async findMyReferralViews(query?: {
     nameOrId?: string
     page?: string

--- a/server/paths/api.ts
+++ b/server/paths/api.ts
@@ -109,6 +109,7 @@ export default {
     create: referralsPath,
     dashboard: dashboardPath,
     delete: referralPath,
+    duplicates: referralsPath.path('duplicates'),
     myDashboard: myDashboardPath,
     show: referralPath,
     statusHistory: statusHistoryPath,

--- a/server/services/referralService.test.ts
+++ b/server/services/referralService.test.ts
@@ -115,6 +115,28 @@ describe('ReferralService', () => {
     })
   })
 
+  describe('getDuplicateReferrals', () => {
+    it('calls the `referralClient.findDuplicateReferrals` method to return a list of duplicate referrals', async () => {
+      const offeringId = 'course-offering-id'
+      const prisonNumber = 'ABC1234'
+      const duplicateReferrals = referralFactory.buildList(2)
+
+      when(referralClient.findDuplicateReferrals)
+        .calledWith(offeringId, prisonNumber)
+        .mockResolvedValue(duplicateReferrals)
+
+      const result = await service.getDuplicateReferrals(username, offeringId, prisonNumber)
+
+      expect(result).toEqual(duplicateReferrals)
+
+      expect(hmppsAuthClientBuilder).toHaveBeenCalled()
+      expect(hmppsAuthClient.getSystemClientToken).toHaveBeenCalledWith(username)
+
+      expect(referralClientBuilder).toHaveBeenCalledWith(systemToken)
+      expect(referralClient.findDuplicateReferrals).toHaveBeenCalledWith(offeringId, prisonNumber)
+    })
+  })
+
   describe('getMyReferralViews', () => {
     it('returns a list of referral views for the logged in user', async () => {
       const referralViews = referralViewFactory.buildList(3)

--- a/server/services/referralService.ts
+++ b/server/services/referralService.ts
@@ -59,6 +59,18 @@ export default class ReferralService {
     return referralClient.findConfirmationText(referralId, chosenStatusCode, query)
   }
 
+  async getDuplicateReferrals(
+    username: Express.User['username'],
+    offeringId: string,
+    prisonNumber: Referral['prisonNumber'],
+  ): Promise<Array<Referral>> {
+    const hmppsAuthClient = this.hmppsAuthClientBuilder()
+    const systemToken = await hmppsAuthClient.getSystemClientToken(username)
+    const referralClient = this.referralClientBuilder(systemToken)
+
+    return referralClient.findDuplicateReferrals(offeringId, prisonNumber)
+  }
+
   async getMyReferralViews(
     username: Express.User['username'],
     query?: {


### PR DESCRIPTION
## Context

We need to check for duplicate referrals before a referral can be transferred.



## Changes in this PR
Add new client and service methods to check for duplicate referrals for a combination of `prisonNumber` and `offeringId`. 




## Release checklist

[Release process documentation](../blob/main/doc/how-to/perform-a-release.md)

As part of our continuous deployment strategy we must ensure that this work is
ready to be released once merged.

### Pre-merge

- [ ] There are changes required to the Accredited Programmes API for this change to work...
  - [ ] ... and they have been released to production already

### Post-merge

<!-- The outer checkboxes can be completed pre-merge -->

- [ ] This adds, extends or meaningfully modifies a feature...
  - [ ] ... and I have written or updated an end-to-end test for the happy path in the [Accredited Programmes E2E repo](https://github.com/ministryofjustice/hmpps-accredited-programmes-e2e)
- [ ] This makes new expectations of the API...
  - [ ] ... and I have notified the API developer(s) of changes to the contract tests (Pact), or the API is already compliant
- [ ] [Manually approve](../doc/how-to/perform-a-release.md#releasing-to-the-preprod-environment) release to preprod
- [ ] [Manually approve](../doc/how-to/perform-a-release.md#releasing-to-the-production-environment) release to prod

<!-- Should a release fail at any step, you as the author should now lead the work to
fix it as soon as possible. You can monitor deployment failures in CircleCI
itself and application errors are found in
[Sentry](https://ministryofjustice.sentry.io/projects/hmpps-accredited-programmes-ui/?project=4505330122686464&referrer=sidebar&statsPeriod=24h). -->
