### PR TITLE
(APG-843) Add HSP detail selections to session

### DIFF
--- a/server/@types/express/index.d.ts
+++ b/server/@types/express/index.d.ts
@@ -3,13 +3,19 @@
 import type { Request as ConnectFlashRequest } from '@types/connect-flash'
 
 import type { ReferralStatusUppercase } from '@accredited-programmes/models'
-import type { BuildingChoicesData, PniFindAndReferData, TransferErrorData } from '@accredited-programmes/ui'
+import type {
+  BuildingChoicesData,
+  HspReferralData,
+  PniFindAndReferData,
+  TransferErrorData,
+} from '@accredited-programmes/ui'
 import type { UserDetails } from '@accredited-programmes/users'
 
 declare module 'express-session' {
   // Declare that the session will potentially contain these additional fields
   interface SessionData {
     buildingChoicesData: BuildingChoicesData
+    hspReferralData: HspReferralData
     nowInMinutes: number
     pniFindAndReferData: PniFindAndReferData
     recentCaseListPath: string

--- a/server/@types/ui/index.d.ts
+++ b/server/@types/ui/index.d.ts
@@ -7,6 +7,7 @@ import type {
   PniScore,
   Referral,
   ReferralStatusHistory,
+  SexualOffenceDetails,
 } from '@accredited-programmes-api'
 import type {
   GovukFrontendButton,
@@ -248,6 +249,12 @@ interface BuildingChoicesData {
   isInAWomensPrison: string
 }
 
+interface HspReferralData {
+  selectedOffenceDetails: Array<SexualOffenceDetails['id']>
+  totalScore: number
+  reason?: string
+}
+
 interface PniFindAndReferData {
   prisonNumber?: PeopleSearchResponse['prisonerNumber']
   programmePathway?: PniScore['programmePathway']
@@ -274,6 +281,7 @@ export type {
   GovukFrontendTagWithText,
   HasHtmlString,
   HasTextString,
+  HspReferralData,
   MojButtonMenu,
   MojButtonMenuButton,
   MojFrontendNavigationItem,

--- a/server/controllers/find/hspDetailsController.test.ts
+++ b/server/controllers/find/hspDetailsController.test.ts
@@ -23,11 +23,15 @@ describe('HspDetailsController', () => {
 
   const hspCourse = courseFactory.build({ name: 'Healthy Sex Programme' })
   const person = personFactory.build({ name: 'Del Hatton' })
+  const selectedOffenceDetails = ['ABC-123']
 
   beforeEach(() => {
     request = createMock<Request>({
       params: { courseId: hspCourse.id },
       session: {
+        hspReferralData: {
+          selectedOffenceDetails,
+        },
         pniFindAndReferData: {
           prisonNumber: person.prisonNumber,
           programmePathway: 'HIGH_INTENSITY_BC',
@@ -85,7 +89,10 @@ describe('HspDetailsController', () => {
 
       expect(FormUtils.setFieldErrors).toHaveBeenCalledWith(request, response, ['sexualOffenceDetails'])
       expect(ReferenceDataUtils.groupOptionsByKey).toHaveBeenCalledWith(sexualOffenceDetails, 'categoryDescription')
-      expect(ReferenceDataUtils.createSexualOffenceDetailsFieldset).toHaveBeenCalledWith(mockGroupedDetailOptions, [])
+      expect(ReferenceDataUtils.createSexualOffenceDetailsFieldset).toHaveBeenCalledWith(
+        mockGroupedDetailOptions,
+        selectedOffenceDetails,
+      )
       expect(response.render).toHaveBeenCalledWith('courses/hsp/details/show', {
         checkboxFieldsets: mockFieldsets,
         hrefs: {
@@ -139,6 +146,10 @@ describe('HspDetailsController', () => {
         const requestHandler = controller.submit()
         await requestHandler(request, response, next)
 
+        expect(request.session.hspReferralData).toEqual({
+          selectedOffenceDetails: ['ABC-123', 'ABC-456'],
+          totalScore: 3,
+        })
         expect(response.send).toHaveBeenCalledWith('Eligible')
       })
     })
@@ -150,6 +161,10 @@ describe('HspDetailsController', () => {
         const requestHandler = controller.submit()
         await requestHandler(request, response, next)
 
+        expect(request.session.hspReferralData).toEqual({
+          selectedOffenceDetails: ['ABC-123'],
+          totalScore: 1,
+        })
         expect(response.redirect).toHaveBeenCalledWith(findPaths.hsp.notEligible.show({ courseId: hspCourse.id }))
       })
     })

--- a/server/controllers/find/personSearchController.test.ts
+++ b/server/controllers/find/personSearchController.test.ts
@@ -27,7 +27,17 @@ describe('PersonSearchController', () => {
 
   beforeEach(() => {
     controller = new PersonSearchController(personService)
-    request = createMock<Request>()
+    request = createMock<Request>({
+      session: {
+        hspReferralData: {
+          selectedOffenceDetails: ['ABC-123'],
+          totalScore: 1,
+        },
+        pniFindAndReferData: {
+          prisonNumber: 'XYZ7890',
+        },
+      },
+    })
     response = createMock<Response>({
       locals: {
         user: {
@@ -58,13 +68,14 @@ describe('PersonSearchController', () => {
     const prisonNumber = 'A1234AA'
     const person = personFactory.build({ prisonNumber })
 
-    it('should redirect to the recommended pathway page', async () => {
+    it('should clear any referral related session data and redirect to the recommended pathway page', async () => {
       when(personService.getPerson).calledWith(username, prisonNumber, []).mockResolvedValue(person)
 
       request.body = { prisonNumber }
 
       await controller.submit()(request, response, next)
 
+      expect(request.session.hspReferralData).toBeUndefined()
       expect(request.session.pniFindAndReferData).toEqual({ prisonNumber })
       expect(response.redirect).toHaveBeenCalledWith(findPaths.pniFind.recommendedPathway.pattern)
     })

--- a/server/controllers/find/personSearchController.ts
+++ b/server/controllers/find/personSearchController.ts
@@ -43,6 +43,7 @@ export default class PersonSearchController {
           canViewAllPrisoners ? [] : res.locals.user.caseloads,
         )
 
+        req.session.hspReferralData = undefined
         req.session.pniFindAndReferData = {
           prisonNumber: person.prisonNumber,
         }

--- a/server/utils/referenceDataUtils.test.ts
+++ b/server/utils/referenceDataUtils.test.ts
@@ -34,7 +34,7 @@ describe('ReferenceDataUtils', () => {
           },
         ],
       }
-      const selectedOptions = ['ABC-456::2']
+      const selectedOptions = ['ABC-456']
 
       expect(ReferenceDataUtils.createSexualOffenceDetailsFieldset(groupedOptions, selectedOptions)).toEqual([
         {

--- a/server/utils/referenceDataUtils.ts
+++ b/server/utils/referenceDataUtils.ts
@@ -4,7 +4,7 @@ import type { GovukFrontendCheckboxesItem, GovukFrontendFieldsetLegend } from '@
 export default class ReferenceDataUtils {
   static createSexualOffenceDetailsFieldset(
     groupedOptions: Record<string, Array<SexualOffenceDetails>>,
-    selectedOptions: Array<string>,
+    selectedOptions?: Array<string>,
   ): Array<{ checkboxes: Array<GovukFrontendCheckboxesItem>; legend: GovukFrontendFieldsetLegend }> {
     return Object.entries(groupedOptions).map(([categoryCode, options]) => ({
       checkboxes: this.sexualOffenceDetailsToCheckboxItems(options, selectedOptions),
@@ -33,18 +33,15 @@ export default class ReferenceDataUtils {
 
   private static sexualOffenceDetailsToCheckboxItems(
     options: Array<SexualOffenceDetails>,
-    selectedOptions: Array<string>,
+    selectedOptions?: Array<string>,
   ): Array<GovukFrontendCheckboxesItem> {
-    return options.map(option => {
-      const optionValue = `${option.id}::${option.score}`
-      return {
-        checked: selectedOptions.includes(optionValue),
-        hint: {
-          text: option.hintText,
-        },
-        text: option.description,
-        value: optionValue,
-      }
-    })
+    return options.map(option => ({
+      checked: selectedOptions?.includes(option.id),
+      hint: {
+        text: option.hintText,
+      },
+      text: option.description,
+      value: `${option.id}::${option.score}`,
+    }))
   }
 }


### PR DESCRIPTION
## Context

Before we create a referral, we need to store the selections made on the Sexual offence details page, so we can submit them along with the other referral data.


## Changes in this PR
- Add `hspReferralData` to `req.session`
- Use these values to maintain those selections if a user navigates back or reloads the page
- Reset `hspReferralData` to `undefined` when a new find and refer journey begins
