### PR TITLE
(APG-910) Create HSP referral

### DIFF
--- a/server/@types/ui/index.d.ts
+++ b/server/@types/ui/index.d.ts
@@ -252,9 +252,9 @@ interface BuildingChoicesData {
 }
 
 interface HspReferralData {
-  selectedOffenceDetails: Array<SexualOffenceDetails['id']>
+  selectedOffences: Array<SexualOffenceDetails['id']>
   totalScore: number
-  reason?: string
+  eligibilityOverrideReason?: string
 }
 
 interface PniFindAndReferData {

--- a/server/controllers/find/coursesController.test.ts
+++ b/server/controllers/find/coursesController.test.ts
@@ -134,6 +134,7 @@ describe('CoursesController', () => {
           updateProgramme: findPaths.course.update.show({ courseId: course.id }),
         },
         isBuildingChoices: false,
+        isHsp: false,
         noOfferingsMessage,
         organisationsTableData: OrganisationUtils.organisationTableRows(
           organisationsWithOfferingIds.filter(
@@ -214,6 +215,7 @@ describe('CoursesController', () => {
             updateProgramme: findPaths.course.update.show({ courseId: course.id }),
           },
           isBuildingChoices: false,
+          isHsp: false,
           noOfferingsMessage,
           organisationsTableData: OrganisationUtils.organisationTableRows(
             organisationsWithOfferingIds.filter(

--- a/server/controllers/find/coursesController.ts
+++ b/server/controllers/find/coursesController.ts
@@ -80,6 +80,7 @@ export default class CoursesController {
           updateProgramme: findPaths.course.update.show({ courseId: course.id }),
         },
         isBuildingChoices: CourseUtils.isBuildingChoices(course.displayName),
+        isHsp: CourseUtils.isHsp(course.name),
         noOfferingsMessage: CourseUtils.noOfferingsMessage(course.name),
         organisationsTableData,
         pageHeading: coursePresenter.displayName,

--- a/server/controllers/find/personSearchController.test.ts
+++ b/server/controllers/find/personSearchController.test.ts
@@ -30,7 +30,7 @@ describe('PersonSearchController', () => {
     request = createMock<Request>({
       session: {
         hspReferralData: {
-          selectedOffenceDetails: ['ABC-123'],
+          selectedOffences: ['ABC-123'],
           totalScore: 1,
         },
         pniFindAndReferData: {

--- a/server/controllers/refer/new/referralsController.test.ts
+++ b/server/controllers/refer/new/referralsController.test.ts
@@ -170,7 +170,39 @@ describe('NewReferralsController', () => {
         username,
         draftReferral.offeringId,
         draftReferral.prisonNumber,
+        undefined,
       )
+    })
+
+    describe('when there is hspReferralData in the session', () => {
+      it('asks the service to create a referral with the hspReferralData from the session', async () => {
+        const hspReferralData = {
+          eligibilityOverrideReason: 'A valid reason',
+          selectedOffences: ['ABC-123'],
+        }
+        request.body.courseOfferingId = draftReferral.offeringId
+        request.body.prisonNumber = draftReferral.prisonNumber
+        request.session.hspReferralData = {
+          ...hspReferralData,
+          totalScore: 1,
+        }
+
+        courseService.getOffering.mockResolvedValue(referableCourseOffering)
+
+        TypeUtils.assertHasUser(request)
+
+        referralService.createReferral.mockResolvedValue(referralFactory.started().build({ id: referralId }))
+
+        const requestHandler = controller.create()
+        await requestHandler(request, response, next)
+
+        expect(referralService.createReferral).toHaveBeenCalledWith(
+          username,
+          draftReferral.offeringId,
+          draftReferral.prisonNumber,
+          hspReferralData,
+        )
+      })
     })
 
     describe('when the course offering is not referable', () => {

--- a/server/controllers/refer/new/referralsController.ts
+++ b/server/controllers/refer/new/referralsController.ts
@@ -116,6 +116,7 @@ export default class NewReferralsController {
 
       const { courseOfferingId, prisonNumber } = req.body
       const { username } = req.user
+      const { hspReferralData } = req.session
 
       const courseOffering = await this.courseService.getOffering(req.user.username, courseOfferingId)
       if (!courseOffering.referable) {
@@ -127,6 +128,12 @@ export default class NewReferralsController {
           username,
           courseOfferingId,
           prisonNumber,
+          hspReferralData
+            ? {
+                eligibilityOverrideReason: hspReferralData.eligibilityOverrideReason,
+                selectedOffences: hspReferralData.selectedOffences,
+              }
+            : undefined,
         )
 
         return res.redirect(referPaths.new.show({ referralId: createReferralResponse.id }))

--- a/server/data/accreditedProgrammesApi/referralClient.ts
+++ b/server/data/accreditedProgrammesApi/referralClient.ts
@@ -14,6 +14,7 @@ import type {
   ReferralView,
 } from '@accredited-programmes/models'
 import type {
+  HspReferralCreate,
   Referral,
   ReferralStatusHistory,
   ReferralUpdate,
@@ -32,6 +33,13 @@ export default class ReferralClient {
     return (await this.restClient.post({
       data: { offeringId: courseOfferingId, prisonNumber },
       path: apiPaths.referrals.create({}),
+    })) as Referral
+  }
+
+  async createHspReferral(createHspBody: HspReferralCreate): Promise<Referral> {
+    return (await this.restClient.post({
+      data: { ...createHspBody },
+      path: apiPaths.referrals.createHsp({}),
     })) as Referral
   }
 

--- a/server/paths/api.ts
+++ b/server/paths/api.ts
@@ -112,6 +112,7 @@ export default {
   referrals: {
     confirmationText: confirmationTextPath,
     create: referralsPath,
+    createHsp: path('/referral/hsp'),
     dashboard: dashboardPath,
     delete: referralPath,
     duplicates: referralsPath.path('duplicates'),

--- a/server/services/courseService.test.ts
+++ b/server/services/courseService.test.ts
@@ -377,6 +377,19 @@ describe('CourseService', () => {
     })
   })
 
+  describe('getNationalOffering', () => {
+    it('returns the offering with the `NAT` organisation ID', async () => {
+      const nationalOffering = courseOfferingFactory.build({ organisationId: 'NAT' })
+      jest
+        .spyOn(service, 'getOfferingsByCourse')
+        .mockResolvedValue([courseOfferingFactory.build({ organisationId: 'MDI' }), nationalOffering])
+
+      const result = await service.getNationalOffering(username, 'courseId')
+
+      expect(result).toEqual(nationalOffering)
+    })
+  })
+
   describe('getOffering', () => {
     it('returns a given offering', async () => {
       const courseOffering = courseOfferingFactory.build()

--- a/server/services/courseService.ts
+++ b/server/services/courseService.ts
@@ -184,6 +184,15 @@ export default class CourseService {
     return courseClient.findCoursesByOrganisation(organisationId)
   }
 
+  async getNationalOffering(
+    username: Express.User['username'],
+    courseId: Course['id'],
+  ): Promise<CourseOffering | undefined> {
+    const offeringsForCourse = await this.getOfferingsByCourse(username, courseId)
+
+    return offeringsForCourse.find(offering => offering.organisationId === 'NAT')
+  }
+
   async getOffering(
     username: Express.User['username'],
     courseOfferingId: CourseOffering['id'],

--- a/server/services/referralService.test.ts
+++ b/server/services/referralService.test.ts
@@ -80,6 +80,34 @@ describe('ReferralService', () => {
       expect(referralClientBuilder).toHaveBeenCalledWith(systemToken)
       expect(referralClient.create).toHaveBeenCalledWith(referral.offeringId, referral.prisonNumber)
     })
+
+    describe('when there is `hspReferralData`', () => {
+      it('calls the referral client createHspReferral method with the hspReferralData', async () => {
+        const referral = referralFactory.started().build()
+        const hspReferralData = {
+          eligibilityOverrideReason: 'A valid reason',
+          selectedOffences: ['ABC-123'],
+        }
+
+        when(referralClient.createHspReferral)
+          .calledWith({ offeringId: referral.offeringId, prisonNumber: referral.prisonNumber, ...hspReferralData })
+          .mockResolvedValue(referral)
+
+        const result = await service.createReferral(
+          username,
+          referral.offeringId,
+          referral.prisonNumber,
+          hspReferralData,
+        )
+
+        expect(result).toEqual(referral)
+
+        expect(hmppsAuthClientBuilder).toHaveBeenCalled()
+        expect(hmppsAuthClient.getSystemClientToken).toHaveBeenCalledWith(username)
+
+        expect(referralClientBuilder).toHaveBeenCalledWith(systemToken)
+      })
+    })
   })
 
   describe('deleteReferral', () => {

--- a/server/services/referralService.ts
+++ b/server/services/referralService.ts
@@ -18,6 +18,7 @@ import type {
 import type { ReferralStatusHistoryPresenter } from '@accredited-programmes/ui'
 import type {
   Course,
+  HspReferralCreate,
   Organisation,
   PniScore,
   Referral,
@@ -41,10 +42,22 @@ export default class ReferralService {
     username: Express.User['username'],
     courseOfferingId: Referral['offeringId'],
     prisonNumber: Referral['prisonNumber'],
+    hspReferralData?: {
+      selectedOffences: HspReferralCreate['selectedOffences']
+      eligibilityOverrideReason?: HspReferralCreate['eligibilityOverrideReason']
+    },
   ): Promise<Referral> {
     const hmppsAuthClient = this.hmppsAuthClientBuilder()
     const systemToken = await hmppsAuthClient.getSystemClientToken(username)
     const referralClient = this.referralClientBuilder(systemToken)
+
+    if (hspReferralData) {
+      return referralClient.createHspReferral({
+        offeringId: courseOfferingId,
+        prisonNumber,
+        ...hspReferralData,
+      })
+    }
 
     return referralClient.create(courseOfferingId, prisonNumber)
   }

--- a/server/views/courses/show.njk
+++ b/server/views/courses/show.njk
@@ -60,7 +60,7 @@
         {% endif %}
       </div>
 
-      {% if organisationsTableData | length %}
+      {% if not isHsp and organisationsTableData.length > 0 %}
         <p data-testid="offerings-text">Select a prison to contact the programme team or make a referral.</p>
 
         {{ locationsTable({locations: organisationsTableData}) }}


### PR DESCRIPTION
## Context

When raising a referral to HSP, we need to call the POST /referral/hsp endpoint with the data collected in the two new HSP related form pages.
