### PR TITLE
(APG-694e) Redirect to newly created referral after transfer

### DIFF
--- a/server/controllers/assess/transferReferralController.test.ts
+++ b/server/controllers/assess/transferReferralController.test.ts
@@ -295,7 +295,17 @@ describe('TransferReferralController', () => {
   })
 
   describe('submit', () => {
-    it('should redirect to the status history page of the original referral', async () => {
+    it('should redirect to the status history page of the newly transferred referral', async () => {
+      const newReferral = referralFactory.submitted().build()
+
+      when(referralService.transferReferralToBuildingChoices)
+        .calledWith(username, {
+          offeringId: buildingChoicesCourseOffering.id,
+          referralId: referral.id,
+          transferReason: 'A good enough reason.',
+        })
+        .mockResolvedValue(newReferral)
+
       request.body = {
         targetOfferingId: buildingChoicesCourseOffering.id,
         transferReason: 'A good enough reason.',
@@ -310,7 +320,7 @@ describe('TransferReferralController', () => {
         transferReason: 'A good enough reason.',
       })
 
-      expect(response.redirect).toHaveBeenCalledWith(assessPaths.show.statusHistory({ referralId: referral.id }))
+      expect(response.redirect).toHaveBeenCalledWith(assessPaths.show.statusHistory({ referralId: newReferral.id }))
     })
 
     describe('when the transfer reason is not provided', () => {

--- a/server/controllers/assess/transferReferralController.ts
+++ b/server/controllers/assess/transferReferralController.ts
@@ -86,13 +86,13 @@ export default class TransferReferralController {
         return res.redirect(assessPaths.transfer.show({ referralId }))
       }
 
-      await this.referralService.transferReferralToBuildingChoices(req.user.username, {
+      const newReferral = await this.referralService.transferReferralToBuildingChoices(req.user.username, {
         offeringId: targetOfferingId,
         referralId,
         transferReason,
       })
 
-      return res.redirect(assessPaths.show.statusHistory({ referralId }))
+      return res.redirect(assessPaths.show.statusHistory({ referralId: newReferral.id }))
     }
   }
 


### PR DESCRIPTION
## Context

We need to redirect to the new referral after transferring to building choices.



## Changes in this PR
Redirect user to status history page of newly created referral.

