### PR TITLE
Move ModSecurity snippet to app-specific config and add logging config

### DIFF
--- a/helm_deploy/hmpps-accredited-programmes-ui/values.yaml
+++ b/helm_deploy/hmpps-accredited-programmes-ui/values.yaml
@@ -13,6 +13,13 @@ generic-service:
     enabled: true
     host: app-hostname.local # override per environment
     tlsSecretName: hmpps-accredited-programmes-ui-cert
+    modsecurity_enabled: true
+    modsecurity_snippet: |
+      SecRuleEngine On
+      SecDefaultAction "phase:2,pass,log,tag:github_team=hmpps-accredited-programmes-devs,tag:namespace={{ .Release.Namespace }}"
+      SecRuleUpdateActionById 949110 "t:none,deny,status:406,logdata:%{SERVER_NAME}"
+      SecRuleUpdateActionById 959100 "t:none,deny,status:406,logdata:%{SERVER_NAME}"
+      SecAction "id:900000,phase:1,nolog,pass,t:none,setvar:tx.paranoia_level=1"
 
   livenessProbe:
     httpGet:

--- a/helm_deploy/values-dev.yaml
+++ b/helm_deploy/values-dev.yaml
@@ -7,12 +7,6 @@ generic-service:
   ingress:
     host: accredited-programmes-dev.hmpps.service.justice.gov.uk
     tlsSecretName: hmpps-accredited-programmes-dev-cert
-    modsecurity_enabled: true
-    modsecurity_snippet: |
-      SecRuleEngine On
-      SecRuleUpdateActionById 949110 "t:none,deny,status:406,logdata:%{SERVER_NAME}"
-      SecRuleUpdateActionById 959100 "t:none,deny,status:406,logdata:%{SERVER_NAME}"
-      SecAction "id:900000,phase:1,nolog,pass,t:none,setvar:tx.paranoia_level=1"
 
   env:
     ENVIRONMENT: dev

--- a/helm_deploy/values-preprod.yaml
+++ b/helm_deploy/values-preprod.yaml
@@ -5,12 +5,6 @@ generic-service:
   ingress:
     host: accredited-programmes-preprod.hmpps.service.justice.gov.uk
     tlsSecretName: hmpps-accredited-programmes-preprod-cert
-    modsecurity_enabled: true
-    modsecurity_snippet: |
-      SecRuleEngine On
-      SecRuleUpdateActionById 949110 "t:none,deny,status:406,logdata:%{SERVER_NAME}"
-      SecRuleUpdateActionById 959100 "t:none,deny,status:406,logdata:%{SERVER_NAME}"
-      SecAction "id:900000,phase:1,nolog,pass,t:none,setvar:tx.paranoia_level=1"
 
   env:
     ENVIRONMENT: preprod

--- a/helm_deploy/values-prod.yaml
+++ b/helm_deploy/values-prod.yaml
@@ -5,12 +5,6 @@ generic-service:
   ingress:
     host: accredited-programmes.hmpps.service.justice.gov.uk
     tlsSecretName: hmpps-accredited-programmes-prod-cert
-    modsecurity_enabled: true
-    modsecurity_snippet: |
-      SecRuleEngine On
-      SecRuleUpdateActionById 949110 "t:none,deny,status:406,logdata:%{SERVER_NAME}"
-      SecRuleUpdateActionById 959100 "t:none,deny,status:406,logdata:%{SERVER_NAME}"
-      SecAction "id:900000,phase:1,nolog,pass,t:none,setvar:tx.paranoia_level=1"
 
   env:
     ENVIRONMENT: prod


### PR DESCRIPTION

## Changes in this PR

- Moved the ModSecurity configuration snippet from shared Helm values to the `hmpps-accredited-programmes-ui` application-specific configuration.
- Added logging configuration for improved traceability.

