### PR TITLE
(APG-843) HSP Sexual offence details page

### DIFF
--- a/server/controllers/find/hspDetailsController.test.ts
+++ b/server/controllers/find/hspDetailsController.test.ts
@@ -1,0 +1,94 @@
+import { type DeepMocked, createMock } from '@golevelup/ts-jest'
+import type { NextFunction, Request, Response } from 'express'
+import { when } from 'jest-when'
+
+import HspDetailsController from './hspDetailsController'
+import { findPaths } from '../../paths'
+import type { CourseService, PersonService } from '../../services'
+import { courseFactory, personFactory } from '../../testutils/factories'
+import { CourseUtils } from '../../utils'
+
+describe('HspDetailsController', () => {
+  const username = 'SOME_USER'
+  let request: DeepMocked<Request>
+  let response: DeepMocked<Response>
+  const next: DeepMocked<NextFunction> = createMock<NextFunction>({})
+  const courseService = createMock<CourseService>({})
+  const personService = createMock<PersonService>({})
+
+  let controller: HspDetailsController
+
+  const hspCourse = courseFactory.build({ name: 'Healthy Sex Programme' })
+  const person = personFactory.build({ name: 'Del Hatton' })
+
+  beforeEach(() => {
+    request = createMock<Request>({
+      params: { courseId: hspCourse.id },
+      session: {
+        pniFindAndReferData: {
+          prisonNumber: person.prisonNumber,
+          programmePathway: 'HIGH_INTENSITY_BC',
+        },
+      },
+      user: { username },
+    })
+
+    response = createMock<Response>({})
+    controller = new HspDetailsController(courseService, personService)
+
+    when(courseService.getCourse).calledWith(username, hspCourse.id).mockResolvedValue(hspCourse)
+    when(personService.getPerson).calledWith(username, person.prisonNumber).mockResolvedValue(person)
+  })
+
+  afterEach(() => {
+    jest.restoreAllMocks()
+  })
+
+  describe('show', () => {
+    it('should render the HSP details page with the correct data', async () => {
+      const requestHandler = controller.show()
+      await requestHandler(request, response, next)
+
+      expect(response.render).toHaveBeenCalledWith('courses/hsp/details/show', {
+        hrefs: {
+          back: findPaths.show({ courseId: hspCourse.id }),
+        },
+        pageHeading: 'Sexual offence details',
+        personName: person.name,
+      })
+    })
+
+    describe('when there is no `prisonNumber` in `session.pniFindAndReferData`', () => {
+      it('should redirect to the person search page', async () => {
+        delete request.session.pniFindAndReferData?.prisonNumber
+
+        const requestHandler = controller.show()
+        await requestHandler(request, response, next)
+
+        expect(response.redirect).toHaveBeenCalledWith(findPaths.pniFind.personSearch.pattern)
+      })
+    })
+
+    describe('when there is no `programmePathway` in `session.pniFindAndReferData`', () => {
+      it('should redirect to the person search page', async () => {
+        delete request.session.pniFindAndReferData?.programmePathway
+
+        const requestHandler = controller.show()
+        await requestHandler(request, response, next)
+
+        expect(response.redirect).toHaveBeenCalledWith(findPaths.pniFind.personSearch.pattern)
+      })
+    })
+
+    describe('when the course is not an HSP course', () => {
+      it('should redirect to the person search page', async () => {
+        jest.spyOn(CourseUtils, 'isHsp').mockReturnValue(false)
+
+        const requestHandler = controller.show()
+        await requestHandler(request, response, next)
+
+        expect(response.redirect).toHaveBeenCalledWith(findPaths.pniFind.personSearch.pattern)
+      })
+    })
+  })
+})

--- a/server/controllers/find/hspDetailsController.ts
+++ b/server/controllers/find/hspDetailsController.ts
@@ -1,0 +1,40 @@
+import type { Request, Response, TypedRequestHandler } from 'express'
+
+import { findPaths } from '../../paths'
+import type { CourseService, PersonService } from '../../services'
+import { CourseUtils, TypeUtils } from '../../utils'
+
+export default class HspDetailsController {
+  constructor(
+    private readonly courseService: CourseService,
+    private readonly personService: PersonService,
+  ) {}
+
+  show(): TypedRequestHandler<Request, Response> {
+    return async (req: Request, res: Response) => {
+      TypeUtils.assertHasUser(req)
+
+      const { username } = req.user
+      const { courseId } = req.params
+      const prisonNumber = req.session.pniFindAndReferData?.prisonNumber
+      const programmePathway = req.session.pniFindAndReferData?.programmePathway
+
+      const course = await this.courseService.getCourse(username, courseId)
+
+      if (!prisonNumber || !programmePathway || !CourseUtils.isHsp(course.displayName)) {
+        return res.redirect(findPaths.pniFind.personSearch.pattern)
+      }
+
+      const person = await this.personService.getPerson(username, prisonNumber)
+      // TODO: Get checkbox items from API
+
+      return res.render('courses/hsp/details/show', {
+        hrefs: {
+          back: findPaths.show({ courseId: course.id }),
+        },
+        pageHeading: 'Sexual offence details',
+        personName: person.name,
+      })
+    }
+  }
+}

--- a/server/controllers/find/index.ts
+++ b/server/controllers/find/index.ts
@@ -6,6 +6,7 @@ import BuildingChoicesController from './buildingChoicesController'
 import BuildingChoicesFormController from './buildingChoicesFormController'
 import CourseOfferingsController from './courseOfferingsController'
 import CoursesController from './coursesController'
+import HspDetailsController from './hspDetailsController'
 import PersonSearchController from './personSearchController'
 import RecommendedPathwayController from './recommendedPathwayController'
 import RecommendedProgrammesController from './recommendedProgrammesController'
@@ -37,6 +38,7 @@ const controllers = (services: Services) => {
     services.courseService,
     services.organisationService,
   )
+  const hspDetailsController = new HspDetailsController(services.courseService, services.personService)
 
   return {
     addCourseController,
@@ -45,6 +47,7 @@ const controllers = (services: Services) => {
     buildingChoicesFormController,
     courseOfferingsController,
     coursesController,
+    hspDetailsController,
     personSearchController,
     recommendedPathwayController,
     recommendedProgrammesController,

--- a/server/paths/find.ts
+++ b/server/paths/find.ts
@@ -11,6 +11,9 @@ const updateCoursePath = coursePath.path('update')
 
 const buildingChoicesPath = findPathBase.path('building-choices/:courseId')
 
+const hspPathBase = coursePath.path('/hsp')
+const hspDetailsPath = hspPathBase.path('details')
+
 const addCourseOfferingPath = coursePath.path('offerings/add')
 const deleteCourseOfferingPath = coursePath.path('offerings/:courseOfferingId/delete')
 const courseOfferingPath = findPathBase.path('offerings/:courseOfferingId')
@@ -32,6 +35,11 @@ export default {
     update: {
       show: updateCoursePath,
       submit: updateCoursePath,
+    },
+  },
+  hsp: {
+    details: {
+      show: hspDetailsPath,
     },
   },
   index: coursesPath,

--- a/server/routes/find.ts
+++ b/server/routes/find.ts
@@ -6,8 +6,13 @@ import { RouteUtils } from '../utils'
 
 export default function routes(controllers: Controllers, router: Router): Router {
   const { get, post } = RouteUtils.actions(router)
-  const { buildingChoicesController, buildingChoicesFormController, coursesController, courseOfferingsController } =
-    controllers
+  const {
+    buildingChoicesController,
+    buildingChoicesFormController,
+    coursesController,
+    courseOfferingsController,
+    hspDetailsController,
+  } = controllers
 
   get(findPaths.index.pattern, coursesController.index())
 
@@ -25,6 +30,8 @@ export default function routes(controllers: Controllers, router: Router): Router
   get(findPaths.pniFind.recommendedPathway.pattern, controllers.recommendedPathwayController.show())
 
   get(findPaths.pniFind.recommendedProgrammes.pattern, controllers.recommendedProgrammesController.show())
+
+  get(findPaths.hsp.details.show.pattern, hspDetailsController.show())
 
   return router
 }

--- a/server/utils/courseUtils.test.ts
+++ b/server/utils/courseUtils.test.ts
@@ -96,6 +96,21 @@ describe('CourseUtils', () => {
     })
   })
 
+  describe('isHsp', () => {
+    it('should ignore case', () => {
+      expect(CourseUtils.isHsp('Healthy Sex Programme')).toBe(true)
+      expect(CourseUtils.isHsp('HEALTHY SEX PROGRAMME')).toBe(true)
+    })
+
+    it('should return false when the course displayName does not equal "healthy sex programme"', () => {
+      expect(CourseUtils.isHsp('Lime Course')).toBe(false)
+    })
+
+    it('should return false when the course displayName is undefined', () => {
+      expect(CourseUtils.isHsp()).toBe(false)
+    })
+  })
+
   describe('noOfferingsMessage', () => {
     it('returns a message for when a course has no offerings', () => {
       expect(CourseUtils.noOfferingsMessage('Test Course')).toBe(

--- a/server/utils/courseUtils.ts
+++ b/server/utils/courseUtils.ts
@@ -64,6 +64,10 @@ export default class CourseUtils {
     return courseDisplayName?.toLowerCase()?.startsWith('building choices:') ?? false
   }
 
+  static isHsp(courseDisplayName?: string): boolean {
+    return courseDisplayName?.toLowerCase().startsWith('healthy sex programme') ?? false
+  }
+
   static noOfferingsMessage(courseName: Course['name']): string {
     const actionStrings = new Map<Course['name'], string>([
       [

--- a/server/views/courses/hsp/details/show.njk
+++ b/server/views/courses/hsp/details/show.njk
@@ -1,0 +1,39 @@
+{% from "govuk/components/back-link/macro.njk" import govukBackLink %}
+{% from "govuk/components/button/macro.njk" import govukButton %}
+
+{% extends "../../../partials/layout.njk" %}
+
+{% block backLink %}
+  {{ govukBackLink({
+    text: "Back",
+    href: hrefs.back
+  }) }}
+{% endblock backLink %}
+
+{% block content %}
+  <div class="govuk-grid-row">
+    <div class="govuk-grid-column-two-thirds">
+      <h1>{{ pageHeading }}</h1>
+
+      <p class="govuk-body">To check eligibility for a referral to Healthy Sex Programme (HSP), give more details about {{ personName | makePossessive }} sexual offending.</p>
+
+      <p class="govuk-body">Include:</p>
+
+      <ul class="govuk-list govuk-list--bullet">
+        <li>previous convictions as well as the index offence</li>
+        <li>legal convictions</li>
+        <li>formal documented offences established through court martial</li>
+        <li>offences left to lie on file</li>
+        <li>charges not pursued, but lying open (ie they have not been found 'not guilty')</li>
+        <li>officially documented charges, but with reasons for not proceeding</li>
+      </ul>
+
+      <p class="govuk-body">Do not include unproved or overturned allegations.</p>
+
+      <hr class="govuk-section-break govuk-section-break--l govuk-section-break--visible">
+
+      <h2 class="govuk-heading-m">Do any of these statements apply to their sexual offending?</h2>
+
+    </div>
+  </div>
+{% endblock content %}


### PR DESCRIPTION
## Context

We require a new page to capture the sexual offence details before someone can be referred to HSP.


## Changes in this PR
- Add basic `isHsp` util method
- Add new controller and page template for Sexual offence details page

Awaiting api endpoint before listing available options on the page and adding the form.
