### PR TITLE
(APG-694a) Move and rename layout used by update status related pages so it can be used for transfer too

### DIFF
--- a/server/views/referrals/partials/changeStatusLayout.njk
+++ b/server/views/referrals/partials/changeStatusLayout.njk
@@ -4,10 +4,10 @@
 {% from "govuk/components/radios/macro.njk" import govukRadios %}
 {% from "moj/components/timeline/macro.njk" import mojTimeline %}
 
-{% extends "../../../partials/layout.njk" %}
+{% extends "../../partials/layout.njk" %}
 
 {% block personBanner %}
-  {% include "../../_personBanner.njk" %}
+  {% include "../_personBanner.njk" %}
 {% endblock personBanner %}
 
 {% block backLink %}

--- a/server/views/referrals/updateStatus/category/show.njk
+++ b/server/views/referrals/updateStatus/category/show.njk
@@ -1,4 +1,4 @@
-{% extends "../partials/layout.njk" %}
+{% extends "../../partials/changeStatusLayout.njk" %}
 
 {% block statusContent %}
   <p>{{ pageDescription }}</p>

--- a/server/views/referrals/updateStatus/decision/show.njk
+++ b/server/views/referrals/updateStatus/decision/show.njk
@@ -1,4 +1,4 @@
-{% extends "../partials/layout.njk" %}
+{% extends "../../partials/changeStatusLayout.njk" %}
 
 {% block statusContent %}
   <p>{{ confirmationText.primaryDescription }}</p>

--- a/server/views/referrals/updateStatus/reason/show.njk
+++ b/server/views/referrals/updateStatus/reason/show.njk
@@ -1,4 +1,4 @@
-{% extends "../partials/layout.njk" %}
+{% extends "../../partials/changeStatusLayout.njk" %}
 
 {% block statusContent %}
   <p>{{ pageDescription }}</p>

--- a/server/views/referrals/updateStatus/selection/show.njk
+++ b/server/views/referrals/updateStatus/selection/show.njk
@@ -2,7 +2,7 @@
 {% from "govuk/components/checkboxes/macro.njk" import govukCheckboxes %}
 {% from "govuk/components/warning-text/macro.njk" import govukWarningText %}
 
-{% extends "../partials/layout.njk" %}
+{% extends "../../partials/changeStatusLayout.njk" %}
 
 {% block statusContent %}
   <p>{{ confirmationText.primaryDescription }}</p>


### PR DESCRIPTION
## Context

The upcoming transfer page shares the same layout as the update status journeys.



## Changes in this PR
Move and rename existing layout template so it can be used by update status and transfer related pages.




## Release checklist

[Release process documentation](../blob/main/doc/how-to/perform-a-release.md)

As part of our continuous deployment strategy we must ensure that this work is
ready to be released once merged.

### Pre-merge

- [ ] There are changes required to the Accredited Programmes API for this change to work...
  - [ ] ... and they have been released to production already

### Post-merge

<!-- The outer checkboxes can be completed pre-merge -->

- [ ] This adds, extends or meaningfully modifies a feature...
  - [ ] ... and I have written or updated an end-to-end test for the happy path in the [Accredited Programmes E2E repo](https://github.com/ministryofjustice/hmpps-accredited-programmes-e2e)
- [ ] This makes new expectations of the API...
  - [ ] ... and I have notified the API developer(s) of changes to the contract tests (Pact), or the API is already compliant
- [ ] [Manually approve](../doc/how-to/perform-a-release.md#releasing-to-the-preprod-environment) release to preprod
- [ ] [Manually approve](../doc/how-to/perform-a-release.md#releasing-to-the-production-environment) release to prod

<!-- Should a release fail at any step, you as the author should now lead the work to
fix it as soon as possible. You can monitor deployment failures in CircleCI
itself and application errors are found in
[Sentry](https://ministryofjustice.sentry.io/projects/hmpps-accredited-programmes-ui/?project=4505330122686464&referrer=sidebar&statsPeriod=24h). -->
