### PR TITLE
(APG-625) Temporarily remove Change LDC status button

### DIFF
--- a/server/utils/referrals/showReferralUtils.test.ts
+++ b/server/utils/referrals/showReferralUtils.test.ts
@@ -67,7 +67,7 @@ describe('ShowReferralUtils', () => {
         })
 
         describe('when the course is Building Choices', () => {
-          it('should show the Update status and Change LDC status buttons in the menu', () => {
+          it.skip('should show the Update status and Change LDC status buttons in the menu', () => {
             expect(
               ShowReferralUtils.buttonMenu(buildingChoicesCourse, submittedReferral, {
                 currentPath: assessPaths.show.statusHistory({ referralId: submittedReferral.id }),

--- a/server/utils/referrals/showReferralUtils.ts
+++ b/server/utils/referrals/showReferralUtils.ts
@@ -44,13 +44,7 @@ export default class ShowReferralUtils {
       })
 
       if (status !== 'on_programme' && !closed) {
-        if (isBuildingChoices) {
-          menuButtons.push({
-            classes: 'govuk-button--secondary',
-            href: assessPaths.updateLdc.show({ referralId: referral.id }),
-            text: 'Change LDC status',
-          })
-        } else {
+        if (!isBuildingChoices) {
           menuButtons.push({
             classes: 'govuk-button--secondary',
             href: assessPaths.transfer.show({ referralId: referral.id }),


### PR DESCRIPTION
## Context

Removed Change LDC status button in button menu, so we don't hold up releases. Will revert when LDC update has been done.


## Release checklist

[Release process documentation](../blob/main/doc/how-to/perform-a-release.md)

As part of our continuous deployment strategy we must ensure that this work is
ready to be released once merged.

### Pre-merge

- [ ] There are changes required to the Accredited Programmes API for this change to work...
  - [ ] ... and they have been released to production already

### Post-merge

<!-- The outer checkboxes can be completed pre-merge -->

- [ ] This adds, extends or meaningfully modifies a feature...
  - [ ] ... and I have written or updated an end-to-end test for the happy path in the [Accredited Programmes E2E repo](https://github.com/ministryofjustice/hmpps-accredited-programmes-e2e)
- [ ] This makes new expectations of the API...
  - [ ] ... and I have notified the API developer(s) of changes to the contract tests (Pact), or the API is already compliant
- [ ] [Manually approve](../doc/how-to/perform-a-release.md#releasing-to-the-preprod-environment) release to preprod
- [ ] [Manually approve](../doc/how-to/perform-a-release.md#releasing-to-the-production-environment) release to prod

<!-- Should a release fail at any step, you as the author should now lead the work to
fix it as soon as possible. You can monitor deployment failures in CircleCI
itself and application errors are found in
[Sentry](https://ministryofjustice.sentry.io/projects/hmpps-accredited-programmes-ui/?project=4505330122686464&referrer=sidebar&statsPeriod=24h). -->
