### PR TITLE
(APG-656c) Show referrer override details on Additional information page

### DIFF
--- a/integration_tests/e2e/assess/show.cy.ts
+++ b/integration_tests/e2e/assess/show.cy.ts
@@ -62,8 +62,16 @@ context('Viewing a submitted referral', () => {
     })
 
     describe('When reviewing additional information', () => {
-      it('shows the correct information', () => {
-        sharedTests.referrals.showsAdditionalInformationPage(ApplicationRoles.ACP_PROGRAMME_TEAM)
+      describe('and the referral is an override', () => {
+        it('should display the the reason for the override and the additional information cards', () => {
+          sharedTests.referrals.showsAdditionalInformationPageWithOverride(ApplicationRoles.ACP_PROGRAMME_TEAM)
+        })
+      })
+
+      describe('and the referral is not an override', () => {
+        it('should display only the additional information card', () => {
+          sharedTests.referrals.showsAdditionalInformationPageWithoutOverride(ApplicationRoles.ACP_PROGRAMME_TEAM)
+        })
       })
 
       describe('When the referral is not submitted', () => {

--- a/integration_tests/e2e/refer/show.cy.ts
+++ b/integration_tests/e2e/refer/show.cy.ts
@@ -52,8 +52,16 @@ context('Viewing a submitted referral', () => {
     })
 
     describe('When reviewing additional information', () => {
-      it('shows the correct information', () => {
-        sharedTests.referrals.showsAdditionalInformationPage(ApplicationRoles.ACP_REFERRER)
+      describe('and the referral is an override', () => {
+        it('should display the the reason for the override and the additional information cards', () => {
+          sharedTests.referrals.showsAdditionalInformationPageWithOverride(ApplicationRoles.ACP_REFERRER)
+        })
+      })
+
+      describe('and the referral is not an override', () => {
+        it('should display only the additional information card', () => {
+          sharedTests.referrals.showsAdditionalInformationPageWithoutOverride(ApplicationRoles.ACP_REFERRER)
+        })
       })
 
       describe('When the referral is not submitted', () => {

--- a/server/controllers/shared/referralsController.ts
+++ b/server/controllers/shared/referralsController.ts
@@ -36,8 +36,19 @@ export default class ReferralsController {
         throw createError(400, 'Referral has not been submitted.')
       }
 
+      const pathways = await this.referralService.getPathways(req.user.username, referral.id)
+      const showOverrideReason = Boolean(pathways.isOverride && referral.referrerOverrideReason)
+
       return res.render('referrals/show/additionalInformation', {
         ...sharedPageData,
+        pniMismatchSummaryListRows: showOverrideReason
+          ? ShowReferralUtils.pniMismatchSummaryListRows(
+              pathways.recommended,
+              pathways.requested,
+              referral.referrerOverrideReason,
+            )
+          : [],
+        showOverrideReason,
         submittedText: `Submitted in referral on ${DateUtils.govukFormattedFullDateString(referral.submittedOn)}.`,
       })
     }

--- a/server/views/referrals/show/additionalInformation.njk
+++ b/server/views/referrals/show/additionalInformation.njk
@@ -14,5 +14,28 @@
     }
   }) }}
 
+  {% if showOverrideReason %}
+    <div class="govuk-summary-card" data-testid="pni-override-summary-card">
+      <div class="govuk-summary-card__title-wrapper">
+        <h2 class="govuk-summary-card__title" data-testid="pni-override-summary-card-title">
+          Reason why the referral does not match the PNI
+        </h2>
+      </div>
+
+      <div class="govuk-summary-card__content">
+        <p class="govuk-body">
+          This referral does not match the recommendation based on the risk and programme needs identifier (PNI) scores.
+        </p>
+
+        {{ govukSummaryList({
+          attributes: {
+            "data-testid": "pni-override-summary-list"
+          },
+          rows: pniMismatchSummaryListRows
+        }) }}
+      </div>
+    </div>
+  {% endif %}
+
   {{ keylessSummaryCard("Additional information", bodyHtml=additionalInformation, testId="additional-information-summary-card") }}
 {% endblock primaryContent %}


### PR DESCRIPTION
## Context

We need to display if a referral is an override and the reason entered by the referrer on the Additional information screen within a referral.

## Changes in this PR
Display new summary card and summary list on the Additonal information screen containing override details.

## Screenshots of UI changes

<img width="735" alt="image" src="https://github.com/user-attachments/assets/091fdcd4-099d-41ec-81a9-e2eacc98c9eb" />
