### PR TITLE
APG-837: Update deselection reasons for keep referral open

### DIFF
--- a/server/controllers/shared/reasonController.test.ts
+++ b/server/controllers/shared/reasonController.test.ts
@@ -132,7 +132,11 @@ describe('ReasonController', () => {
         timelineItems: timelineItems.slice(0, 1),
       })
 
-      expect(referenceDataService.getReferralStatusCodeReasonsWithCategory).toHaveBeenCalledWith(username, 'DESELECTED')
+      expect(referenceDataService.getReferralStatusCodeReasonsWithCategory).toHaveBeenCalledWith(
+        username,
+        'DESELECTED',
+        { deselectAndKeepOpen: false },
+      )
       expect(referralService.getReferral).toHaveBeenCalledWith(username, referral.id)
       expect(referralService.getReferralStatusHistory).toHaveBeenCalledWith(userToken, username, referral.id)
       expect(personService.getPerson).toHaveBeenCalledWith(username, referral.prisonNumber)
@@ -183,6 +187,7 @@ describe('ReasonController', () => {
         expect(referenceDataService.getReferralStatusCodeReasonsWithCategory).toHaveBeenCalledWith(
           username,
           'WITHDRAWN',
+          { deselectAndKeepOpen: false },
         )
         expect(referralService.getReferralStatusHistory).toHaveBeenCalledWith(userToken, username, referral.id)
 
@@ -217,6 +222,7 @@ describe('ReasonController', () => {
         expect(referenceDataService.getReferralStatusCodeReasonsWithCategory).toHaveBeenCalledWith(
           username,
           'DESELECTED',
+          { deselectAndKeepOpen: true },
         )
         expect(referralService.getReferralStatusHistory).toHaveBeenCalledWith(userToken, username, referral.id)
 
@@ -252,6 +258,7 @@ describe('ReasonController', () => {
         expect(referenceDataService.getReferralStatusCodeReasonsWithCategory).toHaveBeenCalledWith(
           username,
           'ASSESSED_SUITABLE',
+          { deselectAndKeepOpen: false },
         )
         expect(referralService.getReferralStatusHistory).toHaveBeenCalledWith(userToken, username, referral.id)
 

--- a/server/controllers/shared/reasonController.ts
+++ b/server/controllers/shared/reasonController.ts
@@ -66,6 +66,7 @@ export default class ReasonController {
         this.referenceDataService.getReferralStatusCodeReasonsWithCategory(
           username,
           decisionForCategoryAndReason as ReferralStatusWithReasons,
+          { deselectAndKeepOpen: initialStatusDecision === 'DESELECTED|OPEN' },
         ),
       ])
 

--- a/server/data/accreditedProgrammesApi/referenceDataClient.ts
+++ b/server/data/accreditedProgrammesApi/referenceDataClient.ts
@@ -56,9 +56,17 @@ export default class ReferenceDataClient {
 
   async findReferralStatusCodeReasonsWithCategory(
     referralStatusCode: Extract<ReferralStatusUppercase, ReferralStatusWithReasons>,
+    query?: {
+      deselectAndKeepOpen?: boolean
+    },
   ): Promise<Array<ReferralStatusReason>> {
     return (await this.restClient.get({
-      path: apiPaths.referenceData.referralStatuses.statusCodeReasonsWithCategories({ referralStatusCode }),
+      path: apiPaths.referenceData.referralStatuses.statusCodeReasonsWithCategories({
+        referralStatusCode,
+      }),
+      query: {
+        ...(query?.deselectAndKeepOpen && { deselectAndKeepOpen: 'true' }),
+      },
     })) as Array<ReferralStatusReason>
   }
 

--- a/server/services/referenceDataService.test.ts
+++ b/server/services/referenceDataService.test.ts
@@ -83,7 +83,7 @@ describe('ReferenceDataService', () => {
       it('calls the `getReferralStatusCodeReasons` method with those same query parameters', async () => {
         const categoryCode = 'B'
         const reasons = referralStatusReasonFactory.buildList(2, { referralCategoryCode: categoryCode })
-        const query = { deselectAndKeepOpen: true }
+        const query = { deselectAndKeepOpen: false }
 
         when(referenceDataClient.findReferralStatusCodeReasons)
           .calledWith(categoryCode, referralStatusCode, query)
@@ -99,12 +99,13 @@ describe('ReferenceDataService', () => {
   describe('getReferralStatusCodeReasonsWithCategory', () => {
     it('should return referral status code reasons with category', async () => {
       const reasons = referralStatusReasonFactory.buildList(2, { referralCategoryCode: 'C' })
+      const query = { deselectAndKeepOpen: false }
 
       when(referenceDataClient.findReferralStatusCodeReasonsWithCategory)
-        .calledWith(referralStatusCode)
+        .calledWith(referralStatusCode, query)
         .mockResolvedValue(reasons)
 
-      const result = await service.getReferralStatusCodeReasonsWithCategory(username, referralStatusCode)
+      const result = await service.getReferralStatusCodeReasonsWithCategory(username, referralStatusCode, query)
 
       expect(result).toEqual(reasons)
     })

--- a/server/services/referenceDataService.ts
+++ b/server/services/referenceDataService.ts
@@ -54,12 +54,15 @@ export default class ReferenceDataService {
   async getReferralStatusCodeReasonsWithCategory(
     username: Express.User['username'],
     referralStatusCode: ReferralStatusWithReasons,
+    query?: {
+      deselectAndKeepOpen?: boolean
+    },
   ): Promise<Array<ReferralStatusReason>> {
     const hmppsAuthClient = this.hmppsAuthClientBuilder()
     const systemToken = await hmppsAuthClient.getSystemClientToken(username)
     const referenceDataClient = this.referenceDataClient(systemToken)
 
-    return referenceDataClient.findReferralStatusCodeReasonsWithCategory(referralStatusCode)
+    return referenceDataClient.findReferralStatusCodeReasonsWithCategory(referralStatusCode, query)
   }
 
   async getReferralStatuses(username: Express.User['username']): Promise<Array<ReferralStatusRefData>> {


### PR DESCRIPTION
## Context

Updates the deselect and keep open page to use the filtered list of reasons

![Screenshot 2025-05-06 at 11 58 47](https://github.com/user-attachments/assets/5e95f335-cb0c-4a63-b02a-78052ed69d26)



## Release checklist

[Release process documentation](../blob/main/doc/how-to/perform-a-release.md)

As part of our continuous deployment strategy we must ensure that this work is
ready to be released once merged.

### Pre-merge

- [ ] There are changes required to the Accredited Programmes API for this change to work...
  - [ ] ... and they have been released to production already

### Post-merge

<!-- The outer checkboxes can be completed pre-merge -->

- [ ] This adds, extends or meaningfully modifies a feature...
  - [ ] ... and I have written or updated an end-to-end test for the happy path in the [Accredited Programmes E2E repo](https://github.com/ministryofjustice/hmpps-accredited-programmes-e2e)
- [ ] This makes new expectations of the API...
  - [ ] ... and I have notified the API developer(s) of changes to the contract tests (Pact), or the API is already compliant
- [ ] [Manually approve](../doc/how-to/perform-a-release.md#releasing-to-the-preprod-environment) release to preprod
- [ ] [Manually approve](../doc/how-to/perform-a-release.md#releasing-to-the-production-environment) release to prod

<!-- Should a release fail at any step, you as the author should now lead the work to
fix it as soon as possible. You can monitor deployment failures in CircleCI
itself and application errors are found in
[Sentry](https://ministryofjustice.sentry.io/projects/hmpps-accredited-programmes-ui/?project=4505330122686464&referrer=sidebar&statsPeriod=24h). -->
