### PR TITLE
Update @ministryofjustice/frontend and use `import`

### DIFF
--- a/integration_tests/pages/page.ts
+++ b/integration_tests/pages/page.ts
@@ -1,4 +1,6 @@
 import type { AxeRules } from '@accredited-programmes/integration-tests'
+// eslint-disable-next-line import/extensions
+import mojFrontendFilters from '@ministryofjustice/frontend/moj/filters/all.js'
 
 import { assessPathBase, findPaths, referPaths } from '../../server/paths'
 import { referPathBase } from '../../server/paths/refer'
@@ -577,9 +579,6 @@ export default abstract class Page {
   }
 
   shouldContainTimelineItems(items: Array<MojTimelineItem>, element: JQuery<HTMLElement>): void {
-    // eslint-disable-next-line global-require, @typescript-eslint/no-var-requires
-    const mojFilters = require('@ministryofjustice/frontend/moj/filters/all')()
-
     cy.wrap(element).within(() => {
       items.forEach((item, itemIndex) => {
         cy.get('.moj-timeline__item')
@@ -592,7 +591,7 @@ export default abstract class Page {
               cy.get('.moj-timeline__byline').should('have.text', `by ${item.byline.text}`)
               cy.get('.moj-timeline__date').should(
                 'contain.text',
-                mojFilters.mojDate(item.datetime.timestamp, item.datetime.type),
+                mojFrontendFilters().mojDate(item.datetime.timestamp, item.datetime.type),
               )
               cy.get('.moj-timeline__description').then(htmlElement => {
                 if ('html' in item) {

--- a/integration_tests/tsconfig.json
+++ b/integration_tests/tsconfig.json
@@ -1,4 +1,5 @@
 {
+  "extends": "@tsconfig/node22/tsconfig.json",
   "compilerOptions": {
     "strict": true,
     "target": "es5",
@@ -16,6 +17,7 @@
       "@govuk-frontend": ["../server/@types/govukFrontend/index.d.ts"],
       "@hmpps-auth": ["../server/@types/hmppsAuth/index.d.ts"],
       "@manage-users-api": ["../server/@types/manageUsersApi/index.d.ts"],
+      "@ministryofjustice/frontend/moj/filters/all.js": ["../server/@types/mojFrontend/index.d.ts"],
       "@prison-api": ["../server/@types/prisonApi/index.d.ts"],
       "@prison-register-api": ["../server/@types/prisonRegisterApi/index.d.ts"],
       "@prisoner-search": ["../server/@types/prisonerSearch/index.d.ts"]

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,7 @@
       "license": "MIT",
       "dependencies": {
         "@faker-js/faker": "^9.0.0",
-        "@ministryofjustice/frontend": "3.5",
+        "@ministryofjustice/frontend": "^3.7.0",
         "@ministryofjustice/hmpps-connect-dps-components": "^2.1.0",
         "@sentry/node": "^9.0.0",
         "agentkeepalive": "^4.3.0",
@@ -1744,19 +1744,17 @@
       "integrity": "sha512-2IHAOaLauc8qaAitvWS+U931T+ze+7MNWrDHY47IENP5y2UA0vqJDu67kWZDdpCN1fFC77sfgfB+HV7SrKshnQ=="
     },
     "node_modules/@ministryofjustice/frontend": {
-      "version": "3.5.0",
-      "resolved": "https://registry.npmjs.org/@ministryofjustice/frontend/-/frontend-3.5.0.tgz",
-      "integrity": "sha512-GbPNJtO2jOMncUAPkgu/e9uuI1FH5pxOYyug29esqpQ6v6AUBBAYbCl2RH/5AC87RJprtMYsM9X/yMBMCGdLnw==",
+      "version": "3.7.0",
+      "resolved": "https://registry.npmjs.org/@ministryofjustice/frontend/-/frontend-3.7.0.tgz",
+      "integrity": "sha512-o84Sqy+1jqc1vaxIZfyG4VwJzdpDUK88O9COJFVLcFmW+Np80onlFlGAVjDUxNHYvtBdJx40w1dayq53wmtxgQ==",
       "license": "MIT",
-      "dependencies": {
-        "govuk-frontend": "^5.0.0",
-        "moment": "^2.27.0"
-      },
       "engines": {
         "node": ">= 4.2.0"
       },
       "peerDependencies": {
-        "jquery": "^3.6.0"
+        "govuk-frontend": "5.x",
+        "jquery": "3.x",
+        "moment": "2.x"
       }
     },
     "node_modules/@ministryofjustice/hmpps-connect-dps-components": {

--- a/package.json
+++ b/package.json
@@ -59,7 +59,7 @@
   },
   "dependencies": {
     "@faker-js/faker": "^9.0.0",
-    "@ministryofjustice/frontend": "3.5",
+    "@ministryofjustice/frontend": "^3.7.0",
     "@ministryofjustice/hmpps-connect-dps-components": "^2.1.0",
     "@sentry/node": "^9.0.0",
     "agentkeepalive": "^4.3.0",

--- a/server/@types/mojFrontend/index.d.ts
+++ b/server/@types/mojFrontend/index.d.ts
@@ -1,0 +1,10 @@
+declare module '@ministryofjustice/frontend/moj/filters/all.js' {
+  interface Filters {
+    mojDate(
+      moment: Date | string, // actual implementation uses moment.MomentInput
+      type?: 'date' | 'datetime' | 'shortdate' | 'shortdatetime' | 'time',
+    ): string
+  }
+
+  export default () => Filters
+}

--- a/server/utils/nunjucksSetup.ts
+++ b/server/utils/nunjucksSetup.ts
@@ -1,4 +1,7 @@
 /* eslint-disable no-param-reassign */
+
+// eslint-disable-next-line import/extensions
+import mojFrontendFilters from '@ministryofjustice/frontend/moj/filters/all.js'
 import type express from 'express'
 import nunjucks from 'nunjucks'
 import type * as pathModule from 'path'
@@ -57,10 +60,5 @@ export default function nunjucksSetup(app: express.Express, path: pathModule.Pla
   njkEnv.addGlobal('findPaths', findPaths)
   njkEnv.addGlobal('referPaths', referPaths)
 
-  // eslint-disable-next-line global-require, @typescript-eslint/no-var-requires
-  const mojFilters = require('@ministryofjustice/frontend/moj/filters/all')()
-
-  Object.keys(mojFilters).forEach(filterName => {
-    njkEnv.addFilter(filterName, mojFilters[filterName])
-  })
+  njkEnv.addFilter('mojDate', mojFrontendFilters().mojDate)
 }


### PR DESCRIPTION
## Context
We should update to the latest version of @ministryofjustice/frontend.

Will also unblock #875 


## Changes in this PR

- Update to @ministryofjustice/frontend v.3.7.0
- Replace require with import
- Add types definition file for the required function

The use of the file extension is temporary until a change in an upcoming release means we can remove it.

In the meantime though, this uses the preferred import method and also updates to the latest version.



## Release checklist

[Release process documentation](../blob/main/doc/how-to/perform-a-release.md)

As part of our continuous deployment strategy we must ensure that this work is
ready to be released once merged.

### Pre-merge

- [ ] There are changes required to the Accredited Programmes API for this change to work...
  - [ ] ... and they have been released to production already

### Post-merge

<!-- The outer checkboxes can be completed pre-merge -->

- [ ] This adds, extends or meaningfully modifies a feature...
  - [ ] ... and I have written or updated an end-to-end test for the happy path in the [Accredited Programmes E2E repo](https://github.com/ministryofjustice/hmpps-accredited-programmes-e2e)
- [ ] This makes new expectations of the API...
  - [ ] ... and I have notified the API developer(s) of changes to the contract tests (Pact), or the API is already compliant
- [ ] [Manually approve](../doc/how-to/perform-a-release.md#releasing-to-the-preprod-environment) release to preprod
- [ ] [Manually approve](../doc/how-to/perform-a-release.md#releasing-to-the-production-environment) release to prod

<!-- Should a release fail at any step, you as the author should now lead the work to
fix it as soon as possible. You can monitor deployment failures in CircleCI
itself and application errors are found in
[Sentry](https://ministryofjustice.sentry.io/projects/hmpps-accredited-programmes-ui/?project=4505330122686464&referrer=sidebar&statsPeriod=24h). -->
