### PR TITLE
(APG-794) Show treatment manager decision for overrides

### DIFF
--- a/integration_tests/e2e/assess/show.cy.ts
+++ b/integration_tests/e2e/assess/show.cy.ts
@@ -66,6 +66,22 @@ context('Viewing a submitted referral', () => {
         it('should display the the reason for the override and the additional information cards', () => {
           sharedTests.referrals.showsAdditionalInformationPageWithOverride(ApplicationRoles.ACP_PROGRAMME_TEAM)
         })
+
+        describe('and the referral has been marked as not eligible', () => {
+          it('should display the the reason for the override and the treatment manager decision', () => {
+            sharedTests.referrals.showsAdditionalInformationPageWithNotEligibleOverride(
+              ApplicationRoles.ACP_PROGRAMME_TEAM,
+            )
+          })
+        })
+
+        describe('and the referral has been marked as not suitable', () => {
+          it('should display the the reason for the override and the treatment manager decision', () => {
+            sharedTests.referrals.showsAdditionalInformationPageWithNotSuitableOverride(
+              ApplicationRoles.ACP_PROGRAMME_TEAM,
+            )
+          })
+        })
       })
 
       describe('and the referral is not an override', () => {

--- a/integration_tests/pages/shared/showReferral/additionalInformation.ts
+++ b/integration_tests/pages/shared/showReferral/additionalInformation.ts
@@ -66,7 +66,18 @@ export default class AdditionalInformationPage extends Page {
     })
   }
 
+  shouldContainTreatmentManagerDecision() {
+    cy.get('[data-testid="treatment-manager-decision-text"]').should(
+      'contain.text',
+      `The person has been assessed as ${this.referral.statusDescription!.toLowerCase()} by the Treatment Manager.`,
+    )
+  }
+
   shouldNotContainPniOverrideSummaryCard() {
     cy.get('[data-testid="pni-override-summary-card"]').should('not.exist')
+  }
+
+  shouldNotContainTreatmentManagerDecision() {
+    cy.get('[data-testid="treatment-manager-decision-text"]').should('not.exist')
   }
 }

--- a/integration_tests/support/sharedTests.ts
+++ b/integration_tests/support/sharedTests.ts
@@ -167,6 +167,62 @@ const sharedTests = {
       })
     },
 
+    showsAdditionalInformationPageWithNotEligibleOverride: (role: ApplicationRole): void => {
+      sharedTests.referrals.beforeEach(role)
+
+      const pniScore = pniScoreFactory.build({
+        programmePathway: 'HIGH_INTENSITY_BC',
+      })
+
+      cy.task('stubPni', {
+        pniScore,
+        prisonNumber: prisoner.prisonerNumber,
+      })
+
+      referral.referrerOverrideReason = 'Referrer override reason'
+      referral.status = 'not_eligible'
+      referral.statusDescription = 'Not eligible'
+
+      const path = pathsByRole(role).show.additionalInformation({ referralId: referral.id })
+      cy.visit(path)
+
+      const additionalInformationPage = Page.verifyOnPage(AdditionalInformationPage, {
+        course,
+        referral,
+      })
+
+      additionalInformationPage.shouldContainPniOverrideSummaryCard(pniScore.programmePathway)
+      additionalInformationPage.shouldContainTreatmentManagerDecision()
+    },
+
+    showsAdditionalInformationPageWithNotSuitableOverride: (role: ApplicationRole): void => {
+      sharedTests.referrals.beforeEach(role)
+
+      const pniScore = pniScoreFactory.build({
+        programmePathway: 'HIGH_INTENSITY_BC',
+      })
+
+      cy.task('stubPni', {
+        pniScore,
+        prisonNumber: prisoner.prisonerNumber,
+      })
+
+      referral.referrerOverrideReason = 'Referrer override reason'
+      referral.status = 'not_suitable'
+      referral.statusDescription = 'Not suitable'
+
+      const path = pathsByRole(role).show.additionalInformation({ referralId: referral.id })
+      cy.visit(path)
+
+      const additionalInformationPage = Page.verifyOnPage(AdditionalInformationPage, {
+        course,
+        referral,
+      })
+
+      additionalInformationPage.shouldContainPniOverrideSummaryCard(pniScore.programmePathway)
+      additionalInformationPage.shouldContainTreatmentManagerDecision()
+    },
+
     showsAdditionalInformationPageWithOverride: (role: ApplicationRole): void => {
       sharedTests.referrals.beforeEach(role)
 
@@ -206,6 +262,7 @@ const sharedTests = {
       )
       additionalInformationPage.shouldContainSubmittedReferralSideNavigation(path, referral.id)
       additionalInformationPage.shouldContainPniOverrideSummaryCard(pniScore.programmePathway)
+      additionalInformationPage.shouldNotContainTreatmentManagerDecision()
       additionalInformationPage.shouldContainAdditionalInformationSummaryCard()
       additionalInformationPage.shouldContainSubmittedText()
     },

--- a/server/controllers/shared/referralsController.test.ts
+++ b/server/controllers/shared/referralsController.test.ts
@@ -176,6 +176,35 @@ describe('ReferralsController', () => {
       })
     })
 
+    describe('when the referral has been marked as not eligible or not suitable', () => {
+      it.each([
+        {
+          status: 'not_eligible',
+          statusDescription: 'Not eligible',
+        },
+        {
+          status: 'not_suitable',
+          statusDescription: 'Not suitable',
+        },
+      ])(
+        'renders the additional information template with the correct response locals for status: $status',
+        async ({ status, statusDescription }) => {
+          referral.status = status
+          referral.statusDescription = statusDescription
+
+          const requestHandler = controller.additionalInformation()
+          await requestHandler(request, response, next)
+
+          expect(response.render).toHaveBeenCalledWith(
+            'referrals/show/additionalInformation',
+            expect.objectContaining({
+              treatmentManagerDecisionText: `The person has been assessed as ${statusDescription.toLowerCase()} by the Treatment Manager.`,
+            }),
+          )
+        },
+      )
+    })
+
     describe('when the referral has not been submitted', () => {
       it('responds with a 400', async () => {
         referral.status = 'referral_started'

--- a/server/controllers/shared/referralsController.ts
+++ b/server/controllers/shared/referralsController.ts
@@ -50,6 +50,9 @@ export default class ReferralsController {
             )
           : [],
         submittedText: `Submitted in referral on ${DateUtils.govukFormattedFullDateString(referral.submittedOn)}.`,
+        treatmentManagerDecisionText: ['not_eligible', 'not_suitable'].includes(sharedPageData.referral.status)
+          ? `The person has been assessed as ${sharedPageData.referral.statusDescription?.toLowerCase()} by the Treatment Manager.`
+          : undefined,
       })
     }
   }

--- a/server/views/referrals/show/additionalInformation.njk
+++ b/server/views/referrals/show/additionalInformation.njk
@@ -33,6 +33,14 @@
           },
           rows: pniMismatchSummaryListRows
         }) }}
+
+        {% if treatmentManagerDecisionText %}
+          <hr class="govuk-section-break govuk-section-break--m govuk-section-break--visible">
+
+          <p data-testid="treatment-manager-decision-text">
+            {{ treatmentManagerDecisionText }}
+          </p>
+        {% endif %}
       </div>
     </div>
   {% endif %}


### PR DESCRIPTION
## Context

When a referral is identified as an override and the treatment manager determines the person is not eligible or not suitable, this should be visible in the additional details section of the referral.



## Changes in this PR
Pass `treatmentManagerDecisionText` to the additional information template when the referral has been marked as `not_eligible` or `not_suitable`.


## Screenshots of UI changes

![image](https://github.com/user-attachments/assets/bb6c4972-1dc4-41d6-8b57-92e0afc0c656)
![image](https://github.com/user-attachments/assets/e8b228c8-d969-4a75-8f9d-7b04417ea580)


## Release checklist

[Release process documentation](../blob/main/doc/how-to/perform-a-release.md)

As part of our continuous deployment strategy we must ensure that this work is
ready to be released once merged.

### Pre-merge

- [ ] There are changes required to the Accredited Programmes API for this change to work...
  - [ ] ... and they have been released to production already

### Post-merge

<!-- The outer checkboxes can be completed pre-merge -->

- [ ] This adds, extends or meaningfully modifies a feature...
  - [ ] ... and I have written or updated an end-to-end test for the happy path in the [Accredited Programmes E2E repo](https://github.com/ministryofjustice/hmpps-accredited-programmes-e2e)
- [ ] This makes new expectations of the API...
  - [ ] ... and I have notified the API developer(s) of changes to the contract tests (Pact), or the API is already compliant
- [ ] [Manually approve](../doc/how-to/perform-a-release.md#releasing-to-the-preprod-environment) release to preprod
- [ ] [Manually approve](../doc/how-to/perform-a-release.md#releasing-to-the-production-environment) release to prod

<!-- Should a release fail at any step, you as the author should now lead the work to
fix it as soon as possible. You can monitor deployment failures in CircleCI
itself and application errors are found in
[Sentry](https://ministryofjustice.sentry.io/projects/hmpps-accredited-programmes-ui/?project=4505330122686464&referrer=sidebar&statsPeriod=24h). -->
