### PR TITLE
(APG-845) Update BC Transfer error message when general offence strand is not offered

### DIFF
--- a/integration_tests/pages/assess/transferError.ts
+++ b/integration_tests/pages/assess/transferError.ts
@@ -42,7 +42,7 @@ export default class TransferErrorPage extends Page {
 
   shouldContainNoCourseText() {
     this.shouldContainText(
-      `This referral cannot be moved because ${this.organisation.name} does not offer Building Choices: ${this.originalCourse.intensity?.toLowerCase()} intensity.`,
+      `This referral cannot be moved because ${this.organisation.name} does not offer the general offence strand of Building Choices: ${this.originalCourse.intensity?.toLowerCase()} intensity.`,
     )
     this.shouldContainText('Close this referral and submit a new one to a different location.')
   }

--- a/server/controllers/assess/transferReferralErrorController.test.ts
+++ b/server/controllers/assess/transferReferralErrorController.test.ts
@@ -173,7 +173,7 @@ describe('TransferReferralErrorController', () => {
           expect(response.render).toHaveBeenCalledWith('referrals/transfer/error/show', {
             backLinkHref: assessPaths.show.personalDetails({ referralId: referral.id }),
             errorText: [
-              `This referral cannot be moved because ${originalOfferingOrganisation.name} does not offer Building Choices: ${originalCourse.intensity?.toLowerCase()} intensity.`,
+              `This referral cannot be moved because ${originalOfferingOrganisation.name} does not offer the general offence strand of Building Choices: ${originalCourse.intensity?.toLowerCase()} intensity.`,
               'Close this referral and submit a new one to a different location.',
             ],
             pageHeading: 'This referral cannot be moved to Building Choices',

--- a/server/controllers/assess/transferReferralErrorController.ts
+++ b/server/controllers/assess/transferReferralErrorController.ts
@@ -52,7 +52,7 @@ export default class TransferReferralErrorController {
         const organisation = await this.organisationService.getOrganisation(token, originalOffering.organisationId)
 
         errorText = [
-          `This referral cannot be moved because ${organisation.name} does not offer Building Choices: ${originalCourse.intensity?.toLowerCase()} intensity.`,
+          `This referral cannot be moved because ${organisation.name} does not offer the general offence strand of Building Choices: ${originalCourse.intensity?.toLowerCase()} intensity.`,
           'Close this referral and submit a new one to a different location.',
         ]
       } else {


### PR DESCRIPTION
## Changes in this PR
Update Transfer to BC error message that only appears when the general offence strand is not available. 


## Screenshots of UI changes

![image](https://github.com/user-attachments/assets/5bf9c8b4-8243-4d53-ab8e-bf8b1291e92b)