### PR TITLE
(APG-795) Update and use shared methods to check for override

### DIFF
--- a/server/controllers/shared/referralsController.test.ts
+++ b/server/controllers/shared/referralsController.test.ts
@@ -131,7 +131,6 @@ describe('ReferralsController', () => {
     when(referralService.getReferral).calledWith(username, originalReferral.id).mockResolvedValue(originalReferral)
     referralService.getStatusTransitions.mockResolvedValue(statusTransitions)
     referralService.getPathways.mockResolvedValue({
-      isOverride: false,
       recommended: 'MODERATE_INTENSITY_BC',
       requested: 'MODERATE',
     })
@@ -267,7 +266,6 @@ describe('ReferralsController', () => {
 
       beforeEach(() => {
         referralService.getPathways.mockResolvedValue({
-          isOverride: true,
           recommended: 'MODERATE_INTENSITY_BC',
           requested: 'HIGH',
         })

--- a/server/controllers/shared/referralsController.ts
+++ b/server/controllers/shared/referralsController.ts
@@ -9,6 +9,7 @@ import {
   DateUtils,
   OffenceUtils,
   PersonUtils,
+  ReferralUtils,
   SentenceInformationUtils,
   ShowReferralUtils,
   TypeUtils,
@@ -37,7 +38,7 @@ export default class ReferralsController {
       }
 
       const pathways = await this.referralService.getPathways(req.user.username, referral.id)
-      const { isOverride } = pathways
+      const isOverride = ReferralUtils.checkIfOverride(pathways.recommended, pathways.requested)
 
       return res.render('referrals/show/additionalInformation', {
         ...sharedPageData,

--- a/server/services/referralService.test.ts
+++ b/server/services/referralService.test.ts
@@ -239,99 +239,44 @@ describe('ReferralService', () => {
       when(referralClient.find).calledWith(referral.id).mockResolvedValue(referral)
     })
 
-    describe('and the PNI matches a `HIGH_MODERATE` course intensity', () => {
-      it('should return that there IS NOT a mismatch, along with the provided pathway and intensity values', async () => {
-        const highModerateIntensityCourse = courseFactory.build({
-          courseOfferings: [courseOffering],
-          intensity: 'HIGH_MODERATE',
-        })
-        const highPniPathway = pniScoreFactory.build({
-          prisonNumber,
-          programmePathway: 'HIGH_INTENSITY_BC',
-        })
-
-        pniService.getPni.mockResolvedValue(highPniPathway)
-        courseService.getCourseByOffering.mockResolvedValue(highModerateIntensityCourse)
-
-        const result = await service.getPathways(userToken, referral.id)
-
-        expect(result).toEqual({
-          isOverride: false,
-          recommended: 'HIGH_INTENSITY_BC',
-          requested: 'HIGH_MODERATE',
-        })
+    it('should return the pathway and intensity values', async () => {
+      const course = courseFactory.build({
+        courseOfferings: [courseOffering],
+        intensity: 'HIGH_MODERATE',
       })
-    })
-
-    describe('and the PNI matches a `MODERATE` course intensity', () => {
-      it('should return that there IS NOT a mismatch, along with the provided pathway and intensity values', async () => {
-        const moderateIntensityCourse = courseFactory.build({
-          courseOfferings: [courseOffering],
-          intensity: 'MODERATE',
-        })
-        const moderatePniPathway = pniScoreFactory.build({
-          prisonNumber,
-          programmePathway: 'MODERATE_INTENSITY_BC',
-        })
-
-        pniService.getPni.mockResolvedValue(moderatePniPathway)
-        courseService.getCourseByOffering.mockResolvedValue(moderateIntensityCourse)
-
-        const result = await service.getPathways(userToken, referral.id)
-
-        expect(result).toEqual({
-          isOverride: false,
-          recommended: 'MODERATE_INTENSITY_BC',
-          requested: 'MODERATE',
-        })
+      const pniScore = pniScoreFactory.build({
+        prisonNumber,
+        programmePathway: 'HIGH_INTENSITY_BC',
       })
-    })
 
-    describe('and the PNI does not match the course intensity', () => {
-      it('should return that there IS a mismatch, along with the provided pathway and intensity values', async () => {
-        const moderateIntensityCourse = courseFactory.build({
-          courseOfferings: [courseOffering],
-          intensity: 'MODERATE',
-        })
-        const highPniPathway = pniScoreFactory.build({
-          prisonNumber,
-          programmePathway: 'HIGH_INTENSITY_BC',
-        })
+      pniService.getPni.mockResolvedValue(pniScore)
+      courseService.getCourseByOffering.mockResolvedValue(course)
 
-        pniService.getPni.mockResolvedValue(highPniPathway)
-        courseService.getCourseByOffering.mockResolvedValue(moderateIntensityCourse)
+      const result = await service.getPathways(userToken, referral.id)
 
-        const result = await service.getPathways(userToken, referral.id)
-
-        expect(result).toEqual({
-          isOverride: true,
-          recommended: 'HIGH_INTENSITY_BC',
-          requested: 'MODERATE',
-        })
+      expect(result).toEqual({
+        recommended: 'HIGH_INTENSITY_BC',
+        requested: 'HIGH_MODERATE',
       })
     })
 
     describe('and the course intensity and programme pathway values are not set', () => {
-      it('should return that there IS a mismatch, along with "Unknown" values', async () => {
+      it('should return an empty object', async () => {
         const unknownCourse = courseFactory.build({
           courseOfferings: [courseOffering],
           intensity: undefined,
         })
-        const highPniPathway = pniScoreFactory.build({
+        const unknownPniScore = pniScoreFactory.build({
           prisonNumber,
           programmePathway: undefined,
         })
 
-        pniService.getPni.mockResolvedValue(highPniPathway)
+        pniService.getPni.mockResolvedValue(unknownPniScore)
         courseService.getCourseByOffering.mockResolvedValue(unknownCourse)
 
         const result = await service.getPathways(userToken, referral.id)
 
-        expect(result).toEqual({
-          isOverride: true,
-          recommended: 'Unknown',
-          requested: 'Unknown',
-        })
+        expect(result).toEqual({})
       })
     })
   })

--- a/server/services/referralService.ts
+++ b/server/services/referralService.ts
@@ -109,33 +109,22 @@ export default class ReferralService {
     username: Express.User['username'],
     referralId: Referral['id'],
   ): Promise<{
-    isOverride: boolean
-    recommended: PniScore['programmePathway']
-    requested: Course['intensity']
+    recommended?: PniScore['programmePathway']
+    requested?: Course['intensity']
   }> {
     const hmppsAuthClient = this.hmppsAuthClientBuilder()
     const systemToken = await hmppsAuthClient.getSystemClientToken(username)
     const referralClient = this.referralClientBuilder(systemToken)
 
-    const unknownString = 'Unknown'
     const referral = await referralClient.find(referralId)
     const [pniScore, course] = await Promise.all([
       this.pniService.getPni(username, referral.prisonNumber),
       this.courseService.getCourseByOffering(username, referral.offeringId),
     ])
 
-    let isOverride
-
-    if (!course?.intensity || !pniScore?.programmePathway) {
-      isOverride = true
-    } else {
-      isOverride = !course.intensity.split('_').includes(pniScore.programmePathway.split('_')[0])
-    }
-
     return {
-      isOverride,
-      recommended: pniScore?.programmePathway || unknownString,
-      requested: course.intensity || unknownString,
+      recommended: pniScore?.programmePathway,
+      requested: course.intensity,
     }
   }
 

--- a/server/utils/referrals/showReferralUtils.ts
+++ b/server/utils/referrals/showReferralUtils.ts
@@ -154,9 +154,9 @@ export default class ShowReferralUtils {
   }
 
   static pniMismatchSummaryListRows(
-    recommendedPathway: PniScore['programmePathway'],
-    requestedPathway: Course['intensity'],
-    referrerOverrideReason: Referral['referrerOverrideReason'],
+    recommendedPathway?: PniScore['programmePathway'],
+    requestedPathway?: Course['intensity'],
+    referrerOverrideReason?: Referral['referrerOverrideReason'],
   ): Array<GovukFrontendSummaryListRowWithKeyAndValue> {
     return [
       {


### PR DESCRIPTION
## Context
We now have some shared methods to help determine if a referral is an override that can be used in multiple places. `getPathways` and `checkIfOverride`.


## Changes in this PR
Update recently added `getPathways` method to return only the pathways, which can then be passed to `checkIfOverride` util method.

Switch to use these methods in:
- `UpdateStatusDecisionController.submit` (no longer uses own private method)
- `ReferralsController.additionalInformation`

These methods can then be used in [APG-655](https://dsdmoj.atlassian.net/jira/software/c/projects/APG/boards/1435?label=Tech&selectedIssue=APG-655)

All areas where we check for an override will then be using the same methods.

[APG-655]: https://dsdmoj.atlassian.net/browse/APG-655?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ