### PR TITLE
(APG-707c) Submit LDC Update

### DIFF
--- a/server/controllers/assess/updateLdcController.test.ts
+++ b/server/controllers/assess/updateLdcController.test.ts
@@ -8,7 +8,10 @@ import { assessPaths } from '../../paths'
 import type { PersonService, ReferralService } from '../../services'
 import { personFactory, referralFactory } from '../../testutils/factories'
 import Helpers from '../../testutils/helpers'
+import { FormUtils } from '../../utils'
 import type { Referral } from '@accredited-programmes-api'
+
+jest.mock('../../utils/formUtils')
 
 describe('UpdateLdcController', () => {
   const username = 'USERNAME'
@@ -51,11 +54,43 @@ describe('UpdateLdcController', () => {
       const requestHandler = controller.show()
       await requestHandler(request, response, next)
 
+      expect(FormUtils.setFieldErrors).toHaveBeenCalledWith(request, response, ['ldcReason'])
       expect(response.render).toHaveBeenCalledWith('referrals/updateLdc/show', {
         backLinkHref: assessPaths.show.personalDetails({ referralId: referral.id }),
         hasLdc: true,
         pageHeading: 'Update Learning disabilities and challenges (LDC)',
         person,
+      })
+    })
+  })
+
+  describe('submit', () => {
+    it('should update the referral with hasLdcBeenOverriddenByProgrammeTeam and redirect to the personal details page', async () => {
+      request.body.ldcReason = ['afcrSuggestion', 'scoresChanged']
+
+      when(referralService.getReferral).calledWith(username, referral.id).mockResolvedValue(referral)
+
+      const requestHandler = controller.submit()
+      await requestHandler(request, response, next)
+
+      expect(referralService.updateReferral).toHaveBeenCalledWith(username, referral.id, {
+        ...referral,
+        hasLdcBeenOverriddenByProgrammeTeam: true,
+      })
+
+      expect(response.redirect).toHaveBeenCalledWith(assessPaths.show.personalDetails({ referralId: referral.id }))
+    })
+
+    describe('when the ldcReason is not provided', () => {
+      it('should set a flash error message and redirect back to the show page', async () => {
+        const requestHandler = controller.submit()
+        await requestHandler(request, response, next)
+
+        expect(request.flash).toHaveBeenCalledWith(
+          'ldcReasonError',
+          'Select a reason for updating the learning disabilities and challenges status',
+        )
+        expect(response.redirect).toHaveBeenCalledWith(assessPaths.updateLdc.show({ referralId: referral.id }))
       })
     })
   })

--- a/server/controllers/assess/updateLdcController.ts
+++ b/server/controllers/assess/updateLdcController.ts
@@ -2,7 +2,7 @@ import type { Request, Response, TypedRequestHandler } from 'express'
 
 import { assessPaths } from '../../paths'
 import type { PersonService, ReferralService } from '../../services'
-import { TypeUtils } from '../../utils'
+import { FormUtils, TypeUtils } from '../../utils'
 
 export default class UpdateLdcController {
   constructor(
@@ -20,12 +20,37 @@ export default class UpdateLdcController {
       const referral = await this.referralService.getReferral(username, referralId)
       const person = await this.personService.getPerson(username, referral.prisonNumber)
 
+      FormUtils.setFieldErrors(req, res, ['ldcReason'])
+
       return res.render('referrals/updateLdc/show', {
         backLinkHref: assessPaths.show.personalDetails({ referralId }),
         hasLdc: referral.hasLdc,
         pageHeading: 'Update Learning disabilities and challenges (LDC)',
         person,
       })
+    }
+  }
+
+  submit(): TypedRequestHandler<Request, Response> {
+    return async (req: Request, res: Response) => {
+      TypeUtils.assertHasUser(req)
+
+      const { referralId } = req.params
+      const { username } = req.user
+
+      if (!req.body.ldcReason) {
+        req.flash('ldcReasonError', 'Select a reason for updating the learning disabilities and challenges status')
+        return res.redirect(assessPaths.updateLdc.show({ referralId }))
+      }
+
+      const referral = await this.referralService.getReferral(username, referralId)
+
+      await this.referralService.updateReferral(username, referralId, {
+        ...referral,
+        hasLdcBeenOverriddenByProgrammeTeam: true,
+      })
+
+      return res.redirect(assessPaths.show.personalDetails({ referralId }))
     }
   }
 }

--- a/server/routes/assess.ts
+++ b/server/routes/assess.ts
@@ -76,6 +76,7 @@ export default function routes(controllers: Controllers, router: Router): Router
   get(assessPaths.transfer.error.show.pattern, transferReferralErrorController.show())
 
   get(assessPaths.updateLdc.show.pattern, updateLdcController.show())
+  post(assessPaths.updateLdc.submit.pattern, updateLdcController.submit())
 
   return router
 }

--- a/server/views/referrals/updateLdc/show.njk
+++ b/server/views/referrals/updateLdc/show.njk
@@ -1,5 +1,6 @@
 {% from "govuk/components/button/macro.njk" import govukButton %}
 {% from "govuk/components/checkboxes/macro.njk" import govukCheckboxes %}
+{% from "govuk/components/error-summary/macro.njk" import govukErrorSummary %}
 
 {% extends "../show/partials/rootLayout.njk" %}
 
@@ -13,6 +14,12 @@
 {% block content %}
   <div class="govuk-grid-row">
     <div class="govuk-grid-column-two-thirds">
+      {% if errors.list.length %}
+        {{ govukErrorSummary({
+          titleText: "There is a problem",
+          errorList: errors.list
+        }) }}
+      {% endif %}
 
       <h1 class="govuk-heading-l">{{ pageHeading }}</h1>
 
@@ -31,34 +38,35 @@
         <input type="hidden" name="_csrf" value="{{ csrfToken }}"/>
 
         {{ govukCheckboxes({
-        name: "ldcReason",
-        fieldset: {
-          attributes: {
-            "data-testid": "ldc-reason-fieldset"
+          name: "ldcReason",
+          errorMessage: errors.messages.ldcReason,
+          fieldset: {
+            attributes: {
+              "data-testid": "ldc-reason-fieldset"
+            },
+            legend: {
+              classes: "govuk-!-margin-bottom-6",
+              text: ["You must give a reason why", person.name, "does not" if hasLdc else "may", "need an LDC-adapted programme."] | join(" ")
+            }
           },
-          legend: {
-            classes: "govuk-!-margin-bottom-6",
-            text: ["You must give a reason why", person.name, "does not" if hasLdc else "may", "need an LDC-adapted programme."] | join(" ")
-          }
-        },
-        hint: {
-          text: "Select all that apply"
-        },
-        items: [
-          {
-            value: "afcrSuggestion",
-            text: ["The Adaptive Functioning Checklist (AFCR) suggested that they are", "not" if hasLdc, "suitable for LDC programmes."] | join(" ")
+          hint: {
+            text: "Select all that apply"
           },
-          {
-            value: "scoresChanged",
-            text: "Their learning screening tool scores have changed."
-          },
-          {
-            value: "whatWorksForMe",
-            text: ["The What works for me meeting found that they", "didn't need an LDC programme." if hasLdc else "were suitable for LDC programmes." ] | join(" ")
-          }
-        ]
-      }) }}
+          items: [
+            {
+              value: "afcrSuggestion",
+              text: ["The Adaptive Functioning Checklist (AFCR) suggested that they are", "not" if hasLdc, "suitable for LDC programmes."] | join(" ")
+            },
+            {
+              value: "scoresChanged",
+              text: "Their learning screening tool scores have changed."
+            },
+            {
+              value: "whatWorksForMe",
+              text: ["The What works for me meeting found that they", "didn't need an LDC programme." if hasLdc else "were suitable for LDC programmes." ] | join(" ")
+            }
+          ]
+        }) }}
 
         <div class="govuk-button-group">
           {{ govukButton({


### PR DESCRIPTION
## Context

Follows on from #920 

We need to be able to submit the decision to update the LDC status.



## Changes in this PR
- Add `submit` method to update referral with `hasLdcBeenOverriddenByProgrammeTeam: true`. 
  - Checkbox selections are irrelevant.  Purely a method of friction at the moment.


## Screenshots of UI changes

![image](https://github.com/user-attachments/assets/2c1d5f21-7530-4b55-9574-0eec24585a34)


## Release checklist

[Release process documentation](../blob/main/doc/how-to/perform-a-release.md)

As part of our continuous deployment strategy we must ensure that this work is
ready to be released once merged.

### Pre-merge

- [ ] There are changes required to the Accredited Programmes API for this change to work...
  - [ ] ... and they have been released to production already

### Post-merge

<!-- The outer checkboxes can be completed pre-merge -->

- [ ] This adds, extends or meaningfully modifies a feature...
  - [ ] ... and I have written or updated an end-to-end test for the happy path in the [Accredited Programmes E2E repo](https://github.com/ministryofjustice/hmpps-accredited-programmes-e2e)
- [ ] This makes new expectations of the API...
  - [ ] ... and I have notified the API developer(s) of changes to the contract tests (Pact), or the API is already compliant
- [ ] [Manually approve](../doc/how-to/perform-a-release.md#releasing-to-the-preprod-environment) release to preprod
- [ ] [Manually approve](../doc/how-to/perform-a-release.md#releasing-to-the-production-environment) release to prod

<!-- Should a release fail at any step, you as the author should now lead the work to
fix it as soon as possible. You can monitor deployment failures in CircleCI
itself and application errors are found in
[Sentry](https://ministryofjustice.sentry.io/projects/hmpps-accredited-programmes-ui/?project=4505330122686464&referrer=sidebar&statsPeriod=24h). -->
