### PR TITLE
APG-861 - Update BC variants endpoint to GET

### DIFF
--- a/integration_tests/mockApis/courses.ts
+++ b/integration_tests/mockApis/courses.ts
@@ -27,15 +27,23 @@ export default {
       },
     }),
 
-  stubBuildingChoicesCourseVariant: (course: Course): SuperAgentRequest =>
+  stubBuildingChoicesCourseVariant: (args: {
+    course: Course
+    isConvictedOfASexualOffence: string
+    isInAWomensPrison: string
+  }): SuperAgentRequest =>
     stubFor({
       request: {
-        method: 'POST',
-        url: apiPaths.courses.buildingChoices({ courseId: course.id }),
+        method: 'GET',
+        queryParameters: {
+          isConvictedOfASexualOffence: { equalTo: args.isConvictedOfASexualOffence },
+          isInAWomensPrison: { equalTo: args.isInAWomensPrison },
+        },
+        urlPath: apiPaths.courses.buildingChoicesVariants({ courseId: args.course.id }),
       },
       response: {
         headers: { 'Content-Type': 'application/json;charset=UTF-8' },
-        jsonBody: course ? [course] : [],
+        jsonBody: args.course ? [args.course] : [],
         status: 200,
       },
     }),

--- a/integration_tests/pages/find/sexualOffenceForm.ts
+++ b/integration_tests/pages/find/sexualOffenceForm.ts
@@ -17,7 +17,11 @@ export default class SexualOffenceFormPage extends Page {
   }
 
   submitForm(bcCourseVariant: Course) {
-    cy.task('stubBuildingChoicesCourseVariant', bcCourseVariant)
+    cy.task('stubBuildingChoicesCourseVariant', {
+      course: bcCourseVariant,
+      isConvictedOfASexualOffence: 'true',
+      isInAWomensPrison: 'false',
+    })
 
     this.selectRadioButton('isConvictedOfSexualOffence', 'true')
     this.shouldContainButton('Continue').click()

--- a/server/data/accreditedProgrammesApi/courseClient.ts
+++ b/server/data/accreditedProgrammesApi/courseClient.ts
@@ -5,7 +5,6 @@ import RestClient from '../restClient'
 import type { CourseCreateRequest, CourseOffering, CoursePrerequisite, Person } from '@accredited-programmes/models'
 import type {
   Audience,
-  BuildingChoicesSearchRequest,
   Course,
   CourseParticipation,
   CourseParticipationCreate,
@@ -86,11 +85,17 @@ export default class CourseClient {
   /* istanbul ignore next */
   async findBuildingChoicesVariants(
     courseId: Course['id'],
-    requestBody: BuildingChoicesSearchRequest,
+    query?: {
+      isConvictedOfSexualOffence: string
+      isInAWomensPrison: string
+    },
   ): Promise<Array<Course>> {
-    return (await this.restClient.post({
-      data: { ...requestBody },
-      path: apiPaths.courses.buildingChoices({ courseId }),
+    return (await this.restClient.get({
+      path: apiPaths.courses.buildingChoicesVariants({ courseId }),
+      query: {
+        ...(query?.isInAWomensPrison && { isInAWomensPrison: query.isInAWomensPrison }),
+        ...(query?.isConvictedOfSexualOffence && { isConvictedOfASexualOffence: query.isConvictedOfSexualOffence }),
+      },
     })) as Array<Course>
   }
 

--- a/server/paths/api.ts
+++ b/server/paths/api.ts
@@ -48,6 +48,7 @@ export default {
     audiences: coursesPath.path('audiences'),
     buildingChoices: buildingChoicesBasePath.path(':courseId'),
     buildingChoicesByReferral: buildingChoicesBasePath.path('referral/:referralId'),
+    buildingChoicesVariants: buildingChoicesBasePath.path(':courseId/course-variants'),
     create: coursesPath,
     index: coursesPath,
     names: courseNamesPath,

--- a/server/services/courseService.test.ts
+++ b/server/services/courseService.test.ts
@@ -223,7 +223,7 @@ describe('CourseService', () => {
       const formRequestBody = { isConvictedOfSexualOffence: 'true', isInAWomensPrison: 'false' }
 
       when(courseClient.findBuildingChoicesVariants)
-        .calledWith(course.id, { isConvictedOfSexualOffence: true, isInAWomensPrison: false })
+        .calledWith(course.id, { isConvictedOfSexualOffence: 'true', isInAWomensPrison: 'false' })
         .mockResolvedValue([course])
 
       const result = await service.getBuildingChoicesVariants(username, course.id, formRequestBody)

--- a/server/services/courseService.ts
+++ b/server/services/courseService.ts
@@ -120,8 +120,8 @@ export default class CourseService {
     }
 
     return courseClient.findBuildingChoicesVariants(courseId, {
-      isConvictedOfSexualOffence: isConvictedOfSexualOffence === 'true',
-      isInAWomensPrison: isInAWomensPrison === 'true',
+      isConvictedOfSexualOffence,
+      isInAWomensPrison,
     })
   }
 


### PR DESCRIPTION
## Changes in this PR

Changes the client to use the new GET version of the BC course variants endpoint


## Screenshots of UI changes

### Before


### After


## Release checklist

[Release process documentation](../blob/main/doc/how-to/perform-a-release.md)

As part of our continuous deployment strategy we must ensure that this work is
ready to be released once merged.

### Pre-merge

- [ ] There are changes required to the Accredited Programmes API for this change to work...
  - [ ] ... and they have been released to production already

### Post-merge

<!-- The outer checkboxes can be completed pre-merge -->

- [ ] This adds, extends or meaningfully modifies a feature...
  - [ ] ... and I have written or updated an end-to-end test for the happy path in the [Accredited Programmes E2E repo](https://github.com/ministryofjustice/hmpps-accredited-programmes-e2e)
- [ ] This makes new expectations of the API...
  - [ ] ... and I have notified the API developer(s) of changes to the contract tests (Pact), or the API is already compliant
- [ ] [Manually approve](../doc/how-to/perform-a-release.md#releasing-to-the-preprod-environment) release to preprod
- [ ] [Manually approve](../doc/how-to/perform-a-release.md#releasing-to-the-production-environment) release to prod

<!-- Should a release fail at any step, you as the author should now lead the work to
fix it as soon as possible. You can monitor deployment failures in CircleCI
itself and application errors are found in
[Sentry](https://ministryofjustice.sentry.io/projects/hmpps-accredited-programmes-ui/?project=4505330122686464&referrer=sidebar&statsPeriod=24h). -->
