### PR TITLE
APG-907 Create HSP details page

### DIFF
--- a/integration_tests/e2e/refer/show.cy.ts
+++ b/integration_tests/e2e/refer/show.cy.ts
@@ -70,6 +70,12 @@ context('Viewing a submitted referral', () => {
         })
       })
     })
+
+    describe('When reviewing hsp referral details', () => {
+      it('shows the hsp details page', () => {
+        sharedTests.referrals.showsHspDetailsPage(ApplicationRoles.ACP_REFERRER)
+      })
+    })
   })
 
   context('And reviewing risks and needs', () => {

--- a/integration_tests/mockApis/referrals.ts
+++ b/integration_tests/mockApis/referrals.ts
@@ -11,6 +11,7 @@ import type {
 } from '@accredited-programmes/models'
 import type {
   CourseOffering,
+  HspReferralDetails,
   PeopleSearchResponse,
   Referral,
   ReferralStatusHistory,
@@ -181,6 +182,22 @@ export default {
       },
     })
   },
+
+  stubHspReferralDetails: (args: {
+    hspReferralDetails: HspReferralDetails
+    referralId: Referral['id']
+  }): SuperAgentRequest =>
+    stubFor({
+      request: {
+        method: 'GET',
+        url: apiPaths.referrals.hspDetails({ referralId: args.referralId }),
+      },
+      response: {
+        headers: { 'Content-Type': 'application/json;charset=UTF-8' },
+        jsonBody: args.hspReferralDetails,
+        status: 200,
+      },
+    }),
 
   stubReferral: (referral: Referral): SuperAgentRequest =>
     stubFor({

--- a/integration_tests/pages/shared/showReferral/hspReferralDetailsPage.ts
+++ b/integration_tests/pages/shared/showReferral/hspReferralDetailsPage.ts
@@ -1,0 +1,39 @@
+import { CourseUtils } from '../../../../server/utils'
+import Page from '../../page'
+import type { Person } from '@accredited-programmes/models'
+import type { GovukFrontendSummaryListRowWithKeyAndValue } from '@accredited-programmes/ui'
+import type { Course } from '@accredited-programmes-api'
+
+export default class HspReferralDetailsPage extends Page {
+  person: Person
+
+  constructor(args: { course: Course; person: Person }) {
+    const { course, person } = args
+    const coursePresenter = CourseUtils.presentCourse(course)
+
+    super(`Referral to ${coursePresenter.displayName}`, {
+      hideTitleServiceName: true,
+      pageTitleOverride: `Referral details for referral to ${coursePresenter.displayName}`,
+    })
+
+    this.person = person
+  }
+
+  shouldContainMinorsSummaryList(listRows: Array<GovukFrontendSummaryListRowWithKeyAndValue>): void {
+    cy.get('[data-testid="offence-against-minors-summary-list"]').then(summaryListElement => {
+      this.shouldContainSummaryListRows(listRows, summaryListElement)
+    })
+  }
+
+  shouldContainOtherSummarySummaryList(listRows: Array<GovukFrontendSummaryListRowWithKeyAndValue>): void {
+    cy.get('[data-testid="offence-other-summary-list"]').then(summaryListElement => {
+      this.shouldContainSummaryListRows(listRows, summaryListElement)
+    })
+  }
+
+  shouldContainViolenceForceSummaryList(listRows: Array<GovukFrontendSummaryListRowWithKeyAndValue>): void {
+    cy.get('[data-testid="offence-violence-force-summary-list"]').then(summaryListElement => {
+      this.shouldContainSummaryListRows(listRows, summaryListElement)
+    })
+  }
+}

--- a/integration_tests/pages/shared/showReferral/hspReferralDetailsPage.ts
+++ b/integration_tests/pages/shared/showReferral/hspReferralDetailsPage.ts
@@ -19,6 +19,12 @@ export default class HspReferralDetailsPage extends Page {
     this.person = person
   }
 
+  shouldContainEligibilityOverrideSummaryCard(): void {
+    cy.get('[data-testid="eligibility-override-summary-card"]').then(summaryCardElement => {
+      this.shouldContainKeylessSummaryCard('Reason for referring this person to HSP', 'Eligible', summaryCardElement)
+    })
+  }
+
   shouldContainMinorsSummaryList(listRows: Array<GovukFrontendSummaryListRowWithKeyAndValue>): void {
     cy.get('[data-testid="offence-against-minors-summary-list"]').then(summaryListElement => {
       this.shouldContainSummaryListRows(listRows, summaryListElement)

--- a/integration_tests/support/sharedTests.ts
+++ b/integration_tests/support/sharedTests.ts
@@ -8,6 +8,7 @@ import {
   courseParticipationFactory,
   drugAlcoholDetailFactory,
   healthFactory,
+  hspReferralDetailsFactory,
   inmateDetailFactory,
   learningNeedsFactory,
   lifestyleFactory,
@@ -29,6 +30,7 @@ import {
 } from '../../server/testutils/factories'
 import { CourseUtils } from '../../server/utils'
 import { releaseDateFields } from '../../server/utils/personUtils'
+import SexualOffenceDetailsUtils from '../../server/utils/sexualOffenceDetailsUtils'
 import auth from '../mockApis/auth'
 import BadRequestPage from '../pages/badRequest'
 import Page from '../pages/page'
@@ -52,6 +54,7 @@ import {
   StatusHistoryPage,
   ThinkingAndBehavingPage,
 } from '../pages/shared'
+import HspReferralDetailsPage from '../pages/shared/showReferral/hspReferralDetailsPage'
 import EmotionalWellbeing from '../pages/shared/showReferral/risksAndNeeds/emotionalWellbeing'
 import type { Person, ReferralStatusRefData, SentenceDetails } from '@accredited-programmes/models'
 import type { ReferralStatusHistoryPresenter } from '@accredited-programmes/ui'
@@ -370,6 +373,36 @@ const sharedTests = {
 
       const badRequestPage = Page.verifyOnPage(BadRequestPage, { errorMessage: 'Referral has not been submitted.' })
       badRequestPage.shouldContain400Heading()
+    },
+
+    showsHspDetailsPage: (role: ApplicationRole): void => {
+      sharedTests.referrals.beforeEach(role)
+
+      const hspReferralDetails = hspReferralDetailsFactory.build()
+      cy.task('stubHspReferralDetails', {
+        hspReferralDetails,
+        referralId: referral.id,
+      })
+
+      const path = pathsByRole(role).show.hspDetails({ referralId: referral.id })
+      cy.visit(path)
+
+      const offenceAgainstMinorsSummaryListRows = SexualOffenceDetailsUtils.offenceSummaryListRows(
+        hspReferralDetails.selectedOffences.filter(detail => detail.categoryCode === 'AGAINST_MINORS'),
+      )
+      const offenceViolenceForceSummaryListRows = SexualOffenceDetailsUtils.offenceSummaryListRows(
+        hspReferralDetails.selectedOffences.filter(
+          detail => detail.categoryCode === 'INCLUDES_VIOLENCE_FORCE_HUMILIATION',
+        ),
+      )
+      const offenceOtherSummaryListRows = SexualOffenceDetailsUtils.offenceSummaryListRows(
+        hspReferralDetails.selectedOffences.filter(detail => detail.categoryCode === 'OTHER'),
+      )
+
+      const hspReferralDetailsPage = Page.verifyOnPage(HspReferralDetailsPage, { course, person })
+      hspReferralDetailsPage.shouldContainMinorsSummaryList(offenceAgainstMinorsSummaryListRows)
+      hspReferralDetailsPage.shouldContainViolenceForceSummaryList(offenceViolenceForceSummaryListRows)
+      hspReferralDetailsPage.shouldContainOtherSummarySummaryList(offenceOtherSummaryListRows)
     },
 
     showsOffenceHistoryPage: (role: ApplicationRole): void => {

--- a/integration_tests/support/sharedTests.ts
+++ b/integration_tests/support/sharedTests.ts
@@ -378,7 +378,7 @@ const sharedTests = {
     showsHspDetailsPage: (role: ApplicationRole): void => {
       sharedTests.referrals.beforeEach(role)
 
-      const hspReferralDetails = hspReferralDetailsFactory.build()
+      const hspReferralDetails = hspReferralDetailsFactory.build({ eligibilityOverrideReason: 'Eligible' })
       cy.task('stubHspReferralDetails', {
         hspReferralDetails,
         referralId: referral.id,
@@ -400,6 +400,7 @@ const sharedTests = {
       )
 
       const hspReferralDetailsPage = Page.verifyOnPage(HspReferralDetailsPage, { course, person })
+      hspReferralDetailsPage.shouldContainEligibilityOverrideSummaryCard()
       hspReferralDetailsPage.shouldContainMinorsSummaryList(offenceAgainstMinorsSummaryListRows)
       hspReferralDetailsPage.shouldContainViolenceForceSummaryList(offenceViolenceForceSummaryListRows)
       hspReferralDetailsPage.shouldContainOtherSummarySummaryList(offenceOtherSummaryListRows)

--- a/server/@types/accreditedProgrammesApi/index.d.ts
+++ b/server/@types/accreditedProgrammesApi/index.d.ts
@@ -351,7 +351,7 @@ export interface ReferralEntity {
   hasReviewedProgrammeHistory: boolean;
   hasReviewedAdditionalInformation?: boolean;
   status: string;
-  /** @example "2025-05-28T14:00:45" */
+  /** @example "2025-06-01T18:47:24" */
   submittedOn?: object;
   deleted: boolean;
   primaryPomStaffId?: number;

--- a/server/controllers/shared/referralsController.test.ts
+++ b/server/controllers/shared/referralsController.test.ts
@@ -11,6 +11,7 @@ import {
   courseFactory,
   courseOfferingFactory,
   courseParticipationFactory,
+  hspReferralDetailsFactory,
   offenceDetailsFactory,
   personFactory,
   referralFactory,
@@ -38,6 +39,7 @@ jest.mock('../../utils/courseParticipationUtils')
 jest.mock('../../utils/personUtils')
 jest.mock('../../utils/sentenceInformationUtils')
 jest.mock('../../utils/referrals/showReferralUtils')
+jest.mock('../../utils/sexualOffenceDetailsUtils')
 
 const mockPersonUtils = PersonUtils as jest.Mocked<typeof PersonUtils>
 const mockShowReferralUtils = ShowReferralUtils as jest.Mocked<typeof ShowReferralUtils>
@@ -583,6 +585,32 @@ describe('ReferralsController', () => {
     })
   })
 
+  describe('hspDetails', () => {
+    beforeAll(() => {
+      response = Helpers.createMockResponseWithCaseloads()
+    })
+
+    it('Renders a response', async () => {
+      // Given
+      request.path = 'hsp-details'
+      const hspReferral = hspReferralDetailsFactory.build()
+      referralService.getHspReferralDetails.mockResolvedValueOnce(hspReferral)
+
+      // When
+      const requestHandler = controller.hspDetails()
+      await requestHandler(request, response, next)
+
+      // Then
+      expect(response.render).toHaveBeenCalledTimes(1)
+      expect(response.render).toHaveBeenCalledWith(
+        'referrals/show/hspDetails',
+        expect.objectContaining({
+          ...sharedPageData,
+        }),
+      )
+    })
+  })
+
   describe('sentenceInformation', () => {
     const mockSentenceInformationUtils = SentenceInformationUtils as jest.Mocked<typeof SentenceInformationUtils>
 
@@ -641,7 +669,6 @@ describe('ReferralsController', () => {
       referral,
       isRefer ? statusTransitions : undefined,
     )
-    expect(mockShowReferralUtils.viewReferralNavigationItems).toHaveBeenCalledWith(path, referral.id)
     expect(mockShowReferralUtils.subNavigationItems).toHaveBeenCalledWith(path, 'referral', referral.id)
     expect(mockShowReferralUtils.buttonMenu).toHaveBeenCalledWith(course, referral, {
       currentPath: path,

--- a/server/controllers/shared/referralsController.ts
+++ b/server/controllers/shared/referralsController.ts
@@ -104,23 +104,21 @@ export default class ReferralsController {
 
       this.validateReferralStatus(referral)
 
-      const hspReferralDetails = await this.referralService.getHspReferralDetails(req.user.username, referral.id)
+      const hspDetails = await this.referralService.getHspReferralDetails(req.user.username, referral.id)
 
       const offenceAgainstMinorsSummaryListRows = SexualOffenceDetailsUtils.offenceSummaryListRows(
-        hspReferralDetails.selectedOffences.filter(detail => detail.categoryCode === 'AGAINST_MINORS'),
+        hspDetails.selectedOffences.filter(detail => detail.categoryCode === 'AGAINST_MINORS'),
       )
       const offenceViolenceForceSummaryListRows = SexualOffenceDetailsUtils.offenceSummaryListRows(
-        hspReferralDetails.selectedOffences.filter(
-          detail => detail.categoryCode === 'INCLUDES_VIOLENCE_FORCE_HUMILIATION',
-        ),
+        hspDetails.selectedOffences.filter(detail => detail.categoryCode === 'INCLUDES_VIOLENCE_FORCE_HUMILIATION'),
       )
       const offenceOtherSummaryListRows = SexualOffenceDetailsUtils.offenceSummaryListRows(
-        hspReferralDetails.selectedOffences.filter(detail => detail.categoryCode === 'OTHER'),
+        hspDetails.selectedOffences.filter(detail => detail.categoryCode === 'OTHER'),
       )
 
       return res.render('referrals/show/hspDetails', {
         ...sharedPageData,
-        eligibilityOverrideReason: hspReferralDetails.eligibilityOverrideReason,
+        eligibilityOverrideReason: hspDetails.eligibilityOverrideReason,
         offenceAgainstMinorsSummaryListRows,
         offenceOtherSummaryListRows,
         offenceViolenceForceSummaryListRows,

--- a/server/controllers/shared/referralsController.ts
+++ b/server/controllers/shared/referralsController.ts
@@ -120,6 +120,7 @@ export default class ReferralsController {
 
       return res.render('referrals/show/hspDetails', {
         ...sharedPageData,
+        eligibilityOverrideReason: hspReferralDetails.eligibilityOverrideReason,
         offenceAgainstMinorsSummaryListRows,
         offenceOtherSummaryListRows,
         offenceViolenceForceSummaryListRows,

--- a/server/paths/assess.ts
+++ b/server/paths/assess.ts
@@ -29,6 +29,7 @@ export default {
   show: {
     additionalInformation: referralShowPathBase.path('additional-information'),
     duplicate: referralShowPathBase.path('duplicate'),
+    hspDetails: referralShowPathBase.path('hsp-details'),
     offenceHistory: referralShowPathBase.path('offence-history'),
     otherReferrals: referralShowPathBase.path('other-referrals'),
     personalDetails: referralShowPathBase.path('personal-details'),

--- a/server/paths/refer.ts
+++ b/server/paths/refer.ts
@@ -77,6 +77,7 @@ export default {
   show: {
     additionalInformation: referralShowPathBase.path('additional-information'),
     duplicate: referralShowPathBase.path('duplicate'),
+    hspDetails: referralShowPathBase.path('hsp-details'),
     offenceHistory: referralShowPathBase.path('offence-history'),
     otherReferrals: referralShowPathBase.path('other-referrals'),
     personalDetails: referralShowPathBase.path('personal-details'),

--- a/server/routes/refer.ts
+++ b/server/routes/refer.ts
@@ -85,6 +85,7 @@ export default function routes(controllers: Controllers, router: Router): Router
   get(referPaths.show.programmeHistoryDetail.pattern, programmeHistoryDetailController.show())
   get(referPaths.show.releaseDates.pattern, referralsController.releaseDates())
   get(referPaths.show.sentenceInformation.pattern, referralsController.sentenceInformation())
+  get(referPaths.show.hspDetails.pattern, referralsController.hspDetails())
 
   get(referPaths.show.risksAndNeeds.alcoholMisuse.pattern, risksAndNeedsController.alcoholMisuse())
   get(referPaths.show.risksAndNeeds.attitudes.pattern, risksAndNeedsController.attitudes())

--- a/server/utils/referrals/showReferralUtils.test.ts
+++ b/server/utils/referrals/showReferralUtils.test.ts
@@ -790,10 +790,19 @@ describe('ShowReferralUtils', () => {
     const mockReferralId = 'mock-referral-id'
 
     describe('when viewing the referral on the refer journey', () => {
-      it('returns navigation items for the view referral pages with the refer paths and sets the requested page as active', () => {
-        const currentRequestPath = referPaths.show.personalDetails({ referralId: mockReferralId })
+      const currentRequestPath = referPaths.show.personalDetails({ referralId: mockReferralId })
 
-        expect(ShowReferralUtils.viewReferralNavigationItems(currentRequestPath, mockReferralId)).toEqual([
+      it('should add the HSP item when the course is a Healthy Sex Programme course', () => {
+        const items = ShowReferralUtils.viewReferralNavigationItems(currentRequestPath, mockReferralId, true)
+        expect(items).toContainEqual({
+          active: false,
+          href: '/refer/referrals/mock-referral-id/hsp-details#content',
+          text: 'HSP details',
+        })
+      })
+
+      it('returns navigation items for the view referral pages with the refer paths and sets the requested page as active', () => {
+        expect(ShowReferralUtils.viewReferralNavigationItems(currentRequestPath, mockReferralId, false)).toEqual([
           {
             active: true,
             href: `${referPaths.show.personalDetails({ referralId: mockReferralId })}#content`,
@@ -837,7 +846,7 @@ describe('ShowReferralUtils', () => {
       it('returns navigation items for the view referral pages with the assess paths and sets the requested page as active', () => {
         const currentRequestPath = assessPaths.show.personalDetails({ referralId: mockReferralId })
 
-        expect(ShowReferralUtils.viewReferralNavigationItems(currentRequestPath, mockReferralId)).toEqual([
+        expect(ShowReferralUtils.viewReferralNavigationItems(currentRequestPath, mockReferralId, false)).toEqual([
           {
             active: true,
             href: `${assessPaths.show.personalDetails({ referralId: mockReferralId })}#content`,

--- a/server/utils/referrals/showReferralUtils.ts
+++ b/server/utils/referrals/showReferralUtils.ts
@@ -308,6 +308,7 @@ export default class ShowReferralUtils {
   static viewReferralNavigationItems(
     currentPath: Request['path'],
     referralId: Referral['id'],
+    showHspItem?: boolean,
   ): Array<MojFrontendNavigationItem> {
     const paths = currentPath.startsWith(assessPathBase.pattern) ? assessPaths : referPaths
 
@@ -341,6 +342,12 @@ export default class ShowReferralUtils {
         text: 'Other referrals',
       },
     ]
+    if (showHspItem) {
+      navigationItems.push({
+        href: paths.show.hspDetails({ referralId }),
+        text: 'HSP details',
+      })
+    }
 
     return navigationItems.map(item => ({
       ...item,

--- a/server/views/referrals/show/hspDetails.njk
+++ b/server/views/referrals/show/hspDetails.njk
@@ -12,6 +12,10 @@
     }
   }) }}
 
+  {% if eligibilityOverrideReason %}
+    {{ keylessSummaryCard("Reason for referring this person to HSP", bodyHtml=eligibilityOverrideReason, testId="eligibility-override-summary-card") }}
+  {% endif %}
+
   {{ govukSummaryList({
     card: {
       title: {

--- a/server/views/referrals/show/hspDetails.njk
+++ b/server/views/referrals/show/hspDetails.njk
@@ -1,5 +1,6 @@
 {% from "govuk/components/inset-text/macro.njk" import govukInsetText %}
 {% from "govuk/components/summary-list/macro.njk" import govukSummaryList %}
+{% from "../../partials/keylessSummaryCard.njk" import keylessSummaryCard %}
 
 {% extends "./partials/referralLayout.njk" %}
 
@@ -12,8 +13,11 @@
     }
   }) }}
 
-  {% if eligibilityOverrideReason %}
-    {{ keylessSummaryCard("Reason for referring this person to HSP", bodyHtml=eligibilityOverrideReason, testId="eligibility-override-summary-card") }}
+  {% if eligibilityOverrideReason and eligibilityOverrideReason | trim | length %}
+    {{ keylessSummaryCard("Reason for referring this person to HSP",
+      bodyHtml=eligibilityOverrideReason,
+      testId="eligibility-override-summary-card")
+    }}
   {% endif %}
 
   {{ govukSummaryList({

--- a/server/views/referrals/show/hspDetails.njk
+++ b/server/views/referrals/show/hspDetails.njk
@@ -1,0 +1,53 @@
+{% from "govuk/components/inset-text/macro.njk" import govukInsetText %}
+{% from "govuk/components/summary-list/macro.njk" import govukSummaryList %}
+
+{% extends "./partials/referralLayout.njk" %}
+
+{% block primaryContent %}
+  {{ govukInsetText({
+    classes: "govuk-!-margin-top-0",
+    text: submittedText,
+    attributes: {
+      "data-testid": "submitted-text"
+    }
+  }) }}
+
+  {{ govukSummaryList({
+    card: {
+      title: {
+        headingLevel: 3,
+        text: "Offences against someone aged under 18"
+      }
+    },
+    rows: offenceAgainstMinorsSummaryListRows,
+    attributes: {
+      "data-testid": "offence-against-minors-summary-list"
+    }
+  }) }}
+
+  {{ govukSummaryList({
+    card: {
+      title: {
+        headingLevel: 3,
+        text: "Sexual offences that include violence, force or humiliation"
+      }
+    },
+    rows: offenceViolenceForceSummaryListRows,
+    attributes: {
+      "data-testid": "offence-violence-force-summary-list"
+    }
+  }) }}
+
+  {{ govukSummaryList({
+    card: {
+      title: {
+        headingLevel: 3,
+        text: "Other sexual offences"
+      }
+    },
+    rows: offenceOtherSummaryListRows,
+    attributes: {
+      "data-testid": "offence-other-summary-list"
+    }
+  }) }}
+{% endblock primaryContent %}


### PR DESCRIPTION
## Changes in this PR

- Added HSP details side nav bar link under Referral Details page
- Added new HSP details page to show selected sexual offence details held against a referral and the eligibility override reason if present
- Updated unit and integration tests for new UI components


