### PR TITLE
(APG-887) HSP referral reason

### DIFF
--- a/server/controllers/find/hspNotEligibleController.test.ts
+++ b/server/controllers/find/hspNotEligibleController.test.ts
@@ -52,6 +52,7 @@ describe('HspNotEligibleController', () => {
       expect(response.render).toHaveBeenCalledWith('courses/hsp/notEligible/show', {
         hrefs: {
           back: findPaths.hsp.details.show({ courseId: hspCourse.id }),
+          continueReferral: findPaths.hsp.reason.show({ courseId: hspCourse.id }),
           programmeIndex: findPaths.pniFind.recommendedProgrammes({}),
         },
         pageHeading: 'Del Hatton may not be eligible for Healthy Sex Programme',

--- a/server/controllers/find/hspNotEligibleController.ts
+++ b/server/controllers/find/hspNotEligibleController.ts
@@ -32,6 +32,7 @@ export default class HspNotEligibleController {
       return res.render('courses/hsp/notEligible/show', {
         hrefs: {
           back: findPaths.hsp.details.show({ courseId: course.id }),
+          continueReferral: findPaths.hsp.reason.show({ courseId: course.id }),
           programmeIndex: findPaths.pniFind.recommendedProgrammes({}),
         },
         pageHeading: `${person.name} may not be eligible for Healthy Sex Programme`,

--- a/server/controllers/find/hspReferralReasonController.test.ts
+++ b/server/controllers/find/hspReferralReasonController.test.ts
@@ -1,0 +1,95 @@
+import { type DeepMocked, createMock } from '@golevelup/ts-jest'
+import type { NextFunction, Request, Response } from 'express'
+import { when } from 'jest-when'
+
+import HspReferralReasonController from './hspReferralReasonController'
+import { findPaths } from '../../paths'
+import type { CourseService } from '../../services'
+import { courseFactory, personFactory } from '../../testutils/factories'
+import { CourseUtils, FormUtils } from '../../utils'
+
+jest.mock('../../utils/formUtils')
+
+describe('HspReferralReasonController', () => {
+  const username = 'SOME_USER'
+  let request: DeepMocked<Request>
+  let response: DeepMocked<Response>
+  const next: DeepMocked<NextFunction> = createMock<NextFunction>({})
+  const courseService = createMock<CourseService>({})
+
+  let controller: HspReferralReasonController
+
+  const hspCourse = courseFactory.build({ name: 'Healthy Sex Programme' })
+  const person = personFactory.build({ name: 'Del Hatton' })
+
+  beforeEach(() => {
+    request = createMock<Request>({
+      params: { courseId: hspCourse.id },
+      session: {
+        pniFindAndReferData: {
+          prisonNumber: person.prisonNumber,
+          programmePathway: 'HIGH_INTENSITY_BC',
+        },
+      },
+      user: { username },
+    })
+
+    response = createMock<Response>({})
+    controller = new HspReferralReasonController(courseService)
+
+    when(courseService.getCourse).calledWith(username, hspCourse.id).mockResolvedValue(hspCourse)
+  })
+
+  afterEach(() => {
+    jest.restoreAllMocks()
+  })
+
+  describe('show', () => {
+    it('should render the HSP referral reason page with the correct data', async () => {
+      const requestHandler = controller.show()
+      await requestHandler(request, response, next)
+
+      expect(FormUtils.setFieldErrors).toHaveBeenCalledWith(request, response, ['hspReferralReason'])
+      expect(response.render).toHaveBeenCalledWith('courses/hsp/reason/show', {
+        hrefs: {
+          back: findPaths.hsp.notEligible.show({ courseId: hspCourse.id }),
+        },
+        maxLength: 5000,
+        pageHeading: 'Reason for referral to HSP',
+      })
+    })
+
+    describe('when there is no `prisonNumber` in `session.pniFindAndReferData`', () => {
+      it('should redirect to the person search page', async () => {
+        delete request.session.pniFindAndReferData?.prisonNumber
+
+        const requestHandler = controller.show()
+        await requestHandler(request, response, next)
+
+        expect(response.redirect).toHaveBeenCalledWith(findPaths.pniFind.personSearch.pattern)
+      })
+    })
+
+    describe('when there is no `programmePathway` in `session.pniFindAndReferData`', () => {
+      it('should redirect to the person search page', async () => {
+        delete request.session.pniFindAndReferData?.programmePathway
+
+        const requestHandler = controller.show()
+        await requestHandler(request, response, next)
+
+        expect(response.redirect).toHaveBeenCalledWith(findPaths.pniFind.personSearch.pattern)
+      })
+    })
+
+    describe('when the course is not an HSP course', () => {
+      it('should redirect to the person search page', async () => {
+        jest.spyOn(CourseUtils, 'isHsp').mockReturnValue(false)
+
+        const requestHandler = controller.show()
+        await requestHandler(request, response, next)
+
+        expect(response.redirect).toHaveBeenCalledWith(findPaths.pniFind.personSearch.pattern)
+      })
+    })
+  })
+})

--- a/server/controllers/find/hspReferralReasonController.ts
+++ b/server/controllers/find/hspReferralReasonController.ts
@@ -1,0 +1,38 @@
+import type { Request, Response, TypedRequestHandler } from 'express'
+
+import { findPaths } from '../../paths'
+import type { CourseService } from '../../services'
+import { CourseUtils, FormUtils, TypeUtils } from '../../utils'
+
+export default class HspReferralReasonController {
+  MAX_LENGTH = 5000
+
+  constructor(private readonly courseService: CourseService) {}
+
+  show(): TypedRequestHandler<Request, Response> {
+    return async (req: Request, res: Response) => {
+      TypeUtils.assertHasUser(req)
+
+      const { username } = req.user
+      const { courseId } = req.params
+      const prisonNumber = req.session.pniFindAndReferData?.prisonNumber
+      const programmePathway = req.session.pniFindAndReferData?.programmePathway
+
+      const course = await this.courseService.getCourse(username, courseId)
+
+      if (!prisonNumber || !programmePathway || !CourseUtils.isHsp(course.displayName)) {
+        return res.redirect(findPaths.pniFind.personSearch.pattern)
+      }
+
+      FormUtils.setFieldErrors(req, res, ['hspReferralReason'])
+
+      return res.render('courses/hsp/reason/show', {
+        hrefs: {
+          back: findPaths.hsp.notEligible.show({ courseId: course.id }),
+        },
+        maxLength: this.MAX_LENGTH,
+        pageHeading: 'Reason for referral to HSP',
+      })
+    }
+  }
+}

--- a/server/controllers/find/hspReferralReasonController.ts
+++ b/server/controllers/find/hspReferralReasonController.ts
@@ -25,6 +25,7 @@ export default class HspReferralReasonController {
       }
 
       FormUtils.setFieldErrors(req, res, ['hspReferralReason'])
+      FormUtils.setFormValues(req, res)
 
       return res.render('courses/hsp/reason/show', {
         hrefs: {
@@ -33,6 +34,34 @@ export default class HspReferralReasonController {
         maxLength: this.MAX_LENGTH,
         pageHeading: 'Reason for referral to HSP',
       })
+    }
+  }
+
+  submit(): TypedRequestHandler<Request, Response> {
+    return async (req: Request, res: Response) => {
+      TypeUtils.assertHasUser(req)
+
+      let hasErrors = false
+      const { courseId } = req.params
+      const { hspReferralReason } = req.body
+      const formattedHspReferralReason = hspReferralReason?.trim()
+
+      if (!formattedHspReferralReason) {
+        req.flash('hspReferralReasonError', 'Please enter a reason for referring this person to HSP')
+        hasErrors = true
+      }
+
+      if (formattedHspReferralReason.length > this.MAX_LENGTH) {
+        req.flash('hspReferralReasonError', `Reason must be less than ${this.MAX_LENGTH} characters`)
+        req.flash('formValues', [JSON.stringify({ formattedHspReferralReason })])
+        hasErrors = true
+      }
+
+      if (hasErrors) {
+        return res.redirect(findPaths.hsp.reason.show({ courseId }))
+      }
+
+      return res.send('Reason entered')
     }
   }
 }

--- a/server/controllers/find/index.ts
+++ b/server/controllers/find/index.ts
@@ -8,6 +8,7 @@ import CourseOfferingsController from './courseOfferingsController'
 import CoursesController from './coursesController'
 import HspDetailsController from './hspDetailsController'
 import HspNotEligibleController from './hspNotEligibleController'
+import HspReferralReasonController from './hspReferralReasonController'
 import PersonSearchController from './personSearchController'
 import RecommendedPathwayController from './recommendedPathwayController'
 import RecommendedProgrammesController from './recommendedProgrammesController'
@@ -45,6 +46,7 @@ const controllers = (services: Services) => {
     services.referenceDataService,
   )
   const hspNotEligibleController = new HspNotEligibleController(services.courseService, services.personService)
+  const hspReferralReasonController = new HspReferralReasonController(services.courseService)
 
   return {
     addCourseController,
@@ -55,6 +57,7 @@ const controllers = (services: Services) => {
     coursesController,
     hspDetailsController,
     hspNotEligibleController,
+    hspReferralReasonController,
     personSearchController,
     recommendedPathwayController,
     recommendedProgrammesController,

--- a/server/paths/find.ts
+++ b/server/paths/find.ts
@@ -45,6 +45,9 @@ export default {
     notEligible: {
       show: hspPathBase.path('not-eligible'),
     },
+    reason: {
+      show: hspPathBase.path('reason'),
+    },
   },
   index: coursesPath,
   offerings: {

--- a/server/paths/find.ts
+++ b/server/paths/find.ts
@@ -13,6 +13,7 @@ const buildingChoicesPath = findPathBase.path('building-choices/:courseId')
 
 const hspPathBase = coursePath.path('/hsp')
 const hspDetailsPath = hspPathBase.path('details')
+const hspReasonPath = hspPathBase.path('reason')
 
 const addCourseOfferingPath = coursePath.path('offerings/add')
 const deleteCourseOfferingPath = coursePath.path('offerings/:courseOfferingId/delete')
@@ -46,7 +47,8 @@ export default {
       show: hspPathBase.path('not-eligible'),
     },
     reason: {
-      show: hspPathBase.path('reason'),
+      show: hspReasonPath,
+      submit: hspReasonPath,
     },
   },
   index: coursesPath,

--- a/server/routes/find.ts
+++ b/server/routes/find.ts
@@ -13,6 +13,7 @@ export default function routes(controllers: Controllers, router: Router): Router
     courseOfferingsController,
     hspDetailsController,
     hspNotEligibleController,
+    hspReferralReasonController,
   } = controllers
 
   get(findPaths.index.pattern, coursesController.index())
@@ -36,6 +37,8 @@ export default function routes(controllers: Controllers, router: Router): Router
   post(findPaths.hsp.details.submit.pattern, hspDetailsController.submit())
 
   get(findPaths.hsp.notEligible.show.pattern, hspNotEligibleController.show())
+
+  get(findPaths.hsp.reason.show.pattern, hspReferralReasonController.show())
 
   return router
 }

--- a/server/routes/find.ts
+++ b/server/routes/find.ts
@@ -39,6 +39,7 @@ export default function routes(controllers: Controllers, router: Router): Router
   get(findPaths.hsp.notEligible.show.pattern, hspNotEligibleController.show())
 
   get(findPaths.hsp.reason.show.pattern, hspReferralReasonController.show())
+  post(findPaths.hsp.reason.submit.pattern, hspReferralReasonController.submit())
 
   return router
 }

--- a/server/views/courses/hsp/reason/show.njk
+++ b/server/views/courses/hsp/reason/show.njk
@@ -32,7 +32,7 @@
         <li>concerns about their ability to manage their sexual interests</li>
       </ul>
 
-      <form>
+      <form method="post">
         <input type="hidden" name="_csrf" value="{{ csrfToken }}"/>
 
         {{ govukCharacterCount({
@@ -45,7 +45,7 @@
           label: {
             text: "What is your reason for referring this person to HSP?"
           },
-          value: formValues.hspReferralReason,
+          value: formValues.formattedHspReferralReason,
           errorMessage: errors.messages.hspReferralReason
         }) }}
 

--- a/server/views/courses/hsp/reason/show.njk
+++ b/server/views/courses/hsp/reason/show.njk
@@ -1,0 +1,58 @@
+{% from "govuk/components/back-link/macro.njk" import govukBackLink %}
+{% from "govuk/components/button/macro.njk" import govukButton %}
+{% from "govuk/components/character-count/macro.njk" import govukCharacterCount %}
+{% from "govuk/components/error-summary/macro.njk" import govukErrorSummary %}
+
+{% extends "../../../partials/layout.njk" %}
+
+{% block backLink %}
+  {{ govukBackLink({
+    text: "Back",
+    href: hrefs.back
+  }) }}
+{% endblock backLink %}
+
+{% block content %}
+  <div class="govuk-grid-row">
+    <div class="govuk-grid-column-two-thirds">
+      {% if errors.list.length %}
+        {{ govukErrorSummary({
+          titleText: "There is a problem",
+          errorList: errors.list
+        }) }}
+      {% endif %}
+
+      <h1>{{ pageHeading }}</h1>
+
+      <p class="govuk-body">Include any information the Treatment Manager should consider when assessing the person's suitability and readiness. For example:</p>
+
+      <ul class="govuk-list govuk-list--bullet">
+        <li>sexual offences not covered in the previous questions</li>
+        <li>self-reported information about their sexual interests</li>
+        <li>concerns about their ability to manage their sexual interests</li>
+      </ul>
+
+      <form>
+        <input type="hidden" name="_csrf" value="{{ csrfToken }}"/>
+
+        {{ govukCharacterCount({
+          id: "hspReferralReason",
+          name: "hspReferralReason",
+          maxlength: maxLength,
+          attributes: {
+            "data-testid": "hsp-reason-text-area"
+          },
+          label: {
+            text: "What is your reason for referring this person to HSP?"
+          },
+          value: formValues.hspReferralReason,
+          errorMessage: errors.messages.hspReferralReason
+        }) }}
+
+        {{ govukButton({
+          text: "Continue"
+        }) }}
+      </form>
+    </div>
+  </div>
+{% endblock content %}


### PR DESCRIPTION
## Context

When a person has been considered not eligible for HSP but the referrer still wishes to continue, we need to allow them to enter a reason why they are continuing with the referral.

## Changes in this PR
- Add new controller for reason page
- Link to new reason page from Continue referral button on the not eligible page


## Screenshots of UI changes
<img width="910" alt="image" src="https://github.com/user-attachments/assets/bf929f79-41e6-49a0-bcaa-857fd29c962c" />

<img width="812" alt="image" src="https://github.com/user-attachments/assets/55416411-3a3f-4e1f-a623-f030e3ec90c0" />

<img width="824" alt="image" src="https://github.com/user-attachments/assets/0a262f3f-d8ab-47d3-ae66-70e7eecb34d8" />
