### PR TITLE
(APG-806) Add link to view all programmes for any user

### DIFF
--- a/integration_tests/e2e/app.cy.ts
+++ b/integration_tests/e2e/app.cy.ts
@@ -64,7 +64,7 @@ context('App', () => {
       cy.visit('/')
 
       const indexPage = Page.verifyOnPage(IndexPage)
-      indexPage.shouldNotContainLink('/find')
+      indexPage.shouldContainLink('Find a programme and make a referral', '/find')
       indexPage.shouldContainLink('Manage your programme team’s referrals', '/assess/referrals/case-list')
       indexPage.shouldContainLink('Reporting data', '/reports')
     })
@@ -77,7 +77,7 @@ context('App', () => {
       cy.visit('/')
 
       const indexPage = Page.verifyOnPage(IndexPage)
-      indexPage.shouldNotContainLink('/find')
+      indexPage.shouldContainLink('Find a programme and make a referral', '/find')
       indexPage.shouldNotContainLink('/refer/referrals/case-list')
       indexPage.shouldNotContainLink('/assess/referrals/case-list')
       indexPage.shouldContainLink('Reporting data', '/reports')

--- a/integration_tests/e2e/pniFind.cy.ts
+++ b/integration_tests/e2e/pniFind.cy.ts
@@ -46,6 +46,7 @@ context('Find programmes based on PNI Pathway', () => {
       const personSearchPage = Page.verifyOnPage(PersonSearchPage)
       personSearchPage.shouldContainPersonSearchInput()
       personSearchPage.shouldContainButton('Continue')
+      personSearchPage.shouldContainLink('See a list of all programmes', findPaths.index({}))
     })
 
     describe('When submitting without a prison number', () => {

--- a/server/controllers/find/personSearchController.test.ts
+++ b/server/controllers/find/personSearchController.test.ts
@@ -45,6 +45,10 @@ describe('PersonSearchController', () => {
 
       expect(FormUtils.setFieldErrors).toHaveBeenCalledWith(request, response, ['prisonNumber'])
       expect(response.render).toHaveBeenCalledWith('find/personSearch', {
+        hrefs: {
+          back: '/',
+          programmes: findPaths.index({}),
+        },
         pageHeading: 'Find recommended programmes',
       })
     })

--- a/server/controllers/find/personSearchController.ts
+++ b/server/controllers/find/personSearchController.ts
@@ -14,6 +14,10 @@ export default class PersonSearchController {
       FormUtils.setFieldErrors(req, res, ['prisonNumber'])
 
       res.render('find/personSearch', {
+        hrefs: {
+          back: '/',
+          programmes: findPaths.index({}),
+        },
         pageHeading: 'Find recommended programmes',
       })
     }

--- a/server/routes/find.ts
+++ b/server/routes/find.ts
@@ -1,36 +1,30 @@
 import type { Router } from 'express'
 
 import type { Controllers } from '../controllers'
-import { ApplicationRoles } from '../middleware'
 import { findPaths } from '../paths'
 import { RouteUtils } from '../utils'
-import type { MiddlewareOptions } from '@accredited-programmes/users'
 
 export default function routes(controllers: Controllers, router: Router): Router {
   const { get, post } = RouteUtils.actions(router)
   const { buildingChoicesController, buildingChoicesFormController, coursesController, courseOfferingsController } =
     controllers
-  const referrers: MiddlewareOptions = { allowedRoles: [ApplicationRoles.ACP_REFERRER] }
-  const editorsAndReferrers: MiddlewareOptions = {
-    allowedRoles: [ApplicationRoles.ACP_EDITOR, ApplicationRoles.ACP_REFERRER],
-  }
 
-  get(findPaths.index.pattern, coursesController.index(), { allowedRoles: [ApplicationRoles.ACP_EDITOR] })
+  get(findPaths.index.pattern, coursesController.index())
 
-  get(findPaths.show.pattern, coursesController.show(), editorsAndReferrers)
-  get(findPaths.offerings.show.pattern, courseOfferingsController.show(), editorsAndReferrers)
+  get(findPaths.show.pattern, coursesController.show())
+  get(findPaths.offerings.show.pattern, courseOfferingsController.show())
 
-  get(findPaths.buildingChoices.show.pattern, buildingChoicesController.show(), editorsAndReferrers)
+  get(findPaths.buildingChoices.show.pattern, buildingChoicesController.show())
 
-  get(findPaths.buildingChoices.form.show.pattern, buildingChoicesFormController.show(), referrers)
-  post(findPaths.buildingChoices.form.submit.pattern, buildingChoicesFormController.submit(), referrers)
+  get(findPaths.buildingChoices.form.show.pattern, buildingChoicesFormController.show())
+  post(findPaths.buildingChoices.form.submit.pattern, buildingChoicesFormController.submit())
 
-  get(findPaths.pniFind.personSearch.pattern, controllers.personSearchController.show(), referrers)
-  post(findPaths.pniFind.personSearch.pattern, controllers.personSearchController.submit(), referrers)
+  get(findPaths.pniFind.personSearch.pattern, controllers.personSearchController.show())
+  post(findPaths.pniFind.personSearch.pattern, controllers.personSearchController.submit())
 
-  get(findPaths.pniFind.recommendedPathway.pattern, controllers.recommendedPathwayController.show(), referrers)
+  get(findPaths.pniFind.recommendedPathway.pattern, controllers.recommendedPathwayController.show())
 
-  get(findPaths.pniFind.recommendedProgrammes.pattern, controllers.recommendedProgrammesController.show(), referrers)
+  get(findPaths.pniFind.recommendedProgrammes.pattern, controllers.recommendedProgrammesController.show())
 
   return router
 }

--- a/server/views/dashboard/index.njk
+++ b/server/views/dashboard/index.njk
@@ -19,16 +19,16 @@
 
   <div class="dashboard__cards-wrapper">
     <div class="govuk-grid-row dashboard__cards">
-      {% if 'ROLE_ACP_REFERRER' in user.roles %}
-        <div class="govuk-grid-column-one-third dashboard__card-wrapper">
-          <div class="dashboard__card">
-            <h2 class="govuk-heading-m dashboard__card-heading">
-              <a class="govuk-link dashboard__card-link" href="{{ findPath }}">Find a programme and make a referral</a>
-            </h2>
-            <p class="govuk-body dashboard__card-description">Search for Accredited Programmes, find out where they’re running and start a referral.</p>
-          </div>
+      <div class="govuk-grid-column-one-third dashboard__card-wrapper">
+        <div class="dashboard__card">
+          <h2 class="govuk-heading-m dashboard__card-heading">
+            <a class="govuk-link dashboard__card-link" href="{{ findPath }}">Find a programme and make a referral</a>
+          </h2>
+          <p class="govuk-body dashboard__card-description">Search for Accredited Programmes, find out where they’re running and start a referral.</p>
         </div>
+      </div>
 
+      {% if 'ROLE_ACP_REFERRER' in user.roles %}
         <div class="govuk-grid-column-one-third dashboard__card-wrapper">
           <div class="dashboard__card">
             <h2 class="govuk-heading-m dashboard__card-heading">

--- a/server/views/find/personSearch.njk
+++ b/server/views/find/personSearch.njk
@@ -8,7 +8,7 @@
 {% block backLink %}
   {{ govukBackLink({
     text: "Back",
-    href: "/"
+    href: hrefs.back
   }) }}
 {% endblock backLink %}
 
@@ -44,6 +44,8 @@
           text: "Continue"
         }) }}
       </form>
+
+      <a class="govuk-link" href="{{ hrefs.programmes }}">See a list of all programmes</a>
     </div>
   </div>
 {% endblock content %}


### PR DESCRIPTION
## Context

Now the PNI is driving referrals we need to reinstate a journey for users to browse the full list of programmes. This should be for viewing purposes only. If anyone wishes to refer to an programme they will still need to do so via a PNI.

## Changes in this PR

- Remove role protection from find routes so any user can access them
- Add "See a list of all programmes" link on the person search page

Note: Search functionality remains but users without the referrer role will only be able to search for people within their caseloads.


## Screenshots of UI changes

![image](https://github.com/user-attachments/assets/d6e391ab-7695-428d-8e26-c6e9350a128e)


