### PR TITLE
(APG-707d) Set `hasLdc` value when updating ldc status on a referral

### DIFF
--- a/server/@types/accreditedProgrammesApi/index.d.ts
+++ b/server/@types/accreditedProgrammesApi/index.d.ts
@@ -41,6 +41,11 @@ export interface ReferralUpdate {
    */
   overrideReason?: string
   /**
+   * Flag to indicate if the person has a Learning Difficulty Challenges
+   * @example true
+   */
+  hasLdc?: boolean
+  /**
    * Flag to indicate if the ldc field was overriden by the programme team
    * @example true
    */
@@ -331,13 +336,12 @@ export interface ReferralEntity {
   oasysConfirmed: boolean
   hasReviewedProgrammeHistory: boolean
   status: string
-  /** @example "2025-03-17T09:12:19" */
+  /** @example "2025-03-26T13:53:14" */
   submittedOn?: any
   deleted: boolean
   primaryPomStaffId?: number
   secondaryPomStaffId?: number
   overrideReason?: string
-  transferReason?: string
   /** @format uuid */
   originalReferralId?: string
   hasLdc?: boolean
@@ -421,11 +425,6 @@ export interface Referral {
    * @example "The reason for going with the recommended course is..."
    */
   overrideReason?: string
-  /**
-   * Reason for transfer to building choices
-   * @example "The reason for transfer to building choices is..."
-   */
-  transferReason?: string
   /**
    * Referral ID of the original referral from which transfer was initiated
    * @format uuid

--- a/server/controllers/assess/updateLdcController.test.ts
+++ b/server/controllers/assess/updateLdcController.test.ts
@@ -72,12 +72,13 @@ describe('UpdateLdcController', () => {
         request.body.ldcReason = ['afcrSuggestion', 'scoresChanged']
       })
 
-      it('should update the referral with hasLdcBeenOverriddenByProgrammeTeam and redirect to the case list for the referrals course', async () => {
+      it('should update the referral with the correct values and then redirect to the case list for the correct course', async () => {
         const requestHandler = controller.submit()
         await requestHandler(request, response, next)
 
         expect(referralService.updateReferral).toHaveBeenCalledWith(username, referral.id, {
           ...referral,
+          hasLdc: false,
           hasLdcBeenOverriddenByProgrammeTeam: true,
         })
         expect(request.flash).toHaveBeenCalledWith(
@@ -90,7 +91,7 @@ describe('UpdateLdcController', () => {
       })
 
       describe('when the referral hasLdc set to false', () => {
-        it('should set the ldcStatusChangedMessage correctly', async () => {
+        it('should update the referral with the correct values', async () => {
           referral.hasLdc = false
 
           when(referralService.getReferral).calledWith(username, referral.id).mockResolvedValue(referral)
@@ -98,6 +99,11 @@ describe('UpdateLdcController', () => {
           const requestHandler = controller.submit()
           await requestHandler(request, response, next)
 
+          expect(referralService.updateReferral).toHaveBeenCalledWith(username, referral.id, {
+            ...referral,
+            hasLdc: true,
+            hasLdcBeenOverriddenByProgrammeTeam: true,
+          })
           expect(request.flash).toHaveBeenCalledWith(
             'ldcStatusChangedMessage',
             `Update: ${person.name} may need an LDC-adapted programme`,

--- a/server/controllers/assess/updateLdcController.ts
+++ b/server/controllers/assess/updateLdcController.ts
@@ -51,6 +51,7 @@ export default class UpdateLdcController {
         this.personService.getPerson(username, referral.prisonNumber),
         this.referralService.updateReferral(username, referralId, {
           ...referral,
+          hasLdc: !referral.hasLdc,
           hasLdcBeenOverriddenByProgrammeTeam: true,
         }),
       ])


### PR DESCRIPTION
## Context

After some discussion, we decided to specify what the `hasLdc` value should be from front end rather than the API.

## Changes in this PR
When updating the ldc status, set `hasLdc` to be the opposite of what it is currently.

