### PR TITLE
Update ModSecurity rules for broader endpoint patterns

### DIFF
--- a/helm_deploy/hmpps-accredited-programmes-ui/values.yaml
+++ b/helm_deploy/hmpps-accredited-programmes-ui/values.yaml
@@ -21,16 +21,12 @@ generic-service:
       SecRuleUpdateActionById 959100 "t:none,deny,status:406,logdata:%{SERVER_NAME}"
       SecAction "id:900000,phase:1,nolog,pass,t:none,setvar:tx.paranoia_level=1"
       
-      SecRule REQUEST_METHOD "@streq PUT" \
-      "id:1000001,phase:1,pass,nolog,chain"
-      SecRule REQUEST_URI "@rx ^/refer/referrals/new/[0-9a-fA-F-]{36}/additional-information$" \
-      "ctl:ruleRemoveByTag=attack-sqli"
+      SecRule REQUEST_URI "@beginsWith /refer/referrals/new" \ 
+        "id:1000001,phase:1,pass,nolog,ctl:ruleRemoveById=942000-942999"
       
-      SecRule REQUEST_METHOD "@streq POST" \
-      "id:1000002,phase:1,pass,nolog,chain"
-      SecRule REQUEST_URI "@rx ^/assess/referrals/[0-9a-fA-F-]{36}/update-status/selection/reason$" \
-      "ctl:ruleRemoveByTag=attack-sqli"
-
+      SecRule REQUEST_URI "@beginsWith /assess/referrals" \ 
+        "id:1000001,phase:1,pass,nolog,ctl:ruleRemoveById=942000-942999"
+    
   livenessProbe:
     httpGet:
       path: /ping


### PR DESCRIPTION
## Context

This pull request updates the ModSecurity rules in the `hmpps-accredited-programmes-ui` configuration to ensure broader endpoint patterns are covered using `ctl:ruleRemoveById`. This change improves the flexibility and accuracy of rule application.

## Changes in this PR

- Modified ModSecurity configuration to replace targeted patterns with `ctl:ruleRemoveById` for broader endpoint matching, and removing XSS and SQLi for those URL patterns.

