### PR TITLE
(APG-625) Add Change LDC Status item to button menu

### DIFF
--- a/assets/scss/local.scss
+++ b/assets/scss/local.scss
@@ -60,8 +60,18 @@
 }
 
 .header-with-actions {
+  .govuk-button-group {
+    align-items: flex-start;
+    margin-bottom: govuk-spacing(3);
+
+    .moj-button-menu__toggle-button {
+      margin-bottom: 0;
+    }
+  }
+
   @include govuk-media-query($from: 1024px) {
     display: flex;
+    gap: govuk-spacing(3);
 
     .header-with-actions__title {
       flex: 1;

--- a/server/controllers/assess/pniController.ts
+++ b/server/controllers/assess/pniController.ts
@@ -68,7 +68,6 @@ export default class PniController {
           { currentPath: req.path, recentCaseListPath: req.session.recentCaseListPath },
           referral,
           undefined,
-          course,
         ),
         pageHeading: `Referral to ${coursePresenter.displayName}`,
         pageSubHeading: 'Programme needs identifier',

--- a/server/controllers/shared/referralsController.test.ts
+++ b/server/controllers/shared/referralsController.test.ts
@@ -528,7 +528,6 @@ describe('ReferralsController', () => {
       { currentPath: path, recentCaseListPath },
       referral,
       isRefer ? statusTransitions : undefined,
-      course,
     )
     expect(mockShowReferralUtils.viewReferralNavigationItems).toHaveBeenCalledWith(path, referral.id)
     expect(mockShowReferralUtils.subNavigationItems).toHaveBeenCalledWith(path, 'referral', referral.id)

--- a/server/controllers/shared/referralsController.ts
+++ b/server/controllers/shared/referralsController.ts
@@ -259,7 +259,6 @@ export default class ReferralsController {
         { currentPath: req.path, recentCaseListPath: req.session.recentCaseListPath },
         referral,
         statusTransitions,
-        course,
       ),
       course,
       courseOffering,

--- a/server/controllers/shared/risksAndNeedsController.test.ts
+++ b/server/controllers/shared/risksAndNeedsController.test.ts
@@ -971,7 +971,6 @@ describe('RisksAndNeedsController', () => {
       { currentPath: path, recentCaseListPath },
       referral,
       isRefer ? statusTransitions : undefined,
-      course,
     )
     expect(mockShowReferralUtils.subNavigationItems).toHaveBeenCalledWith(path, 'risksAndNeeds', referral.id)
 

--- a/server/controllers/shared/risksAndNeedsController.ts
+++ b/server/controllers/shared/risksAndNeedsController.ts
@@ -421,7 +421,6 @@ export default class RisksAndNeedsController {
         { currentPath: req.path, recentCaseListPath: req.session.recentCaseListPath },
         referral,
         statusTransitions,
-        course,
       ),
       hideTitleServiceName: true,
       navigationItems: ShowRisksAndNeedsUtils.navigationItems(req.path, referral.id),

--- a/server/controllers/shared/statusHistoryController.test.ts
+++ b/server/controllers/shared/statusHistoryController.test.ts
@@ -143,7 +143,6 @@ describe('StatusHistoryController', () => {
         { currentPath: request.path, recentCaseListPath },
         referral,
         statusTransitions,
-        course,
       )
       expect(mockShowReferralUtils.statusHistoryTimelineItems).toHaveBeenCalledWith(
         referralStatusHistory,
@@ -204,7 +203,6 @@ describe('StatusHistoryController', () => {
           { currentPath: request.path, recentCaseListPath },
           referral,
           undefined,
-          course,
         )
       })
     })

--- a/server/controllers/shared/statusHistoryController.ts
+++ b/server/controllers/shared/statusHistoryController.ts
@@ -45,7 +45,6 @@ export default class StatusHistoryController {
           { currentPath: req.path, recentCaseListPath: req.session.recentCaseListPath },
           referral,
           statusTransitions,
-          course,
         ),
         hideTitleServiceName: true,
         pageHeading: `Referral to ${coursePresenter.displayName}`,

--- a/server/utils/referrals/showReferralUtils.test.ts
+++ b/server/utils/referrals/showReferralUtils.test.ts
@@ -29,11 +29,16 @@ describe('ShowReferralUtils', () => {
     audience: 'General offence',
     name: 'Building Choices: High Intensity',
   })
+  const becomingNewMePlusCourse = courseFactory.build({
+    alternateName: 'BNM',
+    audience: 'General offence',
+    name: 'Becoming New Me Plus',
+  })
 
-  describe('Menu buttons', () => {
+  describe('buttonMenu', () => {
     describe('when in the assess journey', () => {
-      describe('when the course is not building choices, the referral is not closed or on programme', () => {
-        it('shows the update and move to building choices buttons in the menu', () => {
+      describe('and the course is not Building Choices, the referral is not closed or on programme', () => {
+        it('should show the Update Status and Move to Building Choices buttons in the menu', () => {
           expect(
             ShowReferralUtils.buttonMenu(course, submittedReferral, {
               currentPath: assessPaths.show.statusHistory({ referralId: submittedReferral.id }),
@@ -60,30 +65,116 @@ describe('ShowReferralUtils', () => {
             ],
           })
         })
-        it('when the course is building choices, returns an empty menu', () => {
-          expect(
-            ShowReferralUtils.buttonMenu(buildingChoicesCourse, submittedReferral, {
-              currentPath: assessPaths.show.statusHistory({ referralId: submittedReferral.id }),
-            }),
-          ).toEqual({
-            button: {
-              classes: 'govuk-button--secondary',
-              text: 'Update referral',
-            },
-            items: [],
+
+        describe('when the course is Building Choices', () => {
+          it('should show the Update status and Change LDC status buttons in the menu', () => {
+            expect(
+              ShowReferralUtils.buttonMenu(buildingChoicesCourse, submittedReferral, {
+                currentPath: assessPaths.show.statusHistory({ referralId: submittedReferral.id }),
+              }),
+            ).toEqual({
+              button: {
+                classes: 'govuk-button--secondary',
+                text: 'Update referral',
+              },
+              items: [
+                {
+                  attributes: {
+                    'aria-disabled': false,
+                  },
+                  classes: 'govuk-button--secondary',
+                  href: assessPaths.updateStatus.decision.show({ referralId: submittedReferral.id }),
+                  text: 'Update status',
+                },
+                {
+                  classes: 'govuk-button--secondary',
+                  href: assessPaths.updateLdc.show({ referralId: submittedReferral.id }),
+                  text: 'Change LDC status',
+                },
+              ],
+            })
           })
         })
-        it('when the referral status is on programme, returns an empty menu', () => {
-          expect(
-            ShowReferralUtils.buttonMenu(course, onProgrammeReferral, {
-              currentPath: assessPaths.show.statusHistory({ referralId: submittedReferral.id }),
-            }),
-          ).toEqual({
-            button: {
-              classes: 'govuk-button--secondary',
-              text: 'Update referral',
-            },
-            items: [],
+
+        describe('when the course is not Building Choices', () => {
+          it('should show the Update status and Move to Building choices buttons in the menu', () => {
+            expect(
+              ShowReferralUtils.buttonMenu(becomingNewMePlusCourse, submittedReferral, {
+                currentPath: assessPaths.show.statusHistory({ referralId: submittedReferral.id }),
+              }),
+            ).toEqual({
+              button: {
+                classes: 'govuk-button--secondary',
+                text: 'Update referral',
+              },
+              items: [
+                {
+                  attributes: {
+                    'aria-disabled': false,
+                  },
+                  classes: 'govuk-button--secondary',
+                  href: assessPaths.updateStatus.decision.show({ referralId: submittedReferral.id }),
+                  text: 'Update status',
+                },
+                {
+                  classes: 'govuk-button--secondary',
+                  href: assessPaths.transfer.show({ referralId: submittedReferral.id }),
+                  text: 'Move to Building Choices',
+                },
+              ],
+            })
+          })
+        })
+
+        describe('when the referral is closed', () => {
+          it('should show the Update status button in a disabled state', () => {
+            const closedReferral = referralFactory.closed().build()
+
+            expect(
+              ShowReferralUtils.buttonMenu(course, closedReferral, {
+                currentPath: assessPaths.show.statusHistory({ referralId: closedReferral.id }),
+              }),
+            ).toEqual({
+              button: {
+                classes: 'govuk-button--secondary',
+                text: 'Update referral',
+              },
+              items: [
+                {
+                  attributes: {
+                    'aria-disabled': true,
+                  },
+                  classes: 'govuk-button--secondary',
+                  href: undefined,
+                  text: 'Update status',
+                },
+              ],
+            })
+          })
+        })
+
+        describe('when the referral status is on_programme', () => {
+          it('should show the Update status button', () => {
+            expect(
+              ShowReferralUtils.buttonMenu(course, onProgrammeReferral, {
+                currentPath: assessPaths.show.statusHistory({ referralId: onProgrammeReferral.id }),
+              }),
+            ).toEqual({
+              button: {
+                classes: 'govuk-button--secondary',
+                text: 'Update referral',
+              },
+              items: [
+                {
+                  attributes: {
+                    'aria-disabled': false,
+                  },
+                  classes: 'govuk-button--secondary',
+                  href: assessPaths.updateStatus.decision.show({ referralId: onProgrammeReferral.id }),
+                  text: 'Update status',
+                },
+              ],
+            })
           })
         })
       })
@@ -98,7 +189,6 @@ describe('ShowReferralUtils', () => {
             { currentPath: assessPaths.show.statusHistory({ referralId: submittedReferral.id }) },
             submittedReferral,
             undefined,
-            course,
           ),
         ).toEqual([
           {
@@ -120,7 +210,6 @@ describe('ShowReferralUtils', () => {
               },
               submittedReferral,
               undefined,
-              course,
             ),
           ).toEqual(
             expect.arrayContaining([
@@ -141,7 +230,6 @@ describe('ShowReferralUtils', () => {
             { currentPath: referPaths.show.statusHistory({ referralId: submittedReferral.id }) },
             submittedReferral,
             undefined,
-            course,
           ),
         ).toEqual([
           {
@@ -174,7 +262,6 @@ describe('ShowReferralUtils', () => {
               { currentPath: referPaths.show.statusHistory({ referralId: closedReferral.id }) },
               closedReferral,
               undefined,
-              course,
             ),
           ).toEqual(
             expect.arrayContaining([


### PR DESCRIPTION
## Context

When viewing the referral for a person, we need a new CTA adding which links to the Update LDC Status page.

This is for Building Choices only (both Moderate and High intensity)

## Changes in this PR
- Add Change LDC status button to button menu for referrals to Building Choices that are not closed or On Programme.
- Styling tweaks so menu button displays correctly


## Screenshots of UI changes

<img width="1258" alt="image" src="https://github.com/user-attachments/assets/5697135a-0753-4d5e-b203-8231febce7a6" />


## Release checklist

[Release process documentation](../blob/main/doc/how-to/perform-a-release.md)

As part of our continuous deployment strategy we must ensure that this work is
ready to be released once merged.

### Pre-merge

- [ ] There are changes required to the Accredited Programmes API for this change to work...
  - [ ] ... and they have been released to production already

### Post-merge

<!-- The outer checkboxes can be completed pre-merge -->

- [ ] This adds, extends or meaningfully modifies a feature...
  - [ ] ... and I have written or updated an end-to-end test for the happy path in the [Accredited Programmes E2E repo](https://github.com/ministryofjustice/hmpps-accredited-programmes-e2e)
- [ ] This makes new expectations of the API...
  - [ ] ... and I have notified the API developer(s) of changes to the contract tests (Pact), or the API is already compliant
- [ ] [Manually approve](../doc/how-to/perform-a-release.md#releasing-to-the-preprod-environment) release to preprod
- [ ] [Manually approve](../doc/how-to/perform-a-release.md#releasing-to-the-production-environment) release to prod

<!-- Should a release fail at any step, you as the author should now lead the work to
fix it as soon as possible. You can monitor deployment failures in CircleCI
itself and application errors are found in
[Sentry](https://ministryofjustice.sentry.io/projects/hmpps-accredited-programmes-ui/?project=4505330122686464&referrer=sidebar&statsPeriod=24h). -->
