### PR TITLE
(APG-708) Show success banner after LDC status update

### DIFF
--- a/integration_tests/e2e/assess/updateLdc.cy.ts
+++ b/integration_tests/e2e/assess/updateLdc.cy.ts
@@ -1,6 +1,12 @@
 import { ApplicationRoles } from '../../../server/middleware/roleBasedAccessMiddleware'
 import { assessPaths } from '../../../server/paths'
-import { peopleSearchResponseFactory, personFactory, referralFactory } from '../../../server/testutils/factories'
+import {
+  courseFactory,
+  courseOfferingFactory,
+  peopleSearchResponseFactory,
+  personFactory,
+  referralFactory,
+} from '../../../server/testutils/factories'
 import UpdateLdcPage from '../../pages/assess/updateLdc'
 import Page from '../../pages/page'
 
@@ -38,6 +44,10 @@ context('Updating a persons LDC status for a referral', () => {
     })
 
     it('should show the correct content and allow the form to be submitted', () => {
+      const course = courseFactory.build({
+        courseOfferings: [courseOfferingFactory.build({ id: referralWithLdc.offeringId })],
+      })
+
       const updateLdcPage = Page.verifyOnPage(UpdateLdcPage, {
         person,
       })
@@ -47,10 +57,14 @@ context('Updating a persons LDC status for a referral', () => {
       updateLdcPage.shouldContainLink('Cancel', referralDetailsPath)
 
       updateLdcPage.selectCheckbox('ldcReason')
+      cy.task('stubCourseByOffering', { course, courseOfferingId: referralWithLdc.offeringId })
       cy.task('stubUpdateReferral', referralWithLdc.id)
       updateLdcPage.shouldContainButton('Submit').click()
 
-      cy.location('pathname').should('equal', assessPaths.show.personalDetails({ referralId: referralWithLdc.id }))
+      cy.location('pathname').should(
+        'equal',
+        assessPaths.caseList.show({ courseId: course.id, referralStatusGroup: 'open' }),
+      )
     })
 
     describe('when submitting without selecting a reason', () => {

--- a/integration_tests/pages/assess/updateLdc.ts
+++ b/integration_tests/pages/assess/updateLdc.ts
@@ -1,16 +1,21 @@
+import { courseFactory, courseOfferingFactory, referralViewFactory } from '../../../server/testutils/factories'
 import { StringUtils } from '../../../server/utils'
 import Page from '../page'
 import type { Person } from '@accredited-programmes/models'
+import type { Referral } from '@accredited-programmes-api'
 
 export default class UpdateLdcPage extends Page {
   person: Person
 
-  constructor(args: { person: Person }) {
-    const { person } = args
+  referral: Referral
+
+  constructor(args: { person: Person; referral: Referral }) {
+    const { person, referral } = args
 
     super('Update Learning disabilities and challenges (LDC)', {})
 
     this.person = person
+    this.referral = referral
   }
 
   shouldContainHasLdcContent() {
@@ -64,5 +69,46 @@ export default class UpdateLdcPage extends Page {
         value: 'whatWorksForMe',
       },
     ])
+  }
+
+  shouldUpdateLdcSuccessfully() {
+    const course = courseFactory.build({
+      courseOfferings: [courseOfferingFactory.build({ id: this.referral.offeringId })],
+    })
+    const courseReferralViews = [referralViewFactory.build({ id: this.referral.id, status: this.referral.status })]
+
+    // Stubs for submitting LDC update
+    cy.task('stubCourseByOffering', { course, courseOfferingId: this.referral.offeringId })
+    cy.task('stubUpdateReferral', this.referral.id)
+
+    // Stubs for loading Case List page
+    cy.task('stubCoursesForOrganisation', { courses: [course], organisationId: 'MRI' })
+    cy.task('stubCourseAudiences', { audiences: [], courseId: course.id })
+    cy.task('stubReferralStatuses', [])
+    cy.task('stubFindReferralViews', {
+      organisationId: 'MRI',
+      queryParameters: {
+        courseName: { equalTo: course.name },
+        statusGroup: { equalTo: 'open' },
+      },
+      referralViews: courseReferralViews,
+      totalElements: courseReferralViews.length,
+    })
+    cy.task('stubFindReferralViews', {
+      organisationId: 'MRI',
+      queryParameters: {
+        courseName: { equalTo: course.name },
+        statusGroup: { equalTo: 'closed' },
+      },
+      referralViews: [],
+      totalElements: 0,
+    })
+
+    this.shouldContainButton('Submit').click()
+    this.shouldContainNotificationBanner(
+      'Success',
+      `<h3 class="govuk-notification-banner__heading">LDC status changed</h3>
+       <p class="govuk-body">Update: ${this.person.name} may ${this.referral.hasLdc ? 'not ' : ''}need an LDC-adapted programme</p>`,
+    )
   }
 }

--- a/server/controllers/assess/caseListController.test.ts
+++ b/server/controllers/assess/caseListController.test.ts
@@ -56,7 +56,7 @@ describe('AssessCaseListController', () => {
   beforeEach(() => {
     controller = new AssessCaseListController(courseService, referralService, referenceDataService)
 
-    request = createMock<Request>({ originalUrl, user: { username } })
+    request = createMock<Request>({ flash: jest.fn().mockReturnValue([]), originalUrl, user: { username } })
     response = createMock<Response>({ locals: { user: { activeCaseLoadId, username } } })
   })
 
@@ -328,14 +328,16 @@ describe('AssessCaseListController', () => {
         expect(CaseListUtils.tableRows).toHaveBeenCalledWith(openPaginatedReferralViews.content, columnsToInclude)
       })
 
-      describe('when there are query parameters', () => {
+      describe('when there are query parameters and flash messages', () => {
         it('renders the show template with the correct response locals', async () => {
+          const ldcStatusChangedMessage = 'LDC updated message'
           const uiAudienceQueryParam = 'general offence'
           const uiNameOrIdQueryParam = 'Hatton'
           const uiSortColumnQueryParam = 'surname'
           const uiSortDirectionQueryParam = 'ascending'
           const uiStatusQueryParam = 'REFERRAL_SUBMITTED'
 
+          request.flash = jest.fn().mockReturnValue([ldcStatusChangedMessage])
           request.query = {
             nameOrId: uiNameOrIdQueryParam,
             sortColumn: uiSortColumnQueryParam,
@@ -354,6 +356,7 @@ describe('AssessCaseListController', () => {
           expect(response.render).toHaveBeenCalledWith('referrals/caseList/assess/show', {
             action: assessPaths.caseList.filter({ courseId: limeCourse.id, referralStatusGroup }),
             audienceSelectItems: CaseListUtils.audienceSelectItems(limeCourseAudiences, false, 'general offence'),
+            ldcStatusChangedMessage,
             nameOrId: uiNameOrIdQueryParam,
             pageHeading: 'Lime Course',
             pageTitleOverride: 'Manage open programme team referrals: Lime Course',

--- a/server/controllers/assess/caseListController.ts
+++ b/server/controllers/assess/caseListController.ts
@@ -159,6 +159,7 @@ export default class AssessCaseListController {
         action: assessPaths.caseList.filter({ courseId, referralStatusGroup }),
         /** INFO: This is more recently presented as 'Strands' in UI mock ups */
         audienceSelectItems,
+        ldcStatusChangedMessage: req.flash('ldcStatusChangedMessage')[0],
         nameOrId,
         pageHeading: selectedCourse.name,
         pageTitleOverride: `Manage ${referralStatusGroup} programme team referrals: ${selectedCourse.name}`,

--- a/server/controllers/assess/index.ts
+++ b/server/controllers/assess/index.ts
@@ -40,7 +40,11 @@ const controllers = (services: Services) => {
     services.personService,
   )
 
-  const updateLdcController = new UpdateLdcController(services.personService, services.referralService)
+  const updateLdcController = new UpdateLdcController(
+    services.courseService,
+    services.personService,
+    services.referralService,
+  )
 
   return {
     assessCaseListController,

--- a/server/controllers/assess/updateLdcController.test.ts
+++ b/server/controllers/assess/updateLdcController.test.ts
@@ -9,7 +9,6 @@ import type { CourseService, PersonService, ReferralService } from '../../servic
 import { courseFactory, courseOfferingFactory, personFactory, referralFactory } from '../../testutils/factories'
 import Helpers from '../../testutils/helpers'
 import { FormUtils } from '../../utils'
-import type { Referral } from '@accredited-programmes-api'
 
 jest.mock('../../utils/formUtils')
 
@@ -25,13 +24,18 @@ describe('UpdateLdcController', () => {
   const referralService = createMock<ReferralService>({})
 
   const person = personFactory.build()
-
-  let referral: Referral
+  const courseOffering = courseOfferingFactory.build({})
+  const course = courseFactory.build({ courseOfferings: [courseOffering] })
+  const referral = referralFactory
+    .submitted()
+    .build({ hasLdc: true, offeringId: courseOffering.id, prisonNumber: person.prisonNumber })
 
   let controller: UpdateLdcController
 
   beforeEach(() => {
-    referral = referralFactory.submitted().build({ hasLdc: true, prisonNumber: person.prisonNumber })
+    when(courseService.getCourseByOffering).calledWith(username, referral.offeringId).mockResolvedValue(course)
+    when(personService.getPerson).calledWith(username, referral.prisonNumber).mockResolvedValue(person)
+    when(referralService.getReferral).calledWith(username, referral.id).mockResolvedValue(referral)
 
     controller = new UpdateLdcController(courseService, personService, referralService)
 
@@ -49,9 +53,6 @@ describe('UpdateLdcController', () => {
 
   describe('show', () => {
     it('should render the show page with the correct response locals', async () => {
-      when(personService.getPerson).calledWith(username, referral.prisonNumber).mockResolvedValue(person)
-      when(referralService.getReferral).calledWith(username, referral.id).mockResolvedValue(referral)
-
       const requestHandler = controller.show()
       await requestHandler(request, response, next)
 
@@ -66,26 +67,43 @@ describe('UpdateLdcController', () => {
   })
 
   describe('submit', () => {
-    it('should update the referral with hasLdcBeenOverriddenByProgrammeTeam and redirect to the case list for the referrals course', async () => {
-      const courseOffering = courseOfferingFactory.build({ id: referral.offeringId })
-      const course = courseFactory.build({ courseOfferings: [courseOffering] })
-
-      request.body.ldcReason = ['afcrSuggestion', 'scoresChanged']
-
-      when(courseService.getCourseByOffering).calledWith(username, referral.offeringId).mockResolvedValue(course)
-      when(referralService.getReferral).calledWith(username, referral.id).mockResolvedValue(referral)
-
-      const requestHandler = controller.submit()
-      await requestHandler(request, response, next)
-
-      expect(referralService.updateReferral).toHaveBeenCalledWith(username, referral.id, {
-        ...referral,
-        hasLdcBeenOverriddenByProgrammeTeam: true,
+    describe('when the ldcReason is provided', () => {
+      beforeEach(() => {
+        request.body.ldcReason = ['afcrSuggestion', 'scoresChanged']
       })
 
-      expect(response.redirect).toHaveBeenCalledWith(
-        assessPaths.caseList.show({ courseId: course.id, referralStatusGroup: 'open' }),
-      )
+      it('should update the referral with hasLdcBeenOverriddenByProgrammeTeam and redirect to the case list for the referrals course', async () => {
+        const requestHandler = controller.submit()
+        await requestHandler(request, response, next)
+
+        expect(referralService.updateReferral).toHaveBeenCalledWith(username, referral.id, {
+          ...referral,
+          hasLdcBeenOverriddenByProgrammeTeam: true,
+        })
+        expect(request.flash).toHaveBeenCalledWith(
+          'ldcStatusChangedMessage',
+          `Update: ${person.name} may not need an LDC-adapted programme`,
+        )
+        expect(response.redirect).toHaveBeenCalledWith(
+          assessPaths.caseList.show({ courseId: course.id, referralStatusGroup: 'open' }),
+        )
+      })
+
+      describe('when the referral hasLdc set to false', () => {
+        it('should set the ldcStatusChangedMessage correctly', async () => {
+          referral.hasLdc = false
+
+          when(referralService.getReferral).calledWith(username, referral.id).mockResolvedValue(referral)
+
+          const requestHandler = controller.submit()
+          await requestHandler(request, response, next)
+
+          expect(request.flash).toHaveBeenCalledWith(
+            'ldcStatusChangedMessage',
+            `Update: ${person.name} may need an LDC-adapted programme`,
+          )
+        })
+      })
     })
 
     describe('when the ldcReason is not provided', () => {

--- a/server/controllers/assess/updateLdcController.ts
+++ b/server/controllers/assess/updateLdcController.ts
@@ -46,13 +46,19 @@ export default class UpdateLdcController {
 
       const referral = await this.referralService.getReferral(username, referralId)
 
-      const [referralCourse] = await Promise.all([
+      const [referralCourse, person] = await Promise.all([
         this.courseService.getCourseByOffering(username, referral.offeringId),
+        this.personService.getPerson(username, referral.prisonNumber),
         this.referralService.updateReferral(username, referralId, {
           ...referral,
           hasLdcBeenOverriddenByProgrammeTeam: true,
         }),
       ])
+
+      req.flash(
+        'ldcStatusChangedMessage',
+        `Update: ${person.name} may ${referral.hasLdc ? 'not ' : ''}need an LDC-adapted programme`,
+      )
 
       return res.redirect(assessPaths.caseList.show({ courseId: referralCourse.id, referralStatusGroup: 'open' }))
     }

--- a/server/controllers/assess/updateLdcController.ts
+++ b/server/controllers/assess/updateLdcController.ts
@@ -1,11 +1,12 @@
 import type { Request, Response, TypedRequestHandler } from 'express'
 
 import { assessPaths } from '../../paths'
-import type { PersonService, ReferralService } from '../../services'
+import type { CourseService, PersonService, ReferralService } from '../../services'
 import { FormUtils, TypeUtils } from '../../utils'
 
 export default class UpdateLdcController {
   constructor(
+    private readonly courseService: CourseService,
     private readonly personService: PersonService,
     private readonly referralService: ReferralService,
   ) {}
@@ -45,12 +46,15 @@ export default class UpdateLdcController {
 
       const referral = await this.referralService.getReferral(username, referralId)
 
-      await this.referralService.updateReferral(username, referralId, {
-        ...referral,
-        hasLdcBeenOverriddenByProgrammeTeam: true,
-      })
+      const [referralCourse] = await Promise.all([
+        this.courseService.getCourseByOffering(username, referral.offeringId),
+        this.referralService.updateReferral(username, referralId, {
+          ...referral,
+          hasLdcBeenOverriddenByProgrammeTeam: true,
+        }),
+      ])
 
-      return res.redirect(assessPaths.show.personalDetails({ referralId }))
+      return res.redirect(assessPaths.caseList.show({ courseId: referralCourse.id, referralStatusGroup: 'open' }))
     }
   }
 }

--- a/server/views/referrals/caseList/assess/show.njk
+++ b/server/views/referrals/caseList/assess/show.njk
@@ -1,6 +1,7 @@
 {% from "govuk/components/button/macro.njk" import govukButton %}
 {% from "govuk/components/error-summary/macro.njk" import govukErrorSummary %}
 {% from "govuk/components/input/macro.njk" import govukInput %}
+{% from "govuk/components/notification-banner/macro.njk" import govukNotificationBanner %}
 {% from "govuk/components/pagination/macro.njk" import govukPagination %}
 {% from "govuk/components/select/macro.njk" import govukSelect %}
 {% from "govuk/components/table/macro.njk" import govukTable %}
@@ -29,6 +30,20 @@
       {% endif %}
     </div>
   </div>
+
+  {% if ldcStatusChangedMessage %}
+    {% set html %}
+    <h3 class="govuk-notification-banner__heading">LDC status changed</h3>
+    <p class="govuk-body">{{ ldcStatusChangedMessage }}</p>
+    {% endset %}
+
+    {{ govukNotificationBanner({
+      attributes: { "data-testid": "ldc-status-changed-message" },
+      html: html,
+      titleText: "Success",
+      type: "success"
+    }) }}
+  {% endif %}
 
   <span class="govuk-caption-l">Referrals</span>
   <h1 class="govuk-heading-l">{{ pageHeading }}</h1>


### PR DESCRIPTION
## Context

After updating an LDC status we should redirect back to the case list and show a success message.


## Screenshots of UI changes

<img width="747" alt="image" src="https://github.com/user-attachments/assets/b2eb2632-4fb3-4384-abae-e3f0836e63f3" />

## Release checklist

[Release process documentation](../blob/main/doc/how-to/perform-a-release.md)

As part of our continuous deployment strategy we must ensure that this work is
ready to be released once merged.

### Pre-merge

- [ ] There are changes required to the Accredited Programmes API for this change to work...
  - [ ] ... and they have been released to production already

### Post-merge

<!-- The outer checkboxes can be completed pre-merge -->

- [ ] This adds, extends or meaningfully modifies a feature...
  - [ ] ... and I have written or updated an end-to-end test for the happy path in the [Accredited Programmes E2E repo](https://github.com/ministryofjustice/hmpps-accredited-programmes-e2e)
- [ ] This makes new expectations of the API...
  - [ ] ... and I have notified the API developer(s) of changes to the contract tests (Pact), or the API is already compliant
- [ ] [Manually approve](../doc/how-to/perform-a-release.md#releasing-to-the-preprod-environment) release to preprod
- [ ] [Manually approve](../doc/how-to/perform-a-release.md#releasing-to-the-production-environment) release to prod

<!-- Should a release fail at any step, you as the author should now lead the work to
fix it as soon as possible. You can monitor deployment failures in CircleCI
itself and application errors are found in
[Sentry](https://ministryofjustice.sentry.io/projects/hmpps-accredited-programmes-ui/?project=4505330122686464&referrer=sidebar&statsPeriod=24h). -->
