### PR TITLE
APG-2363 Correct ModSecurity rule ID in `hmpps-accredited-programmes-ui` configuration

### DIFF
--- a/helm_deploy/hmpps-accredited-programmes-ui/values.yaml
+++ b/helm_deploy/hmpps-accredited-programmes-ui/values.yaml
@@ -25,7 +25,7 @@ generic-service:
         "id:1000001,phase:1,pass,nolog,ctl:ruleRemoveById=942000-942999"
       
       SecRule REQUEST_URI "@beginsWith /assess/referrals" \ 
-        "id:1000001,phase:1,pass,nolog,ctl:ruleRemoveById=942000-942999"
+        "id:1000002,phase:1,pass,nolog,ctl:ruleRemoveById=942000-942999"
     
   livenessProbe:
     httpGet:


### PR DESCRIPTION

## Changes in this PR

Fix duplicate modSec id

