### PR TITLE
APG-2363 Remove specific ModSecurity rule actions and streamline configurations

### DIFF
--- a/helm_deploy/hmpps-accredited-programmes-ui/values.yaml
+++ b/helm_deploy/hmpps-accredited-programmes-ui/values.yaml
@@ -17,14 +17,14 @@ generic-service:
     modsecurity_snippet: |
       SecRuleEngine On
       SecDefaultAction "phase:2,pass,log,tag:github_team=hmpps-accredited-programmes-devs,tag:namespace={{ .Release.Namespace }}"
-      SecRuleUpdateActionById 949110 "t:none,deny,status:406,logdata:%{SERVER_NAME}"
-      SecRuleUpdateActionById 959100 "t:none,deny,status:406,logdata:%{SERVER_NAME}"
       SecAction "id:900000,phase:1,nolog,pass,t:none,setvar:tx.paranoia_level=1"
-      
-      SecRule REQUEST_URI "@beginsWith /refer/referrals/new" \ 
+      SecRuleRemoveById 949110
+      SecRuleRemoveById 959100
+
+      SecRule REQUEST_URI "@beginsWith /refer/referrals/new" \
         "id:1000001,phase:1,pass,nolog,ctl:ruleRemoveById=942000-942999"
-      
-      SecRule REQUEST_URI "@beginsWith /assess/referrals" \ 
+
+      SecRule REQUEST_URI "@beginsWith /assess/referrals" \
         "id:1000002,phase:1,pass,nolog,ctl:ruleRemoveById=942000-942999"
     
   livenessProbe:


### PR DESCRIPTION

## Changes in this PR

- Removed specific actions from ModSecurity rules 949110 and 959100 in an effort to prevent HTTP 406 errors 




