### PR TITLE
(APG-887) HSP Not eligible page

### DIFF
--- a/server/controllers/find/hspDetailsController.test.ts
+++ b/server/controllers/find/hspDetailsController.test.ts
@@ -144,13 +144,13 @@ describe('HspDetailsController', () => {
     })
 
     describe('when the total score of the submitted selections does not meet the threshold of 3', () => {
-      it('should return that they are ineligible for HSP', async () => {
+      it('should redirect to the HSP not eligible path', async () => {
         request.body = { sexualOffenceDetails: 'ABC-123::1' }
 
         const requestHandler = controller.submit()
         await requestHandler(request, response, next)
 
-        expect(response.send).toHaveBeenCalledWith('Ineligible')
+        expect(response.redirect).toHaveBeenCalledWith(findPaths.hsp.notEligible.show({ courseId: hspCourse.id }))
       })
     })
 

--- a/server/controllers/find/hspDetailsController.ts
+++ b/server/controllers/find/hspDetailsController.ts
@@ -70,7 +70,7 @@ export default class HspDetailsController {
       const totalScore = selectedValues.reduce((acc, [_value, score]) => acc + parseInt(score, 10), 0)
 
       if (totalScore < this.ELIGIBILITY_THRESHOLD_SCORE) {
-        return res.send('Ineligible')
+        return res.redirect(findPaths.hsp.notEligible.show({ courseId }))
       }
 
       return res.send('Eligible')

--- a/server/controllers/find/hspNotEligibleController.test.ts
+++ b/server/controllers/find/hspNotEligibleController.test.ts
@@ -1,0 +1,96 @@
+import { type DeepMocked, createMock } from '@golevelup/ts-jest'
+import type { NextFunction, Request, Response } from 'express'
+import { when } from 'jest-when'
+
+import HspNotEligibleController from './hspNotEligibleController'
+import { findPaths } from '../../paths'
+import type { CourseService, PersonService } from '../../services'
+import { courseFactory, personFactory } from '../../testutils/factories'
+import { CourseUtils } from '../../utils'
+
+describe('HspNotEligibleController', () => {
+  const username = 'SOME_USER'
+  let request: DeepMocked<Request>
+  let response: DeepMocked<Response>
+  const next: DeepMocked<NextFunction> = createMock<NextFunction>({})
+  const courseService = createMock<CourseService>({})
+  const personService = createMock<PersonService>({})
+
+  let controller: HspNotEligibleController
+
+  const hspCourse = courseFactory.build({ name: 'Healthy Sex Programme' })
+  const person = personFactory.build({ name: 'Del Hatton' })
+
+  beforeEach(() => {
+    request = createMock<Request>({
+      params: { courseId: hspCourse.id },
+      session: {
+        pniFindAndReferData: {
+          prisonNumber: person.prisonNumber,
+          programmePathway: 'HIGH_INTENSITY_BC',
+        },
+      },
+      user: { username },
+    })
+
+    response = createMock<Response>({})
+    controller = new HspNotEligibleController(courseService, personService)
+
+    when(courseService.getCourse).calledWith(username, hspCourse.id).mockResolvedValue(hspCourse)
+    when(personService.getPerson).calledWith(username, person.prisonNumber).mockResolvedValue(person)
+  })
+
+  afterEach(() => {
+    jest.restoreAllMocks()
+  })
+
+  describe('show', () => {
+    it('should render the HSP Not eligible page with the correct data', async () => {
+      const requestHandler = controller.show()
+      await requestHandler(request, response, next)
+
+      expect(response.render).toHaveBeenCalledWith('courses/hsp/notEligible/show', {
+        hrefs: {
+          back: findPaths.hsp.details.show({ courseId: hspCourse.id }),
+          programmeIndex: findPaths.pniFind.recommendedProgrammes({}),
+        },
+        pageHeading: 'Del Hatton may not be eligible for Healthy Sex Programme',
+        pageTitleOverride: 'Not Eligible for HSP',
+        personName: person.name,
+      })
+    })
+
+    describe('when there is no `prisonNumber` in `session.pniFindAndReferData`', () => {
+      it('should redirect to the person search page', async () => {
+        delete request.session.pniFindAndReferData?.prisonNumber
+
+        const requestHandler = controller.show()
+        await requestHandler(request, response, next)
+
+        expect(response.redirect).toHaveBeenCalledWith(findPaths.pniFind.personSearch.pattern)
+      })
+    })
+
+    describe('when there is no `programmePathway` in `session.pniFindAndReferData`', () => {
+      it('should redirect to the person search page', async () => {
+        delete request.session.pniFindAndReferData?.programmePathway
+
+        const requestHandler = controller.show()
+        await requestHandler(request, response, next)
+
+        expect(response.redirect).toHaveBeenCalledWith(findPaths.pniFind.personSearch.pattern)
+      })
+    })
+
+    describe('when the course is not an HSP course', () => {
+      it('should redirect to the person search page', async () => {
+        jest.spyOn(CourseUtils, 'isHsp').mockReturnValue(false)
+
+        const requestHandler = controller.show()
+        await requestHandler(request, response, next)
+
+        expect(response.redirect).toHaveBeenCalledWith(findPaths.pniFind.personSearch.pattern)
+      })
+    })
+  })
+})

--- a/server/controllers/find/hspNotEligibleController.ts
+++ b/server/controllers/find/hspNotEligibleController.ts
@@ -1,0 +1,43 @@
+import type { Request, Response, TypedRequestHandler } from 'express'
+
+import { findPaths } from '../../paths'
+import type { CourseService, PersonService } from '../../services'
+import { CourseUtils, TypeUtils } from '../../utils'
+
+export default class HspNotEligibleController {
+  ELIGIBILITY_THRESHOLD_SCORE = 3
+
+  constructor(
+    private readonly courseService: CourseService,
+    private readonly personService: PersonService,
+  ) {}
+
+  show(): TypedRequestHandler<Request, Response> {
+    return async (req: Request, res: Response) => {
+      TypeUtils.assertHasUser(req)
+
+      const { username } = req.user
+      const { courseId } = req.params
+      const prisonNumber = req.session.pniFindAndReferData?.prisonNumber
+      const programmePathway = req.session.pniFindAndReferData?.programmePathway
+
+      const course = await this.courseService.getCourse(username, courseId)
+
+      if (!prisonNumber || !programmePathway || !CourseUtils.isHsp(course.displayName)) {
+        return res.redirect(findPaths.pniFind.personSearch.pattern)
+      }
+
+      const person = await this.personService.getPerson(username, prisonNumber)
+
+      return res.render('courses/hsp/notEligible/show', {
+        hrefs: {
+          back: findPaths.hsp.details.show({ courseId: course.id }),
+          programmeIndex: findPaths.pniFind.recommendedProgrammes({}),
+        },
+        pageHeading: `${person.name} may not be eligible for Healthy Sex Programme`,
+        pageTitleOverride: 'Not Eligible for HSP',
+        personName: person.name,
+      })
+    }
+  }
+}

--- a/server/controllers/find/index.ts
+++ b/server/controllers/find/index.ts
@@ -7,6 +7,7 @@ import BuildingChoicesFormController from './buildingChoicesFormController'
 import CourseOfferingsController from './courseOfferingsController'
 import CoursesController from './coursesController'
 import HspDetailsController from './hspDetailsController'
+import HspNotEligibleController from './hspNotEligibleController'
 import PersonSearchController from './personSearchController'
 import RecommendedPathwayController from './recommendedPathwayController'
 import RecommendedProgrammesController from './recommendedProgrammesController'
@@ -43,6 +44,7 @@ const controllers = (services: Services) => {
     services.personService,
     services.referenceDataService,
   )
+  const hspNotEligibleController = new HspNotEligibleController(services.courseService, services.personService)
 
   return {
     addCourseController,
@@ -52,6 +54,7 @@ const controllers = (services: Services) => {
     courseOfferingsController,
     coursesController,
     hspDetailsController,
+    hspNotEligibleController,
     personSearchController,
     recommendedPathwayController,
     recommendedProgrammesController,

--- a/server/paths/find.ts
+++ b/server/paths/find.ts
@@ -42,6 +42,9 @@ export default {
       show: hspDetailsPath,
       submit: hspDetailsPath,
     },
+    notEligible: {
+      show: hspPathBase.path('not-eligible'),
+    },
   },
   index: coursesPath,
   offerings: {

--- a/server/routes/find.ts
+++ b/server/routes/find.ts
@@ -12,6 +12,7 @@ export default function routes(controllers: Controllers, router: Router): Router
     coursesController,
     courseOfferingsController,
     hspDetailsController,
+    hspNotEligibleController,
   } = controllers
 
   get(findPaths.index.pattern, coursesController.index())
@@ -33,6 +34,8 @@ export default function routes(controllers: Controllers, router: Router): Router
 
   get(findPaths.hsp.details.show.pattern, hspDetailsController.show())
   post(findPaths.hsp.details.submit.pattern, hspDetailsController.submit())
+
+  get(findPaths.hsp.notEligible.show.pattern, hspNotEligibleController.show())
 
   return router
 }

--- a/server/views/courses/hsp/notEligible/show.njk
+++ b/server/views/courses/hsp/notEligible/show.njk
@@ -1,0 +1,39 @@
+{% from "govuk/components/back-link/macro.njk" import govukBackLink %}
+{% from "govuk/components/button/macro.njk" import govukButton %}
+
+{% extends "../../../partials/layout.njk" %}
+
+{% block backLink %}
+  {{ govukBackLink({
+    text: "Back",
+    href: hrefs.back
+  }) }}
+{% endblock backLink %}
+
+{% block content %}
+  <div class="govuk-grid-row">
+    <div class="govuk-grid-column-two-thirds">
+      <h1>{{ pageHeading }}</h1>
+
+      <p class="govuk-body">Based on the offence details you provided, {{ personName }} may not be eligible for Healthy Sex Programme (HSP).</p>
+
+      <h2 class="govuk-heading-m">If you still want to make a referral</h2>
+
+      <p class="govuk-body">If there are other reasons why the person may be eligible, you can still start a referral.</p>
+
+      <div class="govuk-button-group">
+        {{ govukButton({
+          href: hrefs.programmeIndex,
+          text: "Return to programme list"
+        }) }}
+
+        {{ govukButton({
+          href: hrefs.continueReferral,
+          classes: "govuk-button--secondary",
+          text: "Continue referral"
+        }) }}
+      </div>
+
+    </div>
+  </div>
+{% endblock content %}


### PR DESCRIPTION
## Context

When a referral to HSP does not meet the score threshold, we need to show a page which mentions that the person may not be eligible to be referred to HSP.


## Changes in this PR
- Add new controller and template for HSP not eligible
- Update existing HSP details controller submit method to redirect to this page when they are not eligible


## Screenshots of UI changes

<img width="1198" alt="image" src="https://github.com/user-attachments/assets/e1a5c4a6-3397-48e6-a4ae-f111e38d26bc" />
