### PR TITLE
(APG-694d) Submit a Referral transfer to Building Choices

### DIFF
--- a/server/controllers/assess/transferReferralController.test.ts
+++ b/server/controllers/assess/transferReferralController.test.ts
@@ -119,8 +119,10 @@ describe('TransferReferralController', () => {
 
       expect(request.session.transferErrorData).toBeUndefined()
 
-      expect(FormUtils.setFieldErrors).toHaveBeenCalledWith(request, response, ['reason'])
-      expect(FormUtils.setFormValues).toHaveBeenCalledWith(request, response)
+      expect(FormUtils.setFieldErrors).toHaveBeenCalledWith(request, response, ['transferReason'])
+      expect(FormUtils.setFormValues).toHaveBeenCalledWith(request, response, {
+        targetOfferingId: buildingChoicesCourseOffering.id,
+      })
 
       expect(response.render).toHaveBeenCalledWith('referrals/transfer/show', {
         backLinkHref: assessPaths.show.personalDetails({ referralId: referral.id }),

--- a/server/controllers/assess/transferReferralController.test.ts
+++ b/server/controllers/assess/transferReferralController.test.ts
@@ -293,4 +293,39 @@ describe('TransferReferralController', () => {
       })
     })
   })
+
+  describe('submit', () => {
+    it('should redirect to the status history page of the original referral', async () => {
+      request.body = {
+        targetOfferingId: buildingChoicesCourseOffering.id,
+        transferReason: 'A good enough reason.',
+      }
+
+      const requestHandler = controller.submit()
+      await requestHandler(request, response, next)
+
+      expect(referralService.transferReferralToBuildingChoices).toHaveBeenCalledWith(username, {
+        offeringId: buildingChoicesCourseOffering.id,
+        referralId: referral.id,
+        transferReason: 'A good enough reason.',
+      })
+
+      expect(response.redirect).toHaveBeenCalledWith(assessPaths.show.statusHistory({ referralId: referral.id }))
+    })
+
+    describe('when the transfer reason is not provided', () => {
+      it('should set a flash message and redirect back to the transfer form page', async () => {
+        request.body.transferReason = ''
+
+        const requestHandler = controller.submit()
+        await requestHandler(request, response, next)
+
+        expect(request.flash).toHaveBeenCalledWith(
+          'transferReasonError',
+          'Enter a reason for transferring this referral',
+        )
+        expect(response.redirect).toHaveBeenCalledWith(assessPaths.transfer.show({ referralId: referral.id }))
+      })
+    })
+  })
 })

--- a/server/controllers/assess/transferReferralController.ts
+++ b/server/controllers/assess/transferReferralController.ts
@@ -42,8 +42,8 @@ export default class TransferReferralController {
           this.referralService.getReferralStatusHistory(token, username, referralId),
         ])
 
-        FormUtils.setFieldErrors(req, res, ['reason'])
-        FormUtils.setFormValues(req, res)
+        FormUtils.setFieldErrors(req, res, ['transferReason'])
+        FormUtils.setFormValues(req, res, { targetOfferingId: targetCourse.courseOfferings[0].id })
 
         return res.render('referrals/transfer/show', {
           backLinkHref: assessPaths.show.personalDetails({ referralId }),

--- a/server/controllers/assess/transferReferralController.ts
+++ b/server/controllers/assess/transferReferralController.ts
@@ -74,6 +74,28 @@ export default class TransferReferralController {
     }
   }
 
+  submit(): TypedRequestHandler<Request, Response> {
+    return async (req: Request, res: Response) => {
+      TypeUtils.assertHasUser(req)
+
+      const { referralId } = req.params
+      const { targetOfferingId, transferReason } = req.body
+
+      if (!transferReason) {
+        req.flash('transferReasonError', 'Enter a reason for transferring this referral')
+        return res.redirect(assessPaths.transfer.show({ referralId }))
+      }
+
+      await this.referralService.transferReferralToBuildingChoices(req.user.username, {
+        offeringId: targetOfferingId,
+        referralId,
+        transferReason,
+      })
+
+      return res.redirect(assessPaths.show.statusHistory({ referralId }))
+    }
+  }
+
   private async checkForTargetCourse(pniScore: PniScore | null, username: string, referral: Referral): Promise<Course> {
     if (!pniScore) {
       throw new Error('MISSING_INFORMATION')

--- a/server/routes/assess.ts
+++ b/server/routes/assess.ts
@@ -70,6 +70,7 @@ export default function routes(controllers: Controllers, router: Router): Router
   get(assessPaths.show.duplicate.pattern, referralsController.duplicate())
 
   get(assessPaths.transfer.show.pattern, transferReferralController.show())
+  post(assessPaths.transfer.submit.pattern, transferReferralController.submit())
 
   get(assessPaths.transfer.error.show.pattern, transferReferralErrorController.show())
 

--- a/server/views/referrals/transfer/show.njk
+++ b/server/views/referrals/transfer/show.njk
@@ -8,24 +8,25 @@
 {% endblock statusContent %}
 
 {% block statusAction %}
-  <form action="{{ action }}" method="post">
+  <form method="post">
     <input type="hidden" name="_csrf" value="{{ csrfToken }}"/>
+    <input type="hidden" name="targetOfferingId" value="{{ formValues.targetOfferingId }}"/>
 
     <h2 class="govuk-heading-m">{{ confirmationText.secondaryHeading }}</h2>
 
     <p>{{ confirmationText.secondaryDescription }}</p>
 
     {{ govukCharacterCount({
-      id: "reason",
-      name: "reason",
+      id: "transferReason",
+      name: "transferReason",
       maxlength: maxReasonLength,
       label: {
         text: "Add reason",
         classes: 'govuk-fieldset__legend--s'
       },
       rows: 10,
-      value: formValues.reason,
-      errorMessage: errors.messages.reason
+      value: formValues.transferReason,
+      errorMessage: errors.messages.transferReason
     }) }}
 
     {% if confirmationText.warningText %}


### PR DESCRIPTION
## Context

When transferring an existing referral to Building Choices, we need to be able to enter a reason for the transfer and submit the form.


## Changes in this PR
Add `submit` method to `ReferralTransferController` with form error message if no reason is entered.

Note: Integration test PR to follow


## Screenshots of UI changes
![localhost_3000_assess_referrals_c874b604-4d48-4dbc-9872-522249c5292c_transfer](https://github.com/user-attachments/assets/241b0f4a-1449-4f49-bf3e-f58d6a00359c)



## Release checklist

[Release process documentation](../blob/main/doc/how-to/perform-a-release.md)

As part of our continuous deployment strategy we must ensure that this work is
ready to be released once merged.

### Pre-merge

- [ ] There are changes required to the Accredited Programmes API for this change to work...
  - [ ] ... and they have been released to production already

### Post-merge

<!-- The outer checkboxes can be completed pre-merge -->

- [ ] This adds, extends or meaningfully modifies a feature...
  - [ ] ... and I have written or updated an end-to-end test for the happy path in the [Accredited Programmes E2E repo](https://github.com/ministryofjustice/hmpps-accredited-programmes-e2e)
- [ ] This makes new expectations of the API...
  - [ ] ... and I have notified the API developer(s) of changes to the contract tests (Pact), or the API is already compliant
- [ ] [Manually approve](../doc/how-to/perform-a-release.md#releasing-to-the-preprod-environment) release to preprod
- [ ] [Manually approve](../doc/how-to/perform-a-release.md#releasing-to-the-production-environment) release to prod

<!-- Should a release fail at any step, you as the author should now lead the work to
fix it as soon as possible. You can monitor deployment failures in CircleCI
itself and application errors are found in
[Sentry](https://ministryofjustice.sentry.io/projects/hmpps-accredited-programmes-ui/?project=4505330122686464&referrer=sidebar&statsPeriod=24h). -->
