### PR TITLE
(APG-843) Add checkboxes to sexual offence details page

### DIFF
--- a/server/controllers/find/hspDetailsController.test.ts
+++ b/server/controllers/find/hspDetailsController.test.ts
@@ -4,9 +4,9 @@ import { when } from 'jest-when'
 
 import HspDetailsController from './hspDetailsController'
 import { findPaths } from '../../paths'
-import type { CourseService, PersonService } from '../../services'
-import { courseFactory, personFactory } from '../../testutils/factories'
-import { CourseUtils } from '../../utils'
+import type { CourseService, PersonService, ReferenceDataService } from '../../services'
+import { courseFactory, personFactory, sexualOffenceDetailsFactory } from '../../testutils/factories'
+import { CourseUtils, ReferenceDataUtils } from '../../utils'
 
 describe('HspDetailsController', () => {
   const username = 'SOME_USER'
@@ -15,6 +15,7 @@ describe('HspDetailsController', () => {
   const next: DeepMocked<NextFunction> = createMock<NextFunction>({})
   const courseService = createMock<CourseService>({})
   const personService = createMock<PersonService>({})
+  const referenceDataService = createMock<ReferenceDataService>({})
 
   let controller: HspDetailsController
 
@@ -34,7 +35,7 @@ describe('HspDetailsController', () => {
     })
 
     response = createMock<Response>({})
-    controller = new HspDetailsController(courseService, personService)
+    controller = new HspDetailsController(courseService, personService, referenceDataService)
 
     when(courseService.getCourse).calledWith(username, hspCourse.id).mockResolvedValue(hspCourse)
     when(personService.getPerson).calledWith(username, person.prisonNumber).mockResolvedValue(person)
@@ -45,13 +46,48 @@ describe('HspDetailsController', () => {
   })
 
   describe('show', () => {
+    const sexualOffenceDetails = sexualOffenceDetailsFactory.buildList(3)
+    const mockGroupedDetailOptions = {
+      'Category 1': [
+        { categoryDescription: 'Category 1', description: 'Option 1', hintText: 'Hint 1', id: 'ABC-123', score: 1 },
+        { categoryDescription: 'Category 1', description: 'Option 2', hintText: 'Hint 2', id: 'ABC-456', score: 2 },
+      ],
+      'Category 2': [
+        { categoryDescription: 'Category 2', description: 'Option 3', hintText: 'Hint 3', id: 'ABC-789', score: 3 },
+      ],
+    }
+    const mockFieldsets = [
+      {
+        checkboxes: [
+          { checked: false, hint: { text: 'Hint 1' }, text: 'Option 1', value: 'ABC-123::1' },
+          { checked: false, hint: { text: 'Hint 2' }, text: 'Option 2', value: 'ABC-456::2' },
+        ],
+        legend: { text: 'Category 1' },
+      },
+      {
+        checkboxes: [{ checked: false, hint: { text: 'Hint 3' }, text: 'Option 3', value: 'ABC-789::3' }],
+        legend: { text: 'Category 2' },
+      },
+    ]
+
+    beforeEach(() => {
+      when(referenceDataService.getSexualOffenceDetails).calledWith(username).mockResolvedValue(sexualOffenceDetails)
+
+      jest.spyOn(ReferenceDataUtils, 'groupOptionsByKey').mockReturnValue(mockGroupedDetailOptions)
+      jest.spyOn(ReferenceDataUtils, 'createSexualOffenceDetailsFieldset').mockReturnValue(mockFieldsets)
+    })
+
     it('should render the HSP details page with the correct data', async () => {
       const requestHandler = controller.show()
       await requestHandler(request, response, next)
 
+      expect(ReferenceDataUtils.groupOptionsByKey).toHaveBeenCalledWith(sexualOffenceDetails, 'categoryDescription')
+      expect(ReferenceDataUtils.createSexualOffenceDetailsFieldset).toHaveBeenCalledWith(mockGroupedDetailOptions, [])
       expect(response.render).toHaveBeenCalledWith('courses/hsp/details/show', {
+        checkboxFieldsets: mockFieldsets,
         hrefs: {
           back: findPaths.show({ courseId: hspCourse.id }),
+          programmeIndex: findPaths.pniFind.recommendedProgrammes({}),
         },
         pageHeading: 'Sexual offence details',
         personName: person.name,

--- a/server/controllers/find/index.ts
+++ b/server/controllers/find/index.ts
@@ -38,7 +38,11 @@ const controllers = (services: Services) => {
     services.courseService,
     services.organisationService,
   )
-  const hspDetailsController = new HspDetailsController(services.courseService, services.personService)
+  const hspDetailsController = new HspDetailsController(
+    services.courseService,
+    services.personService,
+    services.referenceDataService,
+  )
 
   return {
     addCourseController,

--- a/server/views/courses/hsp/details/show.njk
+++ b/server/views/courses/hsp/details/show.njk
@@ -1,5 +1,6 @@
 {% from "govuk/components/back-link/macro.njk" import govukBackLink %}
 {% from "govuk/components/button/macro.njk" import govukButton %}
+{% from "govuk/components/checkboxes/macro.njk" import govukCheckboxes %}
 
 {% extends "../../../partials/layout.njk" %}
 
@@ -33,7 +34,37 @@
       <hr class="govuk-section-break govuk-section-break--l govuk-section-break--visible">
 
       <h2 class="govuk-heading-m">Do any of these statements apply to their sexual offending?</h2>
+      <p class="govuk-hint">Select all that apply.</p>
 
+      <form method="post">
+        <input type="hidden" name="_csrf" value="{{ csrfToken }}"/>
+
+        {% for fieldset in checkboxFieldsets %}
+          {{ govukCheckboxes({
+              name: "sexualOffenceDetails",
+              fieldset: {
+                legend: {
+                  text: fieldset.legend.text,
+                  classes: "govuk-fieldset__legend--s"
+                }
+              },
+              items: fieldset.checkboxes,        
+              errorMessage: errors.messages.sexualOffenceDetails
+            }) }}
+        {% endfor %}
+
+        <div class="govuk-button-group">
+          {{ govukButton({
+            text: "Continue"
+          }) }}
+
+          {{ govukButton({
+            href: hrefs.programmeIndex,
+            classes: "govuk-button--secondary",
+            text: "Return to programme list"
+          }) }}
+        </div>
+      </form>
     </div>
   </div>
 {% endblock content %}


### PR DESCRIPTION
## Context

Need to display a list of checkboxes on the HSP SO Details page.

## Changes in this PR
Use recently added utils to display checkboxes on Sexual offence details page.


## Screenshots of UI changes
![localhost_3000_find_programmes_8bf2fabf-8667-4858-bc91-a2bd93f41f48_hsp_details](https://github.com/user-attachments/assets/a815c453-1d18-40bc-b1c4-d2910514ba20)
