### PR TITLE
Bug: Fixes for LDC filter options in assess case list view

### DIFF
--- a/integration_tests/e2e/assess/caseList.cy.ts
+++ b/integration_tests/e2e/assess/caseList.cy.ts
@@ -237,6 +237,7 @@ context('Referral case lists', () => {
           [
             { key: 'strand', value: 'general offence' },
             { key: 'status', value: 'ASSESSMENT_STARTED' },
+            { key: 'hasLdc', value: 'false' },
           ],
         )
         filteredCaseListPage.shouldContainTableOfReferralViews(assessPaths)

--- a/server/controllers/assess/caseListController.test.ts
+++ b/server/controllers/assess/caseListController.test.ts
@@ -288,6 +288,7 @@ describe('AssessCaseListController', () => {
           undefined,
           undefined,
           undefined,
+          undefined,
         )
         expect(PaginationUtils.pagination).toHaveBeenLastCalledWith(
           request.path,
@@ -391,6 +392,7 @@ describe('AssessCaseListController', () => {
             uiSortColumnQueryParam,
             uiSortDirectionQueryParam,
             uiNameOrIdQueryParam,
+            uiHasLdcQueryParam,
           )
           expect(PaginationUtils.pagination).toHaveBeenLastCalledWith(
             request.path,
@@ -481,6 +483,7 @@ describe('AssessCaseListController', () => {
           statusGroup: 'closed',
         })
         expect(CaseListUtils.queryParamsExcludingPage).toHaveBeenLastCalledWith(
+          undefined,
           undefined,
           undefined,
           undefined,

--- a/server/controllers/assess/caseListController.test.ts
+++ b/server/controllers/assess/caseListController.test.ts
@@ -115,7 +115,7 @@ describe('AssessCaseListController', () => {
         undefined,
         undefined,
         nameOrId,
-        true,
+        'true',
       )
       expect(PathUtils.pathWithQuery).toHaveBeenLastCalledWith(redirectPathBase, queryParamsExcludingPage)
       expect(response.redirect).toHaveBeenCalledWith(pathWithQuery)
@@ -278,7 +278,7 @@ describe('AssessCaseListController', () => {
         expect(referralService.getReferralViews).toHaveBeenCalledWith(username, activeCaseLoadId, {
           audience: undefined,
           courseName: 'Lime Course',
-          hasLdc: false,
+          hasLdcString: undefined,
           status: undefined,
           statusGroup: referralStatusGroup,
         })
@@ -336,9 +336,11 @@ describe('AssessCaseListController', () => {
           const uiSortColumnQueryParam = 'surname'
           const uiSortDirectionQueryParam = 'ascending'
           const uiStatusQueryParam = 'REFERRAL_SUBMITTED'
+          const uiHasLdcQueryParam = 'true'
 
           request.flash = jest.fn().mockReturnValue([ldcStatusChangedMessage])
           request.query = {
+            hasLdc: uiHasLdcQueryParam,
             nameOrId: uiNameOrIdQueryParam,
             sortColumn: uiSortColumnQueryParam,
             sortDirection: uiSortDirectionQueryParam,
@@ -376,7 +378,7 @@ describe('AssessCaseListController', () => {
           expect(referralService.getReferralViews).toHaveBeenCalledWith(username, activeCaseLoadId, {
             audience: apiAudienceQueryParam,
             courseName: 'Lime Course',
-            hasLdc: false,
+            hasLdcString: uiHasLdcQueryParam,
             nameOrId: uiNameOrIdQueryParam,
             sortColumn: uiSortColumnQueryParam,
             sortDirection: uiSortDirectionQueryParam,
@@ -474,7 +476,7 @@ describe('AssessCaseListController', () => {
         expect(referralService.getReferralViews).toHaveBeenCalledWith(username, activeCaseLoadId, {
           audience: undefined,
           courseName: 'Lime Course',
-          hasLdc: false,
+          hasLdcString: undefined,
           status: undefined,
           statusGroup: 'closed',
         })

--- a/server/controllers/assess/caseListController.ts
+++ b/server/controllers/assess/caseListController.ts
@@ -32,7 +32,7 @@ export default class AssessCaseListController {
       return res.redirect(
         PathUtils.pathWithQuery(
           assessPaths.caseList.show({ courseId, referralStatusGroup }),
-          CaseListUtils.queryParamsExcludingPage(audience, status, undefined, undefined, nameOrId, hasLdc),
+          CaseListUtils.queryParamsExcludingPage(audience, status, undefined, undefined, nameOrId, hasLdc.toString()),
         ),
       )
     }
@@ -69,8 +69,7 @@ export default class AssessCaseListController {
         sortColumn,
         sortDirection,
       } = req.query as Record<string, string>
-      const hasLdc = hasLdcString === 'true'
-      const referralsFiltered = !!status || !!audience || !!nameOrId || !!hasLdc
+      const referralsFiltered = !!status || !!audience || !!nameOrId || !!hasLdcString
       const { referralStatusGroup } = req.params as { referralStatusGroup: ReferralStatusGroup }
 
       const statusGroups: Array<ReferralStatusGroup> = ['open', 'closed']
@@ -101,7 +100,7 @@ export default class AssessCaseListController {
               const referralViews = await this.referralService.getReferralViews(username, activeCaseLoadId, {
                 audience: CaseListUtils.uiToApiAudienceQueryParam(audience),
                 courseName: selectedCourse.name,
-                hasLdc,
+                hasLdcString,
                 nameOrId,
                 page: page ? (Number(page) - 1).toString() : undefined,
                 sortColumn,
@@ -152,7 +151,7 @@ export default class AssessCaseListController {
       const audienceSelectItems = CaseListUtils.audienceSelectItems(
         courseAudiences,
         CourseUtils.isBuildingChoices(selectedCourse.displayName),
-        audience ? CourseUtils.encodeAudienceAndHasLdc(audience, hasLdc) : undefined,
+        audience ? CourseUtils.encodeAudienceAndHasLdc(audience, hasLdcString === 'true') : undefined,
       )
 
       return res.render('referrals/caseList/assess/show', {

--- a/server/controllers/assess/caseListController.ts
+++ b/server/controllers/assess/caseListController.ts
@@ -125,14 +125,14 @@ export default class AssessCaseListController {
 
       const pagination = PaginationUtils.pagination(
         req.path,
-        CaseListUtils.queryParamsExcludingPage(audience, status, sortColumn, sortDirection, nameOrId),
+        CaseListUtils.queryParamsExcludingPage(audience, status, sortColumn, sortDirection, nameOrId, hasLdcString),
         selectedReferralViews.pageNumber,
         selectedReferralViews.totalPages,
       )
 
       const basePathExcludingSort = PathUtils.pathWithQuery(
         assessPaths.caseList.show({ courseId, referralStatusGroup }),
-        CaseListUtils.queryParamsExcludingSort(audience, status, page, nameOrId),
+        CaseListUtils.queryParamsExcludingSort(audience, status, page, nameOrId, hasLdcString),
       )
 
       /* eslint-disable sort-keys */
@@ -177,7 +177,7 @@ export default class AssessCaseListController {
             closed: allReferralViews.closed.totalElements,
             open: allReferralViews.open.totalElements,
           },
-          CaseListUtils.queryParamsExcludingPage(audience, status, sortColumn, sortDirection, nameOrId),
+          CaseListUtils.queryParamsExcludingPage(audience, status, sortColumn, sortDirection, nameOrId, hasLdcString),
         ),
         tableHeadings: CaseListUtils.sortableTableHeadings(
           basePathExcludingSort,

--- a/server/data/accreditedProgrammesApi/referralClient.test.ts
+++ b/server/data/accreditedProgrammesApi/referralClient.test.ts
@@ -272,7 +272,7 @@ pactWith({ consumer: 'Accredited Programmes UI', provider: 'Accredited Programme
         const result = await referralClient.findReferralViews('BWM', {
           audience: 'General offence',
           courseName: 'Super Course',
-          hasLdc: true,
+          hasLdcString: 'true',
           page: '1',
           status: 'REFERRAL_SUBMITTED',
         })

--- a/server/data/accreditedProgrammesApi/referralClient.ts
+++ b/server/data/accreditedProgrammesApi/referralClient.ts
@@ -115,7 +115,7 @@ export default class ReferralClient {
     query?: {
       audience?: string
       courseName?: string
-      hasLdc?: boolean
+      hasLdcString?: string
       nameOrId?: string
       page?: string
       sortColumn?: string
@@ -135,7 +135,7 @@ export default class ReferralClient {
         ...(query?.sortDirection && { sortDirection: query.sortDirection }),
         ...(query?.status && { status: query.status }),
         ...(query?.statusGroup && { statusGroup: query.statusGroup }),
-        ...(query?.hasLdc && { hasLdc: 'true' }),
+        ...(query?.hasLdcString && { hasLdc: query.hasLdcString }),
         size: '15',
       },
     })) as Paginated<ReferralView>

--- a/server/services/referralService.test.ts
+++ b/server/services/referralService.test.ts
@@ -362,7 +362,7 @@ describe('ReferralService', () => {
         const query: {
           audience: string
           courseName: string
-          hasLdc: boolean
+          hasLdcString: string
           nameOrId: string
           page: string
           sortColumn: string
@@ -372,7 +372,7 @@ describe('ReferralService', () => {
         } = {
           audience: 'General offence',
           courseName: 'Lime Course',
-          hasLdc: true,
+          hasLdcString: 'true',
           nameOrId: 'Hatton',
           page: '1',
           sortColumn: 'surname',

--- a/server/services/referralService.ts
+++ b/server/services/referralService.ts
@@ -151,7 +151,7 @@ export default class ReferralService {
     query?: {
       audience?: string
       courseName?: string
-      hasLdc?: boolean
+      hasLdcString?: string
       nameOrId?: string
       page?: string
       sortColumn?: string

--- a/server/utils/referrals/caseListUtils.test.ts
+++ b/server/utils/referrals/caseListUtils.test.ts
@@ -100,7 +100,7 @@ describe('CaseListUtils', () => {
     const statusQueryParam = { key: 'status', value: 'referral started' as ReferralStatus }
     const sortColumnQueryParam = { key: 'sortColumn', value: 'conditionalReleaseDate' }
     const sortDirectionQueryParam = { key: 'sortDirection', value: 'ascending' }
-    const hasLdcQueryParams = { key: 'hasLdc', value: true }
+    const hasLdcQueryParams = { key: 'hasLdc', value: 'true' }
 
     describe('when all possible params are provided', () => {
       it('returns an array with one `QueryParam` for each, converting audience to "strand"', async () => {

--- a/server/utils/referrals/caseListUtils.test.ts
+++ b/server/utils/referrals/caseListUtils.test.ts
@@ -192,6 +192,7 @@ describe('CaseListUtils', () => {
     const nameOrIdQueryParam = { key: 'nameOrId', value: 'hatton' }
     const statusQueryParam = { key: 'status', value: 'referral started' as ReferralStatus }
     const pageQueryParam = { key: 'page', value: '2' }
+    const hasLdcQueryParam = { key: 'hasLdc', value: 'true' }
 
     describe('when all possible params are provided', () => {
       it('returns an array with one `QueryParam` for each, converting audience to "strand"', async () => {
@@ -201,19 +202,21 @@ describe('CaseListUtils', () => {
             statusQueryParam.value,
             pageQueryParam.value,
             nameOrIdQueryParam.value,
+            hasLdcQueryParam.value,
           ),
         ).toEqual([
           { key: 'strand', value: audienceQueryParam.value },
           { key: 'nameOrId', value: nameOrIdQueryParam.value },
           { key: 'status', value: statusQueryParam.value },
           { key: 'page', value: pageQueryParam.value },
+          { key: 'hasLdc', value: hasLdcQueryParam.value },
         ])
       })
     })
 
     describe('when only status is provided', () => {
       it('returns an array with a status `QueryParam`', async () => {
-        expect(CaseListUtils.queryParamsExcludingSort(undefined, statusQueryParam.value, undefined)).toEqual([
+        expect(CaseListUtils.queryParamsExcludingSort(undefined, statusQueryParam.value)).toEqual([
           { key: 'status', value: statusQueryParam.value },
         ])
       })
@@ -221,7 +224,7 @@ describe('CaseListUtils', () => {
 
     describe('when only strand is provided', () => {
       it('returns an array with a strand `QueryParam`, converted from "audience"', async () => {
-        expect(CaseListUtils.queryParamsExcludingSort(audienceQueryParam.value, undefined, undefined)).toEqual([
+        expect(CaseListUtils.queryParamsExcludingSort(audienceQueryParam.value)).toEqual([
           { key: 'strand', value: audienceQueryParam.value },
         ])
       })
@@ -235,9 +238,17 @@ describe('CaseListUtils', () => {
       })
     })
 
+    describe('when only hasLdc is provided', () => {
+      it('returns an array with a hasLdc `QueryParam`', async () => {
+        expect(
+          CaseListUtils.queryParamsExcludingSort(undefined, undefined, undefined, undefined, hasLdcQueryParam.value),
+        ).toEqual([{ key: 'hasLdc', value: hasLdcQueryParam.value }])
+      })
+    })
+
     describe('when all params are undefined', () => {
       it('returns an empty array', async () => {
-        expect(CaseListUtils.queryParamsExcludingSort(undefined, undefined, undefined)).toEqual([])
+        expect(CaseListUtils.queryParamsExcludingSort()).toEqual([])
       })
     })
   })

--- a/server/utils/referrals/caseListUtils.ts
+++ b/server/utils/referrals/caseListUtils.ts
@@ -93,7 +93,7 @@ export default class CaseListUtils {
     sortColumn?: string,
     sortDirection?: string,
     nameOrId?: string,
-    hasLdc?: boolean,
+    hasLdcString?: string,
   ): Array<QueryParam> {
     const queryParams: Array<QueryParam> = []
 
@@ -114,8 +114,8 @@ export default class CaseListUtils {
       queryParams.push({ key: 'sortDirection', value: sortDirection })
     }
 
-    if (hasLdc) {
-      queryParams.push({ key: 'hasLdc', value: hasLdc.toString() })
+    if (hasLdcString) {
+      queryParams.push({ key: 'hasLdc', value: hasLdcString })
     }
 
     return queryParams

--- a/server/utils/referrals/caseListUtils.ts
+++ b/server/utils/referrals/caseListUtils.ts
@@ -126,6 +126,7 @@ export default class CaseListUtils {
     status?: string,
     page?: string,
     nameOrId?: string,
+    hasLdcString?: string,
   ): Array<QueryParam> {
     const queryParams: Array<QueryParam> = []
 
@@ -143,6 +144,10 @@ export default class CaseListUtils {
 
     if (page) {
       queryParams.push({ key: 'page', value: page })
+    }
+
+    if (hasLdcString) {
+      queryParams.push({ key: 'hasLdc', value: hasLdcString })
     }
 
     return queryParams


### PR DESCRIPTION
## Context

**Bug 1:** LDC related strand values without "LDC Only" should get the referrals with` hasLdc=false`, so we don't include the results with LDC.

**Bug 2:** Strand filter selection should be maintained when clicking the following links:
- Open/Closed tab links
- Pagination links
- Column header sorting links
