### PR TITLE
Update risk of serious recidivism terminology

### DIFF
--- a/integration_tests/pages/shared/showReferral/risksAndNeeds/risksAndAlerts.ts
+++ b/integration_tests/pages/shared/showReferral/risksAndNeeds/risksAndAlerts.ts
@@ -170,7 +170,7 @@ export default class RisksAndAlertsPage extends Page {
         this.risksAndAlerts.rsrScore?.toString(),
       )
 
-      cy.get('[data-testid="osp-c-box"]').then(ospcBoxElement => {
+      cy.get('[data-testid="osp-dc-box"]').then(ospcBoxElement => {
         const { actual, expected } = Helpers.parseHtml(
           ospcBoxElement,
           `${RisksAndAlertsUtils.levelText(RisksAndAlertsUtils.levelOrUnknown(this.risksAndAlerts.ospcScore))} OSP/C`,
@@ -178,7 +178,7 @@ export default class RisksAndAlertsPage extends Page {
         expect(actual).to.equal(expected)
       })
 
-      cy.get('[data-testid="osp-i-box"]').then(ospiBoxElement => {
+      cy.get('[data-testid="osp-iioc-box"]').then(ospiBoxElement => {
         const { actual, expected } = Helpers.parseHtml(
           ospiBoxElement,
           `${RisksAndAlertsUtils.levelText(RisksAndAlertsUtils.levelOrUnknown(this.risksAndAlerts.ospiScore))} OSP/I`,

--- a/integration_tests/pages/shared/showReferral/risksAndNeeds/risksAndAlerts.ts
+++ b/integration_tests/pages/shared/showReferral/risksAndNeeds/risksAndAlerts.ts
@@ -173,7 +173,7 @@ export default class RisksAndAlertsPage extends Page {
       cy.get('[data-testid="osp-dc-box"]').then(ospcBoxElement => {
         const { actual, expected } = Helpers.parseHtml(
           ospcBoxElement,
-          `${RisksAndAlertsUtils.levelText(RisksAndAlertsUtils.levelOrUnknown(this.risksAndAlerts.ospcScore))} OSP/C`,
+          `${RisksAndAlertsUtils.levelText(RisksAndAlertsUtils.levelOrUnknown(this.risksAndAlerts.ospcScore))} OSP/DC`,
         )
         expect(actual).to.equal(expected)
       })
@@ -181,7 +181,7 @@ export default class RisksAndAlertsPage extends Page {
       cy.get('[data-testid="osp-iioc-box"]').then(ospiBoxElement => {
         const { actual, expected } = Helpers.parseHtml(
           ospiBoxElement,
-          `${RisksAndAlertsUtils.levelText(RisksAndAlertsUtils.levelOrUnknown(this.risksAndAlerts.ospiScore))} OSP/I`,
+          `${RisksAndAlertsUtils.levelText(RisksAndAlertsUtils.levelOrUnknown(this.risksAndAlerts.ospiScore))} OSP/IIOC`,
         )
         expect(actual).to.equal(expected)
       })

--- a/server/@types/ui/index.d.ts
+++ b/server/@types/ui/index.d.ts
@@ -203,7 +203,7 @@ type OspBox = {
   dataTestId: string
   levelClass: string
   levelText: string
-  type: 'OSP/C' | 'OSP/I'
+  type: 'OSP/C' | 'OSP/DC' | 'OSP/I' | 'OSP/IIOC'
 }
 
 type RiskBox = {

--- a/server/controllers/shared/risksAndNeedsController.test.ts
+++ b/server/controllers/shared/risksAndNeedsController.test.ts
@@ -733,8 +733,13 @@ describe('RisksAndNeedsController', () => {
         levelClass: 'risk-box--low',
         levelText: 'LOW',
       }
-      const ospcBox: OspBox = { dataTestId: 'osp-c-box', levelClass: 'osp-box--low', levelText: 'LOW', type: 'OSP/C' }
-      const ospiBox: OspBox = { dataTestId: 'ocp-i-box', levelClass: 'osp-box--low', levelText: 'LOW', type: 'OSP/I' }
+      const ospcBox: OspBox = { dataTestId: 'osp-dc-box', levelClass: 'osp-box--low', levelText: 'LOW', type: 'OSP/DC' }
+      const ospiBox: OspBox = {
+        dataTestId: 'osp-iioc-box',
+        levelClass: 'osp-box--low',
+        levelText: 'LOW',
+        type: 'OSP/IIOC',
+      }
       const ovpYear1Box: RiskBox = {
         category: 'OVP Year 1',
         dataTestId: 'ovp-year-1-risk-box',
@@ -786,8 +791,8 @@ describe('RisksAndNeedsController', () => {
       when(mockRisksAndAlertsUtils.riskBox)
         .calledWith('OGRS Year 2', risksAndAlerts.ogrsRisk, `${risksAndAlerts.ogrsYear2?.toString()}%`)
         .mockReturnValue(ogrsYear2Box)
-      when(mockRisksAndAlertsUtils.ospBox).calledWith('OSP/C', risksAndAlerts.ospcScore).mockReturnValue(ospcBox)
-      when(mockRisksAndAlertsUtils.ospBox).calledWith('OSP/I', risksAndAlerts.ospiScore).mockReturnValue(ospiBox)
+      when(mockRisksAndAlertsUtils.ospBox).calledWith('OSP/DC', risksAndAlerts.ospcScore).mockReturnValue(ospcBox)
+      when(mockRisksAndAlertsUtils.ospBox).calledWith('OSP/IIOC', risksAndAlerts.ospiScore).mockReturnValue(ospiBox)
       when(mockRisksAndAlertsUtils.riskBox)
         .calledWith('OVP Year 1', risksAndAlerts.ovpRisk, `${risksAndAlerts.ovpYear1?.toString()}%`)
         .mockReturnValue(ovpYear1Box)

--- a/server/controllers/shared/risksAndNeedsController.ts
+++ b/server/controllers/shared/risksAndNeedsController.ts
@@ -306,8 +306,8 @@ export default class RisksAndNeedsController {
               risksAndAlerts.ogrsRisk,
               risksAndAlerts.ogrsYear2 ? `${risksAndAlerts.ogrsYear2}%` : undefined,
             ),
-            ospcBox: RisksAndAlertsUtils.ospBox('OSP/C', risksAndAlerts.ospcScore),
-            ospiBox: RisksAndAlertsUtils.ospBox('OSP/I', risksAndAlerts.ospiScore),
+            ospcBox: RisksAndAlertsUtils.ospBox('OSP/DC', risksAndAlerts.ospcScore),
+            ospiBox: RisksAndAlertsUtils.ospBox('OSP/IIOC', risksAndAlerts.ospiScore),
             ovpYear1Box: RisksAndAlertsUtils.riskBox(
               'OVP Year 1',
               risksAndAlerts.ovpRisk,

--- a/server/utils/risksAndNeeds/risksAndAlertsUtils.test.ts
+++ b/server/utils/risksAndNeeds/risksAndAlertsUtils.test.ts
@@ -171,17 +171,17 @@ describe('RisksAndAlertsUtils', () => {
 
   describe('ospBox', () => {
     it('formats OSP data in the appropriate format for passing to an OSP box Nunjucks macro', () => {
-      expect(RisksAndAlertsUtils.ospBox('OSP/C', 'VERY_HIGH')).toEqual({
-        dataTestId: 'osp-c-box',
+      expect(RisksAndAlertsUtils.ospBox('OSP/DC', 'VERY_HIGH')).toEqual({
+        dataTestId: 'osp-dc-box',
         levelClass: 'osp-box--very-high',
         levelText: 'VERY HIGH',
-        type: 'OSP/C',
+        type: 'OSP/DC',
       })
     })
 
     describe('when the level is missing', () => {
       it('uses "unknown" for the level', () => {
-        expect(RisksAndAlertsUtils.ospBox('OSP/C', undefined)).toEqual(
+        expect(RisksAndAlertsUtils.ospBox('OSP/DC', undefined)).toEqual(
           expect.objectContaining({
             levelClass: 'osp-box--unknown',
             levelText: 'UNKNOWN',


### PR DESCRIPTION
For all referrals, on the ‘Risks and Needs’ tab, under ‘Risks and alerts’ we have a ‘Risk of serious recidivism’ section.

The High/Medium/Low scores for this are currently against:

OSP/C

OSP/I

These acronyms need to be updated to:

OSP/DC

OSP/IIOC