### PR TITLE
(APG-843) Add submit method for HSP checklist

### DIFF
--- a/server/controllers/find/hspDetailsController.ts
+++ b/server/controllers/find/hspDetailsController.ts
@@ -2,9 +2,11 @@ import type { Request, Response, TypedRequestHandler } from 'express'
 
 import { findPaths } from '../../paths'
 import type { CourseService, PersonService, ReferenceDataService } from '../../services'
-import { CourseUtils, ReferenceDataUtils, TypeUtils } from '../../utils'
+import { CourseUtils, FormUtils, ReferenceDataUtils, TypeUtils } from '../../utils'
 
 export default class HspDetailsController {
+  ELIGIBILITY_THRESHOLD_SCORE = 3
+
   constructor(
     private readonly courseService: CourseService,
     private readonly personService: PersonService,
@@ -33,6 +35,8 @@ export default class HspDetailsController {
 
       const groupedDetailOptions = ReferenceDataUtils.groupOptionsByKey(details, 'categoryDescription')
 
+      FormUtils.setFieldErrors(req, res, ['sexualOffenceDetails'])
+
       return res.render('courses/hsp/details/show', {
         checkboxFieldsets: ReferenceDataUtils.createSexualOffenceDetailsFieldset(groupedDetailOptions, []),
         hrefs: {
@@ -42,6 +46,34 @@ export default class HspDetailsController {
         pageHeading: 'Sexual offence details',
         personName: person.name,
       })
+    }
+  }
+
+  submit(): TypedRequestHandler<Request, Response> {
+    return async (req: Request, res: Response) => {
+      TypeUtils.assertHasUser(req)
+
+      const { courseId } = req.params
+      const { sexualOffenceDetails } = req.body
+
+      if (!sexualOffenceDetails) {
+        req.flash('sexualOffenceDetailsError', 'Please select at least one sexual offence')
+
+        return res.redirect(findPaths.hsp.details.show({ courseId }))
+      }
+
+      const splitChar = '::'
+      const selectedValues = Array.isArray(sexualOffenceDetails)
+        ? sexualOffenceDetails.map(detail => detail.split(splitChar))
+        : [sexualOffenceDetails.split(splitChar)]
+
+      const totalScore = selectedValues.reduce((acc, [_value, score]) => acc + parseInt(score, 10), 0)
+
+      if (totalScore < this.ELIGIBILITY_THRESHOLD_SCORE) {
+        return res.send('Ineligible')
+      }
+
+      return res.send('Eligible')
     }
   }
 }

--- a/server/paths/find.ts
+++ b/server/paths/find.ts
@@ -40,6 +40,7 @@ export default {
   hsp: {
     details: {
       show: hspDetailsPath,
+      submit: hspDetailsPath,
     },
   },
   index: coursesPath,

--- a/server/routes/find.ts
+++ b/server/routes/find.ts
@@ -32,6 +32,7 @@ export default function routes(controllers: Controllers, router: Router): Router
   get(findPaths.pniFind.recommendedProgrammes.pattern, controllers.recommendedProgrammesController.show())
 
   get(findPaths.hsp.details.show.pattern, hspDetailsController.show())
+  post(findPaths.hsp.details.submit.pattern, hspDetailsController.submit())
 
   return router
 }

--- a/server/views/courses/hsp/details/show.njk
+++ b/server/views/courses/hsp/details/show.njk
@@ -1,6 +1,7 @@
 {% from "govuk/components/back-link/macro.njk" import govukBackLink %}
 {% from "govuk/components/button/macro.njk" import govukButton %}
 {% from "govuk/components/checkboxes/macro.njk" import govukCheckboxes %}
+{% from "govuk/components/error-summary/macro.njk" import govukErrorSummary %}
 
 {% extends "../../../partials/layout.njk" %}
 
@@ -14,6 +15,13 @@
 {% block content %}
   <div class="govuk-grid-row">
     <div class="govuk-grid-column-two-thirds">
+      {% if errors.list.length %}
+        {{ govukErrorSummary({
+          titleText: "There is a problem",
+          errorList: errors.list
+        }) }}
+      {% endif %}
+
       <h1>{{ pageHeading }}</h1>
 
       <p class="govuk-body">To check eligibility for a referral to Healthy Sex Programme (HSP), give more details about {{ personName | makePossessive }} sexual offending.</p>


### PR DESCRIPTION
## Changes in this PR
Add submit method for the HSP details check list. This calculates the score from the selections and determines if they are eligible or ineligible for HSP.

Follow on steps to be completed in APG-887


## Screenshots of UI changes

<img width="769" alt="image" src="https://github.com/user-attachments/assets/311331b0-bc9d-4a1e-8e36-b05b479d0330" />
