### PR TITLE
(APG-695a) Prepare existing duplicate page/route to be used for Transfer to BC journey

### DIFF
--- a/server/@types/ui/index.d.ts
+++ b/server/@types/ui/index.d.ts
@@ -244,6 +244,8 @@ interface TransferErrorData {
   errorMessage: string
   originalOfferingId: string
   prisonNumber: string
+  duplicateReferralId?: string
+  originalReferralId?: string
 }
 
 export type {

--- a/server/controllers/shared/referralsController.ts
+++ b/server/controllers/shared/referralsController.ts
@@ -1,7 +1,7 @@
 import type { Request, Response, TypedRequestHandler } from 'express'
 import createError from 'http-errors'
 
-import { findPaths, referPathBase, referPaths } from '../../paths'
+import { assessPaths, findPaths, referPathBase, referPaths } from '../../paths'
 import type { CourseService, OrganisationService, PersonService, ReferralService, UserService } from '../../services'
 import {
   CourseParticipationUtils,
@@ -46,15 +46,20 @@ export default class ReferralsController {
     return async (req: Request, res: Response) => {
       TypeUtils.assertHasUser(req)
 
+      const originalReferralId = req.session.transferErrorData?.originalReferralId
       const sharedPageData = await this.sharedPageData(req, res)
+
+      delete req.session.transferErrorData
 
       return res.render('referrals/show/duplicate', {
         ...sharedPageData,
         hrefs: {
-          back: referPaths.new.people.show({
-            courseOfferingId: sharedPageData.courseOffering.id as string,
-            prisonNumber: sharedPageData.person.prisonNumber,
-          }),
+          back: originalReferralId
+            ? assessPaths.show.personalDetails({ referralId: originalReferralId })
+            : referPaths.new.people.show({
+                courseOfferingId: sharedPageData.courseOffering.id as string,
+                prisonNumber: sharedPageData.person.prisonNumber,
+              }),
           programmes: findPaths.pniFind.recommendedProgrammes({}),
         },
         pageHeading: 'Duplicate referral found',

--- a/server/paths/assess.ts
+++ b/server/paths/assess.ts
@@ -24,6 +24,7 @@ export default {
   },
   show: {
     additionalInformation: referralShowPathBase.path('additional-information'),
+    duplicate: referralShowPathBase.path('duplicate'),
     offenceHistory: referralShowPathBase.path('offence-history'),
     personalDetails: referralShowPathBase.path('personal-details'),
     pni: referralShowPathBase.path('pni'),

--- a/server/routes/assess.ts
+++ b/server/routes/assess.ts
@@ -63,6 +63,8 @@ export default function routes(controllers: Controllers, router: Router): Router
   get(assessPaths.updateStatus.selection.show.pattern, updateStatusSelectionController.show())
   post(assessPaths.updateStatus.selection.reason.submit.pattern, updateStatusSelectionController.submitReason())
 
+  get(assessPaths.show.duplicate.pattern, referralsController.duplicate())
+
   get(assessPaths.transfer.show.pattern, transferReferralController.show())
 
   return router


### PR DESCRIPTION
## Context

When transferring a referral to Building Choices, we will need to still check if there is a duplicate referral to the desired BC programme and offering.


## Changes in this PR
Allow existing duplicate controller method to be used by the Transfer to BC journey.

Please note: CTAs at the bottom of the page will still need to be updated, but this will happen in an upcoming PR.


## Release checklist

[Release process documentation](../blob/main/doc/how-to/perform-a-release.md)

As part of our continuous deployment strategy we must ensure that this work is
ready to be released once merged.

### Pre-merge

- [ ] There are changes required to the Accredited Programmes API for this change to work...
  - [ ] ... and they have been released to production already

### Post-merge

<!-- The outer checkboxes can be completed pre-merge -->

- [ ] This adds, extends or meaningfully modifies a feature...
  - [ ] ... and I have written or updated an end-to-end test for the happy path in the [Accredited Programmes E2E repo](https://github.com/ministryofjustice/hmpps-accredited-programmes-e2e)
- [ ] This makes new expectations of the API...
  - [ ] ... and I have notified the API developer(s) of changes to the contract tests (Pact), or the API is already compliant
- [ ] [Manually approve](../doc/how-to/perform-a-release.md#releasing-to-the-preprod-environment) release to preprod
- [ ] [Manually approve](../doc/how-to/perform-a-release.md#releasing-to-the-production-environment) release to prod

<!-- Should a release fail at any step, you as the author should now lead the work to
fix it as soon as possible. You can monitor deployment failures in CircleCI
itself and application errors are found in
[Sentry](https://ministryofjustice.sentry.io/projects/hmpps-accredited-programmes-ui/?project=4505330122686464&referrer=sidebar&statsPeriod=24h). -->
