### PR TITLE
(APG-849) Remove use of `organisationEnabled` for `CourseOffering`

### DIFF
--- a/integration_tests/e2e/find.cy.ts
+++ b/integration_tests/e2e/find.cy.ts
@@ -15,7 +15,6 @@ context('Find', () => {
   const organisation = OrganisationUtils.organisationFromPrison(prison)
 
   const referableCourseOffering = courseOfferingFactory.build({
-    organisationEnabled: true,
     organisationId: organisation.id,
     referable: true,
   })
@@ -209,28 +208,6 @@ context('Find', () => {
           const courseOfferingPage = Page.verifyOnPage(CourseOfferingPage, {
             course: targetCourse,
             courseOffering: referableCourseOffering,
-            organisation,
-          })
-          courseOfferingPage.shouldNotContainMakeAReferralButtonLink()
-          courseOfferingPage.shouldNotContainUpdateCourseOfferingLink()
-          courseOfferingPage.shouldNotContainDeleteOfferingButton()
-        })
-      })
-
-      describe('and in an organisation where refer IS NOT enabled', () => {
-        it('does not show the "Make a referral" button on an offering', () => {
-          const courseOffering = {
-            ...referableCourseOffering,
-            organisationEnabled: false,
-          }
-
-          cy.task('stubOffering', { courseOffering })
-
-          cy.visit(path)
-
-          const courseOfferingPage = Page.verifyOnPage(CourseOfferingPage, {
-            course: targetCourse,
-            courseOffering,
             organisation,
           })
           courseOfferingPage.shouldNotContainMakeAReferralButtonLink()

--- a/integration_tests/e2e/pniFind.cy.ts
+++ b/integration_tests/e2e/pniFind.cy.ts
@@ -281,7 +281,6 @@ context('Find programmes based on PNI Pathway', () => {
         })
 
         const referableOffering = courseOfferingFactory.build({
-          organisationEnabled: true,
           organisationId: 'MDI',
           referable: true,
         })

--- a/server/@types/models/CourseOffering.ts
+++ b/server/@types/models/CourseOffering.ts
@@ -3,7 +3,6 @@ export type CourseOffering = {
   contactEmail: string
   organisationId: string
   referable: boolean
-  organisationEnabled?: boolean
   secondaryContactEmail?: string
   withdrawn?: boolean
 }

--- a/server/controllers/find/courseOfferingsController.test.ts
+++ b/server/controllers/find/courseOfferingsController.test.ts
@@ -108,7 +108,6 @@ describe('CoursesOfferingsController', () => {
       it('sets canMakeReferral to true', async () => {
         config.flags.referEnabled = true
         courseOffering.referable = true
-        courseOffering.organisationEnabled = true
         response.locals.user.hasReferrerRole = true
         request.session.pniFindAndReferData = {
           prisonNumber: 'A1234AA',

--- a/server/controllers/find/courseOfferingsController.ts
+++ b/server/controllers/find/courseOfferingsController.ts
@@ -48,7 +48,6 @@ export default class CourseOfferingsController {
         canMakeReferral:
           config.flags.referEnabled &&
           courseOffering.referable &&
-          courseOffering.organisationEnabled &&
           res.locals.user.hasReferrerRole &&
           req.session.pniFindAndReferData !== undefined,
         course: coursePresenter,

--- a/server/data/accreditedProgrammesApi/courseClient.ts
+++ b/server/data/accreditedProgrammesApi/courseClient.ts
@@ -23,10 +23,7 @@ export default class CourseClient {
   }
 
   /* istanbul ignore next */
-  async addCourseOffering(
-    courseId: Course['id'],
-    courseOffering: Omit<CourseOffering, 'id' | 'organisationEnabled'>,
-  ): Promise<CourseOffering> {
+  async addCourseOffering(courseId: Course['id'], courseOffering: Omit<CourseOffering, 'id'>): Promise<CourseOffering> {
     return (await this.restClient.post({
       data: courseOffering,
       path: apiPaths.offerings.create({ courseId }),
@@ -164,10 +161,7 @@ export default class CourseClient {
   }
 
   /* istanbul ignore next */
-  async updateCourseOffering(
-    courseId: Course['id'],
-    courseOffering: Omit<CourseOffering, 'organisationEnabled'>,
-  ): Promise<CourseOffering> {
+  async updateCourseOffering(courseId: Course['id'], courseOffering: CourseOffering): Promise<CourseOffering> {
     return (await this.restClient.put({
       data: courseOffering,
       path: apiPaths.offerings.update({ courseId }),

--- a/server/services/courseService.test.ts
+++ b/server/services/courseService.test.ts
@@ -55,7 +55,7 @@ describe('CourseService', () => {
     it('adds a course offering using the `courseOfferingRequest` values', async () => {
       const courseId = courseFactory.build().id
       const courseOffering = courseOfferingFactory.build({})
-      const courseOfferingRequest: Omit<CourseOffering, 'id' | 'organisationEnabled'> = {
+      const courseOfferingRequest: Omit<CourseOffering, 'id'> = {
         contactEmail: courseOffering.contactEmail,
         organisationId: courseOffering.organisationId,
         referable: courseOffering.referable,
@@ -540,7 +540,7 @@ describe('CourseService', () => {
     it('updates a course offering using the `courseOfferingRequest` values', async () => {
       const course = courseFactory.build()
       const courseOffering = courseOfferingFactory.build()
-      const courseOfferingRequest: Omit<CourseOffering, 'organisationEnabled'> = {
+      const courseOfferingRequest: CourseOffering = {
         contactEmail: 'contact-email-1@test.com',
         id: courseOffering.id,
         organisationId: 'MDI',

--- a/server/services/courseService.ts
+++ b/server/services/courseService.ts
@@ -28,7 +28,7 @@ export default class CourseService {
   async addCourseOffering(
     username: Express.User['username'],
     courseId: Course['id'],
-    courseOffering: Omit<CourseOffering, 'id' | 'organisationEnabled'>,
+    courseOffering: Omit<CourseOffering, 'id'>,
   ): Promise<CourseOffering> {
     const hmppsAuthClient = this.hmppsAuthClientBuilder()
     const systemToken = await hmppsAuthClient.getSystemClientToken(username)
@@ -304,7 +304,7 @@ export default class CourseService {
   async updateCourseOffering(
     username: Express.User['username'],
     courseId: Course['id'],
-    courseOffering: Omit<CourseOffering, 'organisationEnabled'>,
+    courseOffering: CourseOffering,
   ): Promise<CourseOffering> {
     const hmppsAuthClient = this.hmppsAuthClientBuilder()
     const systemToken = await hmppsAuthClient.getSystemClientToken(username)

--- a/server/testutils/factories/courseOffering.ts
+++ b/server/testutils/factories/courseOffering.ts
@@ -9,7 +9,6 @@ export default Factory.define<CourseOffering>(({ params }) => {
   return {
     id: faker.string.uuid(), // eslint-disable-next-line sort-keys
     contactEmail: `nobody-${organisationId.toLowerCase()}@digital.justice.gov.uk`,
-    organisationEnabled: faker.helpers.arrayElement([faker.datatype.boolean()]),
     organisationId,
     referable: faker.datatype.boolean(),
     secondaryContactEmail: faker.helpers.arrayElement([


### PR DESCRIPTION
## Context

As part of [APG-653](https://dsdmoj.atlassian.net/browse/APG-653), the enabled organisations table is getting removed. The field `organisationEnabled `is returned when an offering is requested. 

## Changes in this PR

- Remove check for courseOffering.organisationEnabled around **Make a referral** button.
- Remove `organisationEnabled` from `CourseOffering` type.

Would have preferred to use the generated `CourseOffering` type from the swagger API. However `id` can be marked as `null` because the same type is used for the creation of a course offering. 

Have discussed that we add a type type along the lines of CreateCourseOffering which omits an ID and then make CourseOffering.id non nullable. Ticket raised [here](https://dsdmoj.atlassian.net/browse/APG-895).

[APG-653]: https://dsdmoj.atlassian.net/browse/APG-653?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ