### PR TITLE
(APG-695c) Withdraw duplicate

### DIFF
--- a/server/controllers/refer/index.ts
+++ b/server/controllers/refer/index.ts
@@ -2,18 +2,14 @@
 
 import ReferCaseListController from './caseListController'
 import referNewControllers from './new'
-import UpdateStatusActionsController from './updateStatusActionsController'
 import type { Services } from '../../services'
 
 const controllers = (services: Services) => {
   const referCaseListController = new ReferCaseListController(services.referralService)
 
-  const updateStatusActionController = new UpdateStatusActionsController()
-
   return {
     ...referNewControllers(services),
     referCaseListController,
-    updateStatusActionController,
   }
 }
 

--- a/server/controllers/shared/index.ts
+++ b/server/controllers/shared/index.ts
@@ -6,6 +6,7 @@ import ReasonController from './reasonController'
 import ReferralsController from './referralsController'
 import RisksAndNeedsController from './risksAndNeedsController'
 import StatusHistoryController from './statusHistoryController'
+import UpdateStatusActionsController from './updateStatusActionsController'
 import UpdateStatusSelectionController from './updateStatusSelectionController'
 import type { Services } from '../../services'
 
@@ -49,6 +50,8 @@ const controllers = (services: Services) => {
     services.referralService,
   )
 
+  const updateStatusActionController = new UpdateStatusActionsController()
+
   const updateStatusSelectionController = new UpdateStatusSelectionController(
     services.personService,
     services.referenceDataService,
@@ -62,6 +65,7 @@ const controllers = (services: Services) => {
     referralsController,
     risksAndNeedsController,
     statusHistoryController,
+    updateStatusActionController,
     updateStatusSelectionController,
   }
 }

--- a/server/controllers/shared/updateStatusActionsController.test.ts
+++ b/server/controllers/shared/updateStatusActionsController.test.ts
@@ -3,7 +3,7 @@ import { createMock } from '@golevelup/ts-jest'
 import type { NextFunction, Request, Response } from 'express'
 
 import UpdateStatusActionsController from './updateStatusActionsController'
-import { referPaths } from '../../paths'
+import { assessPaths, referPaths } from '../../paths'
 
 describe('UpdateStatusActionsController', () => {
   const referralId = 'REFERRAL-ID'
@@ -19,6 +19,7 @@ describe('UpdateStatusActionsController', () => {
 
     request = createMock<Request>({
       params: { referralId },
+      path: referPaths.withdraw({ referralId }),
       session: {},
     })
     response = createMock<Response>({})
@@ -49,6 +50,16 @@ describe('UpdateStatusActionsController', () => {
         referralId,
       })
       expect(response.redirect).toHaveBeenCalledWith(referPaths.updateStatus.reason.show({ referralId }))
+    })
+
+    describe('when the path does not start with `/refer`', () => {
+      it('should redirect to the assess paths', async () => {
+        request.path = assessPaths.withdraw({ referralId })
+
+        controller.withdraw()(request, response, next)
+
+        expect(response.redirect).toHaveBeenCalledWith(assessPaths.updateStatus.reason.show({ referralId }))
+      })
     })
   })
 })

--- a/server/controllers/shared/updateStatusActionsController.ts
+++ b/server/controllers/shared/updateStatusActionsController.ts
@@ -1,6 +1,6 @@
 import type { Request, Response, TypedRequestHandler } from 'express'
 
-import { referPaths } from '../../paths'
+import { assessPaths, referPaths } from '../../paths'
 import type { ReferralStatusUppercase } from '@accredited-programmes/models'
 
 export default class UpdateStatusActionsController {
@@ -22,6 +22,7 @@ export default class UpdateStatusActionsController {
     return (req: Request, res: Response) => {
       const { referralId } = req.params
       const withdrawStatus = 'WITHDRAWN'
+      const paths = req.path.startsWith('/refer') ? referPaths : assessPaths
 
       req.session.referralStatusUpdateData = {
         decisionForCategoryAndReason: withdrawStatus,
@@ -30,7 +31,7 @@ export default class UpdateStatusActionsController {
         referralId,
       }
 
-      return res.redirect(referPaths.updateStatus.reason.show({ referralId }))
+      return res.redirect(paths.updateStatus.reason.show({ referralId }))
     }
   }
 }

--- a/server/paths/assess.ts
+++ b/server/paths/assess.ts
@@ -78,6 +78,7 @@ export default {
       show: updateStatusSelectionShowPath,
     },
   },
+  withdraw: referralShowPathBase.path('withdraw'),
 }
 
 export { assessPathBase }

--- a/server/routes/assess.ts
+++ b/server/routes/assess.ts
@@ -19,6 +19,7 @@ export default function routes(controllers: Controllers, router: Router): Router
     statusHistoryController,
     transferReferralController,
     transferReferralErrorController,
+    updateStatusActionController,
     updateStatusDecisionController,
     updateStatusSelectionController,
   } = controllers
@@ -63,6 +64,8 @@ export default function routes(controllers: Controllers, router: Router): Router
 
   get(assessPaths.updateStatus.selection.show.pattern, updateStatusSelectionController.show())
   post(assessPaths.updateStatus.selection.reason.submit.pattern, updateStatusSelectionController.submitReason())
+
+  get(assessPaths.withdraw.pattern, updateStatusActionController.withdraw())
 
   get(assessPaths.show.duplicate.pattern, referralsController.duplicate())
 


### PR DESCRIPTION
## Context

We will need to take the user straight into the withdraw journey from the duplicate referral page when making a transfer and there is a duplicate.


## Changes in this PR
Allow `UpdateStatusActionsController` to be used by both refer and assess
