### PR TITLE
(APG-675) Add client and service methods for getting the target BC course by Referral ID

### DIFF
--- a/server/data/accreditedProgrammesApi/courseClient.ts
+++ b/server/data/accreditedProgrammesApi/courseClient.ts
@@ -10,6 +10,8 @@ import type {
   CourseParticipation,
   CourseParticipationCreate,
   CourseParticipationUpdate,
+  PniScore,
+  Referral,
 } from '@accredited-programmes-api'
 import type { SystemToken } from '@hmpps-auth'
 
@@ -69,6 +71,19 @@ export default class CourseClient {
 
   async find(courseId: Course['id']): Promise<Course> {
     return (await this.restClient.get({ path: apiPaths.courses.show({ courseId }) })) as Course
+  }
+
+  /* istanbul ignore next */
+  async findBuildingChoicesCourseByReferral(
+    referralId: Referral['id'],
+    programmePathway?: PniScore['programmePathway'],
+  ): Promise<Course> {
+    return (await this.restClient.get({
+      path: apiPaths.courses.buildingChoicesByReferral({ referralId }),
+      query: {
+        ...(programmePathway && { programmePathway }),
+      },
+    })) as Course
   }
 
   /* istanbul ignore next */

--- a/server/paths/api.ts
+++ b/server/paths/api.ts
@@ -5,6 +5,8 @@ const courseNamesPath = coursesPath.path('course-names')
 const coursePath = coursesPath.path(':courseId')
 const offeringsByCoursePath = coursePath.path('offerings')
 
+const buildingChoicesBasePath = coursesPath.path('building-choices')
+
 const offeringPath = path('/offerings/:courseOfferingId')
 const courseByOfferingPath = offeringPath.path('course')
 
@@ -44,7 +46,8 @@ const referralStatusCodeReasonsPath = referralStatusCodeCategoriesPath.path(':ca
 export default {
   courses: {
     audiences: coursesPath.path('audiences'),
-    buildingChoices: coursesPath.path('building-choices/:courseId'),
+    buildingChoices: buildingChoicesBasePath.path(':courseId'),
+    buildingChoicesByReferral: buildingChoicesBasePath.path('referral/:referralId'),
     create: coursesPath,
     index: coursesPath,
     names: courseNamesPath,

--- a/server/services/courseService.test.ts
+++ b/server/services/courseService.test.ts
@@ -152,6 +152,56 @@ describe('CourseService', () => {
     })
   })
 
+  describe('getBuildingChoicesCourseByReferral', () => {
+    const referralId = 'REFERRAL-ID'
+    const pathway = 'MODERATE_INTENSITY_BC'
+    it('returns the course associated with a given referral', async () => {
+      const course = courseFactory.build()
+
+      when(courseClient.findBuildingChoicesCourseByReferral).calledWith(referralId, pathway).mockResolvedValue(course)
+
+      const result = await service.getBuildingChoicesCourseByReferral(username, referralId, pathway)
+
+      expect(result).toEqual(course)
+
+      expect(courseClientBuilder).toHaveBeenCalledWith(systemToken)
+    })
+
+    describe('when the course client throws a 404 error', () => {
+      it('returns `null`', async () => {
+        const clientError = createError(404)
+
+        when(courseClient.findBuildingChoicesCourseByReferral)
+          .calledWith(referralId, pathway)
+          .mockRejectedValue(clientError)
+
+        const result = await service.getBuildingChoicesCourseByReferral(username, referralId, pathway)
+
+        expect(result).toBeNull()
+
+        expect(courseClientBuilder).toHaveBeenCalledWith(systemToken)
+      })
+    })
+
+    describe('when the course client throws any other error', () => {
+      it('throws a generic error message', async () => {
+        const clientError = createError(500)
+
+        when(courseClient.findBuildingChoicesCourseByReferral)
+          .calledWith(referralId, pathway)
+          .mockRejectedValue(clientError)
+
+        await expect(() =>
+          service.getBuildingChoicesCourseByReferral(username, referralId, pathway),
+        ).rejects.toThrowError(
+          `Error fetching building choices course data for referral ${referralId} and pathway ${pathway}.`,
+        )
+
+        expect(courseClientBuilder).toHaveBeenCalledWith(systemToken)
+      })
+    })
+  })
+
   describe('getCourseNames', () => {
     it('returns a list of all course names', async () => {
       const courses = courseFactory.buildList(3)


### PR DESCRIPTION
## Context

We need to be able to get the target building choices course ID for original referral ID.



## Changes in this PR
Add new client and service methods to get the correct building choices course ID for a given referral ID and pathway.





## Release checklist

[Release process documentation](../blob/main/doc/how-to/perform-a-release.md)

As part of our continuous deployment strategy we must ensure that this work is
ready to be released once merged.

### Pre-merge

- [ ] There are changes required to the Accredited Programmes API for this change to work...
  - [ ] ... and they have been released to production already

### Post-merge

<!-- The outer checkboxes can be completed pre-merge -->

- [ ] This adds, extends or meaningfully modifies a feature...
  - [ ] ... and I have written or updated an end-to-end test for the happy path in the [Accredited Programmes E2E repo](https://github.com/ministryofjustice/hmpps-accredited-programmes-e2e)
- [ ] This makes new expectations of the API...
  - [ ] ... and I have notified the API developer(s) of changes to the contract tests (Pact), or the API is already compliant
- [ ] [Manually approve](../doc/how-to/perform-a-release.md#releasing-to-the-preprod-environment) release to preprod
- [ ] [Manually approve](../doc/how-to/perform-a-release.md#releasing-to-the-production-environment) release to prod

<!-- Should a release fail at any step, you as the author should now lead the work to
fix it as soon as possible. You can monitor deployment failures in CircleCI
itself and application errors are found in
[Sentry](https://ministryofjustice.sentry.io/projects/hmpps-accredited-programmes-ui/?project=4505330122686464&referrer=sidebar&statsPeriod=24h). -->
