### PR TITLE
APG-655 - Fix label for additional info textarea

### DIFF
--- a/integration_tests/pages/refer/new/additionalInformation.ts
+++ b/integration_tests/pages/refer/new/additionalInformation.ts
@@ -17,7 +17,7 @@ export default class NewReferralAdditionalInformationPage extends Page {
   }
 
   shouldContainAdditionalInformationTextArea() {
-    this.shouldContainTextArea('additionalInformation', 'Additional Information')
+    this.shouldContainTextArea('additionalInformation', 'Provide additional information')
   }
 
   shouldContainContinueButton() {

--- a/server/views/referrals/new/additionalInformation/show.njk
+++ b/server/views/referrals/new/additionalInformation/show.njk
@@ -79,7 +79,7 @@
             "data-testid": "additional-information-text-area"
           },
           label: {
-            text: "Additional Information",
+            text: "Provide additional information",
             classes: "govuk-visually-hidden"
           },
           value: formValues.formattedAdditionalInformation or referral.additionalInformation,


### PR DESCRIPTION
Fixes the name of the expected label for additional info textarea


## Release checklist

[Release process documentation](../blob/main/doc/how-to/perform-a-release.md)

As part of our continuous deployment strategy we must ensure that this work is
ready to be released once merged.

### Pre-merge

- [ ] There are changes required to the Accredited Programmes API for this change to work...
  - [ ] ... and they have been released to production already

### Post-merge

<!-- The outer checkboxes can be completed pre-merge -->

- [ ] This adds, extends or meaningfully modifies a feature...
  - [ ] ... and I have written or updated an end-to-end test for the happy path in the [Accredited Programmes E2E repo](https://github.com/ministryofjustice/hmpps-accredited-programmes-e2e)
- [ ] This makes new expectations of the API...
  - [ ] ... and I have notified the API developer(s) of changes to the contract tests (Pact), or the API is already compliant
- [ ] [Manually approve](../doc/how-to/perform-a-release.md#releasing-to-the-preprod-environment) release to preprod
- [ ] [Manually approve](../doc/how-to/perform-a-release.md#releasing-to-the-production-environment) release to prod

<!-- Should a release fail at any step, you as the author should now lead the work to
fix it as soon as possible. You can monitor deployment failures in CircleCI
itself and application errors are found in
[Sentry](https://ministryofjustice.sentry.io/projects/hmpps-accredited-programmes-ui/?project=4505330122686464&referrer=sidebar&statsPeriod=24h). -->
