### PR TITLE
Makes Additional Info step optional

### DIFF
--- a/integration_tests/pages/refer/new/additionalInformation.ts
+++ b/integration_tests/pages/refer/new/additionalInformation.ts
@@ -17,7 +17,7 @@ export default class NewReferralAdditionalInformationPage extends Page {
   }
 
   shouldContainAdditionalInformationTextArea() {
-    this.shouldContainTextArea('additionalInformation', 'Provide additional information')
+    this.shouldContainTextArea('additionalInformation', 'Provide additional information (optional)')
   }
 
   shouldContainContinueButton() {
@@ -31,7 +31,7 @@ export default class NewReferralAdditionalInformationPage extends Page {
   shouldContainInstructions() {
     cy.get('[data-testid="instructions-paragraph"]').should(
       'have.text',
-      'You must provide additional information you feel will help the programme team in their assessment. This might include:',
+      'You may provide additional information you feel will help the programme team in their assessment. This might include:',
     )
 
     const expectedListText = [
@@ -45,9 +45,16 @@ export default class NewReferralAdditionalInformationPage extends Page {
     })
   }
 
+  skipAdditionalInformation() {
+    this.referral = { ...this.referral, hasReviewedAdditionalInformation: true }
+    // We're stubbing the referral here to make sure the updated referral is available on the task list page
+    cy.task('stubReferral', this.referral)
+    this.shouldContainButton('Skip this section').click()
+  }
+
   submitAdditionalInformation(additionalInformation = 'Wheat gluten makes great fake chicken') {
     cy.get('[data-testid="additional-information-text-area"]').type(additionalInformation, { delay: 0 })
-    this.referral = { ...this.referral, additionalInformation }
+    this.referral = { ...this.referral, additionalInformation, hasReviewedAdditionalInformation: true }
     // We're stubbing the referral here to make sure the updated referral is available on the task list page
     cy.task('stubReferral', this.referral)
     this.shouldContainButton('Continue').click()

--- a/server/controllers/refer/new/additionalInformationController.ts
+++ b/server/controllers/refer/new/additionalInformationController.ts
@@ -60,25 +60,25 @@ export default class NewReferralsAdditionalInformationController {
         return res.redirect(authPaths.error({}))
       }
 
-      const formattedAdditionalInformation = req.body.additionalInformation?.trim()
+      const isSkip = req.body.skip === 'true'
+      const hasAdditonalInfo = req.body.additionalInformation?.length > 0
+      const formattedAdditionalInformation = hasAdditonalInfo ? req.body.additionalInformation.trim() : null
 
-      if (!formattedAdditionalInformation) {
-        req.flash('additionalInformationError', 'Enter additional information')
-        hasErrors = true
-      }
+      if (!isSkip) {
+        if (formattedAdditionalInformation?.length > maxLength) {
+          req.flash('additionalInformationError', `Additional information must be ${maxLength} characters or fewer`)
+          req.flash('formValues', [JSON.stringify({ formattedAdditionalInformation })])
+          hasErrors = true
+        }
 
-      if (formattedAdditionalInformation?.length > maxLength) {
-        req.flash('additionalInformationError', `Additional information must be ${maxLength} characters or fewer`)
-        req.flash('formValues', [JSON.stringify({ formattedAdditionalInformation })])
-        hasErrors = true
-      }
-
-      if (hasErrors) {
-        return res.redirect(referPaths.new.additionalInformation.show({ referralId }))
+        if (hasErrors) {
+          return res.redirect(referPaths.new.additionalInformation.show({ referralId }))
+        }
       }
 
       const referralUpdate: ReferralUpdate = {
-        additionalInformation: formattedAdditionalInformation,
+        additionalInformation: isSkip ? referral.additionalInformation : formattedAdditionalInformation,
+        hasReviewedAdditionalInformation: isSkip ? true : hasAdditonalInfo,
         hasReviewedProgrammeHistory: referral.hasReviewedProgrammeHistory,
         oasysConfirmed: referral.oasysConfirmed,
       }

--- a/server/controllers/refer/new/courseParticipationsController.test.ts
+++ b/server/controllers/refer/new/courseParticipationsController.test.ts
@@ -600,6 +600,7 @@ describe('NewReferralsCourseParticipationsController', () => {
       expect(referralService.getReferral).toHaveBeenCalledWith(username, referralId)
       expect(referralService.updateReferral).toHaveBeenCalledWith(username, referralId, {
         additionalInformation: draftReferral.additionalInformation,
+        hasReviewedAdditionalInformation: draftReferral.hasReviewedAdditionalInformation,
         hasReviewedProgrammeHistory,
         oasysConfirmed: draftReferral.oasysConfirmed,
       })

--- a/server/controllers/refer/new/courseParticipationsController.ts
+++ b/server/controllers/refer/new/courseParticipationsController.ts
@@ -293,10 +293,11 @@ export default class NewReferralsCourseParticipationsController {
       }
 
       const hasReviewedProgrammeHistory = req.body.hasReviewedProgrammeHistory === 'true'
-      const { oasysConfirmed, additionalInformation } = referral
+      const { oasysConfirmed, additionalInformation, hasReviewedAdditionalInformation } = referral
 
       const referralUpdate: ReferralUpdate = {
         additionalInformation,
+        hasReviewedAdditionalInformation,
         hasReviewedProgrammeHistory,
         oasysConfirmed,
       }

--- a/server/controllers/refer/new/oasysConfirmationController.test.ts
+++ b/server/controllers/refer/new/oasysConfirmationController.test.ts
@@ -150,6 +150,7 @@ describe('NewReferralsOasysConfirmationController', () => {
       expect(response.redirect).toHaveBeenCalledWith(referPaths.new.show({ referralId }))
       expect(referralService.updateReferral).toHaveBeenCalledWith(username, referralId, {
         additionalInformation: draftReferral.additionalInformation,
+        hasReviewedAdditionalInformation: draftReferral.hasReviewedAdditionalInformation,
         hasReviewedProgrammeHistory: draftReferral.hasReviewedProgrammeHistory,
         oasysConfirmed: true,
       })

--- a/server/controllers/refer/new/oasysConfirmationController.ts
+++ b/server/controllers/refer/new/oasysConfirmationController.ts
@@ -74,6 +74,7 @@ export default class NewReferralsOasysConfirmationController {
 
       const referralUpdate: ReferralUpdate = {
         additionalInformation: referral.additionalInformation,
+        hasReviewedAdditionalInformation: referral.hasReviewedAdditionalInformation,
         hasReviewedProgrammeHistory: referral.hasReviewedProgrammeHistory,
         oasysConfirmed,
       }

--- a/server/testutils/factories/referral.ts
+++ b/server/testutils/factories/referral.ts
@@ -13,7 +13,7 @@ class ReferralFactory extends Factory<Referral> {
 
   started() {
     return this.params({
-      additionalInformation: undefined,
+      hasReviewedAdditionalInformation: false,
       hasReviewedProgrammeHistory: false,
       oasysConfirmed: false,
       status: 'referral_started',
@@ -24,6 +24,7 @@ class ReferralFactory extends Factory<Referral> {
   submittable() {
     return this.params({
       additionalInformation: faker.lorem.paragraph({ max: 5, min: 1 }),
+      hasReviewedAdditionalInformation: true,
       hasReviewedProgrammeHistory: true,
       oasysConfirmed: true,
       status: 'referral_started',
@@ -87,6 +88,7 @@ export default ReferralFactory.define(({ params }) => {
     additionalInformation: faker.lorem.paragraph({ max: 5, min: 0 }),
     closed: closedStatuses.includes(status),
     hasLdcBeenOverriddenByProgrammeTeam: faker.datatype.boolean(),
+    hasReviewedAdditionalInformation: faker.datatype.boolean(),
     hasReviewedProgrammeHistory: faker.datatype.boolean(),
     oasysConfirmed: faker.datatype.boolean(),
     offeringId: faker.string.uuid(),

--- a/server/utils/referrals/newReferralUtils.test.ts
+++ b/server/utils/referrals/newReferralUtils.test.ts
@@ -70,10 +70,10 @@ describe('NewReferralUtils', () => {
       expect(NewReferralUtils.isReadyForSubmission(referral)).toEqual(false)
     })
 
-    it('returns false when additional information not provided', () => {
-      const referral = referralFactory.submittable().build({ additionalInformation: '' })
+    it('returns true when additional information not provided but is marked as reviewed', () => {
+      const referral = referralFactory.submittable().build()
 
-      expect(NewReferralUtils.isReadyForSubmission(referral)).toEqual(false)
+      expect(NewReferralUtils.isReadyForSubmission(referral)).toEqual(true)
     })
 
     it('returns true when programme history reviewed, OASys confirmed, and additional information provided', () => {

--- a/server/utils/referrals/newReferralUtils.ts
+++ b/server/utils/referrals/newReferralUtils.ts
@@ -42,7 +42,9 @@ export default class NewReferralUtils {
   }
 
   static isReadyForSubmission(referral: Referral): boolean {
-    return referral.hasReviewedProgrammeHistory && referral.oasysConfirmed && !!referral.additionalInformation
+    return (
+      referral.hasReviewedProgrammeHistory && referral.oasysConfirmed && !!referral.hasReviewedAdditionalInformation
+    )
   }
 
   static referrerSummaryListRows(
@@ -100,7 +102,7 @@ export default class NewReferralUtils {
           },
           {
             statusTag: NewReferralUtils.taskListStatusTag(
-              referral.additionalInformation ? 'Completed' : 'Not started',
+              referral.hasReviewedAdditionalInformation ? 'Completed' : 'Not started',
               'additional-information-tag',
             ),
             text: 'Add additional information',

--- a/server/views/referrals/new/additionalInformation/show.njk
+++ b/server/views/referrals/new/additionalInformation/show.njk
@@ -34,7 +34,7 @@
 
   <div class="govuk-grid-row">
     <div class="govuk-grid-column-two-thirds">
-      <p class="govuk-body" data-testid="instructions-paragraph">You must provide additional information you feel will help the programme team in their assessment. This might include:</p>
+      <p class="govuk-body" data-testid="instructions-paragraph">You may provide additional information you feel will help the programme team in their assessment. This might include:</p>
 
       <ul class="govuk-list govuk-list--bullet">
         <li>the reason for the referral</li>
@@ -49,13 +49,12 @@
 
       <form action="{{ referPaths.new.additionalInformation.update({ referralId: referral.id }) }}?_method=PUT" method="post">
         <input type="hidden" name="_csrf" value="{{ csrfToken }}"/>
-
         {{ govukCharacterCount({
           id: "additionalInformation",
           name: "additionalInformation",
           maxlength: maxLength,
           label: {
-            text: "Provide additional information",
+            text: "Provide additional information (optional)",
             classes: "govuk-fieldset__legend--s"
           },
           attributes: {
@@ -64,14 +63,24 @@
           value: formValues.formattedAdditionalInformation or referral.additionalInformation,
           errorMessage: errors.messages.additionalInformation
         }) }}
-
-        {{ govukButton({
+        <div class="govuk-button-group">
+          {{ govukButton({
           attributes: {
             'data-testid': 'additional-information-submit-button'
           },
           text: "Continue"
         }) }}
-      </form>
+          {{ govukButton({
+          attributes: {
+            'data-testid': 'additional-information-skip-button'
+          },
+          classes: "govuk-button--secondary",
+          text: "Skip this section",
+          name: "skip",
+          value: "true"
+        }) }}
+        </form>
+      </div>
     </div>
   </div>
 {% endblock content %}


### PR DESCRIPTION
Makes the additional info step in creating a draft referral option. In addition, resets the additional info step if no details are entered and the continue option is selected.

## Screenshots of UI changes

![Screenshot 2025-04-09 at 14 46 49](https://github.com/user-attachments/assets/7334345b-c604-4b13-bcd4-d3d1b66c9f9e)


## Release checklist

[Release process documentation](../blob/main/doc/how-to/perform-a-release.md)

As part of our continuous deployment strategy we must ensure that this work is
ready to be released once merged.

### Pre-merge

- [ ] There are changes required to the Accredited Programmes API for this change to work...
  - [ ] ... and they have been released to production already

### Post-merge

<!-- The outer checkboxes can be completed pre-merge -->

- [ ] This adds, extends or meaningfully modifies a feature...
  - [ ] ... and I have written or updated an end-to-end test for the happy path in the [Accredited Programmes E2E repo](https://github.com/ministryofjustice/hmpps-accredited-programmes-e2e)
- [ ] This makes new expectations of the API...
  - [ ] ... and I have notified the API developer(s) of changes to the contract tests (Pact), or the API is already compliant
- [ ] [Manually approve](../doc/how-to/perform-a-release.md#releasing-to-the-preprod-environment) release to preprod
- [ ] [Manually approve](../doc/how-to/perform-a-release.md#releasing-to-the-production-environment) release to prod

<!-- Should a release fail at any step, you as the author should now lead the work to
fix it as soon as possible. You can monitor deployment failures in CircleCI
itself and application errors are found in
[Sentry](https://ministryofjustice.sentry.io/projects/hmpps-accredited-programmes-ui/?project=4505330122686464&referrer=sidebar&statsPeriod=24h). -->
