### PR TITLE
Add Serious violent reoffending predictor to the OGRS4 version of the…

### DIFF
--- a/server/controllers/shared/risksAndNeedsController.test.ts
+++ b/server/controllers/shared/risksAndNeedsController.test.ts
@@ -855,6 +855,9 @@ describe('RisksAndNeedsController', () => {
             directContactSexualReoffendingScore: 15.2,
             indirectImageContactSexualReoffendingBand: 'Low',
             indirectImageContactSexualReoffendingScore: 5.8,
+            seriousViolentReoffendingBand: 'High',
+            seriousViolentReoffendingScore: 4.56,
+            seriousViolentReoffendingScoreType: 'Static',
             violentReoffendingBand: 'Medium',
             violentReoffendingScore: 38.7,
             violentReoffendingScoreType: 'Static',
@@ -982,6 +985,13 @@ describe('RisksAndNeedsController', () => {
           },
           saraOthersBox,
           saraPartnerBox,
+          seriousViolentReoffendingPredictor: {
+            completedDate: risksAndAlerts.lastUpdated,
+            level: 'HIGH',
+            score: 4.56,
+            staticOrDynamic: 'STATIC',
+            type: 'Serious violent reoffending predictor',
+          },
           subNavigationItems,
           updateWarning: {
             iconFallbackText: 'Warning',

--- a/server/controllers/shared/risksAndNeedsController.ts
+++ b/server/controllers/shared/risksAndNeedsController.ts
@@ -412,6 +412,13 @@ export default class RisksAndNeedsController {
             undefined,
             'sara-partner',
           ),
+          seriousViolentReoffendingPredictor: {
+            completedDate: risksAndAlerts.lastUpdated,
+            level: RisksAndAlertsUtils.levelOrUnknownStr(risksAndAlerts.ogrs4Risks?.seriousViolentReoffendingBand),
+            score: risksAndAlerts.ogrs4Risks?.seriousViolentReoffendingScore,
+            staticOrDynamic: risksAndAlerts.ogrs4Risks?.seriousViolentReoffendingScoreType?.toUpperCase(),
+            type: 'Serious violent reoffending predictor',
+          },
           updateWarning: {
             iconFallbackText: 'Warning',
             text: 'Risk predictor tools updated',

--- a/server/views/referrals/show/risksAndNeeds/ogrs4/predictor-scale/template.njk
+++ b/server/views/referrals/show/risksAndNeeds/ogrs4/predictor-scale/template.njk
@@ -85,13 +85,21 @@
 
     <div class="{{ barTypeClass }}">
       <div data-band-persentage-start="{{ predictorScore.bandPercentages[0] }}" data-band-persentage="{{ predictorScore.bandPercentages[1] }}">
+        <!--Please dont delete these empty spans they are needed!!-->
+        <span></span>
       </div>
       <div data-band-persentage="{{ predictorScore.bandPercentages[2] }}">
+        <!--Please dont delete these empty spans they are needed!!-->
+        <span></span>
       </div>
       <div data-band-persentage="{{ predictorScore.bandPercentages[3] }}">
+        <!--Please dont delete these empty spans they are needed!!-->
+        <span></span>
       </div>
       {% if includeVeryHigh === true %}
         <div data-band-persentage="{{ predictorScore.bandPercentages[4] }}">
+          <!--Please dont delete these empty spans they are needed!!-->
+          <span></span>
         </div>
       {% endif %}
     </div>

--- a/server/views/referrals/show/risksAndNeeds/risksAndAlertsOgrs4.njk
+++ b/server/views/referrals/show/risksAndNeeds/risksAndAlertsOgrs4.njk
@@ -57,6 +57,8 @@
 
       <h3 class="govuk-heading-m">Combined serious reoffending predictor</h3>
       {{ expandedPredictorBadge(combinedSeriousReoffendingPredictor, true, false) }}
+      <p>The combined serious reoffending predictor combines 3 scores:</p>
+      {{ expandedPredictorBadge(seriousViolentReoffendingPredictor, true, false) }}
       {{ expandedPredictorBadge(directContactSexualReoffendingPredictor, true, false) }}
       {{ expandedPredictorBadge(imagesAndIndirectContactSexualReoffendingPredictor, true, false) }}
       {{ roshWidget(roshRiskSummary) }}


### PR DESCRIPTION
Add Serious violent reoffending predictor to the OGRS4 version of the risks and needs page
Also a fix for the broken predictor scale (it was looking like this)

<img width="918" height="406" alt="Screenshot 2026-04-16 at 13 03 34" src="https://github.com/user-attachments/assets/7bc4caeb-3857-419e-bcb3-2b8196256e19" />


<img width="3456" height="7540" alt="image" src="https://github.com/user-attachments/assets/d033703c-1a3b-498b-9b74-69abe688d2cd" />
