### PR TITLE
(APG-695d) Update duplicate page to be used for transfer journey

### DIFF
--- a/server/controllers/refer/new/referralsController.test.ts
+++ b/server/controllers/refer/new/referralsController.test.ts
@@ -79,6 +79,11 @@ describe('NewReferralsController', () => {
           prisonNumber: person.prisonNumber,
           programmePathway: 'HIGH_INTENSITY_BC',
         },
+        transferErrorData: {
+          errorMessage: 'DUPLICATE',
+          originalReferralId: 'original-referral-id',
+          prisonNumber: person.prisonNumber,
+        },
       },
       user: { token: userToken, username },
     })
@@ -197,6 +202,7 @@ describe('NewReferralsController', () => {
         const requestHandler = controller.create()
         await requestHandler(request, response, next)
 
+        expect(request.session.transferErrorData).toBeUndefined()
         expect(response.redirect).toHaveBeenCalledWith(referPaths.show.duplicate({ referralId: duplicateReferral.id }))
       })
     })
@@ -626,6 +632,7 @@ describe('NewReferralsController', () => {
         const requestHandler = controller.submit()
         await requestHandler(request, response, next)
 
+        expect(request.session.transferErrorData).toBeUndefined()
         expect(response.redirect).toHaveBeenCalledWith(referPaths.show.duplicate({ referralId: duplicateReferral.id }))
       })
     })

--- a/server/controllers/refer/new/referralsController.ts
+++ b/server/controllers/refer/new/referralsController.ts
@@ -133,6 +133,7 @@ export default class NewReferralsController {
         const sanitisedError = error as SanitisedError
 
         if (isErrorWithData<Referral>(sanitisedError) && sanitisedError.status === 409) {
+          delete req.session.transferErrorData
           return res.redirect(referPaths.show.duplicate({ referralId: sanitisedError.data.id }))
         }
 
@@ -275,6 +276,7 @@ export default class NewReferralsController {
         const sanitisedError = error as SanitisedError
 
         if (isErrorWithData<Referral>(sanitisedError) && sanitisedError.status === 409) {
+          delete req.session.transferErrorData
           return res.redirect(referPaths.show.duplicate({ referralId: sanitisedError.data.id }))
         }
 

--- a/server/views/referrals/show/duplicate.njk
+++ b/server/views/referrals/show/duplicate.njk
@@ -42,13 +42,34 @@
         iconFallbackText: "Warning"
       }) }}
 
-      {{ govukButton({
-        text: "Return to programme list",
-        href: hrefs.programmes,
-        attributes: {
-          "data-testid": "programme-list-link"
-        }
-      }) }}
+      {% if hrefs.withdraw and withdrawButtonText %}
+        <div class="govuk-button-group">
+          {{ govukButton({
+            text: withdrawButtonText,
+            href: hrefs.withdraw,
+            attributes: {
+              "data-testid": "withdraw-original-referral-link"
+            }
+          }) }}
+
+          {{ govukButton({
+            text: "Cancel",
+            href: hrefs.back,
+            classes: "govuk-button--secondary",
+            attributes: {
+              "data-testid": "cancel-link"
+            }
+          }) }}
+        </div>
+      {% else %}
+        {{ govukButton({
+          text: "Return to programme list",
+          href: hrefs.programmes,
+          attributes: {
+            "data-testid": "programme-list-link"
+          }
+        }) }}
+      {% endif %}
     </div>
   </div>
 {% endblock content %}


### PR DESCRIPTION
## Context

The duplicate page needs to show different actions if it is redirected to as part of the transfer process.


## Changes in this PR
- Use the presence of `transferErrorData` in the session to get the referral and the associated course name to display the "Withdraw to..." and "Cancel" buttons.
- Ensure `transferErrorData` is cleared from session before existing entry points to the duplicate page to ensure that the correct content is shown.


## Screenshots of UI changes

![image](https://github.com/user-attachments/assets/3379874c-e573-4f2a-8063-0c099b260ab2)

