### PR TITLE
Specificy `alertSeverity` for prometheus alerts

### DIFF
--- a/helm_deploy/values-preprod.yaml
+++ b/helm_deploy/values-preprod.yaml
@@ -31,3 +31,6 @@ generic-service:
       - internal
       - prisons
       - private_prisons
+
+generic-prometheus-alerts:
+  alertSeverity: digital-prison-service-dev

--- a/helm_deploy/values-prod.yaml
+++ b/helm_deploy/values-prod.yaml
@@ -31,3 +31,6 @@ generic-service:
       - internal
       - prisons
       - private_prisons
+
+generic-prometheus-alerts:
+  alertSeverity: digital-prison-service


### PR DESCRIPTION
## Context

Looks like a recent upgrade to to 1.11.3 to 1.11.6 requires this to be set.


## Changes in this PR
Specificy ```generic-prometheus-alerts:
  alertSeverity:``` values for pre-prod and prod.