### PR TITLE
(APG-789b) Check for override when marking a referral as Assessed as suitable and ready

### DIFF
--- a/server/@types/models/Referral.ts
+++ b/server/@types/models/Referral.ts
@@ -96,6 +96,8 @@ type ReferralView = {
   tasksCompleted?: number
 }
 
+type ReferralStatusWithReasons = Extract<ReferralStatusUppercase, 'ASSESSED_SUITABLE' | 'DESELECTED' | 'WITHDRAWN'>
+
 export { referralStatusGroups, referralStatuses }
 
 export type {
@@ -106,5 +108,6 @@ export type {
   ReferralStatusRefData,
   ReferralStatusUpdate,
   ReferralStatusUppercase,
+  ReferralStatusWithReasons,
   ReferralView,
 }

--- a/server/@types/models/index.d.ts
+++ b/server/@types/models/index.d.ts
@@ -17,6 +17,7 @@ import type {
   ReferralStatusRefData,
   ReferralStatusUpdate,
   ReferralStatusUppercase,
+  ReferralStatusWithReasons,
   ReferralView,
 } from './Referral'
 import type { Alert, RiskLevel, RisksAndAlerts } from './RisksAndAlerts'
@@ -43,6 +44,7 @@ export type {
   ReferralStatusRefData,
   ReferralStatusUpdate,
   ReferralStatusUppercase,
+  ReferralStatusWithReasons,
   ReferralView,
   RiskLevel,
   RisksAndAlerts,

--- a/server/controllers/assess/index.ts
+++ b/server/controllers/assess/index.ts
@@ -25,6 +25,8 @@ const controllers = (services: Services) => {
   const updateStatusDecisionController = new UpdateStatusDecisionController(
     services.personService,
     services.referralService,
+    services.pniService,
+    services.courseService,
   )
 
   const transferReferralController = new TransferReferralController(

--- a/server/controllers/shared/reasonController.test.ts
+++ b/server/controllers/shared/reasonController.test.ts
@@ -128,6 +128,7 @@ describe('ReasonController', () => {
         pageHeading: 'Deselection reason',
         person,
         reasonsFieldsets,
+        showOther: true,
         timelineItems: timelineItems.slice(0, 1),
       })
 
@@ -175,6 +176,7 @@ describe('ReasonController', () => {
           pageHeading: 'Withdrawal reason',
           person,
           reasonsFieldsets,
+          showOther: true,
           timelineItems: timelineItems.slice(0, 1),
         })
 
@@ -208,12 +210,48 @@ describe('ReasonController', () => {
           pageHeading: 'Deselection reason',
           person,
           reasonsFieldsets,
+          showOther: true,
           timelineItems: timelineItems.slice(0, 1),
         })
 
         expect(referenceDataService.getReferralStatusCodeReasonsWithCategory).toHaveBeenCalledWith(
           username,
           'DESELECTED',
+        )
+        expect(referralService.getReferralStatusHistory).toHaveBeenCalledWith(userToken, username, referral.id)
+
+        expect(FormUtils.setFieldErrors).toHaveBeenCalledWith(request, response, ['reasonCode'])
+        expect(ReferralUtils.groupReasonsByCategory).toHaveBeenCalledWith(referralStatusCodeReasons)
+        expect(ReferralUtils.createReasonsFieldset).toHaveBeenCalledWith(groupedReasons, undefined)
+        expect(ShowReferralUtils.statusHistoryTimelineItems).toHaveBeenCalledWith(referralStatusHistory)
+      })
+    })
+
+    describe('when the status decision is `ASSESSED_SUITABLE`', () => {
+      it('should render the show template with the correct response locals', async () => {
+        request.session.referralStatusUpdateData = {
+          ...referralStatusUpdateData,
+          decisionForCategoryAndReason: 'ASSESSED_SUITABLE',
+          initialStatusDecision: 'ASSESSED_SUITABLE',
+        }
+
+        const requestHandler = controller.show()
+        await requestHandler(request, response, next)
+
+        expect(response.render).toHaveBeenCalledWith('referrals/updateStatus/reason/show', {
+          backLinkHref: referPaths.show.statusHistory({ referralId: referral.id }),
+          pageDescription:
+            'This referral does not match the recommended programme pathway based on the risk and programme needs identifier (PNI) scores.',
+          pageHeading: 'Reason why the referral does not match the PNI',
+          person,
+          reasonsFieldsets,
+          showOther: false,
+          timelineItems: timelineItems.slice(0, 1),
+        })
+
+        expect(referenceDataService.getReferralStatusCodeReasonsWithCategory).toHaveBeenCalledWith(
+          username,
+          'ASSESSED_SUITABLE',
         )
         expect(referralService.getReferralStatusHistory).toHaveBeenCalledWith(userToken, username, referral.id)
 

--- a/server/data/accreditedProgrammesApi/referenceDataClient.ts
+++ b/server/data/accreditedProgrammesApi/referenceDataClient.ts
@@ -7,6 +7,7 @@ import type {
   ReferralStatusCategory,
   ReferralStatusRefData,
   ReferralStatusUppercase,
+  ReferralStatusWithReasons,
 } from '@accredited-programmes/models'
 import type { EnabledOrganisation, ReferralStatusReason } from '@accredited-programmes-api'
 import type { SystemToken } from '@hmpps-auth'
@@ -60,7 +61,7 @@ export default class ReferenceDataClient {
   }
 
   async findReferralStatusCodeReasonsWithCategory(
-    referralStatusCode: Extract<ReferralStatusUppercase, 'DESELECTED' | 'WITHDRAWN'>,
+    referralStatusCode: Extract<ReferralStatusUppercase, ReferralStatusWithReasons>,
   ): Promise<Array<ReferralStatusReason>> {
     return (await this.restClient.get({
       path: apiPaths.referenceData.referralStatuses.statusCodeReasonsWithCategories({ referralStatusCode }),

--- a/server/services/referenceDataService.ts
+++ b/server/services/referenceDataService.ts
@@ -4,6 +4,7 @@ import type {
   ReferralStatusCategory,
   ReferralStatusRefData,
   ReferralStatusUppercase,
+  ReferralStatusWithReasons,
 } from '@accredited-programmes/models'
 import type { EnabledOrganisation, ReferralStatusReason } from '@accredited-programmes-api'
 
@@ -60,7 +61,7 @@ export default class ReferenceDataService {
 
   async getReferralStatusCodeReasonsWithCategory(
     username: Express.User['username'],
-    referralStatusCode: Extract<ReferralStatusUppercase, 'DESELECTED' | 'WITHDRAWN'>,
+    referralStatusCode: ReferralStatusWithReasons,
   ): Promise<Array<ReferralStatusReason>> {
     const hmppsAuthClient = this.hmppsAuthClientBuilder()
     const systemToken = await hmppsAuthClient.getSystemClientToken(username)

--- a/server/utils/referrals/referralUtils.test.ts
+++ b/server/utils/referrals/referralUtils.test.ts
@@ -6,20 +6,98 @@ describe('ReferralUtils', () => {
   describe('createReasonsFieldset', () => {
     it('creates an array of fieldsets with a legend and radios property', () => {
       const groupedOptions = {
-        W_ADMIN: [
-          { code: 'A', description: 'Category A', referralCategoryCode: 'W_ADMIN' },
-          { code: 'B', description: 'Category B', referralCategoryCode: 'W_ADMIN' },
-        ],
+        AS_INCOMPLETE: [{ code: 'A', description: 'Category A', referralCategoryCode: 'AS_INCOMPLETE' }],
+        AS_MOTIVATION: [{ code: 'B', description: 'Category B', referralCategoryCode: 'AS_MOTIVATION' }],
+        AS_OPERATIONAL: [{ code: 'C', description: 'Category C', referralCategoryCode: 'AS_OPERATIONAL' }],
+        AS_PERSONAL: [{ code: 'D', description: 'Category D', referralCategoryCode: 'AS_PERSONAL' }],
+        AS_RISK: [{ code: 'E', description: 'Category E', referralCategoryCode: 'AS_RISK' }],
+        AS_SENTENCE: [{ code: 'F', description: 'Category F', referralCategoryCode: 'AS_SENTENCE' }],
+        W_ADMIN: [{ code: 'G', description: 'Category G', referralCategoryCode: 'W_ADMIN' }],
       }
       expect(ReferralUtils.createReasonsFieldset(groupedOptions)).toEqual([
         {
           legend: {
-            text: 'Administrative error',
+            text: 'Incomplete assessment',
           },
           radios: [
-            { checked: false, text: 'Category A', value: 'A' },
-            { checked: false, text: 'Category B', value: 'B' },
+            {
+              checked: false,
+              text: 'Category A',
+              value: 'A',
+            },
           ],
+          testId: 'AS_INCOMPLETE-reason-options',
+        },
+        {
+          legend: {
+            text: 'Motivation and behaviour',
+          },
+          radios: [
+            {
+              checked: false,
+              text: 'Category B',
+              value: 'B',
+            },
+          ],
+          testId: 'AS_MOTIVATION-reason-options',
+        },
+        {
+          legend: {
+            text: 'Operational',
+          },
+          radios: [
+            {
+              checked: false,
+              text: 'Category C',
+              value: 'C',
+            },
+          ],
+          testId: 'AS_OPERATIONAL-reason-options',
+        },
+        {
+          legend: {
+            text: 'Personal and health',
+          },
+          radios: [
+            {
+              checked: false,
+              text: 'Category D',
+              value: 'D',
+            },
+          ],
+          testId: 'AS_PERSONAL-reason-options',
+        },
+        {
+          legend: {
+            text: 'Risk and need',
+          },
+          radios: [
+            {
+              checked: false,
+              text: 'Category E',
+              value: 'E',
+            },
+          ],
+          testId: 'AS_RISK-reason-options',
+        },
+        {
+          legend: {
+            text: 'Sentence type',
+          },
+          radios: [
+            {
+              checked: false,
+              text: 'Category F',
+              value: 'F',
+            },
+          ],
+          testId: 'AS_SENTENCE-reason-options',
+        },
+        {
+          legend: {
+            text: 'Administrative error',
+          },
+          radios: [{ checked: false, text: 'Category G', value: 'G' }],
           testId: 'W_ADMIN-reason-options',
         },
       ])

--- a/server/utils/referrals/referralUtils.ts
+++ b/server/utils/referrals/referralUtils.ts
@@ -57,10 +57,17 @@ export default class ReferralUtils {
     }, [])
   }
 
+  // This will get replaced by APG-829
   private static categoryCodeToText(code: string): string {
     switch (code.split('_')[1]) {
       case 'ADMIN':
         return 'Administrative error'
+      case 'INCOMPLETE':
+        return 'Incomplete assessment'
+      case 'RISK':
+        return 'Risk and need'
+      case 'SENTENCE':
+        return 'Sentence type'
       case 'MOTIVATION':
         return 'Motivation and behaviour'
       case 'OPERATIONAL':

--- a/server/views/referrals/updateStatus/reason/show.njk
+++ b/server/views/referrals/updateStatus/reason/show.njk
@@ -26,27 +26,29 @@
       }) }}
     {% endfor %}
 
-    <div class="govuk-radios__divider govuk-!-margin-bottom-6">or</div>
+    {% if showOther %}
+      <div class="govuk-radios__divider govuk-!-margin-bottom-6">or</div>
 
-    {{ govukRadios({
-      name: "reasonCode",
-      fieldset: {
-        legend: {
-          text: "Other reason",
-          classes: "govuk-fieldset__legend--m"
+      {{ govukRadios({
+        name: "reasonCode",
+        fieldset: {
+          legend: {
+            text: "Other reason",
+            classes: "govuk-fieldset__legend--m"
+          }
+        },
+        items: [
+          {
+            value: "OTHER",
+            text: "Other"
+          }
+        ],
+        errorMessage: errors.messages.reasonCode,
+        attributes: {
+          "data-testid": "reason-options"
         }
-      },
-      items: [
-        {
-          value: "OTHER",
-          text: "Other"
-        }
-      ],
-      errorMessage: errors.messages.reasonCode,
-      attributes: {
-        "data-testid": "reason-options"
-      }
-    }) }}
+      }) }}
+    {% endif %}
 
     <div class="govuk-button-group">
       {{ govukButton({


### PR DESCRIPTION
## Context

After the ‘Assessment started’ status the PT has the option to update the referral to ‘Assessed as suitable’. If the referral does not align with the PNI pathway (i.e. its an override) then a list of radio button options will capture the reason why the referral is deemed suitable despite the PNI mismatch. This information will be used downstream for Quality Assurance purpose.

## Changes in this PR

- Compare PNI Score Programme pathway against the intensity of the course when selecting "Assessed as suitable and ready to continue".
- If there is a mismatch, it will redirect to the reason step and display a list of possible radio options.


## Screenshots of UI changes
![localhost_3000_assess_referrals_0a5657b7-7573-476b-85de-ec29c03dc887_update-status_reason](https://github.com/user-attachments/assets/5dac789c-8cca-40c8-bdc9-33af0bf155ed)

