### PR TITLE
Force working swagger-typescript-api version for ACP API type generation

### DIFF
--- a/script/utils/generateApiTypes/accreditedProgrammesApi
+++ b/script/utils/generateApiTypes/accreditedProgrammesApi
@@ -3,4 +3,4 @@
 # script/generateApiTypes/accreditedProgrammesApi: Generate types for the Accredited Programmes API.
 #  
 
-npx swagger-typescript-api -p https://accredited-programmes-api-dev.hmpps.service.justice.gov.uk/v3/api-docs -o server/@types/accreditedProgrammesApi -n index.d.ts --no-client
+npx swagger-typescript-api@13.0.23 -p https://accredited-programmes-api-dev.hmpps.service.justice.gov.uk/v3/api-docs -o server/@types/accreditedProgrammesApi -n index.d.ts --no-client


### PR DESCRIPTION
Since 13.0.24 of the swagger-typescript-api the type generation we use against the ACP API OpenApi spec has been failing.

[
![Screenshot 2025-03-25 at 10 28 59](https://github.com/user-attachments/assets/ccb2dc26-e23f-47d3-ba82-803f320537fe)
](url)

This has been tested to be an issue with library as it fails against other public OpenApi specs:

@
![Screenshot 2025-03-25 at 14 49 40](https://github.com/user-attachments/assets/0fada289-a062-4fd8-8727-ea0f5a573cc3)

This has been raised as a problem with the library maintainers and until resolved we will force a working version rather than the latest in our script.


## Release checklist

[Release process documentation](../blob/main/doc/how-to/perform-a-release.md)

As part of our continuous deployment strategy we must ensure that this work is
ready to be released once merged.

### Pre-merge

- [ ] There are changes required to the Accredited Programmes API for this change to work...
  - [ ] ... and they have been released to production already

### Post-merge

<!-- The outer checkboxes can be completed pre-merge -->

- [ ] This adds, extends or meaningfully modifies a feature...
  - [ ] ... and I have written or updated an end-to-end test for the happy path in the [Accredited Programmes E2E repo](https://github.com/ministryofjustice/hmpps-accredited-programmes-e2e)
- [ ] This makes new expectations of the API...
  - [ ] ... and I have notified the API developer(s) of changes to the contract tests (Pact), or the API is already compliant
- [ ] [Manually approve](../doc/how-to/perform-a-release.md#releasing-to-the-preprod-environment) release to preprod
- [ ] [Manually approve](../doc/how-to/perform-a-release.md#releasing-to-the-production-environment) release to prod

<!-- Should a release fail at any step, you as the author should now lead the work to
fix it as soon as possible. You can monitor deployment failures in CircleCI
itself and application errors are found in
[Sentry](https://ministryofjustice.sentry.io/projects/hmpps-accredited-programmes-ui/?project=4505330122686464&referrer=sidebar&statsPeriod=24h). -->
