### PR TITLE
(APG-795) Override text on PNI page

### DIFF
--- a/server/controllers/assess/pniController.ts
+++ b/server/controllers/assess/pniController.ts
@@ -2,7 +2,7 @@ import type { Request, Response, TypedRequestHandler } from 'express'
 
 import { assessPaths } from '../../paths'
 import type { CourseService, PersonService, PniService, ReferralService } from '../../services'
-import { CourseUtils, PniUtils, ShowReferralUtils, TypeUtils } from '../../utils'
+import { CourseUtils, PniUtils, ReferralUtils, ShowReferralUtils, TypeUtils } from '../../utils'
 
 const missingInformationPathway = 'MISSING_INFORMATION'
 
@@ -76,6 +76,9 @@ export default class PniController {
         person,
         referral,
         riskScoresHref: assessPaths.show.risksAndNeeds.risksAndAlerts({ referralId }),
+        showOverrideText:
+          !['on_programme', 'programme_complete'].includes(referral.status) &&
+          ReferralUtils.checkIfOverride(pni?.programmePathway, course.intensity),
         subNavigationItems: ShowReferralUtils.subNavigationItems(req.path, 'pni', referral.id),
         ...templateLocals,
       })

--- a/server/utils/referrals/referralUtils.test.ts
+++ b/server/utils/referrals/referralUtils.test.ts
@@ -4,6 +4,21 @@ import type { ReferralStatusCategory } from '@accredited-programmes/models'
 import type { ReferralStatusReason } from '@accredited-programmes-api'
 
 describe('ReferralUtils', () => {
+  describe('checkIfOverride', () => {
+    it('returns true if the requested intensity is not in the recommended pathway', () => {
+      expect(ReferralUtils.checkIfOverride('HIGH_INTENSITY_BC', 'MODERATE')).toEqual(true)
+    })
+
+    it('returns false if the requested intensity is in the recommended pathway', () => {
+      expect(ReferralUtils.checkIfOverride('HIGH_INTENSITY_BC', 'HIGH_MODERATE')).toEqual(false)
+    })
+
+    it('returns true if either parameter is missing', () => {
+      expect(ReferralUtils.checkIfOverride(undefined, 'HIGH_INTENSITY')).toEqual(true)
+      expect(ReferralUtils.checkIfOverride('LOW_INTENSITY', undefined)).toEqual(true)
+    })
+  })
+
   describe('createReasonsFieldset', () => {
     it('creates an array of fieldsets with a legend and radios property', () => {
       const groupedOptions: Record<string, Array<ReferralStatusReason>> = {

--- a/server/utils/referrals/referralUtils.ts
+++ b/server/utils/referrals/referralUtils.ts
@@ -1,7 +1,15 @@
-import type { ReferralStatusCategory, ReferralStatusReason } from '@accredited-programmes-api'
+import type { Course, PniScore, ReferralStatusCategory, ReferralStatusReason } from '@accredited-programmes-api'
 import type { GovukFrontendFieldsetLegend, GovukFrontendRadiosItem } from '@govuk-frontend'
 
 export default class ReferralUtils {
+  static checkIfOverride(recommended?: PniScore['programmePathway'], requested?: Course['intensity']): boolean {
+    if (!requested || !recommended) {
+      return true
+    }
+
+    return !requested.split('_').includes(recommended.split('_')[0])
+  }
+
   static createReasonsFieldset(
     groupedOptions: Record<ReferralStatusCategory['referralStatusCode'], Array<ReferralStatusReason>>,
     selectedItemCode?: string,

--- a/server/views/referrals/show/partials/rootLayout.njk
+++ b/server/views/referrals/show/partials/rootLayout.njk
@@ -49,6 +49,8 @@
 
   <div class="govuk-grid-row">
     <div class="govuk-grid-column-three-quarters">
+      {% block beforeSupportingContent %}{% endblock beforeSupportingContent %}
+
       <h2 class="govuk-heading-m" data-testid="show-referral-sub-heading">{{ pageSubHeading }}</h2>
 
       {% block supportingContent %}{% endblock supportingContent %}

--- a/server/views/referrals/show/pni/show.njk
+++ b/server/views/referrals/show/pni/show.njk
@@ -1,7 +1,25 @@
+{% from "govuk/components/inset-text/macro.njk" import govukInsetText %}
 {% from "govuk/components/summary-list/macro.njk" import govukSummaryList %}
 {% from "moj/components/timeline/macro.njk" import mojTimeline %}
 
 {% extends "../partials/rootLayout.njk" %}
+
+{% block beforeSupportingContent %}
+  {% if showOverrideText %}
+    {% set html %}
+    <h2 class="govuk-heading-m">Referral does not match PNI</h2>
+    <p class="govuk-body">This referral does not match the recommendation based on the risk and programme needs identifier (PNI) scores.</p>
+    {% endset %}
+
+    {{ govukInsetText({
+      classes: "govuk-!-margin-top-0",
+      html: html,
+      attributes: {
+        "data-testid": "override-inset-text"
+      }
+    }) }}
+  {% endif %}
+{% endblock beforeSupportingContent %}
 
 {% block supportingContent %}
   <p data-testid="programme-needs-identifier-message">This is the recommended Accredited Programmes pathway. It is based on the person's risks and needs.</p>


### PR DESCRIPTION
## Context

When a referral has been submitted and does not match the PNI, the Treatment Manager/ Programme Team is responsible for assessing a persons suitability for a programme and a referral does not align with the PNI.  We should show some additional text at the top of the Programme Needs Identifier page when the referral is classed as an override, but not On programme or Programme complete.


## Changes in this PR
- Add `checkIfOverride` util method to compare PNI Programme pathway against a course intensity
- Show inset text at the top of the referral PNI page


## Screenshots of UI changes

![image](https://github.com/user-attachments/assets/5f79dcda-ff27-49c2-a1c3-7ece754649d0)
