### PR TITLE
APG-2363 Disable ModSecurity in `hmpps-accredited-programmes-ui` Helm configuration

### DIFF
--- a/helm_deploy/hmpps-accredited-programmes-ui/values.yaml
+++ b/helm_deploy/hmpps-accredited-programmes-ui/values.yaml
@@ -13,7 +13,7 @@ generic-service:
     enabled: true
     host: app-hostname.local # override per environment
     tlsSecretName: hmpps-accredited-programmes-ui-cert
-    modsecurity_enabled: true
+    modsecurity_enabled: false
     modsecurity_snippet: |
       SecRuleEngine On
       SecDefaultAction "phase:2,pass,log,tag:github_team=hmpps-accredited-programmes-devs,tag:namespace={{ .Release.Namespace }}"


### PR DESCRIPTION
## Context

Multiple users are experience an HTTP 406 when performing day to day tasks. Temporarily disabling modsec until we can further investigate the false positives that are occuring.



