### PR TITLE
Add button menu to referrals with transfer to BC option

### DIFF
--- a/server/@types/ui/index.d.ts
+++ b/server/@types/ui/index.d.ts
@@ -106,6 +106,7 @@ type OrganisationWithOfferingEmailsPresenter = Organisation & {
 
 type ReferralSharedPageData = {
   additionalInformation: string | undefined
+  buttonMenu: MojButtonMenu
   buttons: Array<GovukFrontendButton>
   course: Course
   courseOffering: CourseOffering
@@ -156,6 +157,7 @@ type ReferralTaskListItem = {
 }
 
 type RisksAndNeedsSharedPageData = {
+  buttonMenu: MojButtonMenu
   buttons: Array<GovukFrontendButton>
   navigationItems: Array<MojFrontendNavigationItem>
   pageHeading: string
@@ -171,6 +173,16 @@ type RisksAndNeedsSharedPageData = {
 type ReferralTaskListSection = {
   heading: string
   items: Array<ReferralTaskListItem>
+}
+
+type MojButtonMenu = {
+  button: MojButtonMenuButton
+  items: Array<GovukFrontendButton>
+}
+
+type MojButtonMenuButton = {
+  text: string
+  classes?: string | null
 }
 
 type MojFrontendNavigationItem = {
@@ -262,6 +274,8 @@ export type {
   GovukFrontendTagWithText,
   HasHtmlString,
   HasTextString,
+  MojButtonMenu,
+  MojButtonMenuButton,
   MojFrontendNavigationItem,
   MojTimelineItem,
   OffenceDetails,

--- a/server/controllers/assess/pniController.ts
+++ b/server/controllers/assess/pniController.ts
@@ -60,9 +60,15 @@ export default class PniController {
       }
 
       return res.render('referrals/show/pni/show', {
+        buttonMenu: ShowReferralUtils.buttonMenu(course, referral, {
+          currentPath: req.path,
+          recentCaseListPath: req.session.recentCaseListPath,
+        }),
         buttons: ShowReferralUtils.buttons(
           { currentPath: req.path, recentCaseListPath: req.session.recentCaseListPath },
           referral,
+          undefined,
+          course,
         ),
         pageHeading: `Referral to ${coursePresenter.displayName}`,
         pageSubHeading: 'Programme needs identifier',

--- a/server/controllers/shared/referralsController.test.ts
+++ b/server/controllers/shared/referralsController.test.ts
@@ -64,6 +64,13 @@ describe('ReferralsController', () => {
   const navigationItems = [{ active: true, href: 'nav-href', text: 'Nav Item' }]
   const subNavigationItems = [{ active: true, href: 'sub-nav-href', text: 'Sub Nav Item' }]
   const buttons = [{ href: 'button-href', text: 'Button' }]
+  const buttonMenu = {
+    button: {
+      classes: 'govuk-button--secondary',
+      text: 'Update referral',
+    },
+    items: [],
+  }
   const referrerEmail = 'referrer.email@test-email.co.uk'
   const recentCaseListPath = '/case-list-path'
   let person: Person
@@ -85,9 +92,11 @@ describe('ReferralsController', () => {
     mockShowReferralUtils.viewReferralNavigationItems.mockReturnValue(navigationItems)
     mockShowReferralUtils.subNavigationItems.mockReturnValue(subNavigationItems)
     mockShowReferralUtils.buttons.mockReturnValue(buttons)
+    mockShowReferralUtils.buttonMenu.mockReturnValue(buttonMenu)
 
     sharedPageData = {
       additionalInformation: referral.additionalInformation,
+      buttonMenu,
       buttons,
       course,
       courseOffering,
@@ -519,9 +528,14 @@ describe('ReferralsController', () => {
       { currentPath: path, recentCaseListPath },
       referral,
       isRefer ? statusTransitions : undefined,
+      course,
     )
     expect(mockShowReferralUtils.viewReferralNavigationItems).toHaveBeenCalledWith(path, referral.id)
     expect(mockShowReferralUtils.subNavigationItems).toHaveBeenCalledWith(path, 'referral', referral.id)
+    expect(mockShowReferralUtils.buttonMenu).toHaveBeenCalledWith(course, referral, {
+      currentPath: path,
+      recentCaseListPath,
+    })
 
     if (isRefer) {
       expect(referralService.getStatusTransitions).toHaveBeenCalledWith(username, referral.id)

--- a/server/controllers/shared/referralsController.ts
+++ b/server/controllers/shared/referralsController.ts
@@ -251,10 +251,15 @@ export default class ReferralsController {
 
     return {
       additionalInformation,
+      buttonMenu: ShowReferralUtils.buttonMenu(course, referral, {
+        currentPath: req.path,
+        recentCaseListPath: req.session.recentCaseListPath,
+      }),
       buttons: ShowReferralUtils.buttons(
         { currentPath: req.path, recentCaseListPath: req.session.recentCaseListPath },
         referral,
         statusTransitions,
+        course,
       ),
       course,
       courseOffering,

--- a/server/controllers/shared/risksAndNeedsController.test.ts
+++ b/server/controllers/shared/risksAndNeedsController.test.ts
@@ -103,6 +103,13 @@ describe('RisksAndNeedsController', () => {
   const navigationItems = [{ active: true, href: 'nav-href', text: 'Nav Item' }]
   const subNavigationItems = [{ active: true, href: 'sub-nav-href', text: 'Sub Nav Item' }]
   const buttons = [{ href: 'button-href', text: 'Button' }]
+  const buttonMenu = {
+    button: {
+      classes: 'govuk-button--secondary',
+      text: 'Update referral',
+    },
+    items: [],
+  }
   const recentCaseListPath = '/case-list-path'
   let person: Person
   let referral: Referral
@@ -118,8 +125,10 @@ describe('RisksAndNeedsController', () => {
     mockShowRisksAndNeedsUtils.navigationItems.mockReturnValue(navigationItems)
     mockShowReferralUtils.subNavigationItems.mockReturnValue(subNavigationItems)
     mockShowReferralUtils.buttons.mockReturnValue(buttons)
+    mockShowReferralUtils.buttonMenu.mockReturnValue(buttonMenu)
 
     sharedPageData = {
+      buttonMenu,
       buttons,
       hideTitleServiceName: true,
       navigationItems,
@@ -962,6 +971,7 @@ describe('RisksAndNeedsController', () => {
       { currentPath: path, recentCaseListPath },
       referral,
       isRefer ? statusTransitions : undefined,
+      course,
     )
     expect(mockShowReferralUtils.subNavigationItems).toHaveBeenCalledWith(path, 'risksAndNeeds', referral.id)
 

--- a/server/controllers/shared/risksAndNeedsController.ts
+++ b/server/controllers/shared/risksAndNeedsController.ts
@@ -413,10 +413,15 @@ export default class RisksAndNeedsController {
     const coursePresenter = CourseUtils.presentCourse(course)
 
     return {
+      buttonMenu: ShowReferralUtils.buttonMenu(course, referral, {
+        currentPath: req.path,
+        recentCaseListPath: req.session.recentCaseListPath,
+      }),
       buttons: ShowReferralUtils.buttons(
         { currentPath: req.path, recentCaseListPath: req.session.recentCaseListPath },
         referral,
         statusTransitions,
+        course,
       ),
       hideTitleServiceName: true,
       navigationItems: ShowRisksAndNeedsUtils.navigationItems(req.path, referral.id),

--- a/server/controllers/shared/statusHistoryController.test.ts
+++ b/server/controllers/shared/statusHistoryController.test.ts
@@ -40,6 +40,13 @@ describe('StatusHistoryController', () => {
   const courseOffering = courseOfferingFactory.build({ organisationId: organisation.id })
   const subNavigationItems = [{ active: true, href: 'sub-nav-href', text: 'Sub Nav Item' }]
   const buttons = [{ href: 'button-href', text: 'Button' }]
+  const buttonMenu = {
+    button: {
+      classes: 'govuk-button--secondary',
+      text: 'Update referral',
+    },
+    items: [],
+  }
   const timelineItems: Array<MojTimelineItem> = [
     {
       byline: { text: 'Test User' },
@@ -74,6 +81,7 @@ describe('StatusHistoryController', () => {
     mockShowReferralUtils.subNavigationItems.mockReturnValue(subNavigationItems)
     mockShowReferralUtils.statusHistoryTimelineItems.mockReturnValue(timelineItems)
     mockShowReferralUtils.buttons.mockReturnValue(buttons)
+    mockShowReferralUtils.buttonMenu.mockReturnValue(buttonMenu)
 
     when(referralService.getReferral).calledWith(username, referral.id, expect.any(Object)).mockResolvedValue(referral)
     when(referralService.getReferral).calledWith(username, originalReferral.id).mockResolvedValue(originalReferral)
@@ -109,6 +117,7 @@ describe('StatusHistoryController', () => {
       await requestHandler(request, response, next)
 
       expect(response.render).toHaveBeenCalledWith('referrals/show/statusHistory/show', {
+        buttonMenu,
         buttons,
         hideTitleServiceName: true,
         pageHeading: `Referral to ${coursePresenter.displayName}`,
@@ -134,6 +143,7 @@ describe('StatusHistoryController', () => {
         { currentPath: request.path, recentCaseListPath },
         referral,
         statusTransitions,
+        course,
       )
       expect(mockShowReferralUtils.statusHistoryTimelineItems).toHaveBeenCalledWith(
         referralStatusHistory,
@@ -194,6 +204,7 @@ describe('StatusHistoryController', () => {
           { currentPath: request.path, recentCaseListPath },
           referral,
           undefined,
+          course,
         )
       })
     })

--- a/server/controllers/shared/statusHistoryController.ts
+++ b/server/controllers/shared/statusHistoryController.ts
@@ -37,10 +37,15 @@ export default class StatusHistoryController {
       const coursePresenter = CourseUtils.presentCourse(course)
 
       return res.render('referrals/show/statusHistory/show', {
+        buttonMenu: ShowReferralUtils.buttonMenu(course, referral, {
+          currentPath: req.path,
+          recentCaseListPath: req.session.recentCaseListPath,
+        }),
         buttons: ShowReferralUtils.buttons(
           { currentPath: req.path, recentCaseListPath: req.session.recentCaseListPath },
           referral,
           statusTransitions,
+          course,
         ),
         hideTitleServiceName: true,
         pageHeading: `Referral to ${coursePresenter.displayName}`,

--- a/server/utils/referrals/showReferralUtils.test.ts
+++ b/server/utils/referrals/showReferralUtils.test.ts
@@ -18,53 +18,94 @@ const mockCaseListUtils = CaseListUtils as jest.Mocked<typeof CaseListUtils>
 
 describe('ShowReferralUtils', () => {
   const submittedReferral = referralFactory.submitted().build()
+  const onProgrammeReferral = referralFactory.build({ status: 'on_programme' })
+  const course = courseFactory.build({
+    alternateName: 'TC+',
+    audience: 'General offence',
+    name: 'Test Course',
+  })
+  const buildingChoicesCourse = courseFactory.build({
+    alternateName: 'BC',
+    audience: 'General offence',
+    name: 'Building Choices: High Intensity',
+  })
+
+  describe('Menu buttons', () => {
+    describe('when in the assess journey', () => {
+      describe('when the course is not building choices, the referral is not closed or on programme', () => {
+        it('shows the update and move to building choices buttons in the menu', () => {
+          expect(
+            ShowReferralUtils.buttonMenu(course, submittedReferral, {
+              currentPath: assessPaths.show.statusHistory({ referralId: submittedReferral.id }),
+            }),
+          ).toEqual({
+            button: {
+              classes: 'govuk-button--secondary',
+              text: 'Update referral',
+            },
+            items: [
+              {
+                attributes: {
+                  'aria-disabled': false,
+                },
+                classes: 'govuk-button--secondary',
+                href: assessPaths.updateStatus.decision.show({ referralId: submittedReferral.id }),
+                text: 'Update status',
+              },
+              {
+                classes: 'govuk-button--secondary',
+                href: assessPaths.transfer.show({ referralId: submittedReferral.id }),
+                text: 'Move to Building Choices',
+              },
+            ],
+          })
+        })
+        it('when the course is building choices, returns an empty menu', () => {
+          expect(
+            ShowReferralUtils.buttonMenu(buildingChoicesCourse, submittedReferral, {
+              currentPath: assessPaths.show.statusHistory({ referralId: submittedReferral.id }),
+            }),
+          ).toEqual({
+            button: {
+              classes: 'govuk-button--secondary',
+              text: 'Update referral',
+            },
+            items: [],
+          })
+        })
+        it('when the referral status is on programme, returns an empty menu', () => {
+          expect(
+            ShowReferralUtils.buttonMenu(course, onProgrammeReferral, {
+              currentPath: assessPaths.show.statusHistory({ referralId: submittedReferral.id }),
+            }),
+          ).toEqual({
+            button: {
+              classes: 'govuk-button--secondary',
+              text: 'Update referral',
+            },
+            items: [],
+          })
+        })
+      })
+    })
+  })
 
   describe('buttons', () => {
     describe('when on the assess journey', () => {
-      it('contains the "Back to referrals" and "Update status" buttons with the corect hrefs', () => {
+      it('contains the "Back to referrals" button with the correct hrefs', () => {
         expect(
           ShowReferralUtils.buttons(
             { currentPath: assessPaths.show.statusHistory({ referralId: submittedReferral.id }) },
             submittedReferral,
+            undefined,
+            course,
           ),
         ).toEqual([
           {
             href: '/assess/referrals/case-list',
             text: 'Back to referrals',
           },
-          {
-            attributes: {
-              'aria-disabled': false,
-            },
-            classes: 'govuk-button--secondary',
-            href: `/assess/referrals/${submittedReferral.id}/update-status/decision`,
-            text: 'Update status',
-          },
         ])
-      })
-
-      describe('and the referral is closed', () => {
-        it('disables the "Update status" button', () => {
-          const closedReferral = referralFactory.closed().build()
-
-          expect(
-            ShowReferralUtils.buttons(
-              { currentPath: assessPaths.show.statusHistory({ referralId: closedReferral.id }) },
-              closedReferral,
-            ),
-          ).toEqual(
-            expect.arrayContaining([
-              {
-                attributes: {
-                  'aria-disabled': true,
-                },
-                classes: 'govuk-button--secondary',
-                href: undefined,
-                text: 'Update status',
-              },
-            ]),
-          )
-        })
       })
 
       describe('and there is a `recentCaseListPath` value', () => {
@@ -78,6 +119,8 @@ describe('ShowReferralUtils', () => {
                 recentCaseListPath,
               },
               submittedReferral,
+              undefined,
+              course,
             ),
           ).toEqual(
             expect.arrayContaining([
@@ -97,6 +140,8 @@ describe('ShowReferralUtils', () => {
           ShowReferralUtils.buttons(
             { currentPath: referPaths.show.statusHistory({ referralId: submittedReferral.id }) },
             submittedReferral,
+            undefined,
+            course,
           ),
         ).toEqual([
           {
@@ -128,6 +173,8 @@ describe('ShowReferralUtils', () => {
             ShowReferralUtils.buttons(
               { currentPath: referPaths.show.statusHistory({ referralId: closedReferral.id }) },
               closedReferral,
+              undefined,
+              course,
             ),
           ).toEqual(
             expect.arrayContaining([
@@ -239,11 +286,6 @@ describe('ShowReferralUtils', () => {
 
   describe('courseOfferingSummaryListRows', () => {
     it('formats course offering information in the appropriate format for passing to a GOV.UK summary list Nunjucks macro', () => {
-      const course = courseFactory.build({
-        alternateName: 'TC+',
-        audience: 'General offence',
-        name: 'Test Course',
-      })
       const coursePresenter = CourseUtils.presentCourse(course)
       const organisation = organisationFactory.build({ name: 'HMP Hewell' })
       const contactEmail = 'bob.smith@test-email.co.uk'

--- a/server/views/referrals/show/partials/rootLayout.njk
+++ b/server/views/referrals/show/partials/rootLayout.njk
@@ -2,6 +2,7 @@
 {% from "govuk/components/button/macro.njk" import govukButton %}
 {% from "moj/components/side-navigation/macro.njk" import mojSideNavigation %}
 {% from "moj/components/sub-navigation/macro.njk" import mojSubNavigation %}
+{% from "moj/components/button-menu/macro.njk" import mojButtonMenu %}
 
 {% extends "../../../partials/layout.njk" %}
 
@@ -34,6 +35,9 @@
             text: button.text
           }) }}
         {% endfor %}
+        {% if buttonMenu.items | length %}
+          {{ mojButtonMenu(buttonMenu) }}
+        {% endif %}
       </div>
     {% endif %}
   </div>


### PR DESCRIPTION
## Changes in this PR

If a referral is open, not already a building choices referral and is open in the assess journey, we display a button menu with the option to start the transfer to building choices journey.

## Screenshots of UI changes

<img width="1247" alt="Screenshot 2025-03-20 at 15 30 08" src="https://github.com/user-attachments/assets/d02b1380-a504-4aee-8612-5aa6199ab332" />


## Release checklist

[Release process documentation](../blob/main/doc/how-to/perform-a-release.md)

As part of our continuous deployment strategy we must ensure that this work is
ready to be released once merged.

### Pre-merge

- [ ] There are changes required to the Accredited Programmes API for this change to work...
  - [ ] ... and they have been released to production already

### Post-merge

<!-- The outer checkboxes can be completed pre-merge -->

- [ ] This adds, extends or meaningfully modifies a feature...
  - [ ] ... and I have written or updated an end-to-end test for the happy path in the [Accredited Programmes E2E repo](https://github.com/ministryofjustice/hmpps-accredited-programmes-e2e)
- [ ] This makes new expectations of the API...
  - [ ] ... and I have notified the API developer(s) of changes to the contract tests (Pact), or the API is already compliant
- [ ] [Manually approve](../doc/how-to/perform-a-release.md#releasing-to-the-preprod-environment) release to preprod
- [ ] [Manually approve](../doc/how-to/perform-a-release.md#releasing-to-the-production-environment) release to prod

<!-- Should a release fail at any step, you as the author should now lead the work to
fix it as soon as possible. You can monitor deployment failures in CircleCI
itself and application errors are found in
[Sentry](https://ministryofjustice.sentry.io/projects/hmpps-accredited-programmes-ui/?project=4505330122686464&referrer=sidebar&statsPeriod=24h). -->
