### PR TITLE
(APG-656a) Add utils to help display referrer override decision content

### DIFF
--- a/server/utils/courseUtils.test.ts
+++ b/server/utils/courseUtils.test.ts
@@ -65,6 +65,18 @@ describe('CourseUtils', () => {
     })
   })
 
+  describe('formatIntensityValue', () => {
+    it.each([
+      ['HIGH', 'High intensity'],
+      ['HIGH_MODERATE', 'High or moderate intensity'],
+      ['MODERATE', 'Moderate intensity'],
+      ['UNKNOWN', 'Unknown'],
+      [undefined, 'Unknown'],
+    ])('returns the correct intensity text for %s', (intensity, expectedText) => {
+      expect(CourseUtils.formatIntensityValue(intensity)).toBe(expectedText)
+    })
+  })
+
   describe('isBuildingChoices', () => {
     it('should ignore case', () => {
       expect(CourseUtils.isBuildingChoices('BUILDING CHOICES: moderate intensity')).toBe(true)

--- a/server/utils/courseUtils.ts
+++ b/server/utils/courseUtils.ts
@@ -50,6 +50,16 @@ export default class CourseUtils {
     })
   }
 
+  static formatIntensityValue(intensity: Course['intensity']): string {
+    const intensityMap: Record<string, string> = {
+      HIGH: 'High',
+      HIGH_MODERATE: 'High or moderate',
+      MODERATE: 'Moderate',
+    }
+
+    return intensity && intensityMap[intensity] ? `${intensityMap[intensity]} intensity` : 'Unknown'
+  }
+
   static isBuildingChoices(courseDisplayName?: string): boolean {
     return courseDisplayName?.toLowerCase()?.startsWith('building choices:') ?? false
   }

--- a/server/utils/referrals/showReferralUtils.test.ts
+++ b/server/utils/referrals/showReferralUtils.test.ts
@@ -10,6 +10,7 @@ import {
   staffDetailFactory,
 } from '../../testutils/factories'
 import CourseUtils from '../courseUtils'
+import PniUtils from '../risksAndNeeds/pniUtils'
 import type { ReferralStatusHistoryPresenter } from '@accredited-programmes/ui'
 
 jest.mock('./caseListUtils')
@@ -399,6 +400,30 @@ describe('ShowReferralUtils', () => {
         {
           key: { text: 'Programme team email address' },
           value: { html: `<a href="mailto:${contactEmail}">${contactEmail}</a>` },
+        },
+      ])
+    })
+  })
+
+  describe('pniMismatchSummaryListRows', () => {
+    it('formats the provided pathways and override reason in the appropriate format for passing to a GOV.UK summary list Nunjucks macro', () => {
+      jest.spyOn(PniUtils, 'formatPathwayValue').mockReturnValue('High intensity')
+      jest.spyOn(CourseUtils, 'formatIntensityValue').mockReturnValue('Moderate intensity')
+
+      expect(
+        ShowReferralUtils.pniMismatchSummaryListRows('HIGH_INTENSITY_BC', 'MODERATE', 'The reason for the override.'),
+      ).toEqual([
+        {
+          key: { text: 'Recommended pathway' },
+          value: { text: 'High intensity' },
+        },
+        {
+          key: { text: 'Requested pathway' },
+          value: { text: 'Moderate intensity' },
+        },
+        {
+          key: { text: 'Reason given by referrer' },
+          value: { text: 'The reason for the override.' },
         },
       ])
     })

--- a/server/utils/referrals/showReferralUtils.ts
+++ b/server/utils/referrals/showReferralUtils.ts
@@ -4,6 +4,7 @@ import CaseListUtils from './caseListUtils'
 import { assessPathBase, assessPaths, referPaths } from '../../paths'
 import CourseUtils from '../courseUtils'
 import DateUtils from '../dateUtils'
+import PniUtils from '../risksAndNeeds/pniUtils'
 import StringUtils from '../stringUtils'
 import type { CourseOffering, Organisation, ReferralStatusRefData } from '@accredited-programmes/models'
 import type {
@@ -14,7 +15,7 @@ import type {
   MojTimelineItem,
   ReferralStatusHistoryPresenter,
 } from '@accredited-programmes/ui'
-import type { Course, Referral } from '@accredited-programmes-api'
+import type { Course, PniScore, Referral } from '@accredited-programmes-api'
 import type { GovukFrontendButton } from '@govuk-frontend'
 import type { User, UserEmail } from '@manage-users-api'
 
@@ -148,6 +149,27 @@ export default class ShowReferralUtils {
       {
         key: { text: 'Programme team email address' },
         value: { html: `<a href="mailto:${contactEmail}">${contactEmail}</a>` },
+      },
+    ]
+  }
+
+  static pniMismatchSummaryListRows(
+    recommendedPathway: PniScore['programmePathway'],
+    requestedPathway: Course['intensity'],
+    referrerOverrideReason: Referral['referrerOverrideReason'],
+  ): Array<GovukFrontendSummaryListRowWithKeyAndValue> {
+    return [
+      {
+        key: { text: 'Recommended pathway' },
+        value: { text: PniUtils.formatPathwayValue(recommendedPathway) },
+      },
+      {
+        key: { text: 'Requested pathway' },
+        value: { text: CourseUtils.formatIntensityValue(requestedPathway) },
+      },
+      {
+        key: { text: 'Reason given by referrer' },
+        value: { text: referrerOverrideReason || 'Not specified' },
       },
     ]
   }

--- a/server/utils/risksAndNeeds/pniUtils.test.ts
+++ b/server/utils/risksAndNeeds/pniUtils.test.ts
@@ -81,7 +81,7 @@ describe('PniUtils', () => {
           'Based on the risk and need scores, Del Hatton may be eligible for the high intensity Accredited Programmes pathway.',
         class: 'pathway-content--high',
         dataTestId: 'high-intensity-pathway-content',
-        headingText: 'High Intensity',
+        headingText: 'High intensity',
       })
     })
 
@@ -93,7 +93,7 @@ describe('PniUtils', () => {
           'Based on the risk and need scores, Del Hatton may be eligible for the moderate intensity Accredited Programmes pathway.',
         class: 'pathway-content--moderate',
         dataTestId: 'moderate-intensity-pathway-content',
-        headingText: 'Moderate Intensity',
+        headingText: 'Moderate intensity',
       })
     })
 
@@ -130,6 +130,19 @@ describe('PniUtils', () => {
         dataTestId: 'error-pathway-content',
         headingText: 'Error',
       })
+    })
+  })
+
+  describe('formatPathwayValue', () => {
+    it.each([
+      ['HIGH_INTENSITY_BC', 'High intensity'],
+      ['MODERATE_INTENSITY_BC', 'Moderate intensity'],
+      ['ALTERNATIVE_PATHWAY', 'Not eligible'],
+      ['MISSING_INFORMATION', 'Information missing'],
+      ['UNKNOWN', 'Unknown'],
+      [undefined, 'Unknown'],
+    ])('returns the correct pathway text for %s', (pathway, expectedText) => {
+      expect(PniUtils.formatPathwayValue(pathway)).toBe(expectedText)
     })
   })
 

--- a/server/utils/risksAndNeeds/pniUtils.ts
+++ b/server/utils/risksAndNeeds/pniUtils.ts
@@ -9,6 +9,17 @@ import type {
 } from '@accredited-programmes-api'
 
 export default class PniUtils {
+  static formatPathwayValue(programmePathway?: PniScore['programmePathway']): string {
+    const pathwayMap: Record<PniScore['programmePathway'], string> = {
+      ALTERNATIVE_PATHWAY: 'Not eligible',
+      HIGH_INTENSITY_BC: 'High intensity',
+      MISSING_INFORMATION: 'Information missing',
+      MODERATE_INTENSITY_BC: 'Moderate intensity',
+    }
+
+    return programmePathway && pathwayMap[programmePathway] ? pathwayMap[programmePathway] : 'Unknown'
+  }
+
   static needScoreToString(needScore?: number | null): string {
     switch (needScore) {
       case 0:
@@ -39,21 +50,21 @@ export default class PniUtils {
           bodyText: `${bodyTextPrefix} be eligible for the high intensity Accredited Programmes pathway.`,
           class: 'pathway-content--high',
           dataTestId: 'high-intensity-pathway-content',
-          headingText: 'High Intensity',
+          headingText: this.formatPathwayValue(programmePathway),
         }
       case 'MODERATE_INTENSITY_BC':
         return {
           bodyText: `${bodyTextPrefix} be eligible for the moderate intensity Accredited Programmes pathway.`,
           class: 'pathway-content--moderate',
           dataTestId: 'moderate-intensity-pathway-content',
-          headingText: 'Moderate Intensity',
+          headingText: this.formatPathwayValue(programmePathway),
         }
       case 'ALTERNATIVE_PATHWAY':
         return {
           bodyText: `${bodyTextPrefix} not be eligible for either the moderate or high intensity Accredited Programmes pathway. Speak to the Offender Management team about other options.`,
           class: 'pathway-content--alternative',
           dataTestId: 'alternative-pathway-content',
-          headingText: 'Not eligible',
+          headingText: this.formatPathwayValue(programmePathway),
         }
       case 'MISSING_INFORMATION':
         return {
@@ -61,7 +72,7 @@ export default class PniUtils {
             'There is not enough information in the risk and need assessment to calculate the recommended programme pathway.',
           class: 'pathway-content--missing',
           dataTestId: 'missing-informaton-pathway-content',
-          headingText: 'Information missing',
+          headingText: this.formatPathwayValue(programmePathway),
         }
       default:
         return {


### PR DESCRIPTION
## Context

To help display the intensity and pathway values, along with an override reason



## Changes in this PR
- Added util methods to convert pathway and intensity values into friendlier strings to display in the UI
- Added `pniMismatchSummaryListRows` method to be used on the Additional Information page


