### PR TITLE
(APG-707b) Use imported `ReferralUpdate` interface/type

### DIFF
--- a/server/@types/models/Referral.ts
+++ b/server/@types/models/Referral.ts
@@ -33,12 +33,6 @@ interface ConfirmationFields {
   warningText: string
 }
 
-type ReferralUpdate = {
-  hasReviewedProgrammeHistory: Referral['hasReviewedProgrammeHistory']
-  oasysConfirmed: Referral['oasysConfirmed']
-  additionalInformation?: Referral['additionalInformation']
-}
-
 type ReferralStatus = (typeof referralStatuses)[number]
 
 type ReferralStatusUppercase = Uppercase<ReferralStatus>
@@ -119,6 +113,5 @@ export type {
   ReferralStatusRefData,
   ReferralStatusUpdate,
   ReferralStatusUppercase,
-  ReferralUpdate,
   ReferralView,
 }

--- a/server/@types/models/index.d.ts
+++ b/server/@types/models/index.d.ts
@@ -18,7 +18,6 @@ import type {
   ReferralStatusRefData,
   ReferralStatusUpdate,
   ReferralStatusUppercase,
-  ReferralUpdate,
   ReferralView,
 } from './Referral'
 import type { Alert, RiskLevel, RisksAndAlerts } from './RisksAndAlerts'
@@ -46,7 +45,6 @@ export type {
   ReferralStatusRefData,
   ReferralStatusUpdate,
   ReferralStatusUppercase,
-  ReferralUpdate,
   ReferralView,
   RiskLevel,
   RisksAndAlerts,

--- a/server/controllers/refer/new/additionalInformationController.ts
+++ b/server/controllers/refer/new/additionalInformationController.ts
@@ -3,7 +3,7 @@ import type { Request, Response, TypedRequestHandler } from 'express'
 import { authPaths, referPaths } from '../../../paths'
 import type { PersonService, ReferralService } from '../../../services'
 import { FormUtils, TypeUtils } from '../../../utils'
-import type { ReferralUpdate } from '@accredited-programmes/models'
+import type { ReferralUpdate } from '@accredited-programmes-api'
 
 const maxLength = 4000
 

--- a/server/controllers/refer/new/courseParticipationsController.ts
+++ b/server/controllers/refer/new/courseParticipationsController.ts
@@ -3,8 +3,7 @@ import type { Request, Response, TypedRequestHandler } from 'express'
 import { referPaths } from '../../../paths'
 import type { CourseService, PersonService, ReferralService } from '../../../services'
 import { CourseParticipationUtils, CourseUtils, FormUtils, TypeUtils } from '../../../utils'
-import type { ReferralUpdate } from '@accredited-programmes/models'
-import type { CourseParticipation } from '@accredited-programmes-api'
+import type { CourseParticipation, ReferralUpdate } from '@accredited-programmes-api'
 
 export default class NewReferralsCourseParticipationsController {
   constructor(

--- a/server/controllers/refer/new/oasysConfirmationController.ts
+++ b/server/controllers/refer/new/oasysConfirmationController.ts
@@ -3,7 +3,7 @@ import type { Request, Response, TypedRequestHandler } from 'express'
 import { authPaths, referPaths } from '../../../paths'
 import type { OasysService, PersonService, ReferralService } from '../../../services'
 import { DateUtils, FormUtils, TypeUtils } from '../../../utils'
-import type { ReferralUpdate } from '@accredited-programmes/models'
+import type { ReferralUpdate } from '@accredited-programmes-api'
 
 export default class NewReferralsOasysConfirmationController {
   constructor(

--- a/server/data/accreditedProgrammesApi/referralClient.test.ts
+++ b/server/data/accreditedProgrammesApi/referralClient.test.ts
@@ -7,8 +7,8 @@ import config from '../../config'
 import { apiPaths } from '../../paths'
 import { referralFactory, referralViewFactory } from '../../testutils/factories'
 import FactoryHelpers from '../../testutils/factories/factoryHelpers'
-import type { Paginated, ReferralUpdate, ReferralView } from '@accredited-programmes/models'
-import type { Referral } from '@accredited-programmes-api'
+import type { Paginated, ReferralView } from '@accredited-programmes/models'
+import type { Referral, ReferralUpdate } from '@accredited-programmes-api'
 
 pactWith({ consumer: 'Accredited Programmes UI', provider: 'Accredited Programmes API' }, provider => {
   let referralClient: ReferralClient

--- a/server/data/accreditedProgrammesApi/referralClient.ts
+++ b/server/data/accreditedProgrammesApi/referralClient.ts
@@ -11,10 +11,14 @@ import type {
   ReferralStatusRefData,
   ReferralStatusUpdate,
   ReferralStatusUppercase,
-  ReferralUpdate,
   ReferralView,
 } from '@accredited-programmes/models'
-import type { Referral, ReferralStatusHistory, TransferReferralRequest } from '@accredited-programmes-api'
+import type {
+  Referral,
+  ReferralStatusHistory,
+  ReferralUpdate,
+  TransferReferralRequest,
+} from '@accredited-programmes-api'
 import type { SystemToken } from '@hmpps-auth'
 
 export default class ReferralClient {
@@ -168,7 +172,7 @@ export default class ReferralClient {
 
   async update(referralId: Referral['id'], referralUpdate: ReferralUpdate): Promise<void> {
     await this.restClient.put({
-      data: referralUpdate,
+      data: { ...referralUpdate },
       path: apiPaths.referrals.update({ referralId }),
     })
   }

--- a/server/services/referralService.test.ts
+++ b/server/services/referralService.test.ts
@@ -13,8 +13,8 @@ import {
   referralStatusRefDataFactory,
   referralViewFactory,
 } from '../testutils/factories'
-import type { ReferralStatusGroup, ReferralStatusUpdate, ReferralUpdate } from '@accredited-programmes/models'
-import type { TransferReferralRequest } from '@accredited-programmes-api'
+import type { ReferralStatusGroup, ReferralStatusUpdate } from '@accredited-programmes/models'
+import type { ReferralUpdate, TransferReferralRequest } from '@accredited-programmes-api'
 
 jest.mock('../data/accreditedProgrammesApi/referralClient')
 jest.mock('../data/hmppsAuthClient')

--- a/server/services/referralService.ts
+++ b/server/services/referralService.ts
@@ -9,11 +9,10 @@ import type {
   ReferralStatusRefData,
   ReferralStatusUpdate,
   ReferralStatusUppercase,
-  ReferralUpdate,
   ReferralView,
 } from '@accredited-programmes/models'
 import type { ReferralStatusHistoryPresenter } from '@accredited-programmes/ui'
-import type { Referral, TransferReferralRequest } from '@accredited-programmes-api'
+import type { Referral, ReferralUpdate, TransferReferralRequest } from '@accredited-programmes-api'
 import type { User } from '@manage-users-api'
 
 export default class ReferralService {


### PR DESCRIPTION
## Context

In preparation for updating a referral with the new `hasLdcBeenOverriddenByProgrammeTeam` property it became clear we need to use the imported interface, rather than our hardcoded type.

## Changes in this PR

- Use imported `ReferralUpdate` interface
- Remove hardcoded `ReferralUpdate` type




## Release checklist

[Release process documentation](../blob/main/doc/how-to/perform-a-release.md)

As part of our continuous deployment strategy we must ensure that this work is
ready to be released once merged.

### Pre-merge

- [ ] There are changes required to the Accredited Programmes API for this change to work...
  - [ ] ... and they have been released to production already

### Post-merge

<!-- The outer checkboxes can be completed pre-merge -->

- [ ] This adds, extends or meaningfully modifies a feature...
  - [ ] ... and I have written or updated an end-to-end test for the happy path in the [Accredited Programmes E2E repo](https://github.com/ministryofjustice/hmpps-accredited-programmes-e2e)
- [ ] This makes new expectations of the API...
  - [ ] ... and I have notified the API developer(s) of changes to the contract tests (Pact), or the API is already compliant
- [ ] [Manually approve](../doc/how-to/perform-a-release.md#releasing-to-the-preprod-environment) release to preprod
- [ ] [Manually approve](../doc/how-to/perform-a-release.md#releasing-to-the-production-environment) release to prod

<!-- Should a release fail at any step, you as the author should now lead the work to
fix it as soon as possible. You can monitor deployment failures in CircleCI
itself and application errors are found in
[Sentry](https://ministryofjustice.sentry.io/projects/hmpps-accredited-programmes-ui/?project=4505330122686464&referrer=sidebar&statsPeriod=24h). -->
