### PR TITLE
APG-685 Add custom additional info for transferred referral

### DIFF
--- a/server/@types/ui/index.d.ts
+++ b/server/@types/ui/index.d.ts
@@ -105,6 +105,7 @@ type OrganisationWithOfferingEmailsPresenter = Organisation & {
 }
 
 type ReferralSharedPageData = {
+  additionalInformation: string | undefined
   buttons: Array<GovukFrontendButton>
   course: Course
   courseOffering: CourseOffering

--- a/server/views/referrals/show/additionalInformation.njk
+++ b/server/views/referrals/show/additionalInformation.njk
@@ -14,5 +14,5 @@
     }
   }) }}
 
-  {{ keylessSummaryCard("Additional information", bodyText=referral.additionalInformation, testId="additional-information-summary-card") }}
+  {{ keylessSummaryCard("Additional information", bodyHtml=additionalInformation, testId="additional-information-summary-card") }}
 {% endblock primaryContent %}


### PR DESCRIPTION
## Context

Adds custom Additional Info content to a referral transferred to building choices, including a link to the original referral.

## Screenshots of UI changes

<img width="1242" alt="Screenshot 2025-03-11 at 11 50 16" src="https://github.com/user-attachments/assets/66f6dba0-29af-4c68-af22-1f9b54afa3da" />


## Release checklist

[Release process documentation](../blob/main/doc/how-to/perform-a-release.md)

As part of our continuous deployment strategy we must ensure that this work is
ready to be released once merged.

### Pre-merge

- [ ] There are changes required to the Accredited Programmes API for this change to work...
  - [ ] ... and they have been released to production already

### Post-merge

<!-- The outer checkboxes can be completed pre-merge -->

- [ ] This adds, extends or meaningfully modifies a feature...
  - [ ] ... and I have written or updated an end-to-end test for the happy path in the [Accredited Programmes E2E repo](https://github.com/ministryofjustice/hmpps-accredited-programmes-e2e)
- [ ] This makes new expectations of the API...
  - [ ] ... and I have notified the API developer(s) of changes to the contract tests (Pact), or the API is already compliant
- [ ] [Manually approve](../doc/how-to/perform-a-release.md#releasing-to-the-preprod-environment) release to preprod
- [ ] [Manually approve](../doc/how-to/perform-a-release.md#releasing-to-the-production-environment) release to prod

<!-- Should a release fail at any step, you as the author should now lead the work to
fix it as soon as possible. You can monitor deployment failures in CircleCI
itself and application errors are found in
[Sentry](https://ministryofjustice.sentry.io/projects/hmpps-accredited-programmes-ui/?project=4505330122686464&referrer=sidebar&statsPeriod=24h). -->
