### PR TITLE
(APG-910) Add methods to get organisation details from AcP API

### DIFF
--- a/server/@types/accreditedProgrammesApi/index.d.ts
+++ b/server/@types/accreditedProgrammesApi/index.d.ts
@@ -163,7 +163,7 @@ export interface CourseOffering {
    * Gender for which course is offered
    * @example "M"
    */
-  gender?: "MALE" | "FEMALE";
+  gender?: "MALE" | "FEMALE" | "ANY";
 }
 
 export interface CoursePrerequisite {
@@ -314,6 +314,14 @@ export interface CourseEntity {
   intensity?: string;
 }
 
+export interface EligibilityOverrideReasonEntity {
+  /** @format uuid */
+  id?: string;
+  reason: string;
+  overrideType: "HEALTHY_SEX_PROGRAMME";
+  referral: any;
+}
+
 export interface OfferingEntity {
   /** @format uuid */
   id?: string;
@@ -343,7 +351,7 @@ export interface ReferralEntity {
   hasReviewedProgrammeHistory: boolean;
   hasReviewedAdditionalInformation?: boolean;
   status: string;
-  /** @example "2025-05-08T10:22:48" */
+  /** @example "2025-05-22T04:44:23" */
   submittedOn?: object;
   deleted: boolean;
   primaryPomStaffId?: number;
@@ -353,10 +361,31 @@ export interface ReferralEntity {
   originalReferralId?: string;
   hasLdc?: boolean;
   hasLdcBeenOverriddenByProgrammeTeam: boolean;
+  /** @uniqueItems true */
+  selectedSexualOffenceDetails: SelectedSexualOffenceDetailsEntity[];
+  /** @uniqueItems true */
+  eligibilityOverrideReasons: EligibilityOverrideReasonEntity[];
 }
 
 export interface ReferrerUserEntity {
   username: string;
+}
+
+export interface SelectedSexualOffenceDetailsEntity {
+  /** @format uuid */
+  id?: string;
+  referral: ReferralEntity;
+  sexualOffenceDetails?: SexualOffenceDetailsEntity;
+}
+
+export interface SexualOffenceDetailsEntity {
+  /** @format uuid */
+  id?: string;
+  category: "AGAINST_MINORS" | "INCLUDES_VIOLENCE_FORCE_HUMILIATION" | "OTHER";
+  description: string;
+  hintText?: string;
+  /** @format int32 */
+  score: number;
 }
 
 export interface ReferralCreate {
@@ -485,6 +514,30 @@ export interface TransferReferralRequest {
    * @example "The reason for tranferring the referal is"
    */
   transferReason: string;
+}
+
+export interface HspReferralCreate {
+  /**
+   * The id (UUID) of the HSP offering
+   * @format uuid
+   * @example "550e8400-e29b-41d4-a716-446655440000"
+   */
+  offeringId: string;
+  /**
+   * The prison number of the person who is being referred.
+   * @example "A1234AA"
+   */
+  prisonNumber: string;
+  /**
+   * The list of IDs of the selected offences.
+   * @example ["dd69bdbe-a61d-45e5-bb20-e52af4a0ac83","550e8400-e29b-41d4-a716-446655440000"]
+   */
+  selectedOffences: string[];
+  /**
+   * The overriding reason why the prisoner should be considered suitable for the course.
+   * @example "The prisoner meets the requirements"
+   */
+  eligibilityOverrideReason?: string;
 }
 
 export interface PeopleSearchResponse {
@@ -820,59 +873,74 @@ export interface StatusContent {
 }
 
 export interface ReferralStatusRefData {
-  /** @example "WITHDRAWN" */
+  /**
+   * A enum-like, computer-friendly string describing the Referral Status
+   * @example "WITHDRAWN"
+   */
   code: string;
-  /** @example "Withdrawn" */
+  /**
+   * A human-readable string describing the Referral Status
+   * @example "Withdrawn"
+   */
   description: string;
-  /** @example "light-grey" */
+  /**
+   * A computer-friendly string describing the colour of the referral for display purposes.  This doesn't correspond to CSS default colours, or to hex values.
+   * @example "light-grey"
+   */
   colour: string;
-  /** @example "The application has been withdrawn" */
+  /**
+   * A human-friendly string that provides information about the status.  These are set by the system, not a human.
+   * @example "The application has been withdrawn"
+   */
   hintText?: string;
-  /** @example "I confirm that this person is eligible." */
+  /**
+   * Human-written text to confirm information about the Status
+   * @example "I confirm that this person is eligible."
+   */
   confirmationText?: string;
   /**
-   * flag to show this status has notes text box
+   * If true, this status should show a notes text box on the UI
    * @example null
    */
   hasNotes?: boolean;
   /**
-   * flag to show this status has confirmation box
+   * If true, this status should show a confirmation box on the UI
    * @example null
    */
   hasConfirmation?: boolean;
   /**
-   * flag to show this is a closed status
+   * If true, this is a closed status
    * @example null
    */
   closed?: boolean;
   /**
-   * flag to show this is a draft status
+   * If true, this is a draft status
    * @example null
    */
   draft?: boolean;
   /**
-   * flag to show this is a hold status
+   * If true, this is a hold status
    * @example null
    */
   hold?: boolean;
   /**
-   * flag to show this is a release status
+   * If true, this is a release status
    * @example null
    */
   release?: boolean;
   /**
-   * flag to show this a bespoke status of deslected and keep open
+   * If true, this a bespoke status of deselected and keep open
    * @example null
    */
   deselectAndKeepOpen?: boolean;
   /**
-   * sort order for statuses
+   * Sort order for statuses (presently this seems to be ignored in the UI)
    * @format int32
    * @example null
    */
   defaultOrder?: number;
   /**
-   * flag to show whether the notes are optional
+   * Flag to show whether the notes are optional
    * @example null
    */
   notesOptional?: boolean;
@@ -1113,27 +1181,30 @@ export interface SexualOffenceDetails {
    */
   id: string;
   /**
-   * The code of the offence category
-   * @example "INCLUDES_VIOLENCE_FORCE_HUMILIATION"
-   */
-  categoryCode: string;
-  /**
-   * The description of the offence category
-   * @example "Other types of sexual offending"
-   */
-  categoryDescription: string;
-  /**
-   * The description of the offence
-   * @example "67ea1478-e4c3-46be-8b7f-86833fb87540"
+   * A human-friendly description of the Offence itself
+   * @example "Evidence of ritualism in the offence"
    */
   description: string;
   /**
    * Further elaborations of the offence
-   * @example "Any use of additional violence or force not necessary to gain victim compliance"
+   * @example "Fixed actions or words, performed in a specific way"
    */
   hintText?: string;
   /**
-   * The score associated with the offence
+   * A computer-friendly identifier for the Offence's category
+   * @example "INCLUDES_VIOLENCE_FORCE_HUMILIATION"
+   */
+  categoryCode:
+    | "AGAINST_MINORS"
+    | "INCLUDES_VIOLENCE_FORCE_HUMILIATION"
+    | "OTHER";
+  /**
+   * A human-friendly description of the Offence's category (i.e. the categoryCode)
+   * @example "Sexual offences that include violence, force or humiliation"
+   */
+  categoryDescription: string;
+  /**
+   * The score associated with the offence, between 1 and 3.
    * @format int32
    * @example 1
    */

--- a/server/data/accreditedProgrammesApi/organisationClient.ts
+++ b/server/data/accreditedProgrammesApi/organisationClient.ts
@@ -1,4 +1,5 @@
 /* istanbul ignore file */
+
 import type { ApiConfig } from '../../config'
 import config from '../../config'
 import { apiPaths } from '../../paths'

--- a/server/data/accreditedProgrammesApi/organisationClient.ts
+++ b/server/data/accreditedProgrammesApi/organisationClient.ts
@@ -1,0 +1,25 @@
+/* istanbul ignore file */
+import type { ApiConfig } from '../../config'
+import config from '../../config'
+import { apiPaths } from '../../paths'
+import RestClient from '../restClient'
+import type { Organisation } from '@accredited-programmes-api'
+import type { SystemToken } from '@hmpps-auth'
+
+export default class OrganisationClient {
+  restClient: RestClient
+
+  constructor(systemToken: SystemToken) {
+    this.restClient = new RestClient(
+      'organisationClient',
+      config.apis.accreditedProgrammesApi as ApiConfig,
+      systemToken,
+    )
+  }
+
+  async findOrganisation(organisationCode: string): Promise<Organisation> {
+    return (await this.restClient.get({
+      path: apiPaths.organisations.show({ organisationCode }),
+    })) as Organisation
+  }
+}

--- a/server/data/index.ts
+++ b/server/data/index.ts
@@ -15,6 +15,7 @@ AppInsightsUtils.buildClient()
 
 import CourseClient from './accreditedProgrammesApi/courseClient'
 import OasysClient from './accreditedProgrammesApi/oasysClient'
+import OrganisationClient from './accreditedProgrammesApi/organisationClient'
 import PersonClient from './accreditedProgrammesApi/personClient'
 import PniClient from './accreditedProgrammesApi/pniClient'
 import ReferenceDataClient from './accreditedProgrammesApi/referenceDataClient'
@@ -42,6 +43,8 @@ const hmppsManageUsersClientBuilder: RestClientBuilder<HmppsManageUsersClient> =
 const courseClientBuilder: RestClientBuilder<CourseClient> = (userToken: Express.User['token']) =>
   new CourseClient(userToken)
 const oasysClientBuilder: RestClientBuilder<OasysClient> = (systemToken: SystemToken) => new OasysClient(systemToken)
+const organisationClientBuilder: RestClientBuilder<OrganisationClient> = (systemToken: SystemToken) =>
+  new OrganisationClient(systemToken)
 const personClientBuilder: RestClientBuilder<PersonClient> = (systemToken: SystemToken) => new PersonClient(systemToken)
 const pniClientBuilder: RestClientBuilder<PniClient> = (systemToken: SystemToken) => new PniClient(systemToken)
 const prisonRegisterApiClientBuilder: RestClientBuilder<PrisonRegisterApiClient> = (userToken: Express.User['token']) =>
@@ -60,6 +63,7 @@ export {
   HmppsAuthClient,
   HmppsManageUsersClient,
   OasysClient,
+  OrganisationClient,
   PersonClient,
   PniClient,
   PrisonApiClient,
@@ -73,6 +77,7 @@ export {
   hmppsAuthClientBuilder,
   hmppsManageUsersClientBuilder,
   oasysClientBuilder,
+  organisationClientBuilder,
   personClientBuilder,
   pniClientBuilder,
   prisonApiClientBuilder,

--- a/server/paths/api.ts
+++ b/server/paths/api.ts
@@ -80,6 +80,7 @@ export default {
   },
   organisations: {
     courses: coursesByOrganisationPath,
+    show: path('/organisation/:organisationCode'),
   },
   participations: {
     create: participationsPath,

--- a/server/services/index.ts
+++ b/server/services/index.ts
@@ -14,6 +14,7 @@ import {
   hmppsAuthClientBuilder,
   hmppsManageUsersClientBuilder,
   oasysClientBuilder,
+  organisationClientBuilder,
   personClientBuilder,
   pniClientBuilder,
   prisonApiClientBuilder,
@@ -26,7 +27,11 @@ import PniService from './pniService'
 
 const services = () => {
   const oasysService = new OasysService(hmppsAuthClientBuilder, oasysClientBuilder)
-  const organisationService = new OrganisationService(prisonRegisterApiClientBuilder)
+  const organisationService = new OrganisationService(
+    hmppsAuthClientBuilder,
+    organisationClientBuilder,
+    prisonRegisterApiClientBuilder,
+  )
   const personService = new PersonService(hmppsAuthClientBuilder, prisonApiClientBuilder, personClientBuilder)
   const userService = new UserService(hmppsManageUsersClientBuilder, prisonApiClientBuilder)
   const referenceDataService = new ReferenceDataService(hmppsAuthClientBuilder, referenceDataClientBuilder)

--- a/server/services/organisationService.ts
+++ b/server/services/organisationService.ts
@@ -1,13 +1,24 @@
 import createError from 'http-errors'
 import type { ResponseError } from 'superagent'
 
-import type { PrisonRegisterApiClient, RestClientBuilder } from '../data'
+import type {
+  HmppsAuthClient,
+  OrganisationClient,
+  PrisonRegisterApiClient,
+  RestClientBuilder,
+  RestClientBuilderWithoutToken,
+} from '../data'
 import { OrganisationUtils, TypeUtils } from '../utils'
 import type { Organisation } from '@accredited-programmes/models'
+import type { Organisation as AcpOrganisation } from '@accredited-programmes-api'
 import type { Prison } from '@prison-register-api'
 
 export default class OrganisationService {
-  constructor(private readonly prisonRegisterApiClientBuilder: RestClientBuilder<PrisonRegisterApiClient>) {}
+  constructor(
+    private readonly hmppsAuthClientBuilder: RestClientBuilderWithoutToken<HmppsAuthClient>,
+    private readonly organisationClientBuilder: RestClientBuilder<OrganisationClient>,
+    private readonly prisonRegisterApiClientBuilder: RestClientBuilder<PrisonRegisterApiClient>,
+  ) {}
 
   async getAllOrganisations(userToken: Express.User['token']): Promise<Array<Prison>> {
     const prisonRegisterApiClient = this.prisonRegisterApiClientBuilder(userToken)
@@ -19,6 +30,10 @@ export default class OrganisationService {
     }
   }
 
+  /*
+   * @deprecated and should be removed when no longer used elsewhere in the codebase
+   * getOrganisationFromAcp should be used instead
+   */
   async getOrganisation(userToken: Express.User['token'], organisationId: Organisation['id']): Promise<Organisation> {
     const prisonRegisterApiClient = this.prisonRegisterApiClientBuilder(userToken)
 
@@ -43,6 +58,25 @@ export default class OrganisationService {
           : knownError.message
 
       throw createError(knownError.status || 500, errorMessage)
+    }
+  }
+
+  async getOrganisationFromAcp(username: Express.User['username'], organisationCode: string): Promise<AcpOrganisation> {
+    const hmppsAuthClient = this.hmppsAuthClientBuilder()
+    const systemToken = await hmppsAuthClient.getSystemClientToken(username)
+
+    const organisationClient = this.organisationClientBuilder(systemToken)
+
+    try {
+      return await organisationClient.findOrganisation(organisationCode)
+    } catch (error) {
+      const knownError = error as ResponseError
+
+      if (knownError.status === 404) {
+        throw createError(knownError.status, `Organisation with code ${organisationCode} not found.`)
+      }
+
+      throw createError(knownError.status || 500, `Error fetching organisation ${organisationCode}.`)
     }
   }
 

--- a/server/testutils/factories/sexualOffenceDetails.ts
+++ b/server/testutils/factories/sexualOffenceDetails.ts
@@ -6,7 +6,7 @@ import type { SexualOffenceDetails } from '@accredited-programmes-api'
 
 export default Factory.define<SexualOffenceDetails>(() => {
   return {
-    categoryCode: `${faker.string.alpha(5)}_${faker.string.alpha(5)}`.toUpperCase(),
+    categoryCode: faker.helpers.arrayElement(['AGAINST_MINORS', 'INCLUDES_VIOLENCE_FORCE_HUMILIATION', 'OTHER']),
     categoryDescription: faker.lorem.sentence(),
     description: faker.lorem.sentence(),
     hintText: FactoryHelpers.optionalArrayElement(faker.lorem.sentence()),

--- a/server/utils/referenceDataUtils.test.ts
+++ b/server/utils/referenceDataUtils.test.ts
@@ -7,7 +7,7 @@ describe('ReferenceDataUtils', () => {
       const groupedOptions: Record<string, Array<SexualOffenceDetails>> = {
         'Category 1': [
           {
-            categoryCode: 'CAT1',
+            categoryCode: 'INCLUDES_VIOLENCE_FORCE_HUMILIATION',
             categoryDescription: 'Category 1',
             description: 'Option 1',
             hintText: 'Hint 1',
@@ -15,7 +15,7 @@ describe('ReferenceDataUtils', () => {
             score: 1,
           },
           {
-            categoryCode: 'CAT1',
+            categoryCode: 'INCLUDES_VIOLENCE_FORCE_HUMILIATION',
             categoryDescription: 'Category 1',
             description: 'Option 2',
             hintText: 'Hint 2',
@@ -25,7 +25,7 @@ describe('ReferenceDataUtils', () => {
         ],
         'Category 2': [
           {
-            categoryCode: 'CAT2',
+            categoryCode: 'OTHER',
             categoryDescription: 'Category 2',
             description: 'Option 3',
             hintText: 'Hint 3',


### PR DESCRIPTION
## Context

We need to use the `/organisation(s)` endpoints from AcP API rather than prison register.

## Changes in this PR
- Type updates (unrelated to new functionality)
- Add new `OrganisationClient`
- Add new `OrganisationService` method to get a single organisation using new client.

