### PR TITLE
Adding in Risk of serious harm heading

### DIFF
--- a/server/views/referrals/show/risksAndNeeds/risksAndAlertsOgrs4.njk
+++ b/server/views/referrals/show/risksAndNeeds/risksAndAlertsOgrs4.njk
@@ -61,6 +61,8 @@
       {{ expandedPredictorBadge(seriousViolentReoffendingPredictor, true, false) }}
       {{ expandedPredictorBadge(directContactSexualReoffendingPredictor, true, false) }}
       {{ expandedPredictorBadge(imagesAndIndirectContactSexualReoffendingPredictor, true, false) }}
+
+      <h2 class="govuk-heading-m">Risk of serious harm</h2>
       {{ roshWidget(roshRiskSummary) }}
       {{ govukInsetText(importedFromNdeliusText) }}
 


### PR DESCRIPTION
'Risk of serious harm' heading was missing on the OGRS4 risk page
<img width="935" height="668" alt="Screenshot 2026-04-22 at 16 28 34" src="https://github.com/user-attachments/assets/c2ec160a-e4b6-4b89-b98a-c48dcc64193b" />
