### PR TITLE
APG-861: Add offering page for Building Choices

### DIFF
--- a/server/controllers/find/addCourseOfferingController.test.ts
+++ b/server/controllers/find/addCourseOfferingController.test.ts
@@ -5,7 +5,7 @@ import type { NextFunction, Request, Response } from 'express'
 import AddCourseOfferingController from './addCourseOfferingController'
 import { findPaths } from '../../paths'
 import type { CourseService, OrganisationService } from '../../services'
-import { courseOfferingFactory, prisonFactory } from '../../testutils/factories'
+import { courseFactory, courseOfferingFactory, prisonFactory } from '../../testutils/factories'
 import { OrganisationUtils } from '../../utils'
 import type { GovukFrontendSelectItem } from '@govuk-frontend'
 
@@ -45,6 +45,8 @@ describe('AddCourseController', () => {
     it('renders the create course offering form template with organisation select items', async () => {
       const organisations = prisonFactory.buildList(3)
       organisationService.getAllOrganisations.mockResolvedValue(organisations)
+      const course = courseFactory.build({ displayName: 'Course Name', id: courseId })
+      courseService.getCourse.mockResolvedValue(course)
 
       const requestHandler = controller.show()
       await requestHandler(request, response, next)
@@ -56,6 +58,7 @@ describe('AddCourseController', () => {
         backLinkHref: '/find/programmes/course-id',
         organisationSelectItems,
         pageHeading: 'Add a Location',
+        showBuildingChoicesOptions: false,
       })
       expect(OrganisationUtils.organisationSelectItems).toHaveBeenCalledWith(organisations)
     })
@@ -78,7 +81,9 @@ describe('AddCourseController', () => {
         withdrawn: false,
       })
 
+      const course = courseFactory.build({ displayName: 'Course Name', id: courseId })
       courseService.addCourseOffering.mockResolvedValue(courseOffering)
+      courseService.getCourse.mockResolvedValue(course)
 
       request.body = newCourseOfferingBody
 

--- a/server/controllers/find/addCourseOfferingController.ts
+++ b/server/controllers/find/addCourseOfferingController.ts
@@ -2,7 +2,7 @@ import type { Request, Response, TypedRequestHandler } from 'express'
 
 import { findPaths } from '../../paths'
 import type { CourseService, OrganisationService } from '../../services'
-import { OrganisationUtils, TypeUtils } from '../../utils'
+import { CourseUtils, OrganisationUtils, TypeUtils } from '../../utils'
 
 export default class AddCourseOfferingController {
   constructor(
@@ -16,8 +16,8 @@ export default class AddCourseOfferingController {
 
       const { courseId } = req.params
 
+      const course = await this.courseService.getCourse(req.user.username, courseId)
       const organisations = await this.organisationService.getAllOrganisations(req.user.token)
-
       const organisationSelectItems = OrganisationUtils.organisationSelectItems(organisations)
 
       res.render('courses/offerings/form/show', {
@@ -25,6 +25,7 @@ export default class AddCourseOfferingController {
         backLinkHref: findPaths.show({ courseId }),
         organisationSelectItems,
         pageHeading: 'Add a Location',
+        showBuildingChoicesOptions: CourseUtils.isBuildingChoices(course.displayName),
       })
     }
   }
@@ -32,12 +33,50 @@ export default class AddCourseOfferingController {
   submit(): TypedRequestHandler<Request, Response> {
     return async (req: Request, res: Response) => {
       TypeUtils.assertHasUser(req)
-
       const { courseId } = req.params
-      const { contactEmail, organisationId, referable, secondaryContactEmail, withdrawn } = req.body as Record<
-        string,
-        string
-      >
+      const {
+        contactEmail,
+        organisationId,
+        referable,
+        secondaryContactEmail,
+        withdrawn,
+        createGeneralOffenceStrand,
+        createSexualOffenceStrand,
+        targetsWomensPrison,
+      } = req.body as Record<string, string>
+
+      if (createGeneralOffenceStrand === 'true' || createSexualOffenceStrand === 'true') {
+        if (createGeneralOffenceStrand === 'true') {
+          const generalOffenceCourses = await this.courseService.getBuildingChoicesVariants(
+            req.user?.username,
+            courseId,
+            { isConvictedOfSexualOffence: 'false', isInAWomensPrison: targetsWomensPrison },
+          )
+          await this.courseService.addCourseOffering(req.user.username, generalOffenceCourses[0].id, {
+            contactEmail,
+            organisationId,
+            referable: referable === 'true',
+            secondaryContactEmail,
+            withdrawn: withdrawn ? withdrawn === 'true' : undefined,
+          })
+        }
+
+        if (createSexualOffenceStrand === 'true') {
+          const sexualOffenceCourses = await this.courseService.getBuildingChoicesVariants(
+            req.user?.username,
+            courseId,
+            { isConvictedOfSexualOffence: 'true', isInAWomensPrison: targetsWomensPrison },
+          )
+          await this.courseService.addCourseOffering(req.user.username, sexualOffenceCourses[0].id, {
+            contactEmail,
+            organisationId,
+            referable: referable === 'true',
+            secondaryContactEmail,
+            withdrawn: withdrawn ? withdrawn === 'true' : undefined,
+          })
+        }
+        return res.redirect(findPaths.buildingChoices.form.show({ courseId }))
+      }
 
       const offering = await this.courseService.addCourseOffering(req.user.username, courseId, {
         contactEmail,
@@ -47,7 +86,7 @@ export default class AddCourseOfferingController {
         withdrawn: withdrawn ? withdrawn === 'true' : undefined,
       })
 
-      res.redirect(findPaths.offerings.show({ courseOfferingId: offering.id }))
+      return res.redirect(findPaths.offerings.show({ courseOfferingId: offering.id }))
     }
   }
 }

--- a/server/controllers/find/buildingChoicesController.test.ts
+++ b/server/controllers/find/buildingChoicesController.test.ts
@@ -117,10 +117,14 @@ describe('BuildingChoicesFormController', () => {
           })),
         )
         expect(response.render).toHaveBeenCalledWith('courses/buildingChoices/show', {
-          backLinkHref: findPaths.buildingChoices.form.show({ courseId }),
           buildingChoicesAnswersSummaryListRows,
           course,
           hideTitleServiceName: true,
+          hrefs: {
+            addOffering: findPaths.offerings.add.create({ courseId: course.id }),
+            back: findPaths.buildingChoices.form.show({ courseId }),
+            updateProgramme: findPaths.course.update.show({ courseId: course.id }),
+          },
           organisationsTableData,
           pageHeading: course.displayName,
           pageTitleOverride: `${course.displayName} programme description`,

--- a/server/controllers/find/buildingChoicesController.ts
+++ b/server/controllers/find/buildingChoicesController.ts
@@ -37,10 +37,14 @@ export default class BuildingChoicesController {
       })
 
       return res.render('courses/buildingChoices/show', {
-        backLinkHref: findPaths.buildingChoices.form.show({ courseId }),
         buildingChoicesAnswersSummaryListRows: CourseUtils.buildingChoicesAnswersSummaryListRows(buildingChoicesData),
         course,
         hideTitleServiceName: true,
+        hrefs: {
+          addOffering: findPaths.offerings.add.create({ courseId: course.id }),
+          back: findPaths.buildingChoices.form.show({ courseId }),
+          updateProgramme: findPaths.course.update.show({ courseId: course.id }),
+        },
         organisationsTableData: OrganisationUtils.organisationTableRows(organisationsWithOfferingIds),
         pageHeading: course.displayName,
         pageTitleOverride: `${course.displayName} programme description`,

--- a/server/views/courses/buildingChoices/show.njk
+++ b/server/views/courses/buildingChoices/show.njk
@@ -7,7 +7,7 @@
 {% block backLink %}
   {{ govukBackLink({
     text: "Back",
-    href: backLinkHref
+    href: hrefs.back
   }) }}
 {% endblock backLink %}
 
@@ -35,7 +35,7 @@
         {% if 'ROLE_ACP_EDITOR' in user.roles %}
           {{ govukButton({
             text: "Add a new location",
-            href: addOfferingPath,
+            href: hrefs.addOffering,
             classes: "govuk-button--secondary",
             attributes: {
               "data-testid": "add-programme-offering-link"

--- a/server/views/courses/offerings/form/show.njk
+++ b/server/views/courses/offerings/form/show.njk
@@ -4,6 +4,7 @@
 {% from "govuk/components/radios/macro.njk" import govukRadios %}
 {% from "govuk/components/select/macro.njk" import govukSelect %}
 {% from "govuk/components/textarea/macro.njk" import govukTextarea %}
+{% from "govuk/components/checkboxes/macro.njk" import govukCheckboxes %}
 
 {% extends "../../../partials/layout.njk" %}
 
@@ -35,6 +36,37 @@
           errorMessage: errors.messages.organisationId,
           value: offering.organisationId
         }) }}
+
+        {% if showBuildingChoicesOptions %}
+          {{ govukCheckboxes({
+              name: "buildingChoicesOptions",
+              fieldset: {
+                legend: {
+                  text: "Variants",
+                  isPageHeading: false,
+                  classes: "govuk-fieldset__legend--s"
+                }
+              },
+              hint: {
+                text: "Select all variants you wish to offer at the above location"
+              },
+              items: [
+                {
+                  value: "createGeneralOffenceStrand",
+                  text: "General Offence"
+                },
+                {
+                  value: "createSexualOffenceStrand",
+                  text: "Sexual Offence"
+                },
+                {
+                  value: "targetsWomensPrison",
+                  text: "Is for a women's prison"
+                }
+              ]
+            })
+          }}
+        {% endif %}
 
         {{ govukInput({
           label: {


### PR DESCRIPTION
## Context
Adds a page for adding new offerings for building choices courses

<img width="958" alt="Screenshot 2025-05-09 at 14 34 54" src="https://github.com/user-attachments/assets/b87c910e-a03a-4c76-b797-f04a516bc318" />


## Screenshots of UI changes

### Before


### After


## Release checklist

[Release process documentation](../blob/main/doc/how-to/perform-a-release.md)

As part of our continuous deployment strategy we must ensure that this work is
ready to be released once merged.

### Pre-merge

- [ ] There are changes required to the Accredited Programmes API for this change to work...
  - [ ] ... and they have been released to production already

### Post-merge

<!-- The outer checkboxes can be completed pre-merge -->

- [ ] This adds, extends or meaningfully modifies a feature...
  - [ ] ... and I have written or updated an end-to-end test for the happy path in the [Accredited Programmes E2E repo](https://github.com/ministryofjustice/hmpps-accredited-programmes-e2e)
- [ ] This makes new expectations of the API...
  - [ ] ... and I have notified the API developer(s) of changes to the contract tests (Pact), or the API is already compliant
- [ ] [Manually approve](../doc/how-to/perform-a-release.md#releasing-to-the-preprod-environment) release to preprod
- [ ] [Manually approve](../doc/how-to/perform-a-release.md#releasing-to-the-production-environment) release to prod

<!-- Should a release fail at any step, you as the author should now lead the work to
fix it as soon as possible. You can monitor deployment failures in CircleCI
itself and application errors are found in
[Sentry](https://ministryofjustice.sentry.io/projects/hmpps-accredited-programmes-ui/?project=4505330122686464&referrer=sidebar&statsPeriod=24h). -->
