### PR TITLE
NOTICKET: Fix persistence of override reason if additional info page errors

### DIFF
--- a/server/controllers/refer/new/additionalInformationController.test.ts
+++ b/server/controllers/refer/new/additionalInformationController.test.ts
@@ -239,13 +239,15 @@ describe('NewReferralsAdditionalInformationController', () => {
           it('redirects to the additional information show action with an error', async () => {
             referralService.getReferral.mockResolvedValue(draftReferral)
             referralService.getPathways.mockResolvedValue(isOverridePathways)
-            request.body.referrerOverrideReason = ''
+            request.body = { additionalInformation: '', referrerOverrideReason: '' }
 
             const requestHandler = controller.update()
             await requestHandler(request, response, next)
 
             expect(request.flash).toHaveBeenCalledWith('referrerOverrideReasonError', 'Override reason is required')
-            expect(request.flash).toHaveBeenCalledWith('formValues', [JSON.stringify({ formattedOverrideReason: '' })])
+            expect(request.flash).toHaveBeenCalledWith('formValues', [
+              JSON.stringify({ formattedAdditionalInformation: null, formattedReferrerOverrideReason: '' }),
+            ])
             expect(response.redirect).toHaveBeenCalledWith(referPaths.new.additionalInformation.show({ referralId }))
           })
         })
@@ -266,7 +268,10 @@ describe('NewReferralsAdditionalInformationController', () => {
             'Additional information must be 4000 characters or fewer',
           )
           expect(request.flash).toHaveBeenCalledWith('formValues', [
-            JSON.stringify({ formattedAdditionalInformation: longAdditionalInformation }),
+            JSON.stringify({
+              formattedAdditionalInformation: longAdditionalInformation,
+              formattedReferrerOverrideReason: null,
+            }),
           ])
           expect(response.redirect).toHaveBeenCalledWith(referPaths.new.additionalInformation.show({ referralId }))
         })

--- a/server/controllers/refer/new/additionalInformationController.ts
+++ b/server/controllers/refer/new/additionalInformationController.ts
@@ -70,31 +70,33 @@ export default class NewReferralsAdditionalInformationController {
       const isSkip = req.body.skip === 'true'
       const hasAdditonalInfo = req.body.additionalInformation?.length > 0
       const formattedAdditionalInformation = hasAdditonalInfo ? req.body.additionalInformation.trim() : null
-      const formattedOverrideReason = isOverride ? req.body.referrerOverrideReason?.trim() : null
+      const formattedReferrerOverrideReason = isOverride ? req.body.referrerOverrideReason?.trim() : null
 
-      if (!isSkip) {
-        if (formattedAdditionalInformation?.length > maxLength) {
-          req.flash('additionalInformationError', `Additional information must be ${maxLength} characters or fewer`)
-          req.flash('formValues', [JSON.stringify({ formattedAdditionalInformation })])
+      if (isOverride) {
+        if (formattedReferrerOverrideReason?.length > maxLength) {
+          req.flash('referrerOverrideReasonError', `Override reason must be ${maxLength} characters or fewer`)
+          hasErrors = true
+        }
+        if (formattedReferrerOverrideReason.length <= 0) {
+          req.flash('referrerOverrideReasonError', 'Override reason is required')
           hasErrors = true
         }
       }
 
-      if (isOverride) {
-        if (formattedOverrideReason.length <= 0) {
-          req.flash('referrerOverrideReasonError', 'Override reason is required')
-          req.flash('formValues', [JSON.stringify({ formattedOverrideReason })])
-          hasErrors = true
-        }
-
-        if (formattedOverrideReason > maxLength) {
-          req.flash('referrerOverrideReasonError', `Override reason must be ${maxLength} characters or fewer`)
-          req.flash('formValues', [JSON.stringify({ formattedOverrideReason })])
+      if (!isSkip) {
+        if (formattedAdditionalInformation?.length > maxLength) {
+          req.flash('additionalInformationError', `Additional information must be ${maxLength} characters or fewer`)
           hasErrors = true
         }
       }
 
       if (hasErrors) {
+        req.flash('formValues', [
+          JSON.stringify({
+            formattedAdditionalInformation,
+            formattedReferrerOverrideReason,
+          }),
+        ])
         return res.redirect(referPaths.new.additionalInformation.show({ referralId }))
       }
 
@@ -103,7 +105,7 @@ export default class NewReferralsAdditionalInformationController {
         hasReviewedAdditionalInformation: isSkip || isOverride ? true : hasAdditonalInfo,
         hasReviewedProgrammeHistory: referral.hasReviewedProgrammeHistory,
         oasysConfirmed: referral.oasysConfirmed,
-        referrerOverrideReason: isOverride ? formattedOverrideReason : null,
+        referrerOverrideReason: isOverride ? formattedReferrerOverrideReason : null,
       }
 
       await this.referralService.updateReferral(req.user.username, referralId, referralUpdate)

--- a/server/views/referrals/new/additionalInformation/show.njk
+++ b/server/views/referrals/new/additionalInformation/show.njk
@@ -57,7 +57,7 @@
             text: "Reason for override",
             classes: "govuk-visually-hidden"
           },
-          value: formValues.formattedReferralOverrideReason or referral.referrerOverrideReason,
+          value: formValues.formattedReferrerOverrideReason or referral.referrerOverrideReason,
           errorMessage: errors.messages.referrerOverrideReason
         }) }}
       {% endif %}


### PR DESCRIPTION
Fixes the issue raised by Anand that the override reason was not persisting on the additional info page when a validation error was encountered

[Release process documentation](../blob/main/doc/how-to/perform-a-release.md)

As part of our continuous deployment strategy we must ensure that this work is
ready to be released once merged.

### Pre-merge

- [ ] There are changes required to the Accredited Programmes API for this change to work...
  - [ ] ... and they have been released to production already

### Post-merge

<!-- The outer checkboxes can be completed pre-merge -->

- [ ] This adds, extends or meaningfully modifies a feature...
  - [ ] ... and I have written or updated an end-to-end test for the happy path in the [Accredited Programmes E2E repo](https://github.com/ministryofjustice/hmpps-accredited-programmes-e2e)
- [ ] This makes new expectations of the API...
  - [ ] ... and I have notified the API developer(s) of changes to the contract tests (Pact), or the API is already compliant
- [ ] [Manually approve](../doc/how-to/perform-a-release.md#releasing-to-the-preprod-environment) release to preprod
- [ ] [Manually approve](../doc/how-to/perform-a-release.md#releasing-to-the-production-environment) release to prod

<!-- Should a release fail at any step, you as the author should now lead the work to
fix it as soon as possible. You can monitor deployment failures in CircleCI
itself and application errors are found in
[Sentry](https://ministryofjustice.sentry.io/projects/hmpps-accredited-programmes-ui/?project=4505330122686464&referrer=sidebar&statsPeriod=24h). -->
