### PR TITLE
Fix to call correctly call `/oauth/token` with username instead of users token

### DIFF
--- a/server/controllers/find/addCourseController.test.ts
+++ b/server/controllers/find/addCourseController.test.ts
@@ -29,6 +29,10 @@ describe('AddCourseController', () => {
     response = createMock<Response>()
   })
 
+  afterEach(() => {
+    jest.clearAllMocks()
+  })
+
   describe('show', () => {
     const audienceSelectItems: Array<GovukFrontendSelectItem> = [
       { text: 'Audience 1', value: '1' },
@@ -41,21 +45,16 @@ describe('AddCourseController', () => {
     })
 
     it('renders the create course form template with audience select items', async () => {
-      const audiences = audienceFactory.buildList(3)
-      courseService.getCourseAudiences.mockResolvedValue(audiences)
-
       const requestHandler = controller.show()
       await requestHandler(request, response, next)
 
-      expect(courseService.getCourseAudiences).toHaveBeenCalledWith(userToken)
-
+      expect(courseService.getCourseAudiences).toHaveBeenCalledWith(username)
       expect(response.render).toHaveBeenCalledWith('courses/form/show', {
         action: '/find/programmes/add',
         audienceSelectItems,
         backLinkHref: '/find/programmes',
         pageHeading: 'Add a Programme',
       })
-      expect(CourseUtils.audienceSelectItems).toHaveBeenCalledWith(audiences)
     })
   })
 

--- a/server/controllers/find/addCourseController.ts
+++ b/server/controllers/find/addCourseController.ts
@@ -27,7 +27,7 @@ export default class AddCourseController {
     return async (req: Request, res: Response) => {
       TypeUtils.assertHasUser(req)
 
-      const audiences = await this.courseService.getCourseAudiences(req.user.token)
+      const audiences = await this.courseService.getCourseAudiences(req.user.username)
 
       res.render('courses/form/show', {
         action: findPaths.course.add.create({}),

--- a/server/controllers/find/courseOfferingsController.ts
+++ b/server/controllers/find/courseOfferingsController.ts
@@ -18,7 +18,7 @@ export default class CourseOfferingsController {
 
       const { courseId, courseOfferingId } = req.params
 
-      await this.courseService.deleteOffering(req.user.token, courseId, courseOfferingId)
+      await this.courseService.deleteOffering(req.user.username, courseId, courseOfferingId)
 
       res.redirect(findPaths.show({ courseId }))
     }
@@ -31,8 +31,8 @@ export default class CourseOfferingsController {
       const buildingChoicesCourseId = req.session.buildingChoicesData?.courseVariantId
 
       const [course, [courseOffering, organisation]] = await Promise.all([
-        this.courseService.getCourseByOffering(req.user.token, req.params.courseOfferingId),
-        this.courseService.getOffering(req.user.token, req.params.courseOfferingId).then(async _courseOffering => {
+        this.courseService.getCourseByOffering(req.user.username, req.params.courseOfferingId),
+        this.courseService.getOffering(req.user.username, req.params.courseOfferingId).then(async _courseOffering => {
           // eslint-disable-next-line
           const _organisation = await this.organisationService.getOrganisation(
             req.user.token,

--- a/server/controllers/find/coursesController.ts
+++ b/server/controllers/find/coursesController.ts
@@ -18,7 +18,7 @@ export default class CoursesController {
       delete req.session.buildingChoicesData
       delete req.session.pniFindAndReferData
 
-      const courses = await this.courseService.getCourses(req.user.token)
+      const courses = await this.courseService.getCourses(req.user.username)
       const coursesToDisplay = courses
         .filter(course => course.displayOnProgrammeDirectory)
         .sort((courseA, courseB) => courseA.name.localeCompare(courseB.name))
@@ -39,8 +39,8 @@ export default class CoursesController {
 
       const isPniFind = req.session.pniFindAndReferData !== undefined
 
-      const course = await this.courseService.getCourse(req.user.token, req.params.courseId)
-      const offerings = await this.courseService.getOfferingsByCourse(req.user.token, course.id)
+      const course = await this.courseService.getCourse(req.user.username, req.params.courseId)
+      const offerings = await this.courseService.getOfferingsByCourse(req.user.username, course.id)
 
       const organisationIds = offerings.map((offering: CourseOffering) => offering.organisationId)
       const organisations = await this.organisationService.getOrganisations(req.user.token, organisationIds)

--- a/server/controllers/find/updateCourseController.test.ts
+++ b/server/controllers/find/updateCourseController.test.ts
@@ -32,29 +32,24 @@ describe('UpdateCourseController', () => {
   })
 
   describe('show', () => {
-    const audienceSelectItems: Array<GovukFrontendSelectItem> = [
-      { text: 'Audience 1', value: '1' },
-      { text: 'Audience 2', value: '2' },
-      { text: 'Audience 3', value: '3' },
-    ]
-
-    beforeEach(() => {
-      mockCourseUtils.audienceSelectItems.mockReturnValue(audienceSelectItems)
-      when(courseService.getCourse).calledWith(username, course.id).mockResolvedValue(course)
-    })
-
     it('renders the update course form template with course values audience select items', async () => {
+      const audienceSelectItems: Array<GovukFrontendSelectItem> = [
+        { text: 'Audience 1', value: '1' },
+        { text: 'Audience 2', value: '2' },
+        { text: 'Audience 3', value: '3' },
+      ]
       const audiences = [
         audienceFactory.build({ id: 'audience-id-1', name: 'All offences' }),
         audienceFactory.build({ id: 'audience-id-2', name: 'Extremism offence' }),
         audienceFactory.build({ id: 'audience-id-3', name: 'General offence' }),
       ]
-      courseService.getCourseAudiences.mockResolvedValue(audiences)
+
+      mockCourseUtils.audienceSelectItems.mockReturnValue(audienceSelectItems)
+      when(courseService.getCourse).calledWith(username, course.id).mockResolvedValue(course)
+      when(courseService.getCourseAudiences).calledWith(username).mockResolvedValue(audiences)
 
       const requestHandler = controller.show()
       await requestHandler(request, response, next)
-
-      expect(courseService.getCourseAudiences).toHaveBeenCalledWith(userToken)
 
       expect(response.render).toHaveBeenCalledWith('courses/form/show', {
         action: `/find/programmes/${course.id}/update?_method=PUT`,

--- a/server/controllers/find/updateCourseController.ts
+++ b/server/controllers/find/updateCourseController.ts
@@ -15,7 +15,7 @@ export default class UpdateCourseController {
       const { courseId } = req.params
 
       const [audiences, course] = await Promise.all([
-        this.courseService.getCourseAudiences(req.user.token),
+        this.courseService.getCourseAudiences(req.user.username),
         this.courseService.getCourse(req.user.username, courseId),
       ])
 

--- a/server/controllers/find/updateCourseOfferingController.test.ts
+++ b/server/controllers/find/updateCourseOfferingController.test.ts
@@ -44,7 +44,7 @@ describe('UpdateCourseOfferingController', () => {
 
     beforeEach(() => {
       mockOrganisationUtils.organisationSelectItems.mockReturnValue(organisationSelectItems)
-      when(courseService.getOffering).calledWith(userToken, courseOffering.id).mockResolvedValue(courseOffering)
+      when(courseService.getOffering).calledWith(username, courseOffering.id).mockResolvedValue(courseOffering)
     })
 
     it('renders the update course offering form template with organisation select items', async () => {
@@ -71,7 +71,7 @@ describe('UpdateCourseOfferingController', () => {
     const course = courseFactory.build({})
 
     beforeEach(() => {
-      when(courseService.getCourseByOffering).calledWith(userToken, courseOffering.id).mockResolvedValue(course)
+      when(courseService.getCourseByOffering).calledWith(username, courseOffering.id).mockResolvedValue(course)
     })
 
     it('updates a course offering and redirects back to the offering page', async () => {

--- a/server/controllers/find/updateCourseOfferingController.ts
+++ b/server/controllers/find/updateCourseOfferingController.ts
@@ -17,7 +17,7 @@ export default class UpdateCourseOfferingController {
       const { courseOfferingId } = req.params
 
       const [offering, organisations] = await Promise.all([
-        this.courseService.getOffering(req.user.token, courseOfferingId),
+        this.courseService.getOffering(req.user.username, courseOfferingId),
         this.organisationService.getAllOrganisations(req.user.token),
       ])
 
@@ -43,7 +43,7 @@ export default class UpdateCourseOfferingController {
         string
       >
 
-      const course = await this.courseService.getCourseByOffering(req.user.token, courseOfferingId)
+      const course = await this.courseService.getCourseByOffering(req.user.username, courseOfferingId)
 
       await this.courseService.updateCourseOffering(req.user.username, course.id, {
         contactEmail,

--- a/server/controllers/refer/new/referralsController.test.ts
+++ b/server/controllers/refer/new/referralsController.test.ts
@@ -2,6 +2,7 @@ import type { DeepMocked } from '@golevelup/ts-jest'
 import { createMock } from '@golevelup/ts-jest'
 import type { NextFunction, Request, Response } from 'express'
 import createError from 'http-errors'
+import { when } from 'jest-when'
 
 import NewReferralsController from './referralsController'
 import { authPaths, findPaths, referPaths } from '../../../paths'
@@ -95,7 +96,11 @@ describe('NewReferralsController', () => {
       referralService,
       userService,
     )
-    courseService.getOffering.mockResolvedValue(referableCourseOffering)
+
+    when(courseService.getOffering)
+      .calledWith(username, referableCourseOffering.id)
+      .mockResolvedValue(referableCourseOffering)
+    when(courseService.getCourseByOffering).calledWith(username, referableCourseOffering.id).mockResolvedValue(course)
   })
 
   afterEach(() => {
@@ -103,9 +108,11 @@ describe('NewReferralsController', () => {
   })
 
   describe('start', () => {
-    it('renders the referral start template', async () => {
-      courseService.getCourseByOffering.mockResolvedValue(course)
+    beforeEach(() => {
+      request.params.courseOfferingId = referableCourseOffering.id
+    })
 
+    it('renders the referral start template', async () => {
       const organisation = organisationFactory.build({ id: referableCourseOffering.organisationId })
       organisationService.getOrganisation.mockResolvedValue(organisation)
 
@@ -238,8 +245,6 @@ describe('NewReferralsController', () => {
     })
 
     it('renders the referral task list page', async () => {
-      courseService.getCourseByOffering.mockResolvedValue(course)
-
       organisationService.getOrganisation.mockResolvedValue(organisation)
 
       personService.getPerson.mockResolvedValue(person)
@@ -270,8 +275,6 @@ describe('NewReferralsController', () => {
 
     describe('when the referral has been requested with an `updatePerson` query', () => {
       it('calls `referralService.getReferral` with the same value', async () => {
-        courseService.getCourseByOffering.mockResolvedValue(course)
-
         organisationService.getOrganisation.mockResolvedValue(organisation)
 
         personService.getPerson.mockResolvedValue(person)
@@ -316,7 +319,6 @@ describe('NewReferralsController', () => {
 
   describe('showPerson', () => {
     it("renders the page for viewing a person's details", async () => {
-      courseService.getCourseByOffering.mockResolvedValue(course)
       personService.getPerson.mockResolvedValue(person)
 
       referralService.getReferral.mockResolvedValue(draftReferral)
@@ -395,7 +397,6 @@ describe('NewReferralsController', () => {
     ]
 
     beforeEach(() => {
-      courseService.getCourseByOffering.mockResolvedValue(course)
       personService.getPerson.mockResolvedValue(person)
       userService.getFullNameFromUsername.mockResolvedValue(referrerName)
       userService.getEmailFromUsername.mockResolvedValue(referrerEmail)

--- a/server/controllers/refer/new/referralsController.ts
+++ b/server/controllers/refer/new/referralsController.ts
@@ -38,8 +38,8 @@ export default class NewReferralsController {
 
       const [person, courseOffering, course, referrerName, referrerEmail] = await Promise.all([
         this.personService.getPerson(req.user.username, referral.prisonNumber),
-        this.courseService.getOffering(req.user.token, referral.offeringId),
-        this.courseService.getCourseByOffering(req.user.token, referral.offeringId),
+        this.courseService.getOffering(req.user.username, referral.offeringId),
+        this.courseService.getCourseByOffering(req.user.username, referral.offeringId),
         this.userService.getFullNameFromUsername(req.user.token, referral.referrerUsername),
         this.userService.getEmailFromUsername(req.user.token, referral.referrerUsername),
       ])
@@ -162,10 +162,12 @@ export default class NewReferralsController {
         return res.redirect(authPaths.error({}))
       }
 
-      const course = await this.courseService.getCourseByOffering(req.user.token, referral.offeringId)
-      const courseOffering = await this.courseService.getOffering(req.user.token, referral.offeringId)
+      const [course, courseOffering, person] = await Promise.all([
+        this.courseService.getCourseByOffering(req.user.username, referral.offeringId),
+        this.courseService.getOffering(req.user.username, referral.offeringId),
+        this.personService.getPerson(req.user.username, referral.prisonNumber),
+      ])
       const organisation = await this.organisationService.getOrganisation(req.user.token, courseOffering.organisationId)
-      const person = await this.personService.getPerson(req.user.username, referral.prisonNumber)
       const coursePresenter = CourseUtils.presentCourse(course)
 
       delete req.session.returnTo
@@ -223,8 +225,10 @@ export default class NewReferralsController {
         return res.redirect(findPaths.pniFind.personSearch({}))
       }
 
-      const course = await this.courseService.getCourseByOffering(req.user.token, req.params.courseOfferingId)
-      const courseOffering = await this.courseService.getOffering(req.user.token, req.params.courseOfferingId)
+      const [course, courseOffering] = await Promise.all([
+        this.courseService.getCourseByOffering(req.user.username, req.params.courseOfferingId),
+        this.courseService.getOffering(req.user.username, req.params.courseOfferingId),
+      ])
       const organisation = await this.organisationService.getOrganisation(req.user.token, courseOffering.organisationId)
       const coursePresenter = CourseUtils.presentCourse(course)
 

--- a/server/controllers/reportsController.test.ts
+++ b/server/controllers/reportsController.test.ts
@@ -1,5 +1,6 @@
 import { type DeepMocked, createMock } from '@golevelup/ts-jest'
 import type { NextFunction, Request, Response } from 'express'
+import { when } from 'jest-when'
 
 import type { ReferenceDataService, StatisticsService } from '../services'
 import ReportsController from './reportsController'
@@ -60,7 +61,7 @@ describe('ReportsController', () => {
     mockStatisticsReportUtils.validateFilterValues.mockReturnValue(errorMessages)
     mockPathUtils.pathWithQuery.mockReturnValue(pathWithQuery)
 
-    referenceDataService.getEnabledOrganisations.mockResolvedValue(enabledOrganisations)
+    when(referenceDataService.getEnabledOrganisations).calledWith(username).mockResolvedValue(enabledOrganisations)
 
     controller = new ReportsController(referenceDataService, statisticsService)
 

--- a/server/controllers/reportsController.ts
+++ b/server/controllers/reportsController.ts
@@ -60,7 +60,7 @@ export default class ReportsController {
             }),
           ),
         ),
-        this.referenceDataService.getEnabledOrganisations(req.user.token),
+        this.referenceDataService.getEnabledOrganisations(req.user.username),
       ])
 
       const selectedPrison = organisations.find(org => org.code === location)?.description


### PR DESCRIPTION
## Context

Some of our service methods were incorrectly being called with the users token, instead of their username, which in turn then called auth to get the system client token.

This was also exposing the users token within App insights under `customDimensions.username`.

## Changes in this PR

- Replace `user.token` with `user.username` in the places where it was incorrect.
- Updated associated tests to mock responses only when correctly called with `username`.
