### PR TITLE
(APG-707a) Update LDC Page

### DIFF
--- a/integration_tests/e2e/assess/updateLdc.cy.ts
+++ b/integration_tests/e2e/assess/updateLdc.cy.ts
@@ -1,0 +1,72 @@
+import { ApplicationRoles } from '../../../server/middleware/roleBasedAccessMiddleware'
+import { assessPaths } from '../../../server/paths'
+import { peopleSearchResponseFactory, personFactory, referralFactory } from '../../../server/testutils/factories'
+import UpdateLdcPage from '../../pages/assess/updateLdc'
+import Page from '../../pages/page'
+
+context('Updating a persons LDC status for a referral', () => {
+  const prisoner = peopleSearchResponseFactory.build({
+    firstName: 'Del',
+    lastName: 'Hatton',
+  })
+  const person = personFactory.build({
+    currentPrison: prisoner.prisonName,
+    name: `${prisoner.firstName} ${prisoner.lastName}`,
+    prisonNumber: prisoner.prisonerNumber,
+  })
+
+  beforeEach(() => {
+    cy.task('reset')
+    cy.task('stubSignIn', { authorities: [ApplicationRoles.ACP_PROGRAMME_TEAM] })
+    cy.task('stubAuthUser')
+    cy.signIn()
+
+    cy.task('stubPrisoner', prisoner)
+  })
+
+  describe('when referral.hasLdc is true', () => {
+    it('should show the correct content', () => {
+      const referralWithLdc = referralFactory.submitted().build({
+        hasLdc: true,
+        prisonNumber: person.prisonNumber,
+      })
+      const referralDetailsPath = assessPaths.show.personalDetails({ referralId: referralWithLdc.id })
+
+      cy.task('stubReferral', referralWithLdc)
+
+      cy.visit(assessPaths.updateLdc.show({ referralId: referralWithLdc.id }))
+
+      const updateLdcPage = Page.verifyOnPage(UpdateLdcPage, {
+        person,
+      })
+      updateLdcPage.shouldHavePersonDetails(person)
+      updateLdcPage.shouldContainBackLink(referralDetailsPath)
+      updateLdcPage.shouldContainHasLdcContent()
+      updateLdcPage.shouldContainButton('Submit')
+      updateLdcPage.shouldContainLink('Cancel', referralDetailsPath)
+    })
+  })
+
+  describe('when referral.hasLdc is false', () => {
+    it('should show the correct content', () => {
+      const referralWithoutLdc = referralFactory.submitted().build({
+        hasLdc: false,
+        prisonNumber: person.prisonNumber,
+      })
+      const referralDetailsPath = assessPaths.show.personalDetails({ referralId: referralWithoutLdc.id })
+
+      cy.task('stubReferral', referralWithoutLdc)
+
+      cy.visit(assessPaths.updateLdc.show({ referralId: referralWithoutLdc.id }))
+
+      const updateLdcPage = Page.verifyOnPage(UpdateLdcPage, {
+        person,
+      })
+      updateLdcPage.shouldHavePersonDetails(person)
+      updateLdcPage.shouldContainBackLink(referralDetailsPath)
+      updateLdcPage.shouldContainNoLdcContent()
+      updateLdcPage.shouldContainButton('Submit')
+      updateLdcPage.shouldContainLink('Cancel', referralDetailsPath)
+    })
+  })
+})

--- a/integration_tests/pages/assess/updateLdc.ts
+++ b/integration_tests/pages/assess/updateLdc.ts
@@ -1,0 +1,68 @@
+import { StringUtils } from '../../../server/utils'
+import Page from '../page'
+import type { Person } from '@accredited-programmes/models'
+
+export default class UpdateLdcPage extends Page {
+  person: Person
+
+  constructor(args: { person: Person }) {
+    const { person } = args
+
+    super('Update Learning disabilities and challenges (LDC)', {})
+
+    this.person = person
+  }
+
+  shouldContainHasLdcContent() {
+    this.shouldContainText(
+      `${StringUtils.makePossessive(this.person.name)} current LDC status: May need an LDC-adapted programme`,
+    )
+
+    cy.get('[data-testid="target-status-heading"]').should(
+      'contain.text',
+      'Update status: Does not need an LDC-adapted programme',
+    )
+
+    cy.get('[data-testid="ldc-reason-fieldset"] legend').should(
+      'contain.text',
+      `You must give a reason why ${this.person.name} does not need an LDC-adapted programme.`,
+    )
+
+    this.shouldContainCheckboxItems([
+      {
+        text: 'The Adaptive Functioning Checklist (AFCR) suggested that they are not suitable for LDC programmes.',
+        value: 'afcrSuggestion',
+      },
+      { text: 'Their learning screening tool scores have changed.', value: 'scoresChanged' },
+      { text: "The What works for me meeting found that they didn't need an LDC programme.", value: 'whatWorksForMe' },
+    ])
+  }
+
+  shouldContainNoLdcContent() {
+    this.shouldContainText(
+      `${StringUtils.makePossessive(this.person.name)} current LDC status: Does not need an LDC-adapted programme`,
+    )
+
+    cy.get('[data-testid="target-status-heading"]').should(
+      'contain.text',
+      'Update status: May need an LDC-adapted programme',
+    )
+
+    cy.get('[data-testid="ldc-reason-fieldset"] legend').should(
+      'contain.text',
+      `You must give a reason why ${this.person.name} may need an LDC-adapted programme.`,
+    )
+
+    this.shouldContainCheckboxItems([
+      {
+        text: 'The Adaptive Functioning Checklist (AFCR) suggested that they are suitable for LDC programmes.',
+        value: 'afcrSuggestion',
+      },
+      { text: 'Their learning screening tool scores have changed.', value: 'scoresChanged' },
+      {
+        text: 'The What works for me meeting found that they were suitable for LDC programmes.',
+        value: 'whatWorksForMe',
+      },
+    ])
+  }
+}

--- a/integration_tests/pages/page.ts
+++ b/integration_tests/pages/page.ts
@@ -27,6 +27,7 @@ import type {
 } from '@accredited-programmes/ui'
 import type { Course, CourseParticipation, Referral } from '@accredited-programmes-api'
 import type {
+  GovukFrontendCheckboxesItem,
   GovukFrontendRadiosItem,
   GovukFrontendSummaryListCardTitle,
   GovukFrontendWarningText,
@@ -129,6 +130,20 @@ export default abstract class Page {
     cy.get(`.govuk-checkboxes__label[for="${name}"]`).then(labelElement => {
       const { actual, expected } = Helpers.parseHtml(labelElement, label)
       expect(actual).to.equal(expected)
+    })
+  }
+
+  shouldContainCheckboxItems(options: Array<GovukFrontendCheckboxesItem>): void {
+    options.forEach((option, optionIndex) => {
+      cy.get('.govuk-checkboxes__item')
+        .eq(optionIndex)
+        .within(() => {
+          cy.get('.govuk-checkboxes__label').then(checkboxLabelElement => {
+            const { actual, expected } = Helpers.parseHtml(checkboxLabelElement, option.text as string)
+            expect(actual).to.equal(expected)
+          })
+          cy.get('.govuk-checkboxes__input').should('have.attr', 'value', option.value)
+        })
     })
   }
 

--- a/server/controllers/assess/index.ts
+++ b/server/controllers/assess/index.ts
@@ -4,6 +4,7 @@ import AssessCaseListController from './caseListController'
 import PniController from './pniController'
 import TransferReferralController from './transferReferralController'
 import TransferReferralErrorController from './transferReferralErrorController'
+import UpdateLdcController from './updateLdcController'
 import UpdateStatusDecisionController from './updateStatusDecisionController'
 import type { Services } from '../../services'
 
@@ -39,11 +40,14 @@ const controllers = (services: Services) => {
     services.personService,
   )
 
+  const updateLdcController = new UpdateLdcController(services.personService, services.referralService)
+
   return {
     assessCaseListController,
     pniController,
     transferReferralController,
     transferReferralErrorController,
+    updateLdcController,
     updateStatusDecisionController,
   }
 }

--- a/server/controllers/assess/updateLdcController.test.ts
+++ b/server/controllers/assess/updateLdcController.test.ts
@@ -1,0 +1,62 @@
+import type { DeepMocked } from '@golevelup/ts-jest'
+import { createMock } from '@golevelup/ts-jest'
+import type { NextFunction, Request, Response } from 'express'
+import { when } from 'jest-when'
+
+import UpdateLdcController from './updateLdcController'
+import { assessPaths } from '../../paths'
+import type { PersonService, ReferralService } from '../../services'
+import { personFactory, referralFactory } from '../../testutils/factories'
+import Helpers from '../../testutils/helpers'
+import type { Referral } from '@accredited-programmes-api'
+
+describe('UpdateLdcController', () => {
+  const username = 'USERNAME'
+
+  let request: DeepMocked<Request>
+  let response: DeepMocked<Response>
+  const next: DeepMocked<NextFunction> = createMock<NextFunction>({})
+
+  const personService = createMock<PersonService>({})
+  const referralService = createMock<ReferralService>({})
+
+  const person = personFactory.build()
+
+  let referral: Referral
+
+  let controller: UpdateLdcController
+
+  beforeEach(() => {
+    referral = referralFactory.submitted().build({ hasLdc: true, prisonNumber: person.prisonNumber })
+
+    controller = new UpdateLdcController(personService, referralService)
+
+    request = createMock<Request>({
+      params: { referralId: referral.id },
+      path: assessPaths.updateLdc.show({ referralId: referral.id }),
+      user: { username },
+    })
+    response = Helpers.createMockResponseWithCaseloads()
+  })
+
+  afterEach(() => {
+    jest.resetAllMocks()
+  })
+
+  describe('show', () => {
+    it('should render the show page with the correct response locals', async () => {
+      when(personService.getPerson).calledWith(username, referral.prisonNumber).mockResolvedValue(person)
+      when(referralService.getReferral).calledWith(username, referral.id).mockResolvedValue(referral)
+
+      const requestHandler = controller.show()
+      await requestHandler(request, response, next)
+
+      expect(response.render).toHaveBeenCalledWith('referrals/updateLdc/show', {
+        backLinkHref: assessPaths.show.personalDetails({ referralId: referral.id }),
+        hasLdc: true,
+        pageHeading: 'Update Learning disabilities and challenges (LDC)',
+        person,
+      })
+    })
+  })
+})

--- a/server/controllers/assess/updateLdcController.ts
+++ b/server/controllers/assess/updateLdcController.ts
@@ -1,0 +1,31 @@
+import type { Request, Response, TypedRequestHandler } from 'express'
+
+import { assessPaths } from '../../paths'
+import type { PersonService, ReferralService } from '../../services'
+import { TypeUtils } from '../../utils'
+
+export default class UpdateLdcController {
+  constructor(
+    private readonly personService: PersonService,
+    private readonly referralService: ReferralService,
+  ) {}
+
+  show(): TypedRequestHandler<Request, Response> {
+    return async (req: Request, res: Response) => {
+      TypeUtils.assertHasUser(req)
+
+      const { referralId } = req.params
+      const { username } = req.user
+
+      const referral = await this.referralService.getReferral(username, referralId)
+      const person = await this.personService.getPerson(username, referral.prisonNumber)
+
+      return res.render('referrals/updateLdc/show', {
+        backLinkHref: assessPaths.show.personalDetails({ referralId }),
+        hasLdc: referral.hasLdc,
+        pageHeading: 'Update Learning disabilities and challenges (LDC)',
+        person,
+      })
+    }
+  }
+}

--- a/server/paths/assess.ts
+++ b/server/paths/assess.ts
@@ -15,6 +15,7 @@ const updateStatusSelectReason = updateStatusPathBase.path('reason')
 const updateStatusSelectionShowPath = updateStatusPathBase.path('selection')
 
 const transferPathBase = referralShowPathBase.path('transfer')
+const updateLdcPath = referralShowPathBase.path('update-ldc')
 
 export default {
   caseList: {
@@ -54,6 +55,10 @@ export default {
     },
     show: transferPathBase,
     submit: transferPathBase,
+  },
+  updateLdc: {
+    show: updateLdcPath,
+    submit: updateLdcPath,
   },
   updateStatus: {
     category: {

--- a/server/routes/assess.ts
+++ b/server/routes/assess.ts
@@ -19,6 +19,7 @@ export default function routes(controllers: Controllers, router: Router): Router
     statusHistoryController,
     transferReferralController,
     transferReferralErrorController,
+    updateLdcController,
     updateStatusActionController,
     updateStatusDecisionController,
     updateStatusSelectionController,
@@ -73,6 +74,8 @@ export default function routes(controllers: Controllers, router: Router): Router
   post(assessPaths.transfer.submit.pattern, transferReferralController.submit())
 
   get(assessPaths.transfer.error.show.pattern, transferReferralErrorController.show())
+
+  get(assessPaths.updateLdc.show.pattern, updateLdcController.show())
 
   return router
 }

--- a/server/utils/nunjucksSetup.ts
+++ b/server/utils/nunjucksSetup.ts
@@ -56,6 +56,7 @@ export default function nunjucksSetup(app: express.Express, path: pathModule.Pla
 
   njkEnv.addFilter('initialiseName', StringUtils.initialiseName)
   njkEnv.addFilter('objectMerge', NunjucksUtils.objectMerge)
+  njkEnv.addFilter('makePossessive', StringUtils.makePossessive)
 
   njkEnv.addGlobal('findPaths', findPaths)
   njkEnv.addGlobal('referPaths', referPaths)

--- a/server/utils/stringUtils.test.ts
+++ b/server/utils/stringUtils.test.ts
@@ -44,6 +44,15 @@ describe('StringUtils', () => {
     })
   })
 
+  describe('makePossessive', () => {
+    it.each([
+      ['a word ending in s', 'James', "James'"],
+      ['a word not ending in s', 'Jameson', "Jameson's"],
+    ])('handles %s: %s -> %s', (_inputType: string, input: string, expectedOutput: string) => {
+      expect(StringUtils.makePossessive(input)).toEqual(expectedOutput)
+    })
+  })
+
   describe('pluralise', () => {
     it.each([
       ['one item', 'item', 1, 'item'],

--- a/server/utils/stringUtils.ts
+++ b/server/utils/stringUtils.ts
@@ -20,6 +20,10 @@ export default class StringUtils {
       .join('')
   }
 
+  static makePossessive(word: string): string {
+    return word.endsWith('s') ? `${word}'` : `${word}'s`
+  }
+
   static pluralise(word: string, count: number): string {
     return count === 1 ? word : `${word}s`
   }

--- a/server/views/referrals/updateLdc/show.njk
+++ b/server/views/referrals/updateLdc/show.njk
@@ -1,0 +1,73 @@
+{% from "govuk/components/button/macro.njk" import govukButton %}
+{% from "govuk/components/checkboxes/macro.njk" import govukCheckboxes %}
+
+{% extends "../show/partials/rootLayout.njk" %}
+
+{% block backLink %}
+  {{ govukBackLink({
+    text: "Back",
+    href: backLinkHref
+  }) }}
+{% endblock backLink %}
+
+{% block content %}
+  <div class="govuk-grid-row">
+    <div class="govuk-grid-column-two-thirds">
+
+      <h1 class="govuk-heading-l">{{ pageHeading }}</h1>
+
+      <p class="govuk-body">
+        {{ person.name | makePossessive }} current LDC status: 
+        <strong class="govuk-!-display-block govuk-!-margin-top-3">{{ 'May' if hasLdc else 'Does not' }} need an LDC-adapted programme</strong>
+      </p>
+
+      <hr class="govuk-section-break govuk-section-break--l govuk-section-break--visible">
+
+      <h2 class="govuk-heading-m" data-testid="target-status-heading">
+        Update status: {{ 'Does not' if hasLdc else 'May' }} need an LDC-adapted programme
+      </h2>
+
+      <form method="post">
+        <input type="hidden" name="_csrf" value="{{ csrfToken }}"/>
+
+        {{ govukCheckboxes({
+        name: "ldcReason",
+        fieldset: {
+          attributes: {
+            "data-testid": "ldc-reason-fieldset"
+          },
+          legend: {
+            classes: "govuk-!-margin-bottom-6",
+            text: ["You must give a reason why", person.name, "does not" if hasLdc else "may", "need an LDC-adapted programme."] | join(" ")
+          }
+        },
+        hint: {
+          text: "Select all that apply"
+        },
+        items: [
+          {
+            value: "afcrSuggestion",
+            text: ["The Adaptive Functioning Checklist (AFCR) suggested that they are", "not" if hasLdc, "suitable for LDC programmes."] | join(" ")
+          },
+          {
+            value: "scoresChanged",
+            text: "Their learning screening tool scores have changed."
+          },
+          {
+            value: "whatWorksForMe",
+            text: ["The What works for me meeting found that they", "didn't need an LDC programme." if hasLdc else "were suitable for LDC programmes." ] | join(" ")
+          }
+        ]
+      }) }}
+
+        <div class="govuk-button-group">
+          {{ govukButton({
+            text: "Submit"
+          }) }}
+
+          <a class="govuk-link" href="{{ backLinkHref }}">Cancel</a>
+        </div>
+      </form>
+    </div>
+  </div>
+{% endblock content %}


### PR DESCRIPTION
## Context

We need to be able to change the LDC (Learning disabilities and challenges) status for a person, on a referral.


## Changes in this PR
Add new `UpdateLdcController` with `show` method to display correct content and checkbox options

## Screenshots of UI changes

`hasLdc: false`
<img width="975" alt="image" src="https://github.com/user-attachments/assets/e3decb8c-a8c8-41e2-8e52-6e73de7fa444" />

`hasLdc: true`
<img width="657" alt="image" src="https://github.com/user-attachments/assets/39a9318c-3e0f-490e-9048-d45681c81f79" />



## Release checklist

[Release process documentation](../blob/main/doc/how-to/perform-a-release.md)

As part of our continuous deployment strategy we must ensure that this work is
ready to be released once merged.

### Pre-merge

- [ ] There are changes required to the Accredited Programmes API for this change to work...
  - [ ] ... and they have been released to production already

### Post-merge

<!-- The outer checkboxes can be completed pre-merge -->

- [ ] This adds, extends or meaningfully modifies a feature...
  - [ ] ... and I have written or updated an end-to-end test for the happy path in the [Accredited Programmes E2E repo](https://github.com/ministryofjustice/hmpps-accredited-programmes-e2e)
- [ ] This makes new expectations of the API...
  - [ ] ... and I have notified the API developer(s) of changes to the contract tests (Pact), or the API is already compliant
- [ ] [Manually approve](../doc/how-to/perform-a-release.md#releasing-to-the-preprod-environment) release to preprod
- [ ] [Manually approve](../doc/how-to/perform-a-release.md#releasing-to-the-production-environment) release to prod

<!-- Should a release fail at any step, you as the author should now lead the work to
fix it as soon as possible. You can monitor deployment failures in CircleCI
itself and application errors are found in
[Sentry](https://ministryofjustice.sentry.io/projects/hmpps-accredited-programmes-ui/?project=4505330122686464&referrer=sidebar&statsPeriod=24h). -->
