### PR TITLE
(APG-656b) Add method to check if a referral is an override

### DIFF
--- a/server/services/index.ts
+++ b/server/services/index.ts
@@ -30,10 +30,16 @@ const services = () => {
   const personService = new PersonService(hmppsAuthClientBuilder, prisonApiClientBuilder, personClientBuilder)
   const userService = new UserService(hmppsManageUsersClientBuilder, prisonApiClientBuilder)
   const referenceDataService = new ReferenceDataService(hmppsAuthClientBuilder, referenceDataClientBuilder)
-  const referralService = new ReferralService(hmppsAuthClientBuilder, referralClientBuilder, userService)
   const courseService = new CourseService(courseClientBuilder, hmppsAuthClientBuilder, userService)
   const pniService = new PniService(hmppsAuthClientBuilder, pniClientBuilder)
   const statisticsService = new StatisticsService(hmppsAuthClientBuilder, statisticsClientBuilder)
+  const referralService = new ReferralService(
+    hmppsAuthClientBuilder,
+    referralClientBuilder,
+    userService,
+    courseService,
+    pniService,
+  )
 
   return {
     courseService,


### PR DESCRIPTION
## Context

There are now multiple places where we need to check if a referral is an override, such as:
- Additional information form when creating a referral
- Additional information page within a referral
- When submitting the pdate status decision form

## Changes in this PR
Added a new method which returns the PNI programme pathway, the intensity of the course on the referral and if we then class the referral to be an override or not.

