### PR TITLE
[APG-945] Add audience filter to HSP referrals

### DIFF
--- a/server/controllers/assess/caseListController.test.ts
+++ b/server/controllers/assess/caseListController.test.ts
@@ -557,7 +557,39 @@ describe('AssessCaseListController', () => {
         expect(request.session.recentCaseListPath).toBe(originalUrl)
         expect(response.render).toHaveBeenCalledWith('referrals/caseList/assess/show', {
           action: assessPaths.caseList.filter({ courseId: hspCourse.id, referralStatusGroup }),
-          audienceSelectItems: [],
+          audienceSelectItems: [
+            {
+              selected: false,
+              text: 'All offences',
+              value: 'all offences',
+            },
+            {
+              selected: false,
+              text: 'Extremism offence',
+              value: 'extremism offence',
+            },
+            {
+              selected: false,
+              text: 'General offence',
+              value: 'general offence',
+            },
+            { selected: false, text: 'Gang offence', value: 'gang offence' },
+            {
+              selected: false,
+              text: 'General violence offence',
+              value: 'general violence offence',
+            },
+            {
+              selected: false,
+              text: 'Intimate partner violence offence',
+              value: 'intimate partner violence offence',
+            },
+            {
+              selected: false,
+              text: 'Sexual offence',
+              value: 'sexual offence',
+            },
+          ],
           pageHeading: 'Healthy Sex Programme',
           pageTitleOverride: 'Manage open programme team referrals: Healthy Sex Programme',
           pagination,
@@ -592,7 +624,7 @@ describe('AssessCaseListController', () => {
           assessPaths.caseList.show({ courseId: hspCourse.id, referralStatusGroup }),
           queryParamsExcludingSort,
         )
-        expect(CaseListUtils.audienceSelectItems).toHaveBeenCalledWith(limeCourseAudiences, false, undefined)
+        expect(CaseListUtils.audienceSelectItems).toHaveBeenCalledWith(limeCourseAudiences, true, undefined)
         expect(CaseListUtils.sortableTableHeadings).toHaveBeenCalledWith(
           pathWithQuery,
           {

--- a/server/controllers/assess/caseListController.ts
+++ b/server/controllers/assess/caseListController.ts
@@ -152,16 +152,17 @@ export default class AssessCaseListController {
 
       req.session.recentCaseListPath = req.originalUrl
 
+      const hasLDCAudience = CourseUtils.isBuildingChoices(selectedCourse.displayName) || isHsp
       const audienceSelectItems = CaseListUtils.audienceSelectItems(
         courseAudiences,
-        CourseUtils.isBuildingChoices(selectedCourse.displayName),
+        hasLDCAudience,
         audience ? CourseUtils.encodeAudienceAndHasLdc(audience, hasLdcString) : undefined,
       )
 
       return res.render('referrals/caseList/assess/show', {
         action: assessPaths.caseList.filter({ courseId, referralStatusGroup }),
         /** INFO: This is more recently presented as 'Strands' in UI mock ups */
-        audienceSelectItems: isHsp ? [] : audienceSelectItems,
+        audienceSelectItems,
         ldcStatusChangedMessage: req.flash('ldcStatusChangedMessage')[0],
         nameOrId,
         pageHeading: selectedCourse.name,


### PR DESCRIPTION
## Context

<!-- Is there a Trello ticket you can link to? -->
<!-- Do you need to add any environment variables? -->
<!-- Is an ADR required? An ADR should be added if this PR introduces a change to the architecture. -->



## Changes in this PR



## Screenshots of UI changes

### Before


### After


## Release checklist

[Release process documentation](../blob/main/doc/how-to/perform-a-release.md)

As part of our continuous deployment strategy we must ensure that this work is
ready to be released once merged.

### Pre-merge

- [ ] There are changes required to the Accredited Programmes API for this change to work...
  - [ ] ... and they have been released to production already

### Post-merge

<!-- The outer checkboxes can be completed pre-merge -->

- [ ] This adds, extends or meaningfully modifies a feature...
  - [ ] ... and I have written or updated an end-to-end test for the happy path in the [Accredited Programmes E2E repo](https://github.com/ministryofjustice/hmpps-accredited-programmes-e2e)
- [ ] This makes new expectations of the API...
  - [ ] ... and I have notified the API developer(s) of changes to the contract tests (Pact), or the API is already compliant
- [ ] [Manually approve](../doc/how-to/perform-a-release.md#releasing-to-the-preprod-environment) release to preprod
- [ ] [Manually approve](../doc/how-to/perform-a-release.md#releasing-to-the-production-environment) release to prod

<!-- Should a release fail at any step, you as the author should now lead the work to
fix it as soon as possible. You can monitor deployment failures in CircleCI
itself and application errors are found in
[Sentry](https://ministryofjustice.sentry.io/projects/hmpps-accredited-programmes-ui/?project=4505330122686464&referrer=sidebar&statsPeriod=24h). -->
