### PR TITLE
(APG-910) Use `/organisation/:code` endpoint throughout

### DIFF
--- a/cypress.config.ts
+++ b/cypress.config.ts
@@ -7,6 +7,7 @@ import courses from './integration_tests/mockApis/courses'
 import courseParticipations from './integration_tests/mockApis/courseParticipations'
 import manageUsers from './integration_tests/mockApis/manageUsers'
 import oasys from './integration_tests/mockApis/oasys'
+import organisations from './integration_tests/mockApis/organisations'
 import prisonApi from './integration_tests/mockApis/prison'
 import prisonRegisterApi from './integration_tests/mockApis/prisonRegister'
 import person from './integration_tests/mockApis/person'
@@ -41,6 +42,7 @@ export const defaultConfig: Cypress.ConfigOptions = {
         ...courseParticipations,
         ...manageUsers,
         ...oasys,
+        ...organisations,
         ...person,
         ...prisonApi,
         ...prisonRegisterApi,

--- a/integration_tests/e2e/assess/transfer.cy.ts
+++ b/integration_tests/e2e/assess/transfer.cy.ts
@@ -6,17 +6,16 @@ import {
   peopleSearchResponseFactory,
   personFactory,
   pniScoreFactory,
-  prisonFactory,
   referralFactory,
   referralStatusHistoryFactory,
   userFactory,
 } from '../../../server/testutils/factories'
-import { OrganisationUtils } from '../../../server/utils'
 import auth from '../../mockApis/auth'
 import TransferPage from '../../pages/assess/transfer'
 import TransferErrorPage from '../../pages/assess/transferError'
 import Page from '../../pages/page'
 import type { ReferralStatusHistoryPresenter } from '@accredited-programmes/ui'
+import type { Organisation } from '@accredited-programmes-api'
 
 context('Transferring a referral to building choices', () => {
   // Person and their PNI score
@@ -39,8 +38,7 @@ context('Transferring a referral to building choices', () => {
   const originalCourse = courseFactory.build({
     courseOfferings: [originalCourseOffering],
   })
-  const prison = prisonFactory.build({ prisonId: originalCourseOffering.organisationId })
-  const organisation = OrganisationUtils.organisationFromPrison(prison)
+  const organisation: Organisation = { code: originalCourseOffering.organisationId, prisonName: 'HMP Test' }
 
   // Target moderate Building Choices course
   const buildingChoicesModerateOffering = courseOfferingFactory.build()
@@ -234,7 +232,7 @@ context('Transferring a referral to building choices', () => {
           referralId: referral.id,
         })
         cy.task('stubOffering', { courseOffering: originalCourseOffering })
-        cy.task('stubPrison', prison)
+        cy.task('stubOrganisation', organisation)
 
         cy.visit(transferPath)
 

--- a/integration_tests/e2e/pniFind.cy.ts
+++ b/integration_tests/e2e/pniFind.cy.ts
@@ -28,6 +28,7 @@ import {
   NewReferralStartPage,
   NewReferralTaskListPage,
 } from '../pages/refer'
+import type { Organisation } from '@accredited-programmes-api'
 
 context('Find programmes based on PNI Pathway', () => {
   const personSearchPath = findPaths.pniFind.personSearch({})
@@ -292,6 +293,10 @@ context('Find programmes based on PNI Pathway', () => {
           prisonId: referableOffering.organisationId,
           prisonName: 'Moorland (HMP)',
         })
+        const organisationFromAcp: Organisation = {
+          code: referablePrison.prisonId,
+          prisonName: referablePrison.prisonName,
+        }
         const referableOrganisation = OrganisationUtils.organisationFromPrison(referablePrison)
         const prisons = [
           referablePrison,
@@ -314,6 +319,7 @@ context('Find programmes based on PNI Pathway', () => {
             })
             cy.task('stubOffering', { courseOffering: referableOffering })
             cy.task('stubCourseByOffering', { course: becomingNewMeCourse, courseOfferingId: referableOffering.id })
+            cy.task('stubOrganisation', organisationFromAcp)
 
             cy.visit(personSearchPath)
 
@@ -372,7 +378,7 @@ context('Find programmes based on PNI Pathway', () => {
             const startReferralPage = Page.verifyOnPage(NewReferralStartPage, {
               course: becomingNewMeCourse,
               courseOffering: referableOffering,
-              organisation: referableOrganisation,
+              organisation: organisationFromAcp,
               prisonNumber,
             })
             startReferralPage.shouldContainBackLink(
@@ -423,7 +429,7 @@ context('Find programmes based on PNI Pathway', () => {
             Page.verifyOnPage(NewReferralTaskListPage, {
               course: becomingNewMeCourse,
               courseOffering: referableOffering,
-              organisation: referableOrganisation,
+              organisation: organisationFromAcp,
               referral,
             })
           })
@@ -462,7 +468,7 @@ context('Find programmes based on PNI Pathway', () => {
               const duplicatePage = Page.verifyOnPage(NewReferralDuplicatePage, {
                 course: becomingNewMeCourse,
                 courseOffering: referableOffering,
-                organisation: referableOrganisation,
+                organisation: organisationFromAcp,
                 person,
                 referral,
               })
@@ -492,6 +498,13 @@ context('Find programmes based on PNI Pathway', () => {
             cy.task('stubPrison', prisonFactory.build({ female: false, prisonId: prisoner.prisonId }))
             cy.task('stubOffering', { courseOffering: referableOffering })
             cy.task('stubCourseByOffering', { course: buildingChoicesCourse, courseOfferingId: referableOffering.id })
+
+            cy.task('stubOrganisation', { code: prisoner.prisonId, gender: 'MALE', prisonName: 'HMP Test' })
+            cy.task('stubOrganisation', {
+              code: referablePrison.prisonId,
+              gender: 'MALE',
+              prisonName: referablePrison.prisonName,
+            })
 
             cy.visit(personSearchPath)
 
@@ -564,7 +577,7 @@ context('Find programmes based on PNI Pathway', () => {
             const startReferralPage = Page.verifyOnPage(NewReferralStartPage, {
               course: buildingChoicesCourse,
               courseOffering: referableOffering,
-              organisation: referableOrganisation,
+              organisation: organisationFromAcp,
               prisonNumber,
             })
             startReferralPage.shouldContainBackLink(
@@ -615,7 +628,7 @@ context('Find programmes based on PNI Pathway', () => {
             Page.verifyOnPage(NewReferralTaskListPage, {
               course: buildingChoicesCourse,
               courseOffering: referableOffering,
-              organisation: referableOrganisation,
+              organisation: organisationFromAcp,
               referral,
             })
           })

--- a/integration_tests/e2e/refer/new/additionalInformation.cy.ts
+++ b/integration_tests/e2e/refer/new/additionalInformation.cy.ts
@@ -6,13 +6,12 @@ import {
   peopleSearchResponseFactory,
   personFactory,
   pniScoreFactory,
-  prisonFactory,
   referralFactory,
 } from '../../../../server/testutils/factories'
-import { OrganisationUtils } from '../../../../server/utils'
 import auth from '../../../mockApis/auth'
 import Page from '../../../pages/page'
 import { NewReferralAdditionalInformationPage, NewReferralTaskListPage } from '../../../pages/refer'
+import type { Organisation } from '@accredited-programmes-api'
 
 context('Additional information', () => {
   const courseOffering = courseOfferingFactory.build()
@@ -94,9 +93,8 @@ context('Additional information', () => {
       cy.task('stubCourseByOffering', { course, courseOfferingId: courseOffering.id })
       cy.task('stubOffering', { courseId: course.id, courseOffering })
 
-      const prison = prisonFactory.build({ prisonId: courseOffering.organisationId })
-      const organisation = OrganisationUtils.organisationFromPrison(prison)
-      cy.task('stubPrison', prison)
+      const organisation: Organisation = { code: courseOffering.organisationId, prisonName: 'HMP Test' }
+      cy.task('stubOrganisation', organisation)
 
       const path = referPaths.new.additionalInformation.show({ referralId: referral.id })
       cy.visit(path)
@@ -119,9 +117,8 @@ context('Additional information', () => {
       cy.task('stubCourseByOffering', { course, courseOfferingId: courseOffering.id })
       cy.task('stubOffering', { courseId: course.id, courseOffering })
 
-      const prison = prisonFactory.build({ prisonId: courseOffering.organisationId })
-      const organisation = OrganisationUtils.organisationFromPrison(prison)
-      cy.task('stubPrison', prison)
+      const organisation: Organisation = { code: courseOffering.organisationId, prisonName: 'HMP Test' }
+      cy.task('stubOrganisation', organisation)
 
       const path = referPaths.new.additionalInformation.show({ referralId: referral.id })
       cy.visit(path)
@@ -221,9 +218,8 @@ context('Additional information with override', () => {
       cy.task('stubCourseByOffering', { course, courseOfferingId: courseOffering.id })
       cy.task('stubOffering', { courseId: course.id, courseOffering })
 
-      const prison = prisonFactory.build({ prisonId: courseOffering.organisationId })
-      const organisation = OrganisationUtils.organisationFromPrison(prison)
-      cy.task('stubPrison', prison)
+      const organisation: Organisation = { code: courseOffering.organisationId, prisonName: 'HMP Test' }
+      cy.task('stubOrganisation', organisation)
 
       const path = referPaths.new.additionalInformation.show({ referralId: referral.id })
       cy.visit(path)

--- a/integration_tests/e2e/refer/new/confirmOasys.cy.ts
+++ b/integration_tests/e2e/refer/new/confirmOasys.cy.ts
@@ -5,13 +5,12 @@ import {
   courseOfferingFactory,
   peopleSearchResponseFactory,
   personFactory,
-  prisonFactory,
   referralFactory,
 } from '../../../../server/testutils/factories'
-import { OrganisationUtils } from '../../../../server/utils'
 import auth from '../../../mockApis/auth'
 import Page from '../../../pages/page'
 import { NewReferralConfirmOasysPage, NewReferralTaskListPage } from '../../../pages/refer'
+import type { Organisation } from '@accredited-programmes-api'
 
 context('OASys confirmation', () => {
   const courseOffering = courseOfferingFactory.build()
@@ -103,9 +102,8 @@ context('OASys confirmation', () => {
       cy.task('stubCourseByOffering', { course, courseOfferingId: courseOffering.id })
       cy.task('stubOffering', { courseId: course.id, courseOffering })
 
-      const prison = prisonFactory.build({ prisonId: courseOffering.organisationId })
-      const organisation = OrganisationUtils.organisationFromPrison(prison)
-      cy.task('stubPrison', prison)
+      const organisation: Organisation = { code: courseOffering.organisationId, prisonName: 'HMP Test' }
+      cy.task('stubOrganisation', organisation)
 
       const path = referPaths.new.confirmOasys.show({ referralId: referral.id })
       cy.visit(path)

--- a/integration_tests/e2e/refer/new/delete.cy.ts
+++ b/integration_tests/e2e/refer/new/delete.cy.ts
@@ -5,13 +5,12 @@ import {
   courseOfferingFactory,
   peopleSearchResponseFactory,
   personFactory,
-  prisonFactory,
   referralFactory,
 } from '../../../../server/testutils/factories'
-import { OrganisationUtils } from '../../../../server/utils'
 import auth from '../../../mockApis/auth'
 import Page from '../../../pages/page'
 import { NewReferralDeletePage, NewReferralTaskListPage } from '../../../pages/refer'
+import type { Organisation } from '@accredited-programmes-api'
 
 context('Deleting a referral', () => {
   const courseOffering = courseOfferingFactory.build()
@@ -53,9 +52,8 @@ context('Deleting a referral', () => {
     const course = courseFactory.build()
     cy.task('stubCourseByOffering', { course, courseOfferingId: courseOffering.id })
 
-    const prison = prisonFactory.build({ prisonId: courseOffering.organisationId })
-    const organisation = OrganisationUtils.organisationFromPrison(prison)
-    cy.task('stubPrison', prison)
+    const organisation: Organisation = { code: courseOffering.organisationId, prisonName: 'HMP Test' }
+    cy.task('stubOrganisation', organisation)
 
     const path = referPaths.new.show({ referralId: referral.id })
     cy.visit(path)

--- a/integration_tests/e2e/refer/new/programmeHistory.cy.ts
+++ b/integration_tests/e2e/refer/new/programmeHistory.cy.ts
@@ -6,11 +6,10 @@ import {
   courseParticipationFactory,
   peopleSearchResponseFactory,
   personFactory,
-  prisonFactory,
   referralFactory,
   userFactory,
 } from '../../../../server/testutils/factories'
-import { type CourseParticipationDetailsBody, OrganisationUtils, StringUtils } from '../../../../server/utils'
+import { type CourseParticipationDetailsBody, StringUtils } from '../../../../server/utils'
 import auth from '../../../mockApis/auth'
 import Page from '../../../pages/page'
 import {
@@ -22,7 +21,7 @@ import {
   NewReferralTaskListPage,
 } from '../../../pages/refer'
 import type { CourseParticipationPresenter } from '@accredited-programmes/ui'
-import type { CourseParticipation } from '@accredited-programmes-api'
+import type { CourseParticipation, Organisation } from '@accredited-programmes-api'
 
 context('Programme history', () => {
   const prisoner = peopleSearchResponseFactory.build({
@@ -81,8 +80,7 @@ context('Programme history', () => {
   })
 
   describe('Showing the programme history page', () => {
-    const prison = prisonFactory.build({ prisonId: courseOffering.organisationId })
-    const organisation = OrganisationUtils.organisationFromPrison(prison)
+    const organisation: Organisation = { code: courseOffering.organisationId, prisonName: 'HMP Test' }
 
     const existingParticipations = [courseParticipationWithKnownCourseName, courseParticipationWithUnknownCourseName]
     const referralParticipations = courseParticipationFactory.buildList(2, {
@@ -139,7 +137,7 @@ context('Programme history', () => {
         beforeEach(() => {
           cy.task('stubCourseByOffering', { course: courses[0], courseOfferingId: courseOffering.id })
           cy.task('stubOffering', { courseId: courses[0].id, courseOffering })
-          cy.task('stubPrison', prison)
+          cy.task('stubOrganisation', organisation)
           cy.task('stubUpdateReferral', referral.id)
         })
 
@@ -196,7 +194,7 @@ context('Programme history', () => {
         beforeEach(() => {
           cy.task('stubCourseByOffering', { course: courses[0], courseOfferingId: courseOffering.id })
           cy.task('stubOffering', { courseId: courses[0].id, courseOffering })
-          cy.task('stubPrison', prison)
+          cy.task('stubOrganisation', organisation)
           cy.task('stubUpdateReferral', referral.id)
         })
 

--- a/integration_tests/e2e/refer/new/show.cy.ts
+++ b/integration_tests/e2e/refer/new/show.cy.ts
@@ -5,13 +5,12 @@ import {
   courseOfferingFactory,
   peopleSearchResponseFactory,
   personFactory,
-  prisonFactory,
   referralFactory,
 } from '../../../../server/testutils/factories'
-import { OrganisationUtils } from '../../../../server/utils'
 import auth from '../../../mockApis/auth'
 import Page from '../../../pages/page'
 import { NewReferralShowPersonPage, NewReferralTaskListPage } from '../../../pages/refer'
+import type { Organisation } from '@accredited-programmes-api'
 
 context('Showing the referral task list and person page', () => {
   const courseOffering = courseOfferingFactory.build()
@@ -53,9 +52,8 @@ context('Showing the referral task list and person page', () => {
     const course = courseFactory.build()
     cy.task('stubCourseByOffering', { course, courseOfferingId: courseOffering.id })
 
-    const prison = prisonFactory.build({ prisonId: courseOffering.organisationId })
-    const organisation = OrganisationUtils.organisationFromPrison(prison)
-    cy.task('stubPrison', prison)
+    const organisation: Organisation = { code: courseOffering.organisationId, prisonName: 'HMP Test' }
+    cy.task('stubOrganisation', organisation)
 
     const path = referPaths.new.show({ referralId: referral.id })
     cy.visit(path)

--- a/integration_tests/e2e/refer/new/submit.cy.ts
+++ b/integration_tests/e2e/refer/new/submit.cy.ts
@@ -6,11 +6,10 @@ import {
   courseParticipationFactory,
   peopleSearchResponseFactory,
   personFactory,
-  prisonFactory,
   referralFactory,
   userFactory,
 } from '../../../../server/testutils/factories'
-import { OrganisationUtils, StringUtils } from '../../../../server/utils'
+import { StringUtils } from '../../../../server/utils'
 import auth from '../../../mockApis/auth'
 import Page from '../../../pages/page'
 import {
@@ -20,6 +19,7 @@ import {
   NewReferralTaskListPage,
 } from '../../../pages/refer'
 import type { CourseParticipationPresenter } from '@accredited-programmes/ui'
+import type { Organisation } from '@accredited-programmes-api'
 import type { UserEmail } from '@manage-users-api'
 
 context('Submitting a referral', () => {
@@ -40,8 +40,7 @@ context('Submitting a referral', () => {
     religionOrBelief: prisoner.religion,
     setting: 'Custody',
   })
-  const prison = prisonFactory.build({ prisonId: courseOffering.organisationId })
-  const organisation = OrganisationUtils.organisationFromPrison(prison)
+  const organisation: Organisation = { code: courseOffering.organisationId, prisonName: 'HMP Test' }
   const addedByUser1 = userFactory.build({ name: 'Bobby Brown', username: auth.mockedUser.username })
   const addedByUser1Email: UserEmail = {
     email: 'referrer.user@email-test.co.uk',
@@ -87,7 +86,7 @@ context('Submitting a referral', () => {
 
     cy.task('stubCourseByOffering', { course, courseOfferingId: courseOffering.id })
     cy.task('stubOffering', { courseId: course.id, courseOffering })
-    cy.task('stubPrison', prison)
+    cy.task('stubOrganisation', organisation)
     cy.task('stubPrisoner', prisoner)
     cy.task('stubUserDetails', addedByUser1)
     cy.task('stubUserDetails', addedByUser2)

--- a/integration_tests/e2e/refer/withdraw.cy.ts
+++ b/integration_tests/e2e/refer/withdraw.cy.ts
@@ -4,7 +4,6 @@ import {
   confirmationFieldsFactory,
   peopleSearchResponseFactory,
   personFactory,
-  prisonFactory,
   referralFactory,
   referralStatusHistoryFactory,
   referralStatusReasonFactory,
@@ -15,10 +14,11 @@ import auth from '../../mockApis/auth'
 import Page from '../../pages/page'
 import { WithdrawConfirmSelectionPage, WithdrawReasonPage } from '../../pages/shared'
 import type { ReferralStatusHistoryPresenter } from '@accredited-programmes/ui'
+import type { Organisation } from '@accredited-programmes-api'
 
 context('Withdraw referral', () => {
   const anotherUser = userFactory.build({ name: 'Joshua Smith' })
-  const prison = prisonFactory.build()
+  const organisation: Organisation = { code: 'WTI', prisonName: 'Whatton' }
   const prisoner = peopleSearchResponseFactory.build({
     firstName: 'Del',
     lastName: 'Hatton',
@@ -77,7 +77,7 @@ context('Withdraw referral', () => {
     cy.task('stubDefaultCaseloads')
     cy.signIn()
 
-    cy.task('stubPrison', prison)
+    cy.task('stubOrganisation', organisation)
     cy.task('stubPrisoner', prisoner)
     cy.task('stubReferral', referral)
     cy.task('stubUserDetails', anotherUser)

--- a/integration_tests/mockApis/organisations.ts
+++ b/integration_tests/mockApis/organisations.ts
@@ -1,0 +1,20 @@
+import type { SuperAgentRequest } from 'superagent'
+
+import { apiPaths } from '../../server/paths'
+import { stubFor } from '../../wiremock'
+import type { Organisation } from '@accredited-programmes-api'
+
+export default {
+  stubOrganisation: (organisation: Organisation): SuperAgentRequest =>
+    stubFor({
+      request: {
+        method: 'GET',
+        url: apiPaths.organisations.show({ organisationCode: organisation.code! }),
+      },
+      response: {
+        headers: { 'Content-Type': 'application/json;charset=UTF-8' },
+        jsonBody: organisation,
+        status: 200,
+      },
+    }),
+}

--- a/integration_tests/pages/assess/transferError.ts
+++ b/integration_tests/pages/assess/transferError.ts
@@ -1,7 +1,7 @@
 import { assessPaths } from '../../../server/paths'
 import Page from '../page'
-import type { Organisation, Person } from '@accredited-programmes/models'
-import type { Course, Referral } from '@accredited-programmes-api'
+import type { Person } from '@accredited-programmes/models'
+import type { Course, Organisation, Referral } from '@accredited-programmes-api'
 
 export default class TransferErrorPage extends Page {
   organisation: Organisation
@@ -42,7 +42,7 @@ export default class TransferErrorPage extends Page {
 
   shouldContainNoCourseText() {
     this.shouldContainText(
-      `This referral cannot be moved because ${this.organisation.name} does not offer the general offence strand of Building Choices: ${this.originalCourse.intensity?.toLowerCase()} intensity.`,
+      `This referral cannot be moved because ${this.organisation.prisonName} does not offer the general offence strand of Building Choices: ${this.originalCourse.intensity?.toLowerCase()} intensity.`,
     )
     this.shouldContainText('Close this referral and submit a new one to a different location.')
   }

--- a/integration_tests/pages/page.ts
+++ b/integration_tests/pages/page.ts
@@ -13,7 +13,7 @@ import {
   ShowRisksAndNeedsUtils,
 } from '../../server/utils'
 import Helpers from '../support/helpers'
-import type { CourseOffering, Organisation, Person, ReferralStatusRefData } from '@accredited-programmes/models'
+import type { CourseOffering, Person, ReferralStatusRefData } from '@accredited-programmes/models'
 import type {
   CourseParticipationPresenter,
   CoursePresenter,
@@ -25,7 +25,7 @@ import type {
   MojTimelineItem,
   ReferralStatusHistoryPresenter,
 } from '@accredited-programmes/ui'
-import type { Course, CourseParticipation, Referral } from '@accredited-programmes-api'
+import type { Course, CourseParticipation, Organisation, Referral } from '@accredited-programmes-api'
 import type {
   GovukFrontendCheckboxesItem,
   GovukFrontendRadiosItem,
@@ -151,7 +151,7 @@ export default abstract class Page {
     applicantName: User['name'],
     course: CoursePresenter,
     contactEmail: CourseOffering['contactEmail'],
-    organisationName: Organisation['name'],
+    organisationName: Organisation['prisonName'],
   ) {
     cy.get('[data-testid="course-offering-summary-list"]').then(summaryListElement => {
       this.shouldContainSummaryListRows(
@@ -316,7 +316,7 @@ export default abstract class Page {
     const { course, organisation } = pageWithOrganisationAndCoursePresenter
 
     cy.get('[data-testid="organisation-and-course"]').then(organisationAndCourseHeading => {
-      const expectedText = `${organisation.name} | ${course.displayName}`
+      const expectedText = `${organisation.prisonName} | ${course.displayName}`
       const { actual, expected } = Helpers.parseHtml(organisationAndCourseHeading, expectedText)
       expect(actual).to.equal(expected)
     })

--- a/integration_tests/pages/refer/new/checkAnswers.ts
+++ b/integration_tests/pages/refer/new/checkAnswers.ts
@@ -1,9 +1,9 @@
 import { referPaths } from '../../../../server/paths'
 import { CourseUtils, NewReferralUtils } from '../../../../server/utils'
 import Page from '../../page'
-import type { CourseOffering, Organisation, Person } from '@accredited-programmes/models'
+import type { CourseOffering, Person } from '@accredited-programmes/models'
 import type { CourseParticipationPresenter, CoursePresenter } from '@accredited-programmes/ui'
-import type { Course, Referral } from '@accredited-programmes-api'
+import type { Course, Organisation, Referral } from '@accredited-programmes-api'
 import type { User, UserEmail } from '@manage-users-api'
 
 export default class NewReferralCheckAnswersPage extends Page {

--- a/integration_tests/pages/refer/new/duplicate.ts
+++ b/integration_tests/pages/refer/new/duplicate.ts
@@ -1,8 +1,8 @@
 import { CourseUtils, ShowReferralUtils } from '../../../../server/utils'
 import Page from '../../page'
-import type { CourseOffering, Organisation, Person } from '@accredited-programmes/models'
+import type { CourseOffering, Person } from '@accredited-programmes/models'
 import type { CoursePresenter } from '@accredited-programmes/ui'
-import type { Course, Referral } from '@accredited-programmes-api'
+import type { Course, Organisation, Referral } from '@accredited-programmes-api'
 import type { User } from '@manage-users-api'
 
 export default class NewReferralDuplicatePage extends Page {
@@ -40,7 +40,7 @@ export default class NewReferralDuplicatePage extends Page {
           this.person.name,
           this.course,
           this.courseOffering.contactEmail,
-          this.organisation.name,
+          this.organisation.prisonName,
         ),
         summaryListElement,
       )
@@ -50,7 +50,7 @@ export default class NewReferralDuplicatePage extends Page {
   shouldContainReferralExistsText() {
     cy.get('[data-testid="referral-exists-text"]').should(
       'have.text',
-      `A referral already exists for ${this.person.name} to ${this.course.displayName} at ${this.organisation.name}.`,
+      `A referral already exists for ${this.person.name} to ${this.course.displayName} at ${this.organisation.prisonName}.`,
     )
   }
 

--- a/integration_tests/pages/refer/new/start.ts
+++ b/integration_tests/pages/refer/new/start.ts
@@ -1,9 +1,9 @@
 import { referPaths } from '../../../../server/paths'
 import { CourseUtils } from '../../../../server/utils'
 import Page from '../../page'
-import type { CourseOffering, Organisation } from '@accredited-programmes/models'
+import type { CourseOffering } from '@accredited-programmes/models'
 import type { CoursePresenter } from '@accredited-programmes/ui'
-import type { Course } from '@accredited-programmes-api'
+import type { Course, Organisation } from '@accredited-programmes-api'
 
 export default class NewReferralStartPage extends Page {
   course: CoursePresenter

--- a/integration_tests/pages/refer/new/taskList.ts
+++ b/integration_tests/pages/refer/new/taskList.ts
@@ -2,9 +2,9 @@ import { referPaths } from '../../../../server/paths'
 import { CourseUtils, NewReferralUtils } from '../../../../server/utils'
 import Helpers from '../../../support/helpers'
 import Page from '../../page'
-import type { CourseOffering, Organisation } from '@accredited-programmes/models'
+import type { CourseOffering } from '@accredited-programmes/models'
 import type { CoursePresenter } from '@accredited-programmes/ui'
-import type { Course, Referral } from '@accredited-programmes-api'
+import type { Course, Organisation, Referral } from '@accredited-programmes-api'
 
 export default class NewReferralTaskListPage extends Page {
   course: CoursePresenter

--- a/integration_tests/support/sharedTests.ts
+++ b/integration_tests/support/sharedTests.ts
@@ -17,7 +17,6 @@ import {
   peopleSearchResponseFactory,
   personFactory,
   pniScoreFactory,
-  prisonFactory,
   psychiatricFactory,
   referralFactory,
   referralStatusHistoryFactory,
@@ -28,7 +27,7 @@ import {
   sentenceDetailsFactory,
   userFactory,
 } from '../../server/testutils/factories'
-import { CourseUtils, OrganisationUtils } from '../../server/utils'
+import { CourseUtils } from '../../server/utils'
 import { releaseDateFields } from '../../server/utils/personUtils'
 import auth from '../mockApis/auth'
 import BadRequestPage from '../pages/badRequest'
@@ -56,7 +55,7 @@ import {
 import EmotionalWellbeing from '../pages/shared/showReferral/risksAndNeeds/emotionalWellbeing'
 import type { Person, ReferralStatusRefData, SentenceDetails } from '@accredited-programmes/models'
 import type { ReferralStatusHistoryPresenter } from '@accredited-programmes/ui'
-import type { CourseParticipation, PeopleSearchResponse, Referral } from '@accredited-programmes-api'
+import type { CourseParticipation, Organisation, PeopleSearchResponse, Referral } from '@accredited-programmes-api'
 import type { User, UserEmail } from '@manage-users-api'
 
 type ApplicationRole = `${ApplicationRoles}`
@@ -64,7 +63,8 @@ type ApplicationRole = `${ApplicationRoles}`
 const course = courseFactory.build({ intensity: 'MODERATE' })
 const coursePresenter = CourseUtils.presentCourse(course)
 const courseOffering = courseOfferingFactory.build()
-const prison = prisonFactory.build({ prisonId: courseOffering.organisationId })
+// const prison = prisonFactory.build({ prisonId: courseOffering.organisationId })
+const organisation: Organisation = { code: courseOffering.organisationId, prisonName: 'HMP Test' }
 let prisoner: PeopleSearchResponse
 const defaultPrisoner = peopleSearchResponseFactory.build({
   bookingId: 'A-BOOKING-ID',
@@ -101,7 +101,6 @@ const recentCompletedAssessmentDate = '2023-12-19'
 const recentCompletedAssessmentDateString = '19 December 2023'
 let referral: Referral
 let referringUser: User
-const organisation = OrganisationUtils.organisationFromPrison(prison)
 const user = userFactory.build()
 const addedByUser1Email: UserEmail = {
   email: 'referrer.email@test-email.co.uk',
@@ -156,7 +155,7 @@ const sharedTests = {
 
       cy.task('stubCourseByOffering', { course, courseOfferingId: courseOffering.id })
       cy.task('stubOffering', { courseId: course.id, courseOffering })
-      cy.task('stubPrison', prison)
+      cy.task('stubOrganisation', organisation)
       cy.task('stubPrisoner', prisoner)
       cy.task('stubReferral', referral)
       cy.task('stubUserDetails', referringUser)
@@ -252,7 +251,7 @@ const sharedTests = {
         person.name,
         coursePresenter,
         courseOffering.contactEmail,
-        organisation.name,
+        organisation.prisonName,
       )
       additionalInformationPage.shouldContainSubmissionSummaryList(
         referral.submittedOn,
@@ -315,7 +314,7 @@ const sharedTests = {
         person.name,
         coursePresenter,
         courseOffering.contactEmail,
-        organisation.name,
+        organisation.prisonName,
       )
       offenceHistoryPage.shouldContainSubmissionSummaryList(
         referral.submittedOn,
@@ -351,7 +350,7 @@ const sharedTests = {
         person.name,
         coursePresenter,
         courseOffering.contactEmail,
-        organisation.name,
+        organisation.prisonName,
       )
       programmeHistoryPage.shouldContainSubmissionSummaryList(
         referral.submittedOn,
@@ -419,7 +418,7 @@ const sharedTests = {
         person.name,
         coursePresenter,
         courseOffering.contactEmail,
-        organisation.name,
+        organisation.prisonName,
       )
       offenceHistoryPage.shouldContainSubmissionSummaryList(
         referral.submittedOn,
@@ -451,7 +450,7 @@ const sharedTests = {
         person.name,
         coursePresenter,
         courseOffering.contactEmail,
-        organisation.name,
+        organisation.prisonName,
       )
       personalDetailsPage.shouldContainSubmissionSummaryList(
         referral.submittedOn,
@@ -488,7 +487,7 @@ const sharedTests = {
         person.name,
         coursePresenter,
         courseOffering.contactEmail,
-        organisation.name,
+        organisation.prisonName,
       )
       programmeHistoryPage.shouldContainSubmissionSummaryList(
         referral.submittedOn,
@@ -521,7 +520,7 @@ const sharedTests = {
         person.name,
         coursePresenter,
         courseOffering.contactEmail,
-        organisation.name,
+        organisation.prisonName,
       )
       releaseDatesPage.shouldContainSubmissionSummaryList(
         referral.submittedOn,
@@ -563,7 +562,7 @@ const sharedTests = {
         person.name,
         coursePresenter,
         courseOffering.contactEmail,
-        organisation.name,
+        organisation.prisonName,
       )
       releaseDatesPage.shouldContainSubmissionSummaryList(
         referral.submittedOn,
@@ -597,7 +596,7 @@ const sharedTests = {
         person.name,
         coursePresenter,
         courseOffering.contactEmail,
-        organisation.name,
+        organisation.prisonName,
       )
       sentenceInformationPage.shouldContainSubmissionSummaryList(
         referral.submittedOn,
@@ -639,7 +638,7 @@ const sharedTests = {
         person.name,
         coursePresenter,
         courseOffering.contactEmail,
-        organisation.name,
+        organisation.prisonName,
       )
       sentenceInformationPage.shouldContainSubmissionSummaryList(
         referral.submittedOn,

--- a/server/@types/ui/index.d.ts
+++ b/server/@types/ui/index.d.ts
@@ -1,5 +1,6 @@
 import type { Organisation, Person, RiskLevel } from '@accredited-programmes/models'
 import type {
+  Organisation as AcpOrganisation,
   Course,
   CourseOffering,
   CourseParticipation,
@@ -115,7 +116,7 @@ type ReferralSharedPageData = {
   courseOfferingSummaryListRows: Array<GovukFrontendSummaryListRowWithKeyAndValue>
   hideTitleServiceName: boolean
   navigationItems: Array<MojFrontendNavigationItem>
-  organisation: Organisation
+  organisation: AcpOrganisation
   pageHeading: string
   pageSubHeading: string
   pageTitleOverride: string

--- a/server/controllers/assess/transferReferralErrorController.test.ts
+++ b/server/controllers/assess/transferReferralErrorController.test.ts
@@ -6,15 +6,9 @@ import { when } from 'jest-when'
 import TransferReferralErrorController from './transferReferralErrorController'
 import { assessPaths } from '../../paths'
 import type { CourseService, OrganisationService, PersonService } from '../../services'
-import {
-  courseFactory,
-  courseOfferingFactory,
-  organisationFactory,
-  personFactory,
-  referralFactory,
-} from '../../testutils/factories'
+import { courseFactory, courseOfferingFactory, personFactory, referralFactory } from '../../testutils/factories'
 import Helpers from '../../testutils/helpers'
-import type { Referral } from '@accredited-programmes-api'
+import type { Organisation, Referral } from '@accredited-programmes-api'
 
 describe('TransferReferralErrorController', () => {
   const userToken = 'SOME_TOKEN'
@@ -29,8 +23,8 @@ describe('TransferReferralErrorController', () => {
   const personService = createMock<PersonService>({})
 
   const person = personFactory.build()
-  const originalOfferingOrganisation = organisationFactory.build()
-  const originalCourseOffering = courseOfferingFactory.build({ organisationId: originalOfferingOrganisation.id })
+  const originalOfferingOrganisation: Organisation = { code: 'WTI', gender: 'MALE', prisonName: 'Whatton' }
+  const originalCourseOffering = courseOfferingFactory.build({ organisationId: originalOfferingOrganisation.code })
   const originalCourse = courseFactory.build({
     courseOfferings: [originalCourseOffering],
     intensity: 'MODERATE',
@@ -158,8 +152,8 @@ describe('TransferReferralErrorController', () => {
           when(courseService.getOffering)
             .calledWith(username, originalCourseOffering.id)
             .mockResolvedValue(originalCourseOffering)
-          when(organisationService.getOrganisation)
-            .calledWith(userToken, originalCourseOffering.organisationId)
+          when(organisationService.getOrganisationFromAcp)
+            .calledWith(username, originalCourseOffering.organisationId)
             .mockResolvedValue(originalOfferingOrganisation)
 
           request.session.transferErrorData = {
@@ -173,7 +167,7 @@ describe('TransferReferralErrorController', () => {
           expect(response.render).toHaveBeenCalledWith('referrals/transfer/error/show', {
             backLinkHref: assessPaths.show.personalDetails({ referralId: referral.id }),
             errorText: [
-              `This referral cannot be moved because ${originalOfferingOrganisation.name} does not offer the general offence strand of Building Choices: ${originalCourse.intensity?.toLowerCase()} intensity.`,
+              `This referral cannot be moved because ${originalOfferingOrganisation.prisonName} does not offer the general offence strand of Building Choices: ${originalCourse.intensity?.toLowerCase()} intensity.`,
               'Close this referral and submit a new one to a different location.',
             ],
             pageHeading: 'This referral cannot be moved to Building Choices',

--- a/server/controllers/assess/transferReferralErrorController.ts
+++ b/server/controllers/assess/transferReferralErrorController.ts
@@ -19,7 +19,7 @@ export default class TransferReferralErrorController {
       let errorText: Array<string>
 
       const { referralId } = req.params
-      const { token, username } = req.user
+      const { username } = req.user
       const { transferErrorData } = req.session
 
       if (!transferErrorData) {
@@ -49,10 +49,13 @@ export default class TransferReferralErrorController {
           this.courseService.getCourseByOffering(username, originalOfferingId),
           this.courseService.getOffering(username, originalOfferingId),
         ])
-        const organisation = await this.organisationService.getOrganisation(token, originalOffering.organisationId)
+        const organisation = await this.organisationService.getOrganisationFromAcp(
+          username,
+          originalOffering.organisationId,
+        )
 
         errorText = [
-          `This referral cannot be moved because ${organisation.name} does not offer the general offence strand of Building Choices: ${originalCourse.intensity?.toLowerCase()} intensity.`,
+          `This referral cannot be moved because ${organisation.prisonName} does not offer the general offence strand of Building Choices: ${originalCourse.intensity?.toLowerCase()} intensity.`,
           'Close this referral and submit a new one to a different location.',
         ]
       } else {

--- a/server/controllers/find/buildingChoicesFormController.test.ts
+++ b/server/controllers/find/buildingChoicesFormController.test.ts
@@ -5,8 +5,9 @@ import type { NextFunction, Request, Response } from 'express'
 import BuildingChoicesFormController from './buildingChoicesFormController'
 import { findPaths } from '../../paths'
 import type { OrganisationService, PersonService } from '../../services'
-import { organisationFactory, personFactory } from '../../testutils/factories'
+import { personFactory } from '../../testutils/factories'
 import { FormUtils } from '../../utils'
+import type { Organisation } from '@accredited-programmes-api'
 
 jest.mock('../../utils/formUtils')
 
@@ -56,7 +57,7 @@ describe('BuildingChoicesFormController', () => {
     describe('when the user is coming from the PNI find page', () => {
       const prisonNumber = 'ABC1234'
       const person = personFactory.build({ name: 'Del Hatton', prisonId: 'HEW', prisonNumber })
-      const organisation = organisationFactory.build({ id: 'HEW' })
+      const organisation: Organisation = { code: 'HEW', gender: 'MALE', prisonName: 'Hewell' }
 
       beforeEach(() => {
         request.session.pniFindAndReferData = {
@@ -67,7 +68,7 @@ describe('BuildingChoicesFormController', () => {
       })
 
       it('should render the buildingChoices/show template with correct response locals', async () => {
-        organisationService.getOrganisation.mockResolvedValue(organisation)
+        organisationService.getOrganisationFromAcp.mockResolvedValue(organisation)
 
         const requestHandler = controller.show()
         await requestHandler(request, response, next)
@@ -87,7 +88,7 @@ describe('BuildingChoicesFormController', () => {
 
       describe('when the organisation is a women’s prison', () => {
         it('should set `isInAWomensPrison` default form value to `true`', async () => {
-          organisationService.getOrganisation.mockResolvedValue({ ...organisation, female: true })
+          organisationService.getOrganisationFromAcp.mockResolvedValue({ ...organisation, gender: 'FEMALE' })
 
           const requestHandler = controller.show()
           await requestHandler(request, response, next)

--- a/server/controllers/find/buildingChoicesFormController.ts
+++ b/server/controllers/find/buildingChoicesFormController.ts
@@ -15,7 +15,7 @@ export default class BuildingChoicesFormController {
     return async (req: Request, res: Response) => {
       TypeUtils.assertHasUser(req)
 
-      const { username, token } = req.user
+      const { username } = req.user
       const pniFindPrisonNumber = req.session.pniFindAndReferData?.prisonNumber
       const pageTitleOverride = "About the person you're referring"
       const formTemplate = 'courses/buildingChoices/form/show'
@@ -35,10 +35,10 @@ export default class BuildingChoicesFormController {
 
       const person = await this.personService.getPerson(username, pniFindPrisonNumber)
       const organisation = person.prisonId
-        ? await this.organisationService.getOrganisation(token, person.prisonId)
+        ? await this.organisationService.getOrganisationFromAcp(username, person.prisonId)
         : undefined
 
-      const isInAWomensPrisonValue = organisation?.female?.toString() ?? ''
+      const isInAWomensPrisonValue = organisation?.gender ? (organisation.gender === 'FEMALE').toString() : ''
 
       FormUtils.setFormValues(req, res, { isInAWomensPrison: isInAWomensPrisonValue })
 

--- a/server/controllers/refer/new/referralsController.test.ts
+++ b/server/controllers/refer/new/referralsController.test.ts
@@ -13,7 +13,6 @@ import {
   courseFactory,
   courseOfferingFactory,
   courseParticipationFactory,
-  organisationFactory,
   personFactory,
   referralFactory,
 } from '../../../testutils/factories'
@@ -24,6 +23,7 @@ import type {
   GovukFrontendSummaryListRowWithKeyAndValue,
   GovukFrontendSummaryListWithRowsWithKeysAndValues,
 } from '@accredited-programmes/ui'
+import type { Organisation } from '@accredited-programmes-api'
 
 jest.mock('../../../utils/courseUtils')
 jest.mock('../../../utils/formUtils')
@@ -113,8 +113,8 @@ describe('NewReferralsController', () => {
     })
 
     it('renders the referral start template', async () => {
-      const organisation = organisationFactory.build({ id: referableCourseOffering.organisationId })
-      organisationService.getOrganisation.mockResolvedValue(organisation)
+      const organisation: Organisation = { code: referableCourseOffering.organisationId, prisonName: 'HMP Test' }
+      organisationService.getOrganisationFromAcp.mockResolvedValue(organisation)
 
       const requestHandler = controller.start()
       await requestHandler(request, response, next)
@@ -237,7 +237,7 @@ describe('NewReferralsController', () => {
   })
 
   describe('show', () => {
-    const organisation = organisationFactory.build({ id: referableCourseOffering.organisationId })
+    const organisation: Organisation = { code: referableCourseOffering.organisationId, prisonName: 'HMP Test' }
 
     beforeEach(() => {
       request.params.referralId = referralId
@@ -245,7 +245,7 @@ describe('NewReferralsController', () => {
     })
 
     it('renders the referral task list page', async () => {
-      organisationService.getOrganisation.mockResolvedValue(organisation)
+      organisationService.getOrganisationFromAcp.mockResolvedValue(organisation)
 
       personService.getPerson.mockResolvedValue(person)
       referralService.getReferral.mockResolvedValue(draftReferral)
@@ -275,7 +275,7 @@ describe('NewReferralsController', () => {
 
     describe('when the referral has been requested with an `updatePerson` query', () => {
       it('calls `referralService.getReferral` with the same value', async () => {
-        organisationService.getOrganisation.mockResolvedValue(organisation)
+        organisationService.getOrganisationFromAcp.mockResolvedValue(organisation)
 
         personService.getPerson.mockResolvedValue(person)
         referralService.getReferral.mockResolvedValue(draftReferral)
@@ -383,7 +383,7 @@ describe('NewReferralsController', () => {
     const coursePresenter = createMock<CoursePresenter>({
       audience: audienceFactory.build().name,
     })
-    const organisation = organisationFactory.build({ id: referableCourseOffering.organisationId })
+    const organisation: Organisation = { code: referableCourseOffering.organisationId, prisonName: 'HMP Test' }
     const participationsForReferral = courseParticipationFactory.buildList(2, { isDraft: true })
     const summaryListOptions: Array<GovukFrontendSummaryListWithRowsWithKeysAndValues> = [
       {
@@ -409,7 +409,7 @@ describe('NewReferralsController', () => {
 
       TypeUtils.assertHasUser(request)
 
-      organisationService.getOrganisation.mockResolvedValue(organisation)
+      organisationService.getOrganisationFromAcp.mockResolvedValue(organisation)
 
       courseService.getCourse.mockResolvedValue(course)
       ;(CourseUtils.presentCourse as jest.Mock).mockReturnValue(coursePresenter)

--- a/server/controllers/refer/new/referralsController.ts
+++ b/server/controllers/refer/new/referralsController.ts
@@ -45,7 +45,7 @@ export default class NewReferralsController {
       ])
 
       const [organisation, participationsForReferral] = await Promise.all([
-        this.organisationService.getOrganisation(req.user.token, courseOffering.organisationId),
+        this.organisationService.getOrganisationFromAcp(req.user.username, courseOffering.organisationId),
         this.courseService.getParticipationsByReferral(req.user.username, referralId),
       ])
 
@@ -168,7 +168,10 @@ export default class NewReferralsController {
         this.courseService.getOffering(req.user.username, referral.offeringId),
         this.personService.getPerson(req.user.username, referral.prisonNumber),
       ])
-      const organisation = await this.organisationService.getOrganisation(req.user.token, courseOffering.organisationId)
+      const organisation = await this.organisationService.getOrganisationFromAcp(
+        req.user.username,
+        courseOffering.organisationId,
+      )
       const coursePresenter = CourseUtils.presentCourse(course)
 
       delete req.session.returnTo
@@ -230,7 +233,10 @@ export default class NewReferralsController {
         this.courseService.getCourseByOffering(req.user.username, req.params.courseOfferingId),
         this.courseService.getOffering(req.user.username, req.params.courseOfferingId),
       ])
-      const organisation = await this.organisationService.getOrganisation(req.user.token, courseOffering.organisationId)
+      const organisation = await this.organisationService.getOrganisationFromAcp(
+        req.user.token,
+        courseOffering.organisationId,
+      )
       const coursePresenter = CourseUtils.presentCourse(course)
 
       return res.render('referrals/new/start', {

--- a/server/controllers/shared/referralsController.test.ts
+++ b/server/controllers/shared/referralsController.test.ts
@@ -12,7 +12,6 @@ import {
   courseOfferingFactory,
   courseParticipationFactory,
   offenceDetailsFactory,
-  organisationFactory,
   personFactory,
   referralFactory,
   referralStatusRefDataFactory,
@@ -31,7 +30,7 @@ import {
 } from '../../utils'
 import type { Person, ReferralStatusRefData } from '@accredited-programmes/models'
 import type { GovukFrontendSummaryListRowWithKeyAndValue, ReferralSharedPageData } from '@accredited-programmes/ui'
-import type { Referral } from '@accredited-programmes-api'
+import type { Organisation, Referral } from '@accredited-programmes-api'
 import type { GovukFrontendSummaryList, GovukFrontendTable } from '@govuk-frontend'
 import type { User } from '@manage-users-api'
 
@@ -59,8 +58,8 @@ describe('ReferralsController', () => {
 
   const course = courseFactory.build()
   const coursePresenter = CourseUtils.presentCourse(course)
-  const organisation = organisationFactory.build()
-  const courseOffering = courseOfferingFactory.build({ organisationId: organisation.id })
+  const organisation: Organisation = { code: 'WTI', gender: 'Male', prisonName: 'Whatton' }
+  const courseOffering = courseOfferingFactory.build({ organisationId: organisation.code })
   const navigationItems = [{ active: true, href: 'nav-href', text: 'Nav Item' }]
   const subNavigationItems = [{ active: true, href: 'sub-nav-href', text: 'Sub Nav Item' }]
   const buttons = [{ href: 'button-href', text: 'Button' }]
@@ -106,7 +105,7 @@ describe('ReferralsController', () => {
         person.name,
         coursePresenter,
         referrerEmail,
-        organisation.name,
+        organisation.prisonName!,
       ),
       hideTitleServiceName: true,
       navigationItems,
@@ -127,7 +126,7 @@ describe('ReferralsController', () => {
 
     courseService.getCourseByOffering.mockResolvedValue(course)
     courseService.getOffering.mockResolvedValue(courseOffering)
-    organisationService.getOrganisation.mockResolvedValue(organisation)
+    organisationService.getOrganisationFromAcp.mockResolvedValue(organisation)
     personService.getPerson.mockResolvedValue(person)
     when(referralService.getReferral).calledWith(username, referral.id, expect.any(Object)).mockResolvedValue(referral)
     when(referralService.getReferral).calledWith(username, originalReferral.id).mockResolvedValue(originalReferral)
@@ -300,7 +299,7 @@ describe('ReferralsController', () => {
         .mockResolvedValue([
           {
             course: courseFactory.build({ audience: 'General offence', name: 'Becoming New Me Plus' }),
-            organisation: organisationFactory.build({ name: 'Whatton' }),
+            organisation: { code: 'WTI', prisonName: 'Whatton' },
             referral,
             status: referralStatusRefDataFactory.build({ colour: 'blue', description: 'Referral started' }),
             user: userFactory.build({ name: 'Joe Bloggs' }),
@@ -350,7 +349,7 @@ describe('ReferralsController', () => {
         },
         pageHeading: 'Duplicate referral found',
         pageTitleOverride: 'Duplicate referral found',
-        summaryText: `A referral already exists for ${sharedPageData.person.name} to ${sharedPageData.course.displayName} at ${sharedPageData.organisation.name}.`,
+        summaryText: `A referral already exists for ${sharedPageData.person.name} to ${sharedPageData.course.displayName} at ${sharedPageData.organisation.prisonName}.`,
       })
     })
 
@@ -636,7 +635,7 @@ describe('ReferralsController', () => {
     expect(courseService.getCourseByOffering).toHaveBeenCalledWith(username, referral.offeringId)
     expect(courseService.getOffering).toHaveBeenCalledWith(username, referral.offeringId)
     expect(personService.getPerson).toHaveBeenCalledWith(username, person.prisonNumber)
-    expect(organisationService.getOrganisation).toHaveBeenCalledWith(userToken, organisation.id)
+    expect(organisationService.getOrganisationFromAcp).toHaveBeenCalledWith(username, organisation.code)
     expect(mockShowReferralUtils.buttons).toHaveBeenCalledWith(
       { currentPath: path, recentCaseListPath },
       referral,

--- a/server/controllers/shared/referralsController.ts
+++ b/server/controllers/shared/referralsController.ts
@@ -91,7 +91,7 @@ export default class ReferralsController {
         },
         pageHeading: 'Duplicate referral found',
         pageTitleOverride: 'Duplicate referral found',
-        summaryText: `A referral already exists for ${sharedPageData.person.name} to ${sharedPageData.course.displayName} at ${sharedPageData.organisation.name}.`,
+        summaryText: `A referral already exists for ${sharedPageData.person.name} to ${sharedPageData.course.displayName} at ${sharedPageData.organisation.prisonName}.`,
         withdrawButtonText,
       })
     }
@@ -139,7 +139,7 @@ export default class ReferralsController {
         tableRows: otherReferrals.map(({ referral: otherReferral, course, organisation, user, status }) => [
           { text: course.name },
           { text: course.audience },
-          { text: organisation.name },
+          { text: organisation.prisonName },
           { text: user.name },
           {
             attributes: {
@@ -288,7 +288,7 @@ export default class ReferralsController {
         isRefer ? this.referralService.getStatusTransitions(username, referral.id) : undefined,
       ])
 
-    const organisation = await this.organisationService.getOrganisation(userToken, courseOffering.organisationId)
+    const organisation = await this.organisationService.getOrganisationFromAcp(username, courseOffering.organisationId)
 
     const coursePresenter = CourseUtils.presentCourse(course)
 
@@ -309,7 +309,7 @@ export default class ReferralsController {
         person.name,
         coursePresenter,
         courseOffering.contactEmail,
-        organisation.name,
+        organisation.prisonName,
       ),
       hideTitleServiceName: true,
       navigationItems: ShowReferralUtils.viewReferralNavigationItems(req.path, referral.id),

--- a/server/services/referralService.test.ts
+++ b/server/services/referralService.test.ts
@@ -14,7 +14,6 @@ import {
   confirmationFieldsFactory,
   courseFactory,
   courseOfferingFactory,
-  organisationFactory,
   pniScoreFactory,
   referralFactory,
   referralStatusHistoryFactory,
@@ -23,7 +22,7 @@ import {
   userFactory,
 } from '../testutils/factories'
 import type { ReferralStatus, ReferralStatusGroup, ReferralStatusUpdate } from '@accredited-programmes/models'
-import type { ReferralUpdate, TransferReferralRequest } from '@accredited-programmes-api'
+import type { Organisation, ReferralUpdate, TransferReferralRequest } from '@accredited-programmes-api'
 
 jest.mock('../data/accreditedProgrammesApi/referralClient')
 jest.mock('../data/hmppsAuthClient')
@@ -246,16 +245,16 @@ describe('ReferralService', () => {
       const expectedResponse = otherReferrals.map(otherReferral => {
         const user = userFactory.build({ username: otherReferral.referrerUsername })
         const status = referralStatusRefDataFactory.build()
-        const organisation = organisationFactory.build()
+        const organisation: Organisation = { code: 'WTI', prisonName: 'WTI' }
         const offering = courseOfferingFactory.build({
           id: otherReferral.offeringId,
-          organisationId: organisation.id,
+          organisationId: organisation.code,
         })
         const course = courseFactory.build({ courseOfferings: [offering] })
 
         when(courseService.getOffering).calledWith(username, otherReferral.offeringId).mockResolvedValue(offering)
         when(courseService.getCourseByOffering).calledWith(username, otherReferral.offeringId).mockResolvedValue(course)
-        when(organisationService.getOrganisation)
+        when(organisationService.getOrganisationFromAcp)
           .calledWith(username, offering.organisationId)
           .mockResolvedValue(organisation)
         when(referenceDataService.getReferralStatusCodeData)

--- a/server/services/referralService.ts
+++ b/server/services/referralService.ts
@@ -7,7 +7,6 @@ import logger from '../../logger'
 import type { HmppsAuthClient, ReferralClient, RestClientBuilder, RestClientBuilderWithoutToken } from '../data'
 import type {
   ConfirmationFields,
-  Organisation,
   Paginated,
   ReferralStatus,
   ReferralStatusGroup,
@@ -17,7 +16,14 @@ import type {
   ReferralView,
 } from '@accredited-programmes/models'
 import type { ReferralStatusHistoryPresenter } from '@accredited-programmes/ui'
-import type { Course, PniScore, Referral, ReferralUpdate, TransferReferralRequest } from '@accredited-programmes-api'
+import type {
+  Course,
+  Organisation,
+  PniScore,
+  Referral,
+  ReferralUpdate,
+  TransferReferralRequest,
+} from '@accredited-programmes-api'
 import type { User } from '@manage-users-api'
 
 export default class ReferralService {
@@ -127,7 +133,7 @@ export default class ReferralService {
         const offering = await this.courseService.getOffering(user.username, referral.offeringId)
         return {
           course: await this.courseService.getCourseByOffering(user.username, referral.offeringId),
-          organisation: await this.organisationService.getOrganisation(user.token, offering.organisationId),
+          organisation: await this.organisationService.getOrganisationFromAcp(user.username, offering.organisationId),
           referral,
           status: await this.referenceDataService.getReferralStatusCodeData(
             user.username,
@@ -208,7 +214,7 @@ export default class ReferralService {
 
   async getReferralViews(
     username: Express.User['username'],
-    organisationId: Organisation['id'],
+    organisationId: string,
     query?: {
       audience?: string
       courseName?: string

--- a/server/utils/referrals/newReferralUtils.test.ts
+++ b/server/utils/referrals/newReferralUtils.test.ts
@@ -1,13 +1,8 @@
 import NewReferralUtils from './newReferralUtils'
-import {
-  courseFactory,
-  courseOfferingFactory,
-  organisationFactory,
-  personFactory,
-  referralFactory,
-} from '../../testutils/factories'
+import { courseFactory, courseOfferingFactory, personFactory, referralFactory } from '../../testutils/factories'
 import CourseUtils from '../courseUtils'
 import type { ReferralTaskListItem, ReferralTaskListSection } from '@accredited-programmes/ui'
+import type { Organisation } from '@accredited-programmes-api'
 
 describe('NewReferralUtils', () => {
   describe('courseOfferingSummaryListRows', () => {
@@ -19,7 +14,7 @@ describe('NewReferralUtils', () => {
       })
       const courseOffering = courseOfferingFactory.build({ contactEmail: 'nobody-hmp-what@digital.justice.gov.uk' })
       const coursePresenter = CourseUtils.presentCourse(course)
-      const organisation = organisationFactory.build({ name: 'HMP Hewell' })
+      const organisation: Organisation = { code: 'HEW', gender: 'Male', prisonName: 'HMP Hewell' }
       const person = personFactory.build({ name: 'Del Hatton' })
 
       expect(

--- a/server/utils/referrals/newReferralUtils.ts
+++ b/server/utils/referrals/newReferralUtils.ts
@@ -1,5 +1,5 @@
 import { referPaths } from '../../paths'
-import type { CourseOffering, Organisation, Person } from '@accredited-programmes/models'
+import type { CourseOffering, Person } from '@accredited-programmes/models'
 import type {
   CoursePresenter,
   GovukFrontendSummaryListRowWithKeyAndValue,
@@ -7,7 +7,7 @@ import type {
   ReferralTaskListStatusTag,
   ReferralTaskListStatusText,
 } from '@accredited-programmes/ui'
-import type { Referral } from '@accredited-programmes-api'
+import type { Organisation, Referral } from '@accredited-programmes-api'
 import type { User, UserEmail } from '@manage-users-api'
 
 export default class NewReferralUtils {
@@ -32,7 +32,7 @@ export default class NewReferralUtils {
       },
       {
         key: { text: 'Programme location' },
-        value: { text: organisation.name },
+        value: { text: organisation.prisonName },
       },
       {
         key: { text: 'Programme team email address' },

--- a/server/utils/referrals/showReferralUtils.ts
+++ b/server/utils/referrals/showReferralUtils.ts
@@ -6,7 +6,7 @@ import CourseUtils from '../courseUtils'
 import DateUtils from '../dateUtils'
 import PniUtils from '../risksAndNeeds/pniUtils'
 import StringUtils from '../stringUtils'
-import type { CourseOffering, Organisation, ReferralStatusRefData } from '@accredited-programmes/models'
+import type { CourseOffering, ReferralStatusRefData } from '@accredited-programmes/models'
 import type {
   CoursePresenter,
   GovukFrontendSummaryListRowWithKeyAndValue,
@@ -15,7 +15,7 @@ import type {
   MojTimelineItem,
   ReferralStatusHistoryPresenter,
 } from '@accredited-programmes/ui'
-import type { Course, PniScore, Referral } from '@accredited-programmes-api'
+import type { Course, Organisation, PniScore, Referral } from '@accredited-programmes-api'
 import type { GovukFrontendButton } from '@govuk-frontend'
 import type { User, UserEmail } from '@manage-users-api'
 
@@ -127,7 +127,7 @@ export default class ShowReferralUtils {
     applicantName: User['name'],
     coursePresenter: CoursePresenter,
     contactEmail: CourseOffering['contactEmail'],
-    organisationName: Organisation['name'],
+    organisationName: Organisation['prisonName'],
   ): Array<GovukFrontendSummaryListRowWithKeyAndValue> {
     return [
       {

--- a/server/views/referrals/new/_organisationAndCourse.njk
+++ b/server/views/referrals/new/_organisationAndCourse.njk
@@ -1,3 +1,3 @@
 <h2 class="govuk-heading-m" data-testid="organisation-and-course">
-  <span class="govuk-!-font-weight-regular">{{ organisation.name }} | </span>{{ course.displayName }}
+  <span class="govuk-!-font-weight-regular">{{ organisation.prisonName }} | </span>{{ course.displayName }}
 </h2>


### PR DESCRIPTION
## Context

Since we have added the `NAT` organisation to our database, we can no longer use the prison register API (which we shouldn't really have been doing anyway).


## Changes in this PR
This PR changes all the places we call prison register API to get the details for a single prison/organisation.  This will enable referrals to HSP which use the `NAT` organisation code to display correctly.

There is one page remaining where we still call prison register API for a single organisation, which is the course offering page.  This is because it contains the address information which is not yet returned from the AcP API endpoint.  [APG-925](https://dsdmoj.atlassian.net/browse/APG-925)

To do: Once the client and service methods have been used for prison register API, we should remove the `fromAcp` from the end of the method name and also change the organisation test factory to match the data shape expected from the AcP API `Organisation`.

[APG-925]: https://dsdmoj.atlassian.net/browse/APG-925?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ