### PR TITLE
(APG-675) Transfer Referral Unhappy Paths

### DIFF
--- a/server/controllers/assess/index.ts
+++ b/server/controllers/assess/index.ts
@@ -3,6 +3,7 @@
 import AssessCaseListController from './caseListController'
 import PniController from './pniController'
 import TransferReferralController from './transferReferralController'
+import TransferReferralErrorController from './transferReferralErrorController'
 import UpdateStatusDecisionController from './updateStatusDecisionController'
 import type { Services } from '../../services'
 
@@ -32,10 +33,17 @@ const controllers = (services: Services) => {
     services.referralService,
   )
 
+  const transferReferralErrorController = new TransferReferralErrorController(
+    services.courseService,
+    services.organisationService,
+    services.personService,
+  )
+
   return {
     assessCaseListController,
     pniController,
     transferReferralController,
+    transferReferralErrorController,
     updateStatusDecisionController,
   }
 }

--- a/server/controllers/assess/transferReferralController.test.ts
+++ b/server/controllers/assess/transferReferralController.test.ts
@@ -250,9 +250,7 @@ describe('TransferReferralController', () => {
           originalOfferingId: referral.offeringId,
           prisonNumber: person.prisonNumber,
         })
-        expect(response.redirect).toHaveBeenCalledWith(
-          `${assessPaths.transfer.show({ referralId: referral.id })}/error`,
-        )
+        expect(response.redirect).toHaveBeenCalledWith(assessPaths.transfer.error.show({ referralId: referral.id }))
       })
     })
   })

--- a/server/controllers/assess/transferReferralController.ts
+++ b/server/controllers/assess/transferReferralController.ts
@@ -67,7 +67,7 @@ export default class TransferReferralController {
           prisonNumber: person.prisonNumber,
         }
 
-        return res.redirect(`${assessPaths.transfer.show({ referralId: referral.id })}/error`)
+        return res.redirect(assessPaths.transfer.error.show({ referralId: referral.id }))
       }
     }
   }

--- a/server/controllers/assess/transferReferralErrorController.test.ts
+++ b/server/controllers/assess/transferReferralErrorController.test.ts
@@ -1,0 +1,186 @@
+import type { DeepMocked } from '@golevelup/ts-jest'
+import { createMock } from '@golevelup/ts-jest'
+import type { NextFunction, Request, Response } from 'express'
+import { when } from 'jest-when'
+
+import TransferReferralErrorController from './transferReferralErrorController'
+import { assessPaths } from '../../paths'
+import type { CourseService, OrganisationService, PersonService } from '../../services'
+import {
+  courseFactory,
+  courseOfferingFactory,
+  organisationFactory,
+  personFactory,
+  referralFactory,
+} from '../../testutils/factories'
+import Helpers from '../../testutils/helpers'
+import type { Referral } from '@accredited-programmes-api'
+
+describe('TransferReferralErrorController', () => {
+  const userToken = 'SOME_TOKEN'
+  const username = 'USERNAME'
+
+  let request: DeepMocked<Request>
+  let response: DeepMocked<Response>
+  const next: DeepMocked<NextFunction> = createMock<NextFunction>({})
+
+  const courseService = createMock<CourseService>({})
+  const organisationService = createMock<OrganisationService>({})
+  const personService = createMock<PersonService>({})
+
+  const person = personFactory.build()
+  const originalOfferingOrganisation = organisationFactory.build()
+  const originalCourseOffering = courseOfferingFactory.build({ organisationId: originalOfferingOrganisation.id })
+  const originalCourse = courseFactory.build({
+    courseOfferings: [originalCourseOffering],
+    intensity: 'MODERATE',
+  })
+  let referral: Referral
+
+  let controller: TransferReferralErrorController
+
+  beforeEach(() => {
+    referral = referralFactory.submitted().build({ prisonNumber: person.prisonNumber })
+
+    when(personService.getPerson).calledWith(username, referral.prisonNumber).mockResolvedValue(person)
+
+    controller = new TransferReferralErrorController(courseService, organisationService, personService)
+
+    request = createMock<Request>({
+      params: { referralId: referral.id },
+      path: assessPaths.transfer.error.show({ referralId: referral.id }),
+      user: { token: userToken, username },
+    })
+    response = Helpers.createMockResponseWithCaseloads()
+  })
+
+  afterEach(() => {
+    jest.resetAllMocks()
+  })
+
+  describe('show', () => {
+    it('should redirect to personal details if there is no transfer error data', async () => {
+      const requestHandler = controller.show()
+      await requestHandler(request, response, next)
+
+      expect(response.redirect).toHaveBeenCalledWith(assessPaths.show.personalDetails({ referralId: referral.id }))
+    })
+
+    describe('when there is `transferErrorData` in the session', () => {
+      const transferErrorDataDefaults = {
+        originalOfferingId: originalCourseOffering.id,
+        prisonNumber: person.prisonNumber,
+      }
+
+      it('should render the error page with the correct response locals', async () => {
+        request.session.transferErrorData = {
+          ...transferErrorDataDefaults,
+          errorMessage: 'AN_ERROR',
+        }
+
+        const requestHandler = controller.show()
+        await requestHandler(request, response, next)
+
+        expect(response.render).toHaveBeenCalledWith('referrals/transfer/error/show', {
+          backLinkHref: assessPaths.show.personalDetails({ referralId: referral.id }),
+          errorText: ['This referral cannot be moved at the moment because of an error. Try again later.'],
+          pageHeading: 'Cannot complete move to Building Choices',
+          person,
+        })
+      })
+
+      describe('and the `errorMessage` is `DUPLICATE`', () => {
+        it('should redirect to the duplicate referral page', async () => {
+          request.session.transferErrorData = {
+            ...transferErrorDataDefaults,
+            duplicateReferralId: 'duplicate-referral-id',
+            errorMessage: 'DUPLICATE',
+          }
+
+          const requestHandler = controller.show()
+          await requestHandler(request, response, next)
+
+          expect(response.redirect).toHaveBeenCalledWith(
+            assessPaths.show.duplicate({ referralId: 'duplicate-referral-id' }),
+          )
+        })
+      })
+
+      describe('and the `errorMessage` is `MISSING_INFORMATION`', () => {
+        it('should render the error page with the correct response locals', async () => {
+          request.session.transferErrorData = {
+            ...transferErrorDataDefaults,
+            errorMessage: 'MISSING_INFORMATION',
+          }
+
+          const requestHandler = controller.show()
+          await requestHandler(request, response, next)
+
+          expect(response.render).toHaveBeenCalledWith('referrals/transfer/error/show', {
+            backLinkHref: assessPaths.show.personalDetails({ referralId: referral.id }),
+            errorText: [
+              `This referral cannot be moved. Risk and need scores are missing for ${person.name}, so the recommended programme intensity (high or moderate) cannot be calculated.`,
+              `You can see which scores are missing in the <a href="${assessPaths.show.pni({ referralId: referral.id })}">programme needs identifier</a>.`,
+              'Update the missing information in OASys to move the referral, or withdraw this referral and submit a new one.',
+            ],
+            pageHeading: 'This referral cannot be moved to Building Choices',
+            person,
+          })
+        })
+      })
+
+      describe('and the `errorMessage` is `ALTERNATIVE_PATHWAY`', () => {
+        it('should render the error page with the correct response locals', async () => {
+          request.session.transferErrorData = {
+            ...transferErrorDataDefaults,
+            errorMessage: 'ALTERNATIVE_PATHWAY',
+          }
+
+          const requestHandler = controller.show()
+          await requestHandler(request, response, next)
+
+          expect(response.render).toHaveBeenCalledWith('referrals/transfer/error/show', {
+            backLinkHref: assessPaths.show.personalDetails({ referralId: referral.id }),
+            errorText: [
+              `This referral cannot be moved because the risk and need scores suggest that ${person.name} is not eligible for Building Choices. You can see these scores in the programme needs identifier.`,
+            ],
+            pageHeading: 'This referral cannot be moved to Building Choices',
+            person,
+          })
+        })
+      })
+
+      describe('and the `errorMessage` is `NO_COURSE`', () => {
+        it('should render the error page with the correct response locals', async () => {
+          when(courseService.getCourseByOffering)
+            .calledWith(username, originalCourseOffering.id)
+            .mockResolvedValue(originalCourse)
+          when(courseService.getOffering)
+            .calledWith(username, originalCourseOffering.id)
+            .mockResolvedValue(originalCourseOffering)
+          when(organisationService.getOrganisation)
+            .calledWith(userToken, originalCourseOffering.organisationId)
+            .mockResolvedValue(originalOfferingOrganisation)
+
+          request.session.transferErrorData = {
+            ...transferErrorDataDefaults,
+            errorMessage: 'NO_COURSE',
+          }
+
+          const requestHandler = controller.show()
+          await requestHandler(request, response, next)
+
+          expect(response.render).toHaveBeenCalledWith('referrals/transfer/error/show', {
+            backLinkHref: assessPaths.show.personalDetails({ referralId: referral.id }),
+            errorText: [
+              `This referral cannot be moved because ${originalOfferingOrganisation.name} does not offer Building Choices: ${originalCourse.intensity?.toLowerCase()} intensity.`,
+              'Close this referral and submit a new one to a different location.',
+            ],
+            pageHeading: 'This referral cannot be moved to Building Choices',
+            person,
+          })
+        })
+      })
+    })
+  })
+})

--- a/server/controllers/assess/transferReferralErrorController.ts
+++ b/server/controllers/assess/transferReferralErrorController.ts
@@ -1,0 +1,71 @@
+import type { Request, Response, TypedRequestHandler } from 'express'
+
+import { assessPaths } from '../../paths'
+import type { CourseService, OrganisationService, PersonService } from '../../services'
+import { TypeUtils } from '../../utils'
+
+export default class TransferReferralErrorController {
+  constructor(
+    private readonly courseService: CourseService,
+    private readonly organisationService: OrganisationService,
+    private readonly personService: PersonService,
+  ) {}
+
+  show(): TypedRequestHandler<Request, Response> {
+    return async (req: Request, res: Response) => {
+      TypeUtils.assertHasUser(req)
+
+      let pageHeading = 'This referral cannot be moved to Building Choices'
+      let errorText: Array<string>
+
+      const { referralId } = req.params
+      const { token, username } = req.user
+      const { transferErrorData } = req.session
+
+      if (!transferErrorData) {
+        return res.redirect(assessPaths.show.personalDetails({ referralId }))
+      }
+
+      const { errorMessage, originalOfferingId, prisonNumber, duplicateReferralId } = transferErrorData
+
+      if (errorMessage === 'DUPLICATE' && duplicateReferralId) {
+        return res.redirect(assessPaths.show.duplicate({ referralId: duplicateReferralId }))
+      }
+
+      const person = await this.personService.getPerson(username, prisonNumber)
+
+      if (errorMessage === 'MISSING_INFORMATION') {
+        errorText = [
+          `This referral cannot be moved. Risk and need scores are missing for ${person.name}, so the recommended programme intensity (high or moderate) cannot be calculated.`,
+          `You can see which scores are missing in the <a href="${assessPaths.show.pni({ referralId })}">programme needs identifier</a>.`,
+          'Update the missing information in OASys to move the referral, or withdraw this referral and submit a new one.',
+        ]
+      } else if (errorMessage === 'ALTERNATIVE_PATHWAY') {
+        errorText = [
+          `This referral cannot be moved because the risk and need scores suggest that ${person.name} is not eligible for Building Choices. You can see these scores in the programme needs identifier.`,
+        ]
+      } else if (errorMessage === 'NO_COURSE') {
+        const [originalCourse, originalOffering] = await Promise.all([
+          this.courseService.getCourseByOffering(username, originalOfferingId),
+          this.courseService.getOffering(username, originalOfferingId),
+        ])
+        const organisation = await this.organisationService.getOrganisation(token, originalOffering.organisationId)
+
+        errorText = [
+          `This referral cannot be moved because ${organisation.name} does not offer Building Choices: ${originalCourse.intensity?.toLowerCase()} intensity.`,
+          'Close this referral and submit a new one to a different location.',
+        ]
+      } else {
+        errorText = ['This referral cannot be moved at the moment because of an error. Try again later.']
+        pageHeading = 'Cannot complete move to Building Choices'
+      }
+
+      return res.render('referrals/transfer/error/show', {
+        backLinkHref: assessPaths.show.personalDetails({ referralId }),
+        errorText,
+        pageHeading,
+        person,
+      })
+    }
+  }
+}

--- a/server/routes/assess.ts
+++ b/server/routes/assess.ts
@@ -18,6 +18,7 @@ export default function routes(controllers: Controllers, router: Router): Router
     risksAndNeedsController,
     statusHistoryController,
     transferReferralController,
+    transferReferralErrorController,
     updateStatusDecisionController,
     updateStatusSelectionController,
   } = controllers
@@ -66,6 +67,8 @@ export default function routes(controllers: Controllers, router: Router): Router
   get(assessPaths.show.duplicate.pattern, referralsController.duplicate())
 
   get(assessPaths.transfer.show.pattern, transferReferralController.show())
+
+  get(assessPaths.transfer.error.show.pattern, transferReferralErrorController.show())
 
   return router
 }

--- a/server/views/referrals/transfer/error/show.njk
+++ b/server/views/referrals/transfer/error/show.njk
@@ -1,0 +1,32 @@
+{% from "govuk/components/button/macro.njk" import govukButton %}
+
+{% extends "../../show/partials/rootLayout.njk" %}
+
+{% block backLink %}
+  {{ govukBackLink({
+    text: "Back",
+    href: backLinkHref
+  }) }}
+{% endblock backLink %}
+
+{% block content %}
+  <div class="govuk-grid-row">
+    <div class="govuk-grid-column-two-thirds">
+
+      <h1 class="govuk-heading-l">{{ pageHeading }}</h1>
+
+      {% for text in errorText %}
+        <p class="govuk-body">{{ text | safe }}</p>
+      {% endfor %}
+    </div>
+  </div>
+
+  <div class="govuk-grid-row">
+    <div class="govuk-grid-column-two-thirds">
+      {{ govukButton({
+        text: "Return to referral details",
+        href: backLinkHref
+      }) }}
+    </div>
+  </div>
+{% endblock content %}


### PR DESCRIPTION
## Context

When an existing referral cannot be transferred to an equivalent Building Choices programme then we need to display appropriate messaging.

## Changes in this PR
Add new `TransferReferralErrorController` which conditionally displays the correct content, depending on the `errorMessage` value which is stored in the session.

There is an exception where the user will be redirected if there is already an existing referral to the same BC course offering for the person, aka duplicate. 

**Note:**
The gist of these changes were initially made in #869, however we would have had to duplicate a lot of the checks for the happy path.  This keeps the checks in one place (`TransferReferralController.show`) and this page just handles the errors set in the session.

## Screenshots of UI changes

General error (OAsys down etc):
![image](https://github.com/user-attachments/assets/1570864d-26c3-40ba-ad05-5892aa65e7c5)

Missing Information:
![image](https://github.com/user-attachments/assets/31046658-6515-4130-a1dd-b1dd84e24ee1)

Alternative Pathway/Not eligible:
![image](https://github.com/user-attachments/assets/2b2a7846-270d-4283-85a7-9e8abcebef12)

No equivalent BC course at current referral location:
![image](https://github.com/user-attachments/assets/e73f0cdb-4d5e-4277-8b84-a5d6a612760e)



## Release checklist

[Release process documentation](../blob/main/doc/how-to/perform-a-release.md)

As part of our continuous deployment strategy we must ensure that this work is
ready to be released once merged.

### Pre-merge

- [ ] There are changes required to the Accredited Programmes API for this change to work...
  - [ ] ... and they have been released to production already

### Post-merge

<!-- The outer checkboxes can be completed pre-merge -->

- [ ] This adds, extends or meaningfully modifies a feature...
  - [ ] ... and I have written or updated an end-to-end test for the happy path in the [Accredited Programmes E2E repo](https://github.com/ministryofjustice/hmpps-accredited-programmes-e2e)
- [ ] This makes new expectations of the API...
  - [ ] ... and I have notified the API developer(s) of changes to the contract tests (Pact), or the API is already compliant
- [ ] [Manually approve](../doc/how-to/perform-a-release.md#releasing-to-the-preprod-environment) release to preprod
- [ ] [Manually approve](../doc/how-to/perform-a-release.md#releasing-to-the-production-environment) release to prod

<!-- Should a release fail at any step, you as the author should now lead the work to
fix it as soon as possible. You can monitor deployment failures in CircleCI
itself and application errors are found in
[Sentry](https://ministryofjustice.sentry.io/projects/hmpps-accredited-programmes-ui/?project=4505330122686464&referrer=sidebar&statsPeriod=24h). -->
