### PR TITLE
APG-679 Add disclaimer on data time period to reports page

### DIFF
--- a/server/controllers/reportsController.test.ts
+++ b/server/controllers/reportsController.test.ts
@@ -48,6 +48,8 @@ describe('ReportsController', () => {
     value: '123',
   }
 
+  const dataDisclaimer = 'Data collected through the Accredited Programmes service on DPS, which launched in May 2024.'
+
   let controller: ReportsController
 
   beforeEach(() => {
@@ -125,6 +127,7 @@ describe('ReportsController', () => {
       )
 
       expect(response.render).toHaveBeenCalledWith('reports/show', {
+        dataDisclaimer,
         errorMessages,
         filterFormAction: '/reports',
         filterValues: {},
@@ -160,6 +163,7 @@ describe('ReportsController', () => {
         expect(StatisticsReportUtils.reportContentDataBlock).toHaveBeenCalledWith(reportContent)
 
         expect(response.render).toHaveBeenCalledWith('reports/show', {
+          dataDisclaimer,
           errorMessages,
           filterFormAction: '/reports',
           filterValues: { location: 'MDI', period: 'lastSixMonths' },

--- a/server/controllers/reportsController.ts
+++ b/server/controllers/reportsController.ts
@@ -76,7 +76,11 @@ export default class ReportsController {
         .filter(Boolean)
         .join(' ')
 
+      const dataDisclaimer =
+        'Data collected through the Accredited Programmes service on DPS, which launched in May 2024.'
+
       res.render('reports/show', {
+        dataDisclaimer,
         errorMessages,
         filterFormAction: reportsPaths.filter({}),
         filterValues: { dateFrom, dateTo, location, period: periodQuery, region },

--- a/server/views/reports/show.njk
+++ b/server/views/reports/show.njk
@@ -70,6 +70,7 @@
 
 {% block content %}
   <h1 class="govuk-heading-l govuk-!-margin-bottom-1">{{ pageHeading }}</h1>
+  <p class="govuk-body govuk-!-font-size-12 govuk-!-margin-bottom-8">{{ dataDisclaimer }}</p>
   <p class="govuk-body govuk-!-font-size-24 govuk-!-margin-bottom-8">{{ subHeading }}</p>
 
   <div class="govuk-grid-row">


### PR DESCRIPTION
## Context

Adds a disclaimer to the reporting page to inform users of the period our data for referrals covers


## Screenshots of UI changes

<img width="1247" alt="Screenshot 2025-03-21 at 15 20 11" src="https://github.com/user-attachments/assets/b5fbe745-8730-4588-9843-2a1555726c1c" />

## Release checklist

[Release process documentation](../blob/main/doc/how-to/perform-a-release.md)

As part of our continuous deployment strategy we must ensure that this work is
ready to be released once merged.

### Pre-merge

- [ ] There are changes required to the Accredited Programmes API for this change to work...
  - [ ] ... and they have been released to production already

### Post-merge

<!-- The outer checkboxes can be completed pre-merge -->

- [ ] This adds, extends or meaningfully modifies a feature...
  - [ ] ... and I have written or updated an end-to-end test for the happy path in the [Accredited Programmes E2E repo](https://github.com/ministryofjustice/hmpps-accredited-programmes-e2e)
- [ ] This makes new expectations of the API...
  - [ ] ... and I have notified the API developer(s) of changes to the contract tests (Pact), or the API is already compliant
- [ ] [Manually approve](../doc/how-to/perform-a-release.md#releasing-to-the-preprod-environment) release to preprod
- [ ] [Manually approve](../doc/how-to/perform-a-release.md#releasing-to-the-production-environment) release to prod

<!-- Should a release fail at any step, you as the author should now lead the work to
fix it as soon as possible. You can monitor deployment failures in CircleCI
itself and application errors are found in
[Sentry](https://ministryofjustice.sentry.io/projects/hmpps-accredited-programmes-ui/?project=4505330122686464&referrer=sidebar&statsPeriod=24h). -->
