### PR TITLE
(APG-656d) Show override details even if there is no override reason

### DIFF
--- a/server/controllers/shared/referralsController.test.ts
+++ b/server/controllers/shared/referralsController.test.ts
@@ -170,8 +170,8 @@ describe('ReferralsController', () => {
 
       expect(response.render).toHaveBeenCalledWith('referrals/show/additionalInformation', {
         ...sharedPageData,
+        isOverride: false,
         pniMismatchSummaryListRows: [],
-        showOverrideReason: false,
         submittedText: `Submitted in referral on ${DateUtils.govukFormattedFullDateString(referral.submittedOn)}.`,
       })
     })
@@ -200,8 +200,8 @@ describe('ReferralsController', () => {
 
         expect(response.render).toHaveBeenCalledWith('referrals/show/additionalInformation', {
           ...sharedPageData,
+          isOverride: false,
           pniMismatchSummaryListRows: [],
-          showOverrideReason: false,
           submittedText: `Submitted in referral on ${DateUtils.govukFormattedFullDateString(referral.submittedOn)}.`,
         })
       })
@@ -220,15 +220,15 @@ describe('ReferralsController', () => {
 
           expect(response.render).toHaveBeenCalledWith('referrals/show/additionalInformation', {
             ...sharedPageData,
+            isOverride: false,
             pniMismatchSummaryListRows: [],
-            showOverrideReason: false,
             submittedText: `Submitted in referral on ${DateUtils.govukFormattedFullDateString(referral.submittedOn)}.`,
           })
         })
       })
     })
 
-    describe('overrides', () => {
+    describe('and the referral is an override', () => {
       const pniMismatchSummaryListRows: Array<GovukFrontendSummaryListRowWithKeyAndValue> = [
         {
           key: { text: 'Fake summary list key' },
@@ -237,48 +237,24 @@ describe('ReferralsController', () => {
       ]
 
       beforeEach(() => {
+        referralService.getPathways.mockResolvedValue({
+          isOverride: true,
+          recommended: 'MODERATE_INTENSITY_BC',
+          requested: 'HIGH',
+        })
+
         mockShowReferralUtils.pniMismatchSummaryListRows.mockReturnValue(pniMismatchSummaryListRows)
       })
 
-      describe('when the referral is currently an override', () => {
-        beforeEach(() => {
-          referralService.getPathways.mockResolvedValue({
-            isOverride: true,
-            recommended: 'MODERATE_INTENSITY_BC',
-            requested: 'HIGH',
-          })
-        })
+      it('renders the additional information template with the correct response locals', async () => {
+        const requestHandler = controller.additionalInformation()
+        await requestHandler(request, response, next)
 
-        describe('and has an override reason', () => {
-          it('renders the additional information template with the correct response locals', async () => {
-            referral.referrerOverrideReason = 'Override reason'
-
-            const requestHandler = controller.additionalInformation()
-            await requestHandler(request, response, next)
-
-            expect(response.render).toHaveBeenCalledWith('referrals/show/additionalInformation', {
-              ...sharedPageData,
-              pniMismatchSummaryListRows,
-              showOverrideReason: true,
-              submittedText: `Submitted in referral on ${DateUtils.govukFormattedFullDateString(referral.submittedOn)}.`,
-            })
-          })
-        })
-
-        describe('and does not have an override reason', () => {
-          it('renders the additional information template with the correct response locals', async () => {
-            referral.referrerOverrideReason = undefined
-
-            const requestHandler = controller.additionalInformation()
-            await requestHandler(request, response, next)
-
-            expect(response.render).toHaveBeenCalledWith('referrals/show/additionalInformation', {
-              ...sharedPageData,
-              pniMismatchSummaryListRows: [],
-              showOverrideReason: false,
-              submittedText: `Submitted in referral on ${DateUtils.govukFormattedFullDateString(referral.submittedOn)}.`,
-            })
-          })
+        expect(response.render).toHaveBeenCalledWith('referrals/show/additionalInformation', {
+          ...sharedPageData,
+          isOverride: true,
+          pniMismatchSummaryListRows,
+          submittedText: `Submitted in referral on ${DateUtils.govukFormattedFullDateString(referral.submittedOn)}.`,
         })
       })
     })

--- a/server/controllers/shared/referralsController.ts
+++ b/server/controllers/shared/referralsController.ts
@@ -37,18 +37,18 @@ export default class ReferralsController {
       }
 
       const pathways = await this.referralService.getPathways(req.user.username, referral.id)
-      const showOverrideReason = Boolean(pathways.isOverride && referral.referrerOverrideReason)
+      const { isOverride } = pathways
 
       return res.render('referrals/show/additionalInformation', {
         ...sharedPageData,
-        pniMismatchSummaryListRows: showOverrideReason
+        isOverride,
+        pniMismatchSummaryListRows: isOverride
           ? ShowReferralUtils.pniMismatchSummaryListRows(
               pathways.recommended,
               pathways.requested,
               referral.referrerOverrideReason,
             )
           : [],
-        showOverrideReason,
         submittedText: `Submitted in referral on ${DateUtils.govukFormattedFullDateString(referral.submittedOn)}.`,
       })
     }

--- a/server/utils/referrals/showReferralUtils.test.ts
+++ b/server/utils/referrals/showReferralUtils.test.ts
@@ -406,10 +406,12 @@ describe('ShowReferralUtils', () => {
   })
 
   describe('pniMismatchSummaryListRows', () => {
-    it('formats the provided pathways and override reason in the appropriate format for passing to a GOV.UK summary list Nunjucks macro', () => {
+    beforeEach(() => {
       jest.spyOn(PniUtils, 'formatPathwayValue').mockReturnValue('High intensity')
       jest.spyOn(CourseUtils, 'formatIntensityValue').mockReturnValue('Moderate intensity')
+    })
 
+    it('formats the provided pathways and override reason in the appropriate format for passing to a GOV.UK summary list Nunjucks macro', () => {
       expect(
         ShowReferralUtils.pniMismatchSummaryListRows('HIGH_INTENSITY_BC', 'MODERATE', 'The reason for the override.'),
       ).toEqual([
@@ -426,6 +428,25 @@ describe('ShowReferralUtils', () => {
           value: { text: 'The reason for the override.' },
         },
       ])
+    })
+
+    describe('when the referral has no override reason', () => {
+      it('returns the summary list with the reason not set', () => {
+        expect(ShowReferralUtils.pniMismatchSummaryListRows('HIGH_INTENSITY_BC', 'MODERATE', undefined)).toEqual([
+          {
+            key: { text: 'Recommended pathway' },
+            value: { text: 'High intensity' },
+          },
+          {
+            key: { text: 'Requested pathway' },
+            value: { text: 'Moderate intensity' },
+          },
+          {
+            key: { text: 'Reason given by referrer' },
+            value: { text: '' },
+          },
+        ])
+      })
     })
   })
 

--- a/server/utils/referrals/showReferralUtils.ts
+++ b/server/utils/referrals/showReferralUtils.ts
@@ -169,7 +169,7 @@ export default class ShowReferralUtils {
       },
       {
         key: { text: 'Reason given by referrer' },
-        value: { text: referrerOverrideReason || 'Not specified' },
+        value: { text: referrerOverrideReason || '' },
       },
     ]
   }

--- a/server/views/referrals/show/additionalInformation.njk
+++ b/server/views/referrals/show/additionalInformation.njk
@@ -14,7 +14,7 @@
     }
   }) }}
 
-  {% if showOverrideReason %}
+  {% if isOverride %}
     <div class="govuk-summary-card" data-testid="pni-override-summary-card">
       <div class="govuk-summary-card__title-wrapper">
         <h2 class="govuk-summary-card__title" data-testid="pni-override-summary-card-title">


### PR DESCRIPTION
## Context

We are happy to show the Override summary on a referral even while there is currently no functionality to add the reason just yet.

## Changes in this PR
Remove the additional conditional check for `referrerOverrideReason`.

This means that a referrer and a PT can still see if the referral is classed as an override based on the comparison of the PNI Pathway and the Course intensity values.

