### PR TITLE
Add ModSecurity rules for specific endpoints

### DIFF
--- a/helm_deploy/hmpps-accredited-programmes-ui/values.yaml
+++ b/helm_deploy/hmpps-accredited-programmes-ui/values.yaml
@@ -20,6 +20,16 @@ generic-service:
       SecRuleUpdateActionById 949110 "t:none,deny,status:406,logdata:%{SERVER_NAME}"
       SecRuleUpdateActionById 959100 "t:none,deny,status:406,logdata:%{SERVER_NAME}"
       SecAction "id:900000,phase:1,nolog,pass,t:none,setvar:tx.paranoia_level=1"
+      
+      SecRule REQUEST_METHOD "@streq PUT" \
+      "id:1000001,phase:1,pass,nolog,chain"
+      SecRule REQUEST_URI "@rx ^/refer/referrals/new/[0-9a-fA-F-]{36}/additional-information$" \
+      "ctl:ruleRemoveByTag=attack-sqli"
+      
+      SecRule REQUEST_METHOD "@streq POST" \
+      "id:1000002,phase:1,pass,nolog,chain"
+      SecRule REQUEST_URI "@rx ^/assess/referrals/[0-9a-fA-F-]{36}/update-status/selection/reason$" \
+      "ctl:ruleRemoveByTag=attack-sqli"
 
   livenessProbe:
     httpGet:


### PR DESCRIPTION
## Context

Please see justification in JIRA ticket: https://dsdmoj.atlassian.net/browse/APG-2363

## Changes in this PR

- Added ModSecurity rules to the `hmpps-accredited-programmes-ui` configuration to enhance security for specific URLs.

